### PR TITLE
Rename project from to granite.build in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "granite-build-tools"
+name = "granite.build"
 version = "0.3.0"
 authors = [
     { name = "Akash Nayak", email = "akash.nayak1@ibm.com" },

--- a/src/gbcli/commands/command_version.py
+++ b/src/gbcli/commands/command_version.py
@@ -61,10 +61,10 @@ def cli(ctx, check_updates, client, format, quiet):
             ctx.exit(1)  # Exit with a non-zero status
         else:
             click.echo(
-                f"The current client version ({get_current_version('granite-build-tools')}) is up to date."
+                f"The current client version ({get_current_version('granite.build')}) is up to date."
             )
     else:
-        client_version = get_current_version("granite-build-tools")
+        client_version = get_current_version("granite.build")
         gbserver_version = None
 
         if not client:

--- a/src/gbcli/utils/versionutil.py
+++ b/src/gbcli/utils/versionutil.py
@@ -39,13 +39,13 @@ def check_current_and_latest_versions() -> str:
     user_token = credentials.get("token", section="user.github")
     repo_org, repo_name = GBCLI_REPO_URL.split("/")[3:]
     latest_version = get_latest_version(user_token, repo_org, repo_name)
-    current_version = get_current_version("granite-build-tools")
+    current_version = get_current_version("granite.build")
 
     if Version(current_version) < Version(latest_version):
         return (
             f"A new version of {PROJECT_NAME} CLI ({latest_version}) is available. "
             f"You are currently running version {current_version}. "
-            "Run `pip install --upgrade granite-build-tools` or a command suitable to your environment to upgrade."
+            "Run `pip install --upgrade granite.build` or a command suitable to your environment to upgrade."
         )
     else:
         return ""

--- a/src/gbserver/__init__.py
+++ b/src/gbserver/__init__.py
@@ -21,4 +21,4 @@ The version of the package.
 
 from importlib.metadata import version
 
-__version__ = version("granite-build-tools")
+__version__ = version("granite.build")


### PR DESCRIPTION
## Description

- Rename the project package to granite.build in pyproject.toml to align with the project's actual name and domain

- Test plan

  - Verify `pip install -e .` still works with the new package name
  - Confirm CI passes without regressions