### PR TITLE
Set GBSERVER_AUTH_MODE to multi as the default for all environments

### DIFF
--- a/k8s/chart/values-dev.yaml
+++ b/k8s/chart/values-dev.yaml
@@ -21,8 +21,6 @@ deployments:
         cpu: "2"
       requests:
         cpu: "2"
-    env:
-      GBSERVER_AUTH_MODE: multi
 ingresses:
   enable: false
 pvcs:

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -84,7 +84,7 @@ deployments:
       DMF_CACHE: /tmp/dmf_cache
       GBSERVER_SQL_SSLROOT_CERT: ibm-cloud-databases.cert
       GBSERVER_REST_SERVER_WORKERS: "4"
-      GBSERVER_AUTH_MODE: github
+      GBSERVER_AUTH_MODE: multi
       GBSERVER_LINEAGE_PROVIDER: wandb
       GBSERVER_WANDB_BASE_URL: https://ibm.wandb.io
       GBSERVER_WANDB_PROJECT: lineage-tracking


### PR DESCRIPTION
## Summary
  - Promote `GBSERVER_AUTH_MODE: multi` to `values.yaml` as the default auth mode for all environments
  - Remove the now-redundant `GBSERVER_AUTH_MODE: multi` override from `values-dev.yaml`

  ## Test plan
  - [ ] Verify dev environment continues to use multi auth mode (inherited from shared values)
  - [ ] Verify staging/prod environments switch from `github` to `multi` auth mode without service disruption
  - [ ] Confirm REST API authentication works with both GitHub token and any additional auth methods supported by multi mode