### PR TITLE
isort format fix

### DIFF
--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -29,10 +29,10 @@ from gbserver.lineage.openlineage_models import (
     ArtifactGraphRequest,
     ArtifactGraphResponse,
     ArtifactRunEntry,
-    LineageNodeRef,
 )
 from gbserver.lineage.openlineage_models import LineageEvent as OpenLineageEvent
 from gbserver.lineage.openlineage_models import (
+    LineageNodeRef,
     PaginatedResponse,
     TagSearchRequest,
 )


### PR DESCRIPTION
## Description

The previous PR introduced the lint violation which should have been caught. This PR fixes it.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
