### PR TITLE
feat: disable lakehouse lineage feature by default

### DIFF
--- a/src/gbserver/types/gbserverenvconfig.py
+++ b/src/gbserver/types/gbserverenvconfig.py
@@ -101,7 +101,7 @@ _GBSERVER_ENVIRONMENT_CONFIGS = {
                 "GBSERVER_FEATURE_LAKEHOUSE_SPACE_MEMBERSHIP", False
             ),
             "lakehouse_lineage": getenv_boolean(
-                "GBSERVER_FEATURE_LAKEHOUSE_LINEAGE", True
+                "GBSERVER_FEATURE_LAKEHOUSE_LINEAGE", False
             ),
         },
     ),
@@ -122,7 +122,7 @@ _GBSERVER_ENVIRONMENT_CONFIGS = {
                 "GBSERVER_FEATURE_LAKEHOUSE_SPACE_MEMBERSHIP", False
             ),
             "lakehouse_lineage": getenv_boolean(
-                "GBSERVER_FEATURE_LAKEHOUSE_LINEAGE", True
+                "GBSERVER_FEATURE_LAKEHOUSE_LINEAGE", False
             ),
         },
     ),
@@ -164,7 +164,7 @@ _GBSERVER_ENVIRONMENT_CONFIGS = {
                 "GBSERVER_FEATURE_LAKEHOUSE_SPACE_MEMBERSHIP", False
             ),
             "lakehouse_lineage": getenv_boolean(
-                "GBSERVER_FEATURE_LAKEHOUSE_LINEAGE", True
+                "GBSERVER_FEATURE_LAKEHOUSE_LINEAGE", False
             ),
         },
     ),


### PR DESCRIPTION
Set GBSERVER_FEATURE_LAKEHOUSE_LINEAGE default to False in all environments (DEV, STAGING, PROD).

## Summary
  - Set `GBSERVER_FEATURE_LAKEHOUSE_LINEAGE` default to `False` in all environments (DEV, STAGING, PROD)

  ## Test plan
  - [ ] Verify lakehouse lineage is not triggered during builds unless explicitly enabled via env var
  - [ ] Confirm existing builds without lineage dependency are unaffected

  Title: Disable lakehouse lineage feature by default

Note that there are pending bugfixes to the test cases that showed inconsistencies among the environments. This PR is a step to have same behaviors among environments. We're not removing the feature flags yes- cleanups will be handled separately after fully confirming the functions.