### PR TITLE
Emit one wandb run per output artifact so JobStats counts match target output count  

### DIFF
--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -282,6 +282,17 @@ def get_artifact_graph(request: ArtifactGraphRequest):
                 tags=tags,
                 inputs=inputs,
                 outputs=outputs,
+                job_id=metadata.get("job_id") or "",
+                job_status=metadata.get("job_status") or "",
+                job_started_at=metadata.get("job_started_at") or "",
+                job_completed_at=metadata.get("job_completed_at") or "",
+                release_id=metadata.get("release_id") or "",
+                category=metadata.get("category") or "",
+                owner=metadata.get("owner") or "",
+                source_code_details=metadata.get("source_code_details") or {},
+                job_input_params=metadata.get("job_input_params") or {},
+                execution_stats=metadata.get("execution_stats") or {},
+                job_output_stats=metadata.get("job_output_stats") or {},
             )
         )
 

--- a/src/gbserver/lineage/openlineage_models.py
+++ b/src/gbserver/lineage/openlineage_models.py
@@ -143,6 +143,17 @@ class ArtifactRunEntry(BaseModel):
     tags: List[str] = Field(default_factory=list)
     inputs: List[LineageNodeRef] = Field(default_factory=list)
     outputs: List[LineageNodeRef] = Field(default_factory=list)
+    job_id: str = ""
+    job_status: str = ""
+    job_started_at: str = ""
+    job_completed_at: str = ""
+    release_id: str = ""
+    category: str = ""
+    owner: str = ""
+    source_code_details: Dict[str, Any] = Field(default_factory=dict)
+    job_input_params: Dict[str, Any] = Field(default_factory=dict)
+    execution_stats: Dict[str, Any] = Field(default_factory=dict)
+    job_output_stats: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ArtifactGraphResponse(BaseModel):

--- a/src/gbserver/lineage/openlineage_service.py
+++ b/src/gbserver/lineage/openlineage_service.py
@@ -38,6 +38,12 @@ class LineageService(ABC):
         pass
 
     @abstractmethod
+    def count_runs_by_tags(
+        self, tags: List[str], required_tags: Optional[List[str]] = None
+    ) -> int:
+        pass
+
+    @abstractmethod
     def get_artifact_graph(
         self,
         artifact_name: Optional[str] = None,

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -275,6 +275,16 @@ class WandBLineageStore(ILineageStore):
                     "inputs": inputs,
                     "outputs": outputs,
                 }
+                # Give each output-artifact event its own wandb run so
+                # history rows are not collapsed when multiple events share
+                # a single resumed run. Keeps counts aligned with the number
+                # of output artifacts. The job_id in job_details still points
+                # back to the logical target (targetrun.uuid).
+                job_id = base_event["run"]["facets"]["job_details"]["job_id"]
+                event["run"] = {
+                    **base_event["run"],
+                    "runId": f"{job_id}-{output_uuid}",
+                }
                 target_events.append(event)
             events_list.extend(target_events)
             events_dict[target_artifact_name] = target_events
@@ -388,9 +398,11 @@ class WandBLineageStore(ILineageStore):
     def count_release_ids(
         self, release_id: str, target_id: Optional[str] = None
     ) -> int:
-
+        # One wandb run is created per (target, output artifact), so counting
+        # runs tagged with this build_id (and optionally target_id) directly
+        # yields the number of jobstats records without scanning run history.
         required = [f"target_id={target_id}"] if target_id else None
-        return self._service.count_events_by_tags(
+        return self._service.count_runs_by_tags(
             [f"build_id={release_id}"], required_tags=required
         )
 
@@ -465,6 +477,7 @@ class WandBLineageStore(ILineageStore):
                         "job_started_at": event_time,
                         "job_completed_at": event_time,
                         "release_id": artifact.uuid,
+                        "owner": artifact.username,
                         "job_output_stats": {},
                     },
                 },

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import re
 from collections import deque
-from typing import Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, cast
 
 import wandb
 from huggingface_hub import dataset_info, model_info
@@ -57,6 +57,7 @@ class WandBLineageService(LineageService):
             entity=GBSERVER_WANDB_ENTITY,
             id=run_id,
             name=job_name,
+            resume="allow",
         )
 
         self._runs[run_id] = run
@@ -220,8 +221,9 @@ class WandBLineageService(LineageService):
             #     continue
             outputs.append(self._artifact_to_openlineage_dataset(artifact))
 
-        job_name = run.config.get("job_name", run.name or "unknown")
-        event_type = run.config.get("event_type", "OTHER")
+        config = run.config or {}
+        job_name = config.get("job_name", run.name or "unknown")
+        event_type = config.get("event_type", "OTHER")
         event_time = run.summary.get("last_event_time", run.createdAt)
         namespace = f"{run.entity}/{run.project}"
 
@@ -232,7 +234,43 @@ class WandBLineageService(LineageService):
                     key, value = tag.split("=", 1)
                     tags_facet[key] = value
 
-        run_facets = {"tags": tags_facet} if tags_facet else {}
+        run_facets: Dict[str, Any] = {}
+        if tags_facet:
+            run_facets["tags"] = tags_facet
+
+        job_input_params = config.get("job_input_params")
+        if job_input_params is not None:
+            run_facets["job_input_params"] = job_input_params
+
+        execution_stats = config.get("execution_stats")
+        if execution_stats is not None:
+            run_facets["execution_stats"] = execution_stats
+
+        source_code_url = config.get("source_code_url")
+        if source_code_url is not None:
+            run_facets["source_code"] = {
+                "url": source_code_url,
+                "commit_hash": "",
+                "path": "",
+            }
+
+        job_details: Dict[str, Any] = {}
+        for key in (
+            "job_id",
+            "job_type",
+            "category",
+            "job_status",
+            "job_started_at",
+            "job_completed_at",
+            "release_id",
+            "owner",
+        ):
+            if key in config:
+                job_details[key] = config.get(key, "")
+        if "job_output_stats" in config:
+            job_details["job_output_stats"] = config.get("job_output_stats", {})
+        if job_details:
+            run_facets["job_details"] = job_details
 
         job_facets: Dict[str, Dict] = {}
         if run.notes:
@@ -629,6 +667,31 @@ class WandBLineageService(LineageService):
                                     "job_type": run_config.get("job_type", ""),
                                     "state": getattr(run, "state", None),
                                     "created_at": getattr(run, "createdAt", None),
+                                    "job_id": run_config.get("job_id", ""),
+                                    "job_status": run_config.get("job_status", ""),
+                                    "job_started_at": run_config.get(
+                                        "job_started_at", ""
+                                    ),
+                                    "job_completed_at": run_config.get(
+                                        "job_completed_at", ""
+                                    ),
+                                    "release_id": run_config.get("release_id", ""),
+                                    "category": run_config.get("category", ""),
+                                    "owner": run_config.get("owner", ""),
+                                    "source_code_details": {
+                                        "url": run_config.get("source_code_url", ""),
+                                        "commit_hash": "",
+                                        "path": "",
+                                    },
+                                    "job_input_params": run_config.get(
+                                        "job_input_params", {}
+                                    ),
+                                    "execution_stats": run_config.get(
+                                        "execution_stats", {}
+                                    ),
+                                    "job_output_stats": run_config.get(
+                                        "job_output_stats", {}
+                                    ),
                                 },
                                 "tags": run_tags,
                             }
@@ -699,6 +762,31 @@ class WandBLineageService(LineageService):
             return total
         except Exception as e:
             logger.error("Failed to count events by tags: %s", e)
+            return 0
+
+    def count_runs_by_tags(
+        self, tags: list, required_tags: Optional[list] = None
+    ) -> int:
+        try:
+            api = wandb.Api()
+            project_path = (
+                f"{GBSERVER_WANDB_ENTITY}/{GBSERVER_WANDB_PROJECT}"
+                if GBSERVER_WANDB_ENTITY
+                else GBSERVER_WANDB_PROJECT
+            )
+            runs = api.runs(
+                project_path,
+                filters={"tags": {"$in": tags}} if tags else {},
+            )
+            required = set(required_tags or [])
+            total = 0
+            for run in runs:
+                if required and not required.issubset(set(run.tags or [])):
+                    continue
+                total += 1
+            return total
+        except Exception as e:
+            logger.error("Failed to count runs by tags: %s", e)
             return 0
 
     def search_lineage_by_tags(

--- a/test/integration/ibm/lineage/test_openlineage_service.py
+++ b/test/integration/ibm/lineage/test_openlineage_service.py
@@ -52,6 +52,12 @@ class MockLineageService(LineageService):
         total, _ = self.search_lineage_by_tags(tags, limit=len(self.events), offset=0)
         return total
 
+    def count_runs_by_tags(
+        self, tags: List[str], required_tags: Optional[List[str]] = None
+    ) -> int:
+        total, _ = self.search_lineage_by_tags(tags, limit=len(self.events), offset=0)
+        return total
+
     def search_lineage_by_tags(
         self, tags: List[str], limit: int = 10, offset: int = 0
     ) -> Tuple[int, List[Dict]]:


### PR DESCRIPTION
  - Each output artifact on a target now gets its own wandb run  (`runId = {target_uuid}-{output_uuid}`), so the number of JobStats records matches the number of outputs produced by the  target. Previously all events for one target shared a single   `runId`, causing wandb's init/finish/resume cycle to collapse Nhistory rows into 1.
  - `count_release_ids` now calls a new `count_runs_by_tags` on the lineage service, counting wandb runs directly instead of   scanning per-run history. 
  - Enriched openlineage event facets and artifact-run API    response with `job_id`, `job_status`, `job_started_at`,        
  `job_completed_at`, `release_id`, `category`, `owner`, `source_code_details`, `job_input_params`, `execution_stats`,  
  and `job_output_stats`.  
  - Added `owner` (from `artifact.username`) to the registered-artifact jobstats payload.  