### PR TITLE
fix: add count_events_by_tags + enrich jobstats artifact facets   

### DIFF
--- a/src/gbserver/lineage/openlineage_service.py
+++ b/src/gbserver/lineage/openlineage_service.py
@@ -32,6 +32,12 @@ class LineageService(ABC):
         pass
 
     @abstractmethod
+    def count_events_by_tags(
+        self, tags: List[str], required_tags: Optional[List[str]] = None
+    ) -> int:
+        pass
+
+    @abstractmethod
     def get_artifact_graph(
         self,
         artifact_name: Optional[str] = None,

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -74,8 +74,25 @@ def _lh_uri_to_namespace_and_name(uri: str) -> Optional[Tuple[str, str]]:
     return namespace, name
 
 
+def _build_target_artifact_reference(
+    target_name: str,
+    target_artifact_name: str,
+    is_input: bool,
+    index: int,
+) -> str:
+    in_or_out = "inputs" if is_input else "outputs"
+    reference = f"{target_name}.{in_or_out}.{target_artifact_name}"
+    if index >= 0:
+        reference = f"{reference}[{index}]"
+    return reference
+
+
 def _artifact_to_lineage_entry(
-    artifact: ArtifactRegistration, target_artifact_name: str = ""
+    artifact: ArtifactRegistration,
+    target_artifact_name: str = "",
+    target_name: str = "",
+    is_input: bool = True,
+    index: int = -1,
 ) -> dict:
     from urllib.parse import urlparse
 
@@ -90,10 +107,19 @@ def _artifact_to_lineage_entry(
     namespace = artifact.uri
     name = artifact.name or target_artifact_name or artifact.uuid
 
+    target_artifact_reference = _build_target_artifact_reference(
+        target_name, target_artifact_name, is_input, index
+    )
+
     facets: dict[str, Any] = {
         "artifact_id": artifact.uuid,
         "artifact_uri": artifact.uri,
         "artifact_type": artifact_type.name,
+        "gb-artifact-id": artifact.uuid,
+        "gb-artifact-uri": artifact.uri,
+        "gb-build-id": artifact.created_by_build_id,
+        "gb-target-id": artifact.created_by_target_id,
+        "gb-build-target-artifact": target_artifact_reference,
     }
     facets.update(artifact.model_dump(mode="json"))
 
@@ -147,7 +173,13 @@ class WandBLineageStore(ILineageStore):
             artifact = storage.artifact_registry.get_by_uuid(uuid)
             if artifact and isinstance(artifact, ArtifactRegistration):
                 inputs.append(
-                    _artifact_to_lineage_entry(artifact, target_artifact_name)
+                    _artifact_to_lineage_entry(
+                        artifact,
+                        target_artifact_name,
+                        target_name=targetrun.name,
+                        is_input=True,
+                        index=-1,
+                    )
                 )
 
         step_configs = []
@@ -222,12 +254,22 @@ class WandBLineageStore(ILineageStore):
             output_artifact_list,
         ) in targetrun.output_artifacts.items():
             target_events: List[dict] = []
+            include_index = len(output_artifact_list) > 1
+            index = -1
             for output_uuid in output_artifact_list:
+                if include_index:
+                    index += 1
                 artifact = storage.artifact_registry.get_by_uuid(output_uuid)
                 outputs = []
                 if artifact and isinstance(artifact, ArtifactRegistration):
                     outputs.append(
-                        _artifact_to_lineage_entry(artifact, target_artifact_name)
+                        _artifact_to_lineage_entry(
+                            artifact,
+                            target_artifact_name,
+                            target_name=targetrun.name,
+                            is_input=False,
+                            index=index,
+                        )
                     )
                 event = {
                     **base_event,
@@ -347,17 +389,11 @@ class WandBLineageStore(ILineageStore):
     def count_release_ids(
         self, release_id: str, target_id: Optional[str] = None
     ) -> int:
-        total, results = self._service.search_lineage_by_tags(
-            [f"build_id={release_id}"], limit=10000, offset=0
+
+        required = [f"target_id={target_id}"] if target_id else None
+        return self._service.count_events_by_tags(
+            [f"build_id={release_id}"], required_tags=required
         )
-        if target_id is None:
-            return total
-        count = 0
-        for event in results:
-            tags = event.get("run", {}).get("facets", {}).get("tags", {})
-            if tags.get("target_id") == target_id:
-                count += 1
-        return count
 
     def does_release_id_exist(
         self,
@@ -373,8 +409,30 @@ class WandBLineageStore(ILineageStore):
         artifact: ArtifactRegistration,
         sources: list[ArtifactRegistration],
     ) -> dict:
-        inputs = [_artifact_to_lineage_entry(src) for src in sources]
-        outputs = [_artifact_to_lineage_entry(artifact)]
+        use_index = len(sources) > 0
+        inputs = []
+        index = -1
+        for src in sources:
+            if use_index:
+                index += 1
+            inputs.append(
+                _artifact_to_lineage_entry(
+                    src,
+                    target_artifact_name=src.name,
+                    target_name=src.name,
+                    is_input=True,
+                    index=index,
+                )
+            )
+        outputs = [
+            _artifact_to_lineage_entry(
+                artifact,
+                target_artifact_name=artifact.name,
+                target_name="pseudo-target",
+                is_input=False,
+                index=-1,
+            )
+        ]
 
         event_time = artifact.created_at.isoformat()
 

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -24,7 +24,6 @@ from gbserver.storage.artifact_registration import ArtifactRegistration
 from gbserver.storage.singleton_storage import SingletonAdminStorage
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
-from gbserver.types.artifact import ArtifactType
 from gbserver.types.constants import (
     GB_JOB_STATS_DETAIL_CATEGORY,
     GB_JOB_STATS_DETAIL_REGISTERED_ARTIFACT_JOB_NAME,

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -20,9 +20,9 @@ import re
 from collections import deque
 from typing import Dict, List, Literal, Optional, Tuple, cast
 
+import wandb
 from huggingface_hub import dataset_info, model_info
 
-import wandb
 from gbcommon.uri.hf import HfURI
 from gbserver.lineage.openlineage_service import LineageService
 from gbserver.lineage.openlineage_utils import (

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -20,9 +20,9 @@ import re
 from collections import deque
 from typing import Dict, List, Literal, Optional, Tuple, cast
 
-import wandb
 from huggingface_hub import dataset_info, model_info
 
+import wandb
 from gbcommon.uri.hf import HfURI
 from gbserver.lineage.openlineage_service import LineageService
 from gbserver.lineage.openlineage_utils import (

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -670,6 +670,37 @@ class WandBLineageService(LineageService):
             "truncated": truncated,
         }
 
+    def count_events_by_tags(
+        self, tags: list, required_tags: Optional[list] = None
+    ) -> int:
+        try:
+            api = wandb.Api()
+            project_path = (
+                f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}"
+                if GBSERVER_WANDB_ENTITY
+                else GBSERVER_WANDB_PROJECT
+            )
+            runs = api.runs(
+                project_path,
+                filters={"tags": {"$in": tags}} if tags else {},
+            )
+            required = set(required_tags or [])
+            total = 0
+            # run.log({"openlineage_event": <dict>}) flattens the dict in
+            # history, so there is no top-level "openlineage_event" column.
+            # Count rows by a stable flattened sub-key instead.
+            marker = "openlineage_event.eventType"
+            for run in runs:
+                if required and not required.issubset(set(run.tags or [])):
+                    continue
+                for row in run.scan_history(keys=[marker]):
+                    if row.get(marker) is not None:
+                        total += 1
+            return total
+        except Exception as e:
+            logger.error("Failed to count events by tags: %s", e)
+            return 0
+
     def search_lineage_by_tags(
         self, tags: list, limit: int = 10, offset: int = 0
     ) -> Tuple[int, list]:

--- a/test/integration/ibm/buildwatcher/test_buildrunner_1step.py
+++ b/test/integration/ibm/buildwatcher/test_buildrunner_1step.py
@@ -4,7 +4,6 @@ from typing import Self
 import pytest
 from lib.buildwatcher.buildtest import (
     AbstractBuildRunnerTest,
-    AbstractBuildTest,
     BuildTestSpecification,
     ClassTestedEnum,
     ExpectedTarget,

--- a/test/integration/ibm/lineage/test_openlineage_service.py
+++ b/test/integration/ibm/lineage/test_openlineage_service.py
@@ -46,6 +46,12 @@ class MockLineageService(LineageService):
         run_id = event["run"]["runId"]
         self.events[run_id] = event
 
+    def count_events_by_tags(
+        self, tags: List[str], required_tags: Optional[List[str]] = None
+    ) -> int:
+        total, _ = self.search_lineage_by_tags(tags, limit=len(self.events), offset=0)
+        return total
+
     def search_lineage_by_tags(
         self, tags: List[str], limit: int = 10, offset: int = 0
     ) -> Tuple[int, List[Dict]]:

--- a/test/integration/ibm/lineage/test_openlineage_service.py
+++ b/test/integration/ibm/lineage/test_openlineage_service.py
@@ -69,6 +69,7 @@ class MockLineageService(LineageService):
         self,
         artifact_name: Optional[str] = None,
         artifact_url: Optional[str] = None,
+        artifact_type: Optional[str] = None,
         max_depth: int = 10,
         direction: str = "downstream",
     ) -> Optional[Dict]:
@@ -294,12 +295,10 @@ class TestOpenLineageAPI:
         assert response.status_code == 200
         body = response.json()
         assert "root_id" in body
-        assert "nodes" in body
-        assert "edges" in body
-        assert body["nodes"][0]["is_root"] is True
-        assert body["nodes"][0]["node_type"] == "artifact"
-        assert len(body["nodes"]) == 3
-        assert len(body["edges"]) == 2
+        assert "runs" in body
+        assert "truncated" in body
+        assert len(body["runs"]) == 2
+        assert body["truncated"] is False
 
     def test_get_artifact_graph_not_found(self):
         response = self.client.post(
@@ -323,7 +322,7 @@ class TestOpenLineageAPI:
         assert response.status_code == 200
         body = response.json()
         assert body["truncated"] is True
-        assert len(body["nodes"]) == 1
+        assert len(body["runs"]) == 0
 
     def test_get_artifact_graph_upstream(self):
         response = self.client.post(
@@ -332,9 +331,8 @@ class TestOpenLineageAPI:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["nodes"][0]["is_root"] is True
-        assert len(body["nodes"]) == 3
-        assert any(n["name"] == "base-training" for n in body["nodes"])
+        assert len(body["runs"]) == 1
+        assert body["runs"][0]["job_name"] == "base-training"
 
     def test_get_artifact_graph_both_directions(self):
         response = self.client.post(
@@ -343,12 +341,10 @@ class TestOpenLineageAPI:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["nodes"][0]["is_root"] is True
-        assert len(body["nodes"]) == 5
-        assert len(body["edges"]) == 4
-        node_names = {n["name"] for n in body["nodes"]}
-        assert "tunedmodel" in node_names
-        assert "base-training" in node_names
+        assert len(body["runs"]) == 2
+        job_names = {r["job_name"] for r in body["runs"]}
+        assert "tunedmodel" in job_names
+        assert "base-training" in job_names
 
     def test_get_artifact_graph_by_url(self):
         response = self.client.post(
@@ -359,8 +355,7 @@ class TestOpenLineageAPI:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["nodes"][0]["is_root"] is True
-        assert len(body["nodes"]) == 3
+        assert len(body["runs"]) == 2
 
     def test_get_artifact_graph_by_url_not_found(self):
         response = self.client.post(

--- a/test/integration/ibm/lineage/test_wandb_jobstats.py
+++ b/test/integration/ibm/lineage/test_wandb_jobstats.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Dict, List, Optional
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
  Summary                                                                  
                                                                           
  - Add count_events_by_tags abstract method to LineageService with a WandB
   implementation that counts OpenLineage events directly via scan_history 
  (avoids fetching full event bodies).
  - Rework WandBLineageStore.count_release_ids to use the new counting API
  with required_tags, replacing the previous approach of fetching up to 10
  000 events and filtering in Python.
  - Enrich jobstats lineage entries with gb-artifact-id, gb-artifact-uri,
  gb-build-id, gb-target-id, and gb-build-target-artifact facets, plus a
  target_name.(inputs|outputs).artifact_name[index] reference string for
  multi-artifact targets.
  - Update MockLineageService and tests to match the new get_artifact_graph
   response shape (runs/truncated instead of nodes/edges) and implement the
   new abstract method.
  - Minor cleanup: remove unused imports in test_buildrunner_1step.py and
  test_wandb_jobstats.py.

  Test plan

  - pytest -s test/integration/ibm/lineage/test_openlineage_service.py     
  - pytest -s test/integration/ibm/lineage/test_wandb_jobstats.py
  - Verify count_release_ids against a real WandB project returns the same 
  total as the previous search-based implementation.    