### PR TITLE
Fix .gitignore pattern for root-level .sh files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ docs/superpowers
 # from env var GBSERVER_LOG_FILE=gbserver-log.txt
 gbserver-log.txt
 **/gbserverworkspace/
-./*.sh
+/*.sh
 # vi files
 **/*.swp
 **/*.swo


### PR DESCRIPTION
## Summary
  - Fix invalid `.gitignore` pattern `./*.sh` → `/*.sh` so root-level shell scripts are correctly ignored

## Details
  The `./` prefix in gitignore is treated as a literal directory component, not a relative path. This caused `.sh` files in the repository root to remain untracked instead of being ignored.
  The correct syntax uses a leading `/` to anchor the glob to the repo root.

## Test plan
  - [x] Verified with `git check-ignore -v sync-from-upstream.sh` that the file is now matched by the pattern