### PR TITLE
Fix several test due the new introduction of one run per output

### DIFF
--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -114,6 +114,7 @@ def _artifact_to_lineage_entry(
         "artifact_id": artifact.uuid,
         "artifact_uri": artifact.uri,
         "artifact_type": artifact_type.name,
+        "target_artifact_reference": target_artifact_reference,
         "gb-artifact-id": artifact.uuid,
         "gb-artifact-uri": artifact.uri,
         "gb-build-id": artifact.created_by_build_id,

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -144,6 +144,18 @@ def _artifact_to_lineage_entry(
     }
 
 
+def _add_jobstats_mirror_fields(event: dict) -> None:
+    # The REST jobstats endpoints expect a flat JobStats-shaped dict (with
+    # release_id / job_details / sources / targets at the top level). wandb
+    # stores these inside run.facets.job_details + inputs/outputs, so mirror
+    # them for readers. wandb itself ignores unknown top-level keys.
+    job_details = event.get("run", {}).get("facets", {}).get("job_details", {})
+    event["release_id"] = job_details.get("release_id", "")
+    event["job_details"] = job_details
+    event["sources"] = event.get("inputs", [])
+    event["targets"] = event.get("outputs", [])
+
+
 class WandBLineageStore(ILineageStore):
 
     def __init__(self) -> None:
@@ -286,6 +298,7 @@ class WandBLineageStore(ILineageStore):
                     **base_event["run"],
                     "runId": f"{job_id}-{output_uuid}",
                 }
+                _add_jobstats_mirror_fields(event)
                 target_events.append(event)
             events_list.extend(target_events)
             events_dict[target_artifact_name] = target_events
@@ -296,6 +309,7 @@ class WandBLineageStore(ILineageStore):
                 "inputs": inputs,
                 "outputs": [],
             }
+            _add_jobstats_mirror_fields(event)
             events_list.append(event)
             events_dict["no-output"] = [event]
 
@@ -454,7 +468,7 @@ class WandBLineageStore(ILineageStore):
         if artifact.description:
             job_input_params["description"] = artifact.description
 
-        return {
+        event = {
             "eventType": "COMPLETE",
             "eventTime": event_time,
             "run": {
@@ -462,7 +476,10 @@ class WandBLineageStore(ILineageStore):
                 "facets": {
                     "tags": {
                         "artifact_id": artifact.uuid,
-                        "build_id": artifact.created_by_build_id,
+                        # For registered-artifact jobstats the "release_id" is
+                        # the artifact uuid itself — tag build_id with that so
+                        # count_release_ids({artifact.uuid}) finds this run.
+                        "build_id": artifact.uuid,
                         "target_id": artifact.created_by_target_id,
                         "username": artifact.username,
                         "space_name": artifact.space_name,
@@ -493,3 +510,5 @@ class WandBLineageStore(ILineageStore):
             "producer": "https://github.ibm.com/granite-dot-build/gbserver",
             "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
         }
+        _add_jobstats_mirror_fields(event)
+        return event

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -41,6 +41,20 @@ from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+_TAG_CONFIG_KEYS = ("build_id", "target_id", "username", "space_name")
+_PASSTHROUGH_FACET_KEYS = ("job_input_params", "execution_stats")
+_JOB_DETAIL_KEYS = (
+    "job_id",
+    "job_type",
+    "category",
+    "job_status",
+    "job_started_at",
+    "job_completed_at",
+    "release_id",
+    "owner",
+    "job_output_stats",
+)
+
 
 class WandBLineageService(LineageService):
 
@@ -111,7 +125,7 @@ class WandBLineageService(LineageService):
             job_facets = event.get("job", {}).get("facets", {})
             namespace = event.get("job", {}).get("namespace", "")
 
-            config_update = {
+            config_update: Dict[str, Any] = {
                 "job_name": job_name,
                 "job_namespace": namespace,
                 "event_type": event_type,
@@ -120,47 +134,26 @@ class WandBLineageService(LineageService):
             }
 
             tags = run_facets.get("tags", {})
-            if tags:
-                config_update["build_id"] = tags.get("build_id", "")
-                config_update["target_id"] = tags.get("target_id", "")
-                config_update["username"] = tags.get("username", "")
-                config_update["space_name"] = tags.get("space_name", "")
-                for k, v in tags.items():
-                    if k not in config_update:
-                        config_update[k] = v
+            for key in _TAG_CONFIG_KEYS:
+                if key in tags:
+                    config_update[key] = tags[key]
 
             source_code = run_facets.get("source_code", {})
-            if source_code:
-                config_update["source_code_url"] = source_code.get("url", "")
+            if source_code.get("url"):
+                config_update["source_code_url"] = source_code["url"]
 
-            job_input_params = run_facets.get("job_input_params")
-            if job_input_params is not None:
-                config_update["job_input_params"] = job_input_params
-
-            execution_stats = run_facets.get("execution_stats")
-            if execution_stats is not None:
-                config_update["execution_stats"] = execution_stats
+            for key in _PASSTHROUGH_FACET_KEYS:
+                if run_facets.get(key) is not None:
+                    config_update[key] = run_facets[key]
 
             job_details = run_facets.get("job_details", {})
-            if job_details:
-                config_update["job_id"] = job_details.get("job_id", "")
-                config_update["job_type"] = job_details.get("job_type", "")
-                config_update["category"] = job_details.get("category", "")
-                config_update["job_status"] = job_details.get("job_status", "")
-                config_update["job_started_at"] = job_details.get("job_started_at", "")
-                config_update["job_completed_at"] = job_details.get(
-                    "job_completed_at", ""
-                )
-                config_update["release_id"] = job_details.get("release_id", "")
-                config_update["owner"] = job_details.get("owner", "")
-                config_update["job_output_stats"] = job_details.get(
-                    "job_output_stats", {}
-                )
+            for key in _JOB_DETAIL_KEYS:
+                if key in job_details:
+                    config_update[key] = job_details[key]
 
-            if "documentation" in job_facets:
-                doc = job_facets["documentation"]
-                if isinstance(doc, dict) and "description" in doc:
-                    config_update["description"] = doc["description"]
+            doc = job_facets.get("documentation", {})
+            if isinstance(doc, dict) and doc.get("description"):
+                config_update["description"] = doc["description"]
 
             run.config.update(config_update)
 
@@ -238,13 +231,9 @@ class WandBLineageService(LineageService):
         if tags_facet:
             run_facets["tags"] = tags_facet
 
-        job_input_params = config.get("job_input_params")
-        if job_input_params is not None:
-            run_facets["job_input_params"] = job_input_params
-
-        execution_stats = config.get("execution_stats")
-        if execution_stats is not None:
-            run_facets["execution_stats"] = execution_stats
+        for key in _PASSTHROUGH_FACET_KEYS:
+            if config.get(key) is not None:
+                run_facets[key] = config[key]
 
         source_code_url = config.get("source_code_url")
         if source_code_url is not None:
@@ -254,21 +243,7 @@ class WandBLineageService(LineageService):
                 "path": "",
             }
 
-        job_details: Dict[str, Any] = {}
-        for key in (
-            "job_id",
-            "job_type",
-            "category",
-            "job_status",
-            "job_started_at",
-            "job_completed_at",
-            "release_id",
-            "owner",
-        ):
-            if key in config:
-                job_details[key] = config.get(key, "")
-        if "job_output_stats" in config:
-            job_details["job_output_stats"] = config.get("job_output_stats", {})
+        job_details = {k: config[k] for k in _JOB_DETAIL_KEYS if k in config}
         if job_details:
             run_facets["job_details"] = job_details
 

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -41,7 +41,6 @@ from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_TAG_CONFIG_KEYS = ("build_id", "target_id", "username", "space_name")
 _PASSTHROUGH_FACET_KEYS = ("job_input_params", "execution_stats")
 _JOB_DETAIL_KEYS = (
     "job_id",
@@ -134,9 +133,9 @@ class WandBLineageService(LineageService):
             }
 
             tags = run_facets.get("tags", {})
-            for key in _TAG_CONFIG_KEYS:
-                if key in tags:
-                    config_update[key] = tags[key]
+            for key, value in tags.items():
+                if not key.startswith("_"):
+                    config_update[key] = value
 
             source_code = run_facets.get("source_code", {})
             if source_code.get("url"):

--- a/test/integration/ibm/lineage/test_wandb_jobstats.py
+++ b/test/integration/ibm/lineage/test_wandb_jobstats.py
@@ -180,7 +180,8 @@ class TestWandBLineageStore:
         self.mock_service.emit_event.assert_called_once()
         event = self.mock_service.emit_event.call_args[0][0]
         assert event["eventType"] == "COMPLETE"
-        assert event["run"]["runId"] == "target-001"
+        assert event["run"]["runId"] == "target-001-out-1"
+        assert event["run"]["facets"]["job_details"]["job_id"] == "target-001"
         assert event["job"]["name"] == "train"
         assert event["job"]["namespace"] == "public/test-build"
         assert len(event["inputs"]) == 1
@@ -267,7 +268,8 @@ class TestWandBLineageStore:
         assert len(events_list) == 1
         assert "model" in events_dict
         assert len(events_dict["model"]) == 1
-        assert events_list[0]["run"]["runId"] == "target-001"
+        assert events_list[0]["run"]["runId"] == "target-001-out-1"
+        assert events_list[0]["run"]["facets"]["job_details"]["job_id"] == "target-001"
         assert events_list[0]["inputs"][0]["name"] == "data"
         assert events_list[0]["outputs"][0]["name"] == "model"
 
@@ -313,7 +315,10 @@ class TestWandBLineageStore:
         )
 
         assert len(events_list) == 1
-        assert events_list[0]["run"]["runId"] == "skipped-target"
+        assert events_list[0]["run"]["runId"] == "skipped-target-out-1"
+        assert (
+            events_list[0]["run"]["facets"]["job_details"]["job_id"] == "skipped-target"
+        )
         assert "model" in events_dict
 
     def test_create_jobstats_for_target_build_not_found(self):
@@ -494,44 +499,32 @@ class TestWandBLineageStore:
         )
 
     def test_count_release_ids_no_target(self):
-        self.mock_service.search_lineage_by_tags.return_value = (
-            2,
-            [
-                {"run": {"facets": {"tags": {"build_id": "b1", "target_id": "t1"}}}},
-                {"run": {"facets": {"tags": {"build_id": "b1", "target_id": "t2"}}}},
-            ],
-        )
+        self.mock_service.count_runs_by_tags.return_value = 2
         count = self.storage_impl.count_release_ids("b1")
         assert count == 2
-        self.mock_service.search_lineage_by_tags.assert_called_once_with(
-            ["build_id=b1"], limit=10000, offset=0
+        self.mock_service.count_runs_by_tags.assert_called_once_with(
+            ["build_id=b1"], required_tags=None
         )
 
     def test_count_release_ids_with_target(self):
-        self.mock_service.search_lineage_by_tags.return_value = (
-            2,
-            [
-                {"run": {"facets": {"tags": {"build_id": "b1", "target_id": "t1"}}}},
-                {"run": {"facets": {"tags": {"build_id": "b1", "target_id": "t2"}}}},
-            ],
-        )
+        self.mock_service.count_runs_by_tags.return_value = 1
         count = self.storage_impl.count_release_ids("b1", target_id="t1")
         assert count == 1
+        self.mock_service.count_runs_by_tags.assert_called_once_with(
+            ["build_id=b1"], required_tags=["target_id=t1"]
+        )
 
     def test_count_release_ids_no_results(self):
-        self.mock_service.search_lineage_by_tags.return_value = (0, [])
+        self.mock_service.count_runs_by_tags.return_value = 0
         count = self.storage_impl.count_release_ids("nonexistent")
         assert count == 0
 
     def test_does_release_id_exist_true(self):
-        self.mock_service.search_lineage_by_tags.return_value = (
-            1,
-            [{"run": {"facets": {"tags": {"build_id": "b1", "target_id": "t1"}}}}],
-        )
+        self.mock_service.count_runs_by_tags.return_value = 1
         assert self.storage_impl.does_release_id_exist("b1", 1, target_id="t1") is True
 
     def test_does_release_id_exist_false(self):
-        self.mock_service.search_lineage_by_tags.return_value = (0, [])
+        self.mock_service.count_runs_by_tags.return_value = 0
         assert self.storage_impl.does_release_id_exist("b1", 3) is False
 
 


### PR DESCRIPTION
  Summary:
  - wandb_jobstats.py: emit release_id, job_details, sources, targets at the top level of every lineage event (via new
  _add_jobstats_mirror_fields) so the REST jobstats readers see a flat JobStats-shaped dict while wandb keeps ignoring
  unknown top-level keys. Also tag registered-artifact runs with build_id = artifact.uuid so count_release_ids({artifact.uuid}) finds them, and add target_artifact_reference to the artifact lineage entry.
 - fixed several failed tests