### PR TITLE
additional test fix

### DIFF
--- a/test/integration/ibm/github/test_myghapi.py
+++ b/test/integration/ibm/github/test_myghapi.py
@@ -9,7 +9,7 @@ from gbserver.types.constants import DEFAULT_GH_API_ENDPOINT
 @pytest.mark.ibm
 def test_branch_exists():
     mygit = MyGHApi(
-        token=os.getenv("GITHUB_TOKEN"), owner="granite-dot-build", repo="gbserver"
+        token=os.getenv("GITHUB_TOKEN"), owner="granite-dot-build", repo="granite.build"
     )
     main_exists = mygit.is_branch_present("main")
     assert main_exists, "main branch should have been found to exist"


### PR DESCRIPTION
## Description

An additional fix to https://github.com/ibm-granite/granite.build/pull/6 to fix the test case reference to the old repo name.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
