### PR TITLE
Add test-extended target for running only extended tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ PYTEST_NUM_TEST_PROC ?= auto
 #PYTEST_DIST_MODE ?= worksteal 	# 26 min, but faile test_build_watcher_c/gpu
 PYTEST_DIST_MODE ?= loadgroup
 DEFAULT_PYTEST_MARKERS ?= not secret_manager and not nats_server and not docker_required
-PR_PYTEST_MARKERS ?= $(DEFAULT_PYTEST_MARKERS) 
+PR_PYTEST_MARKERS ?= $(DEFAULT_PYTEST_MARKERS) and not extended_testing_only
 MERGE_PYTEST_MARKERS ?=  $(DEFAULT_PYTEST_MARKERS)
 STANDALONE_PYTEST_MARKERS ?= not secret_manager and not nats_server and not docker_required and not ibm and not nats
 
@@ -232,7 +232,7 @@ cicd-merge-test:
 	$(MAKE) cicd-venv
 	$(MAKE) test-merge 
 
-.PHONY: test-merge 
+.PHONY: test-merge
 test-merge:
 	#source $(VENVDIR)/bin/activate && pytest --cov -s test
 	#source $(VENVDIR)/bin/activate && $(MAKE) start-docker	# Needed by some build integration tests
@@ -244,6 +244,19 @@ test-merge:
 		args=(--durations=20 --cov --cov-report=xml --junitxml=report.xml) && \
 		args+=(-n ${PYTEST_NUM_TEST_PROC} --dist=${PYTEST_DIST_MODE} -s) && \
 		args+=(-m '$(MERGE_PYTEST_MARKERS)' --strict-markers) && \
+		pytest "$${args[@]}" test/unit test/e2e test/integration/ibm && \
+		coverage report --fail-under=$(MIN_COVERAGE) --sort=Cover
+
+.PHONY: test-extended
+test-extended:
+	source $(VENVDIR)/bin/activate && \
+		export GBTEST_MODE=live && \
+		export GBTEST_ENABLE_EXTENDED_TESTS=true &&	\
+		export GBSERVER_IMAGE_TAG=${IMAGE_TAG} && \
+		export GBSERVER_SIDECAR_MONITORING_IMAGE_TAG=${SIDECAR_IMAGE_TAG} && \
+		args=(--durations=20 --cov --cov-report=xml --junitxml=report.xml) && \
+		args+=(-n ${PYTEST_NUM_TEST_PROC} --dist=${PYTEST_DIST_MODE} -s) && \
+		args+=(-m '$(MERGE_PYTEST_MARKERS) and extended_testing_only' --strict-markers) && \
 		pytest "$${args[@]}" test/unit test/e2e test/integration/ibm && \
 		coverage report --fail-under=$(MIN_COVERAGE) --sort=Cover
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ markers = [
     "slow: tests that run for longer",
     "hf_integration: tests that perform real integration with HuggingFace Hub",
     "live: opt specific services into live mode (e.g. @pytest.mark.live('storage', 'github'))",
+    "extended_testing_only: tests that only run in the extended (merge) CI suite",
 ]
 testpaths = ["test/unit", "test/integration", "test/e2e"]
 norecursedirs = [".venv", ".git", "dist", "__pycache__", "*.egg-info"]

--- a/test/lib/constants.py
+++ b/test/lib/constants.py
@@ -101,11 +101,17 @@ ENV_VAR_GBTEST_ENABLE_EXTENDED_TESTS = TEST_ENV_VAR_PREFIX + "ENABLE_EXTENDED_TE
 #   @extended_testing_only
 #   def test_something_slow(self): ...
 
-is_extended_testing_enabled = os.environ.get(ENV_VAR_GBTEST_ENABLE_EXTENDED_TESTS, "false").lower() == "true" 
-extended_testing_only = pytest.mark.skipif(
-    not is_extended_testing_enabled,
-    reason=f"{ENV_VAR_GBTEST_ENABLE_EXTENDED_TESTS} is set to false",
-)
+is_extended_testing_enabled = os.environ.get(ENV_VAR_GBTEST_ENABLE_EXTENDED_TESTS, "false").lower() == "true"
+
+
+def extended_testing_only(func):
+    """Mark a test to only run in the extended (merge) CI suite."""
+    func = pytest.mark.extended_testing_only(func)
+    func = pytest.mark.skipif(
+        not is_extended_testing_enabled,
+        reason=f"{ENV_VAR_GBTEST_ENABLE_EXTENDED_TESTS} is set to false",
+    )(func)
+    return func
 
 
 def failed_build_assert_message(build_id: str, message: str) -> str:


### PR DESCRIPTION
## Summary

  - Add `test-extended` Makefile target that runs only tests marked `extended_testing_only`
  - Exclude `extended_testing_only` from `PR_PYTEST_MARKERS` so `test-pr` never collects them
  - Convert `extended_testing_only` from a plain `pytest.mark.skipif` to a decorator that applies both a selectable `pytest.mark.extended_testing_only` marker and the runtime `skipif` guard
  - Register `extended_testing_only` in `pyproject.toml` for `--strict-markers` compatibility

  ### Test target behavior

  | Target | Selects | Extended tests |
  |--------|---------|----------------|
  | `test-pr` | `DEFAULT_PYTEST_MARKERS and not extended_testing_only` | excluded |
  | `test-extended` | `MERGE_PYTEST_MARKERS and extended_testing_only` | only these |
  | `test-merge` | `MERGE_PYTEST_MARKERS` | included (union of both) |

  ## Test plan

  - [ ] `make test-pr` — verify extended tests are not collected
  - [ ] `make test-extended` — verify only extended tests run
  - [ ] `make test-merge` — verify both regular and extended tests run
  - [ ] Run `pytest --collect-only -m 'extended_testing_only' test/` with `GBTEST_ENABLE_EXTENDED_TESTS=true` to confirm marker selection works
  - [ ] Run `pytest --collect-only -m 'not extended_testing_only' test/` to confirm extended tests are excluded