### PR TITLE
  Add artifact lineage graph traversal (upstream + downstream)  

### DIFF
--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -327,8 +327,8 @@ class GBClient:
         def artifact_lineage(self, token: str, artifact_name: str):
             return artifact_lineage(token, artifact_name)
 
-        def artifact_lineage_hf(self, repo_id: str):
-            return artifact_lineage_hf(self.github_token, repo_id)
+        def artifact_lineage_hf(self, artifact_uri: str):
+            return artifact_lineage_hf(self.github_token, artifact_uri)
 
         def artifact_list(
             self,

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -1471,10 +1471,14 @@ def _lineage_hf(ctx, artifact_client, artifact, format, quiet):
 
         for run in runs:
             inputs_list = [
-                _format_ref(ref) for ref in run.get("inputs", []) if ref.get("node_type") == "artifact"
+                _format_ref(ref)
+                for ref in run.get("inputs", [])
+                if ref.get("node_type") == "artifact"
             ]
             outputs_list = [
-                _format_ref(ref) for ref in run.get("outputs", []) if ref.get("node_type") == "artifact"
+                _format_ref(ref)
+                for ref in run.get("outputs", [])
+                if ref.get("node_type") == "artifact"
             ]
             inputs_str = "\n".join(inputs_list)
             outputs_str = "\n".join(outputs_list)

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -1419,16 +1419,15 @@ def _lineage_lh(ctx, artifact_client, artifact, format, quiet, echo_callback):
 
 
 def _lineage_hf(ctx, artifact_client, artifact, format, quiet):
-    org, repo_name, artifact_type, _ = parse_hf_uri(artifact["uri"])
-    repo_id = f"{org}/{repo_name}"
+    artifact_uri = artifact["uri"]
 
     if not quiet:
-        click.echo(f"(2/2) Fetching artifact lineage for {repo_id}...")
+        click.echo(f"(2/2) Fetching artifact lineage for {artifact_uri}...")
 
     response = (
-        artifact_client.artifact_lineage_hf(repo_id)
+        artifact_client.artifact_lineage_hf(artifact_uri)
         if quiet
-        else execute_with_spinner(artifact_client.artifact_lineage_hf, repo_id)
+        else execute_with_spinner(artifact_client.artifact_lineage_hf, artifact_uri)
     )
 
     runs = response.get("runs", [])
@@ -1439,71 +1438,61 @@ def _lineage_hf(ctx, artifact_client, artifact, format, quiet):
     if format == "json":
         click.echo("\n" + json.dumps(response, indent=2, default=str))
     else:
-        if format == "full":
-            headers = ARTIFACT_LINEAGE_FULL_HEADERS
-        else:
-            headers = ARTIFACT_LINEAGE_DEFAULT_HEADERS
-
         table = Table(title="Artifact Lineage", padding=(0, 1))
-        for header in headers:
-            table.add_column(header, overflow="fold")
+        table.add_column("Job Name", overflow="fold")
+        table.add_column("Job Type", overflow="fold")
+        table.add_column("Run ID", overflow="fold")
+        table.add_column("Status", overflow="fold")
+        table.add_column("Created At", overflow="fold")
+        table.add_column("Inputs", overflow="fold")
+        table.add_column("Outputs", overflow="fold")
+
+        def _format_ref(ref):
+            uri = ref.get("uri", "")
+            name = ref.get("name", "")
+            if uri and uri.startswith("hf://"):
+                parts = [p for p in uri.replace("hf://", "").split("/") if p]
+                if parts[0] in ("datasets", "spaces", "buckets"):
+                    artifact_type = parts[0].rstrip("s").capitalize()
+                    repo_id = "/".join(parts[1:3])
+                elif "." in parts[0]:
+                    # host is present, check next segment
+                    if len(parts) > 1 and parts[1] in ("datasets", "spaces", "buckets"):
+                        artifact_type = parts[1].rstrip("s").capitalize()
+                        repo_id = "/".join(parts[2:4])
+                    else:
+                        artifact_type = "Model"
+                        repo_id = "/".join(parts[1:3])
+                else:
+                    artifact_type = "Model"
+                    repo_id = "/".join(parts[0:2])
+                return f"{artifact_type}:\n{repo_id}|{uri}"
+            return f"{name}\n{uri}" if uri else name
 
         for run in runs:
-            run_obj = run.get("run", {})
-            job_obj = run.get("job", {})
-            tags = run_obj.get("facets", {}).get("tags", {})
-            inputs = run.get("inputs", [])
-            outputs = run.get("outputs", [])
-
-            artifact_id = artifact.get("uuid", "-")
-            job_name = job_obj.get("name", "-")
-            job_id = run_obj.get("runId", "-")
-            job_status = run.get("eventType", "-")
-            source = ", ".join(i.get("name", "") for i in inputs) or "-"
-            target = ", ".join(o.get("name", "") for o in outputs) or "-"
-
-            if format == "full":
-                table.add_row(
-                    artifact_id,
-                    job_obj.get("namespace", "-"),
-                    job_name,
-                    job_id,
-                    "-",
-                    run.get("eventTime", "-"),
-                    run.get("eventTime", "-"),
-                    job_status,
-                    tags.get("username", "-"),
-                    source,
-                    "-",
-                    ", ".join(
-                        i.get("facets", {}).get("artifact_type", "-") for i in inputs
-                    )
-                    or "-",
-                    ", ".join(i.get("uri", "-") for i in inputs) or "-",
-                    target,
-                    "-",
-                    ", ".join(
-                        o.get("facets", {}).get("artifact_type", "-") for o in outputs
-                    )
-                    or "-",
-                    ", ".join(o.get("uri", "-") for o in outputs) or "-",
-                    run.get("producer", "-"),
-                    "-",
-                    "-",
-                    "-",
-                )
-            else:
-                table.add_row(
-                    artifact_id,
-                    job_name,
-                    job_id,
-                    job_status,
-                    source,
-                    target,
-                )
+            inputs_list = [
+                _format_ref(ref) for ref in run.get("inputs", []) if ref.get("node_type") == "artifact"
+            ]
+            outputs_list = [
+                _format_ref(ref) for ref in run.get("outputs", []) if ref.get("node_type") == "artifact"
+            ]
+            inputs_str = "\n".join(inputs_list)
+            outputs_str = "\n".join(outputs_list)
+            table.add_row(
+                run.get("job_name", "-"),
+                run.get("job_type", "-"),
+                run.get("run_id", "-"),
+                run.get("status", "-"),
+                run.get("created_at", "-"),
+                inputs_str or "-",
+                outputs_str or "-",
+            )
 
         console = Console()
         console.print(table)
+
+        if response.get("truncated"):
+            click.echo("(graph truncated at max depth)")
 
 
 @cli.command()
@@ -1559,7 +1548,7 @@ def lineage(ctx, artifact_id: str, format: str, skip_version_check: bool, quiet:
         id_format = parse_artifact_identifier(artifact_id)
         if id_format in ["uuid", "uri"]:
             if not quiet:
-                click.echo(f"(1/?) Obtaining artifact..")
+                click.echo(f"(1/2) Obtaining artifact..")
 
             artifact = (
                 artifact_client.fetch_artifact(artifact_id, callback=echo_callback)

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -920,7 +920,6 @@ def artifact_lineage_hf(
     }
     if artifact_type:
         body["artifact_type"] = artifact_type
-    print(body)
     response = gb_server_request(
         user_token=github_token,
         url=url,

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -907,15 +907,15 @@ def artifact_lineage(token: str, artifact_name: str):
     )
 
 
-def artifact_lineage_hf(github_token: str, repo_id: str):
+def artifact_lineage_hf(github_token: str, artifact_uri: str):
     from gbcli.utils.gbconstants import GBSERVER_LINEAGE_API
 
-    url = f"{GBSERVER_LINEAGE_API}artifact/runs"
+    url = f"{GBSERVER_LINEAGE_API}artifact"
     response = gb_server_request(
         user_token=github_token,
         url=url,
         http_method="post",
-        body={"repo_id": repo_id, "limit": 100, "offset": 0},
+        body={"artifact_url": artifact_uri},
         params=None,
     )
     return response

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -907,15 +907,25 @@ def artifact_lineage(token: str, artifact_name: str):
     )
 
 
-def artifact_lineage_hf(github_token: str, artifact_uri: str):
+def artifact_lineage_hf(
+    github_token: str, artifact_uri: str, artifact_type: Optional[str] = None
+):
     from gbcli.utils.gbconstants import GBSERVER_LINEAGE_API
 
     url = f"{GBSERVER_LINEAGE_API}artifact"
+    body: dict[str, Any] = {
+        "artifact_url": artifact_uri,
+        "max_depth": 10,
+        "direction": "both",
+    }
+    if artifact_type:
+        body["artifact_type"] = artifact_type
+    print(body)
     response = gb_server_request(
         user_token=github_token,
         url=url,
         http_method="post",
-        body={"artifact_url": artifact_uri},
+        body=body,
         params=None,
     )
     return response

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -150,7 +150,8 @@ ENVIRONMENT_CONFIGS = {
     "DEV": {
         "env": "DEV",
         "lakehouse_environment": "STAGING",
-        "gbserver_host": "https://api.llm-build-dev.vpc-int.res.ibm.com",
+        # "gbserver_host": "https://api.llm-build-dev.vpc-int.res.ibm.com",
+        "gbserver_host": "http://localhost:8081",
         "default_space": "public",
         "dmf_ui": "https://ui2.dmf-staging.vpc-int.res.ibm.com",
         "config_spaces": "dev.gb.spaces",

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -150,8 +150,7 @@ ENVIRONMENT_CONFIGS = {
     "DEV": {
         "env": "DEV",
         "lakehouse_environment": "STAGING",
-        # "gbserver_host": "https://api.llm-build-dev.vpc-int.res.ibm.com",
-        "gbserver_host": "http://localhost:8081",
+        "gbserver_host": "https://api.llm-build-dev.vpc-int.res.ibm.com",
         "default_space": "public",
         "dmf_ui": "https://ui2.dmf-staging.vpc-int.res.ibm.com",
         "config_spaces": "dev.gb.spaces",

--- a/src/gbcli/utils/gbserver.py
+++ b/src/gbcli/utils/gbserver.py
@@ -328,7 +328,7 @@ def get_build(build_id: str, token: str, gbserver_api: str) -> Any:
 def get_build_lineage(build_id: str, token: str, gbserver_api: str) -> Any:
     build_lineage_url = f"{gbserver_api}build/{build_id}"
 
-    a= gb_server_request(
+    a = gb_server_request(
         user_token=token,
         url=build_lineage_url,
         http_method="get",

--- a/src/gbcli/utils/gbserver.py
+++ b/src/gbcli/utils/gbserver.py
@@ -316,7 +316,6 @@ def get_builds(
 
 def get_build(build_id: str, token: str, gbserver_api: str) -> Any:
     build_details_url = f"{gbserver_api}{build_id}"
-
     return gb_server_request(
         user_token=token,
         url=build_details_url,
@@ -329,13 +328,14 @@ def get_build(build_id: str, token: str, gbserver_api: str) -> Any:
 def get_build_lineage(build_id: str, token: str, gbserver_api: str) -> Any:
     build_lineage_url = f"{gbserver_api}build/{build_id}"
 
-    return gb_server_request(
+    a= gb_server_request(
         user_token=token,
         url=build_lineage_url,
         http_method="get",
         body=None,
         params=None,
     )
+    return a
 
 
 def get_build_events(build_id: str, token: str, gbserver_api: str) -> Any:

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel, ConfigDict
@@ -25,7 +26,10 @@ if TYPE_CHECKING:
     from lakehouse.api import JobStats
 
 from gbserver.lineage.openlineage_models import (
-    ArtifactLineageRequest,
+    ArtifactGraphRequest,
+    ArtifactGraphResponse,
+    ArtifactRunEntry,
+    LineageNodeRef,
 )
 from gbserver.lineage.openlineage_models import LineageEvent as OpenLineageEvent
 from gbserver.lineage.openlineage_models import (
@@ -33,10 +37,25 @@ from gbserver.lineage.openlineage_models import (
     TagSearchRequest,
 )
 from gbserver.lineage.openlineage_service import LineageService, LineageServiceFactory
+from gbserver.lineage.openlineage_utils import parse_hf_url
 from gbserver.storage.singleton_storage import get_admin_storage
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.types.constants import GBSERVER_LINEAGE_PROVIDER
+
+
+def _uri_from_url(url: Optional[str]) -> Optional[str]:
+    """Derive an hf:// URI from a huggingface.co URL."""
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or "huggingface.co"
+        org, name, artifact_type = parse_hf_url(url)
+        type_part = f"{artifact_type}s/" if artifact_type != "model" else ""
+        return f"hf://{host}/{type_part}{org}/{name}"
+    except Exception:
+        return url
 
 lineage_api = FastAPI()
 
@@ -146,28 +165,124 @@ def search_lineage_events(request: TagSearchRequest):
     )
 
 
-@lineage_api.post("/artifact/runs")
-def get_lineage_by_artifact(request: ArtifactLineageRequest):
-    service = _get_openlineage_service()
-    total, results = service.search_runs_by_artifact(
-        request.repo_id, request.artifact_type, request.limit, request.offset
-    )
-    return PaginatedResponse(
-        count=len(results),
-        total=total,
-        limit=request.limit,
-        offset=request.offset,
-        runs=results,
-    )
+@lineage_api.post("/artifact")
+def get_artifact_graph(request: ArtifactGraphRequest):
+    """Get the lineage DAG for an artifact, traversing downstream or upstream."""
+    if request.direction not in ("downstream", "upstream", "both"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="direction must be 'downstream', 'upstream', or 'both'",
+        )
 
+    if not request.artifact_name and not request.artifact_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Either artifact_name or artifact_url must be provided",
+        )
 
-@lineage_api.get("/{run_id}")
-def get_lineage_event(run_id: str):
     service = _get_openlineage_service()
-    result = service.get_run_lineage(run_id)
+    try:
+        result = service.get_artifact_graph(
+            artifact_name=request.artifact_name,
+            artifact_url=request.artifact_url,
+            artifact_type=request.artifact_type,
+            max_depth=request.max_depth,
+            direction=request.direction,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
     if result is None:
+        identifier = request.artifact_name or request.artifact_url
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Run not found: {run_id}",
+            detail=f"Artifact not found: {identifier}",
         )
-    return result
+
+    nodes = result.get("nodes", [])
+    edges = result.get("edges", [])
+
+    nodes_by_id = {node["id"]: node for node in nodes}
+    run_nodes = [n for n in nodes if n.get("node_type") == "run"]
+
+    runs: list[ArtifactRunEntry] = []
+    for run in run_nodes:
+        node_id = run["id"]
+        metadata = run.get("metadata") or {}
+        tags = run.get("tags") or []
+
+        inputs: list[LineageNodeRef] = []
+        outputs: list[LineageNodeRef] = []
+        for edge in edges:
+            if edge["target"] == node_id:
+                source_node = nodes_by_id.get(edge["source"], {})
+                node_type = source_node.get("node_type", "")
+                if node_type == "artifact":
+                    source_meta = source_node.get("metadata") or {}
+                    uri = source_meta.get("uri") or _uri_from_url(source_meta.get("url"))
+                    inputs.append(
+                        LineageNodeRef(
+                            node_type="artifact",
+                            name=source_node.get("name", edge["source"]),
+                            uri=uri,
+                            url=source_meta.get("url"),
+                        )
+                    )
+                elif node_type == "run":
+                    source_meta = source_node.get("metadata") or {}
+                    inputs.append(
+                        LineageNodeRef(
+                            node_type="run",
+                            name=source_node.get("name", ""),
+                            run_id=source_meta.get("run_id"),
+                            job_name=source_meta.get("job_name"),
+                        )
+                    )
+            elif edge["source"] == node_id:
+                target_node = nodes_by_id.get(edge["target"], {})
+                node_type = target_node.get("node_type", "")
+                if node_type == "artifact":
+                    target_meta = target_node.get("metadata") or {}
+                    uri = target_meta.get("uri") or _uri_from_url(target_meta.get("url"))
+                    outputs.append(
+                        LineageNodeRef(
+                            node_type="artifact",
+                            name=target_node.get("name", edge["target"]),
+                            uri=uri,
+                            url=target_meta.get("url"),
+                        )
+                    )
+                elif node_type == "run":
+                    target_meta = target_node.get("metadata") or {}
+                    outputs.append(
+                        LineageNodeRef(
+                            node_type="run",
+                            name=target_node.get("name", ""),
+                            run_id=target_meta.get("run_id"),
+                            job_name=target_meta.get("job_name"),
+                        )
+                    )
+
+        runs.append(
+            ArtifactRunEntry(
+                job_name=metadata.get("job_name") or run.get("name", ""),
+                job_namespace=metadata.get("job_namespace") or "",
+                job_type=metadata.get("job_type") or "",
+                run_id=metadata.get("run_id") or "",
+                created_at=metadata.get("created_at") or "",
+                status=metadata.get("state") or "",
+                tags=tags,
+                inputs=inputs,
+                outputs=outputs,
+            )
+        )
+
+    return ArtifactGraphResponse(
+        root_id=result["root_id"],
+        runs=runs,
+        truncated=result["truncated"],
+    )
+

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -57,6 +57,7 @@ def _uri_from_url(url: Optional[str]) -> Optional[str]:
     except Exception:
         return url
 
+
 lineage_api = FastAPI()
 
 
@@ -222,7 +223,9 @@ def get_artifact_graph(request: ArtifactGraphRequest):
                 node_type = source_node.get("node_type", "")
                 if node_type == "artifact":
                     source_meta = source_node.get("metadata") or {}
-                    uri = source_meta.get("uri") or _uri_from_url(source_meta.get("url"))
+                    uri = source_meta.get("uri") or _uri_from_url(
+                        source_meta.get("url")
+                    )
                     inputs.append(
                         LineageNodeRef(
                             node_type="artifact",
@@ -246,7 +249,9 @@ def get_artifact_graph(request: ArtifactGraphRequest):
                 node_type = target_node.get("node_type", "")
                 if node_type == "artifact":
                     target_meta = target_node.get("metadata") or {}
-                    uri = target_meta.get("uri") or _uri_from_url(target_meta.get("url"))
+                    uri = target_meta.get("uri") or _uri_from_url(
+                        target_meta.get("url")
+                    )
                     outputs.append(
                         LineageNodeRef(
                             node_type="artifact",
@@ -285,4 +290,3 @@ def get_artifact_graph(request: ArtifactGraphRequest):
         runs=runs,
         truncated=result["truncated"],
     )
-

--- a/src/gbserver/lineage/openlineage_models.py
+++ b/src/gbserver/lineage/openlineage_models.py
@@ -17,9 +17,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RunState(str, Enum):
@@ -89,16 +89,63 @@ class TagSearchRequest(BaseModel):
     offset: int = 0
 
 
-class ArtifactLineageRequest(BaseModel):
-    repo_id: str
-    artifact_type: Optional[str] = None
-    limit: int = 10
-    offset: int = 0
-
-
 class PaginatedResponse(BaseModel):
     count: int
     total: int
     limit: int
     offset: int
     runs: list
+
+
+class GraphNodeType(str, Enum):
+    ARTIFACT = "artifact"
+    RUN = "run"
+
+
+class GraphNode(BaseModel):
+    id: str
+    node_type: GraphNodeType
+    name: str
+    artifact_type: Optional[str] = None
+    is_root: bool = False
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphEdge(BaseModel):
+    source: str
+    target: str
+
+
+class ArtifactGraphRequest(BaseModel):
+    artifact_name: Optional[str] = None
+    artifact_url: Optional[str] = None
+    artifact_type: Optional[str] = None
+    max_depth: int = Field(default=10, ge=1, le=50)
+    direction: str = "downstream"
+
+
+class LineageNodeRef(BaseModel):
+    node_type: str
+    name: str = ""
+    uri: Optional[str] = None
+    url: Optional[str] = None
+    run_id: Optional[str] = None
+    job_name: Optional[str] = None
+
+
+class ArtifactRunEntry(BaseModel):
+    job_name: str = ""
+    job_namespace: str = ""
+    job_type: str = ""
+    run_id: str = ""
+    created_at: str = ""
+    status: str = ""
+    tags: List[str] = Field(default_factory=list)
+    inputs: List[LineageNodeRef] = Field(default_factory=list)
+    outputs: List[LineageNodeRef] = Field(default_factory=list)
+
+
+class ArtifactGraphResponse(BaseModel):
+    root_id: str
+    runs: List[ArtifactRunEntry]
+    truncated: bool = False

--- a/src/gbserver/lineage/openlineage_models.py
+++ b/src/gbserver/lineage/openlineage_models.py
@@ -121,7 +121,7 @@ class ArtifactGraphRequest(BaseModel):
     artifact_url: Optional[str] = None
     artifact_type: Optional[str] = None
     max_depth: int = Field(default=10, ge=1, le=50)
-    direction: str = "downstream"
+    direction: str = "both"
 
 
 class LineageNodeRef(BaseModel):

--- a/src/gbserver/lineage/openlineage_service.py
+++ b/src/gbserver/lineage/openlineage_service.py
@@ -17,19 +17,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type
-
-if TYPE_CHECKING:
-    pass
+from typing import Dict, List, Optional, Tuple, Type
 
 
 class LineageService(ABC):
     @abstractmethod
     def emit_event(self, event: Dict) -> None:
-        pass
-
-    @abstractmethod
-    def get_run_lineage(self, run_id: str) -> Optional[Dict]:
         pass
 
     @abstractmethod
@@ -39,13 +32,14 @@ class LineageService(ABC):
         pass
 
     @abstractmethod
-    def search_runs_by_artifact(
+    def get_artifact_graph(
         self,
-        repo_id: str,
+        artifact_name: Optional[str] = None,
+        artifact_url: Optional[str] = None,
         artifact_type: Optional[str] = None,
-        limit: int = 10,
-        offset: int = 0,
-    ) -> Tuple[int, List[Dict]]:
+        max_depth: int = 10,
+        direction: str = "downstream",
+    ) -> Optional[Dict]:
         pass
 
 

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -422,7 +422,9 @@ class WandBLineageService(LineageService):
             else GBSERVER_WANDB_PROJECT
         )
 
-        search_types = [artifact_type] if artifact_type else ["model", "dataset", "bucket"]
+        search_types = (
+            [artifact_type] if artifact_type else ["model", "dataset", "bucket"]
+        )
         for art_type in search_types:
             try:
                 type_obj = api.artifact_type(art_type, project_path)
@@ -550,11 +552,11 @@ class WandBLineageService(LineageService):
 
             edge_set: set = set()
             edges: List[Dict] = []
-            for e in down["edges"] + up["edges"]:
-                key = (e["source"], e["target"])
+            for edge in down["edges"] + up["edges"]:
+                key = (edge["source"], edge["target"])
                 if key not in edge_set:
                     edge_set.add(key)
-                    edges.append(e)
+                    edges.append(edge)
 
             return {
                 "root_id": root_id,
@@ -604,9 +606,7 @@ class WandBLineageService(LineageService):
                     if not hasattr(run, "id") or not hasattr(run, "entity"):
                         continue
                     run_id = f"{run.entity}/{run.project}/{run.id}"
-                    edges.append(
-                        {"source": item.qualified_name, "target": run_id}
-                    )
+                    edges.append({"source": item.qualified_name, "target": run_id})
 
                     if run_id not in visited_runs:
                         visited_runs.add(run_id)
@@ -623,7 +623,9 @@ class WandBLineageService(LineageService):
                                 "metadata": {
                                     "run_id": run.id,
                                     "job_name": run_config.get("job_name", run_name),
-                                    "job_namespace": run_config.get("job_namespace", ""),
+                                    "job_namespace": run_config.get(
+                                        "job_namespace", ""
+                                    ),
                                     "job_type": run_config.get("job_type", ""),
                                     "state": getattr(run, "state", None),
                                     "created_at": getattr(run, "createdAt", None),
@@ -707,4 +709,3 @@ class WandBLineageService(LineageService):
         except Exception as e:
             logger.error("Failed to search lineage by tags: %s", e)
             return 0, []
-

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Dict, List, Literal, Optional, Tuple, cast
 
 import wandb
@@ -193,7 +194,7 @@ class WandBLineageService(LineageService):
             logger.error("Failed to process lineage event: %s", e)
             raise
 
-    def get_run_lineage(self, run_id: str) -> Optional[Dict]:
+    def _get_run_lineage(self, run_id: str) -> Optional[Dict]:
         try:
             api = wandb.Api()
             path = (
@@ -411,6 +412,262 @@ class WandBLineageService(LineageService):
                     "Using existing HF %s input: %s", resource_type, resource_id
                 )
 
+    def _resolve_artifact_by_url(self, api, url: str):
+        org, name, artifact_type = parse_hf_url(url)
+        repo_id = f"{org}/{name}"
+
+        project_path = (
+            f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}"
+            if GBSERVER_WANDB_ENTITY
+            else GBSERVER_WANDB_PROJECT
+        )
+
+        search_types = [artifact_type] if artifact_type else ["model", "dataset", "bucket"]
+        for art_type in search_types:
+            try:
+                type_obj = api.artifact_type(art_type, project_path)
+                for collection in type_obj.collections():
+                    for artifact in collection.artifacts():
+                        meta = artifact.metadata or {}
+                        if meta.get("repo_id") == repo_id:
+                            return artifact
+            except Exception:
+                continue
+        return None
+
+    @staticmethod
+    def _with_version(name: str) -> str:
+        if ":" in name:
+            return name
+        return f"{name}:latest"
+
+    def _resolve_url_from_uri(self, uri: str) -> str:
+        org, name, artifact_type = parse_hf_uri(uri)
+        repo_id = f"{org}/{name}"
+        return get_huggingface_hub_url(artifact_type, repo_id)
+
+    def _get_artifact_names_from_url(self, url: str) -> List[str]:
+        org, name, _ = parse_hf_url(url)
+        candidates = [self._sanitize_artifact_name(name)]
+        repo_id_sanitized = self._sanitize_artifact_name(f"{org}/{name}")
+        if repo_id_sanitized != candidates[0]:
+            candidates.append(repo_id_sanitized)
+        return candidates
+
+    def get_artifact_graph(
+        self,
+        artifact_name: Optional[str] = None,
+        artifact_url: Optional[str] = None,
+        artifact_type: Optional[str] = None,
+        max_depth: int = 10,
+        direction: str = "downstream",
+    ) -> Optional[Dict]:
+        try:
+            api = wandb.Api()
+            root_artifact = None
+
+            if artifact_name:
+                hf_prefixes = ("datasets/", "models/", "buckets/", "spaces/")
+                has_version = ":" in artifact_name
+                if artifact_name.startswith(hf_prefixes):
+                    parts = artifact_name.split("/")
+                    hf_type = parts[0].rstrip("s")
+                    repo_id = "/".join(parts[1:])
+                    artifact_url = get_huggingface_hub_url(hf_type, repo_id)
+                elif not has_version and artifact_name.count("/") == 1:
+                    org, name = artifact_name.split("/")
+                    candidates = [
+                        self._sanitize_artifact_name(name),
+                        self._sanitize_artifact_name(artifact_name),
+                    ]
+                    for candidate in candidates:
+                        try:
+                            full_name = f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}/{self._with_version(candidate)}"
+                            root_artifact = api.artifact(full_name)
+                            break
+                        except Exception:
+                            continue
+                elif artifact_name.count("/") < 2:
+                    full_name = f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}/{self._with_version(artifact_name)}"
+                    root_artifact = api.artifact(full_name)
+                else:
+                    full_name = self._with_version(artifact_name)
+                    root_artifact = api.artifact(full_name)
+
+            if root_artifact is None and artifact_url:
+                if artifact_url.startswith("hf://"):
+                    artifact_url = self._resolve_url_from_uri(artifact_url)
+                for candidate in self._get_artifact_names_from_url(artifact_url):
+                    try:
+                        full_name = f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}/{self._with_version(candidate)}"
+                        root_artifact = api.artifact(full_name)
+                        break
+                    except Exception:
+                        continue
+                if root_artifact is None:
+                    root_artifact = self._resolve_artifact_by_url(api, artifact_url)
+
+            if root_artifact is None:
+                logger.warning(
+                    "Artifact not found: artifact_name=%s, artifact_url=%s",
+                    artifact_name,
+                    artifact_url,
+                )
+                return None
+        except Exception as e:
+            logger.error(
+                "Error resolving artifact: artifact_name=%s, artifact_url=%s, error=%s",
+                artifact_name,
+                artifact_url,
+                e,
+            )
+            return None
+
+        if artifact_type and root_artifact.type != artifact_type:
+            raise ValueError(
+                f"Artifact type mismatch: expected '{artifact_type}', "
+                f"but artifact '{root_artifact.name}' has type '{root_artifact.type}'"
+            )
+
+        root_id = root_artifact.qualified_name
+        root_node = {
+            "id": root_id,
+            "node_type": "artifact",
+            "name": root_artifact.name,
+            "artifact_type": root_artifact.type,
+            "is_root": True,
+            "metadata": root_artifact.metadata or {},
+        }
+
+        if direction == "both":
+            down = self._traverse_graph(root_artifact, root_id, max_depth, "downstream")
+            up = self._traverse_graph(root_artifact, root_id, max_depth, "upstream")
+
+            node_map: Dict[str, Dict] = {root_id: root_node}
+            for n in down["nodes"] + up["nodes"]:
+                node_map[n["id"]] = n
+            node_map[root_id] = root_node
+
+            edge_set: set = set()
+            edges: List[Dict] = []
+            for e in down["edges"] + up["edges"]:
+                key = (e["source"], e["target"])
+                if key not in edge_set:
+                    edge_set.add(key)
+                    edges.append(e)
+
+            return {
+                "root_id": root_id,
+                "nodes": list(node_map.values()),
+                "edges": edges,
+                "truncated": down["truncated"] or up["truncated"],
+            }
+
+        result = self._traverse_graph(root_artifact, root_id, max_depth, direction)
+        result["nodes"].insert(0, root_node)
+        return result
+
+    def _traverse_graph(
+        self,
+        root_artifact,
+        root_id: str,
+        max_depth: int,
+        direction: str,
+    ) -> Dict:
+        nodes: List[Dict] = []
+        edges: List[Dict] = []
+        visited_artifacts: set = {root_id}
+        visited_runs: set = set()
+        truncated = False
+
+        queue: deque = deque()
+        queue.append(("artifact", root_artifact, 0))
+
+        while queue:
+            item_type, item, depth = queue.popleft()
+
+            if depth >= max_depth:
+                truncated = True
+                continue
+
+            if item_type == "artifact":
+                if direction == "downstream":
+                    next_runs = list(item.used_by())
+                else:
+                    try:
+                        producer = item.logged_by()
+                    except (AttributeError, Exception):
+                        producer = None
+                    next_runs = [producer] if producer else []
+
+                for run in next_runs:
+                    if not hasattr(run, "id") or not hasattr(run, "entity"):
+                        continue
+                    run_id = f"{run.entity}/{run.project}/{run.id}"
+                    edges.append(
+                        {"source": item.qualified_name, "target": run_id}
+                    )
+
+                    if run_id not in visited_runs:
+                        visited_runs.add(run_id)
+                        run_name = getattr(run, "name", None) or run.id
+                        run_config = getattr(run, "config", {}) or {}
+                        run_tags = list(getattr(run, "tags", None) or [])
+                        nodes.append(
+                            {
+                                "id": run_id,
+                                "node_type": "run",
+                                "name": run_name,
+                                "artifact_type": None,
+                                "is_root": False,
+                                "metadata": {
+                                    "run_id": run.id,
+                                    "job_name": run_config.get("job_name", run_name),
+                                    "job_namespace": run_config.get("job_namespace", ""),
+                                    "job_type": run_config.get("job_type", ""),
+                                    "state": getattr(run, "state", None),
+                                    "created_at": getattr(run, "createdAt", None),
+                                },
+                                "tags": run_tags,
+                            }
+                        )
+                        queue.append(("run", run, depth + 1))
+
+            elif item_type == "run":
+                if direction == "downstream":
+                    next_artifacts = list(item.logged_artifacts())
+                else:
+                    next_artifacts = list(item.used_artifacts())
+
+                for artifact in next_artifacts:
+                    if self._is_wandb_system_artifact(artifact):
+                        continue
+
+                    art_id = artifact.qualified_name
+                    run_id = f"{item.entity}/{item.project}/{item.id}"
+                    edges.append({"source": run_id, "target": art_id})
+
+                    if art_id not in visited_artifacts:
+                        visited_artifacts.add(art_id)
+                        nodes.append(
+                            {
+                                "id": art_id,
+                                "node_type": "artifact",
+                                "name": artifact.name,
+                                "artifact_type": artifact.type,
+                                "is_root": False,
+                                "metadata": artifact.metadata or {},
+                            }
+                        )
+                        queue.append(("artifact", artifact, depth + 1))
+
+        return {
+            "root_id": root_id,
+            "nodes": nodes,
+            "edges": edges,
+            "truncated": truncated,
+        }
+
     def search_lineage_by_tags(
         self, tags: list, limit: int = 10, offset: int = 0
     ) -> Tuple[int, list]:
@@ -435,7 +692,7 @@ class WandBLineageService(LineageService):
 
             results = []
             for run in paginated_runs:
-                lineage = self.get_run_lineage(run.id)
+                lineage = self._get_run_lineage(run.id)
                 if lineage:
                     results.append(lineage)
 
@@ -451,91 +708,3 @@ class WandBLineageService(LineageService):
             logger.error("Failed to search lineage by tags: %s", e)
             return 0, []
 
-    def _search_by_artifact_type(
-        self, api, project_path: str, repo_id: str, artifact_type: str
-    ) -> List[str]:
-        seen_run_ids: set = set()
-        matching_run_ids: List[str] = []
-
-        art_type = api.artifact_type(artifact_type, project_path)
-        for collection in art_type.collections():
-            for artifact in collection.artifacts():
-                meta = artifact.metadata or {}
-                if meta.get("repo_id") != repo_id:
-                    continue
-
-                for run in artifact.used_by():
-                    if run.id not in seen_run_ids:
-                        seen_run_ids.add(run.id)
-                        matching_run_ids.append(run.id)
-
-                producer = artifact.logged_by()
-                if producer and producer.id not in seen_run_ids:
-                    seen_run_ids.add(producer.id)
-                    matching_run_ids.append(producer.id)
-
-        return matching_run_ids
-
-    def _search_by_runs(self, api, project_path: str, repo_id: str) -> List[str]:
-        matching_run_ids: List[str] = []
-
-        runs = api.runs(project_path)
-        for run in runs:
-            for artifact in run.used_artifacts():
-                meta = artifact.metadata or {}
-                if meta.get("repo_id") == repo_id:
-                    matching_run_ids.append(run.id)
-                    break
-            else:
-                for artifact in run.logged_artifacts():
-                    meta = artifact.metadata or {}
-                    if meta.get("repo_id") == repo_id:
-                        matching_run_ids.append(run.id)
-                        break
-
-        return matching_run_ids
-
-    def search_runs_by_artifact(
-        self,
-        repo_id: str,
-        artifact_type: Optional[str] = None,
-        limit: int = 10,
-        offset: int = 0,
-    ) -> Tuple[int, list]:
-        try:
-            api = wandb.Api()
-
-            project_path = (
-                f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}"
-                if GBSERVER_WANDB_ENTITY
-                else GBSERVER_WANDB_PROJECT
-            )
-
-            if artifact_type:
-                matching_run_ids = self._search_by_artifact_type(
-                    api, project_path, repo_id, artifact_type
-                )
-            else:
-                matching_run_ids = self._search_by_runs(api, project_path, repo_id)
-
-            total_count = len(matching_run_ids)
-            paginated_ids = matching_run_ids[offset : offset + limit]
-
-            results = []
-            for run_id in paginated_ids:
-                lineage = self.get_run_lineage(run_id)
-                if lineage:
-                    results.append(lineage)
-
-            logger.info(
-                "Found %d runs (page) with artifact: %s (type=%s), total: %d",
-                len(results),
-                repo_id,
-                artifact_type or "any",
-                total_count,
-            )
-            return total_count, results
-
-        except Exception as e:
-            logger.error("Failed to search lineage by artifact: %s", e)
-            return 0, []

--- a/test/integration/ibm/lineage/test_openlineage_service.py
+++ b/test/integration/ibm/lineage/test_openlineage_service.py
@@ -101,7 +101,11 @@ class MockLineageService(LineageService):
                     "name": "tunedmodel",
                     "artifact_type": None,
                     "is_root": False,
-                    "metadata": {"run_id": "run-123", "state": "finished", "created_at": "2025-03-19T18:00:00"},
+                    "metadata": {
+                        "run_id": "run-123",
+                        "state": "finished",
+                        "created_at": "2025-03-19T18:00:00",
+                    },
                 }
             )
             edges.append({"source": root_id, "target": run_id})
@@ -128,7 +132,11 @@ class MockLineageService(LineageService):
                     "name": "base-training",
                     "artifact_type": None,
                     "is_root": False,
-                    "metadata": {"run_id": "run-000", "state": "finished", "created_at": "2025-03-18T10:00:00"},
+                    "metadata": {
+                        "run_id": "run-000",
+                        "state": "finished",
+                        "created_at": "2025-03-18T10:00:00",
+                    },
                 }
             )
             edges.append({"source": root_id, "target": producer_run_id})
@@ -345,7 +353,9 @@ class TestOpenLineageAPI:
     def test_get_artifact_graph_by_url(self):
         response = self.client.post(
             "api/v1/lineage/artifact",
-            json={"artifact_url": "https://huggingface.co/buckets/ibm-research/test-bucket"},
+            json={
+                "artifact_url": "https://huggingface.co/buckets/ibm-research/test-bucket"
+            },
         )
         assert response.status_code == 200
         body = response.json()

--- a/test/integration/ibm/lineage/test_openlineage_service.py
+++ b/test/integration/ibm/lineage/test_openlineage_service.py
@@ -23,11 +23,6 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from gbserver.lineage.openlineage_models import (
-    LineageEvent,
-    PaginatedResponse,
-    RunState,
-)
 from gbserver.lineage.openlineage_service import LineageService, LineageServiceFactory
 
 pytestmark = pytest.mark.ibm
@@ -51,9 +46,6 @@ class MockLineageService(LineageService):
         run_id = event["run"]["runId"]
         self.events[run_id] = event
 
-    def get_run_lineage(self, run_id: str) -> Dict:
-        return self.events.get(run_id)
-
     def search_lineage_by_tags(
         self, tags: List[str], limit: int = 10, offset: int = 0
     ) -> Tuple[int, List[Dict]]:
@@ -73,28 +65,93 @@ class MockLineageService(LineageService):
         total = len(all_events)
         return total, all_events[offset : offset + limit]
 
-    def search_runs_by_artifact(
+    def get_artifact_graph(
         self,
-        repo_id: str,
-        artifact_type: Optional[str] = None,
-        limit: int = 10,
-        offset: int = 0,
-    ) -> Tuple[int, List[Dict]]:
-        matching = []
-        for ev in self.events.values():
-            for ds in ev.get("inputs", []) + ev.get("outputs", []):
-                facets = ds.get("facets", {})
-                if repo_id != facets.get("repo_id", ""):
-                    continue
-                if (
-                    artifact_type is not None
-                    and facets.get("artifact_type") != artifact_type
-                ):
-                    continue
-                matching.append(ev)
-                break
-        total = len(matching)
-        return total, matching[offset : offset + limit]
+        artifact_name: Optional[str] = None,
+        artifact_url: Optional[str] = None,
+        max_depth: int = 10,
+        direction: str = "downstream",
+    ) -> Optional[Dict]:
+        if artifact_name == "not-found:v0":
+            return None
+        if artifact_url == "https://huggingface.co/org/not-found":
+            return None
+        if not artifact_name and not artifact_url:
+            return None
+
+        display_name = artifact_name or artifact_url
+        root_id = f"entity/project/{display_name}"
+        root_node = {
+            "id": root_id,
+            "node_type": "artifact",
+            "name": display_name,
+            "artifact_type": "model",
+            "is_root": True,
+            "metadata": {},
+        }
+        nodes = [root_node]
+        edges = []
+
+        if max_depth > 1 and direction in ("downstream", "both"):
+            run_id = "entity/project/run-123"
+            nodes.append(
+                {
+                    "id": run_id,
+                    "node_type": "run",
+                    "name": "tunedmodel",
+                    "artifact_type": None,
+                    "is_root": False,
+                    "metadata": {"run_id": "run-123", "state": "finished", "created_at": "2025-03-19T18:00:00"},
+                }
+            )
+            edges.append({"source": root_id, "target": run_id})
+
+            output_id = "entity/project/output-model:v0"
+            nodes.append(
+                {
+                    "id": output_id,
+                    "node_type": "artifact",
+                    "name": "output-model:v0",
+                    "artifact_type": "model",
+                    "is_root": False,
+                    "metadata": {},
+                }
+            )
+            edges.append({"source": run_id, "target": output_id})
+
+        if max_depth > 1 and direction in ("upstream", "both"):
+            producer_run_id = "entity/project/run-000"
+            nodes.append(
+                {
+                    "id": producer_run_id,
+                    "node_type": "run",
+                    "name": "base-training",
+                    "artifact_type": None,
+                    "is_root": False,
+                    "metadata": {"run_id": "run-000", "state": "finished", "created_at": "2025-03-18T10:00:00"},
+                }
+            )
+            edges.append({"source": root_id, "target": producer_run_id})
+
+            input_id = "entity/project/raw-data:v0"
+            nodes.append(
+                {
+                    "id": input_id,
+                    "node_type": "artifact",
+                    "name": "raw-data:v0",
+                    "artifact_type": "dataset",
+                    "is_root": False,
+                    "metadata": {},
+                }
+            )
+            edges.append({"source": producer_run_id, "target": input_id})
+
+        return {
+            "root_id": root_id,
+            "nodes": nodes,
+            "edges": edges,
+            "truncated": max_depth <= 1,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -170,18 +227,6 @@ class TestOpenLineageAPI:
         response = self.client.post("api/v1/lineage/", json={"invalid": "data"})
         assert response.status_code == 422
 
-    def test_get_lineage_event_found(self):
-        self.mock_service.emit_event(_make_sample_event("run-abc"))
-        response = self.client.get("api/v1/lineage/run-abc")
-        assert response.status_code == 200
-        body = response.json()
-        assert body["run"]["runId"] == "run-abc"
-        assert body["job"]["name"] == "train_model"
-
-    def test_get_lineage_event_not_found(self):
-        response = self.client.get("api/v1/lineage/nonexistent-id")
-        assert response.status_code == 404
-
     def test_search_lineage_by_tags(self):
         self.mock_service.emit_event(_make_sample_event("run-1"))
         response = self.client.post("api/v1/lineage/search", json={"tags": ["env=dev"]})
@@ -223,59 +268,6 @@ class TestOpenLineageAPI:
         assert body["limit"] == 2
         assert body["offset"] == 1
 
-    def test_get_lineage_by_artifact(self):
-        self.mock_service.emit_event(_make_sample_event("run-art"))
-        response = self.client.post(
-            "api/v1/lineage/artifact/runs",
-            json={"repo_id": "org/granite-model"},
-        )
-        assert response.status_code == 200
-        body = response.json()
-        assert body["total"] == 1
-        assert len(body["runs"]) == 1
-
-    def test_get_lineage_by_artifact_no_match(self):
-        self.mock_service.emit_event(_make_sample_event("run-x"))
-        response = self.client.post(
-            "api/v1/lineage/artifact/runs",
-            json={"repo_id": "org/nonexistent"},
-        )
-        assert response.status_code == 200
-        body = response.json()
-        assert body["total"] == 0
-        assert body["runs"] == []
-
-    def test_get_lineage_by_artifact_with_type_filter(self):
-        ev = _make_sample_event(
-            "run-typed",
-            outputs=[
-                {
-                    "namespace": "huggingface://datasets",
-                    "name": "org/my-dataset",
-                    "facets": {
-                        "repo_id": "org/my-dataset",
-                        "artifact_type": "dataset",
-                    },
-                }
-            ],
-        )
-        self.mock_service.emit_event(ev)
-        response = self.client.post(
-            "api/v1/lineage/artifact/runs",
-            json={"repo_id": "org/my-dataset", "artifact_type": "dataset"},
-        )
-        assert response.status_code == 200
-        body = response.json()
-        assert body["total"] == 1
-
-        response = self.client.post(
-            "api/v1/lineage/artifact/runs",
-            json={"repo_id": "org/my-dataset", "artifact_type": "model"},
-        )
-        assert response.status_code == 200
-        body = response.json()
-        assert body["total"] == 0
-
     def test_existing_build_endpoint_still_works(self):
         response = self.client.get("api/v1/lineage/build/non-existent-uuid")
         assert response.status_code == 404
@@ -283,3 +275,93 @@ class TestOpenLineageAPI:
     def test_existing_target_endpoint_still_works(self):
         response = self.client.get("api/v1/lineage/target/non-existent-uuid")
         assert response.status_code == 404
+
+    # --- Artifact Graph Endpoint ---
+
+    def test_get_artifact_graph(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_name": "my-model:v0"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "root_id" in body
+        assert "nodes" in body
+        assert "edges" in body
+        assert body["nodes"][0]["is_root"] is True
+        assert body["nodes"][0]["node_type"] == "artifact"
+        assert len(body["nodes"]) == 3
+        assert len(body["edges"]) == 2
+
+    def test_get_artifact_graph_not_found(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_name": "not-found:v0"},
+        )
+        assert response.status_code == 404
+
+    def test_get_artifact_graph_invalid_direction(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_name": "my-model:v0", "direction": "invalid"},
+        )
+        assert response.status_code == 400
+
+    def test_get_artifact_graph_max_depth(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_name": "my-model:v0", "max_depth": 1},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["truncated"] is True
+        assert len(body["nodes"]) == 1
+
+    def test_get_artifact_graph_upstream(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_name": "my-model:v0", "direction": "upstream"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["nodes"][0]["is_root"] is True
+        assert len(body["nodes"]) == 3
+        assert any(n["name"] == "base-training" for n in body["nodes"])
+
+    def test_get_artifact_graph_both_directions(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_name": "my-model:v0", "direction": "both"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["nodes"][0]["is_root"] is True
+        assert len(body["nodes"]) == 5
+        assert len(body["edges"]) == 4
+        node_names = {n["name"] for n in body["nodes"]}
+        assert "tunedmodel" in node_names
+        assert "base-training" in node_names
+
+    def test_get_artifact_graph_by_url(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_url": "https://huggingface.co/buckets/ibm-research/test-bucket"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["nodes"][0]["is_root"] is True
+        assert len(body["nodes"]) == 3
+
+    def test_get_artifact_graph_by_url_not_found(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={"artifact_url": "https://huggingface.co/org/not-found"},
+        )
+        assert response.status_code == 404
+
+    def test_get_artifact_graph_no_params(self):
+        response = self.client.post(
+            "api/v1/lineage/artifact",
+            json={},
+        )
+        assert response.status_code == 400

--- a/test/unit/lineage/test_openlineage_models.py
+++ b/test/unit/lineage/test_openlineage_models.py
@@ -18,7 +18,6 @@ import pytest
 from pydantic import ValidationError
 
 from gbserver.lineage.openlineage_models import (
-    ArtifactLineageRequest,
     Dataset,
     Job,
     LineageEvent,
@@ -94,19 +93,6 @@ class TestTagSearchRequest:
         assert req.tags == ["env=prod", "team=ml"]
         assert req.limit == 50
         assert req.offset == 20
-
-
-class TestArtifactLineageRequest:
-    def test_construction(self):
-        req = ArtifactLineageRequest(repo_id="org/my-model")
-        assert req.repo_id == "org/my-model"
-        assert req.limit == 10
-        assert req.offset == 0
-
-    def test_custom_pagination(self):
-        req = ArtifactLineageRequest(repo_id="org/data", limit=5, offset=10)
-        assert req.limit == 5
-        assert req.offset == 10
 
 
 class TestPaginatedResponse:


### PR DESCRIPTION
- Extend the `/lineage/artifact` API to return a full upstream +   downstream artifact graph with configurable `max_depth` and   `direction`, backed by a new WandB-service traversal implementation.                                                   
- Rework the `gbcli artifact lineage` HuggingFace flow to send the full artifact URI (not just `org/repo`), and render a flattened  runs table with per-row input/output artifact references.
 - Update OpenLineage models (`ArtifactGraphRequest`/`Response`,   `ArtifactRunEntry`, `LineageNodeRef`) and integration tests to    cover the new graph-shaped payload.
