### PR TITLE
Fix GBCLI_REPO_URL typo and enable artifact filter by default

### DIFF
--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -165,7 +165,7 @@ ENVIRONMENT_CONFIGS = {
                 "GBSERVER_BUILD_EVENTS", True
             ),  # Default false
             "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", False
+                "GBSERVER_ARTIFACT_FILTER", True
             ),  # Default false
             "gbserver_build_update": getenv_boolean(
                 "GBSERVER_BUILD_UPDATE", True
@@ -259,7 +259,7 @@ HF_RESOURCE_GROUP_ID_DEFAULT = gb_environment_config().get(
 # gbcli
 GBCLI_REPO_URL = os.environ.get(
     "GBCLI_REPO_URL",
-    "https://github.ibm.com/granite-dot-build/granite.buid",
+    "https://github.ibm.com/granite-dot-build/granite.build",
 )
 
 # assets


### PR DESCRIPTION

### Summary
- Fix typo in `GBCLI_REPO_URL`: `granite.buid` → `granite.build`
- Change `GBSERVER_ARTIFACT_FILTER` default from `False` to `True`

### Details

**Typo fix:** The `GBCLI_REPO_URL` constant pointed to `https://github.ibm.com/granite-dot-build/granite.buid` (missing the `l` in `build`). This would cause failures for any code relying on this URL as the default repo
  location.

**Artifact filter default:** `GBSERVER_ARTIFACT_FILTER` is now enabled by default. This aligns with the other event flags in the `ENVIRONMENT_CONFIGS` block (`GBSERVER_BUILD_EVENTS`, `GBSERVER_BUILD_UPDATE`) which already
   default to `True`.

### Test plan
- [ ] Verify `GBCLI_REPO_URL` resolves correctly with the fixed spelling
- [ ] Confirm artifact filtering works as expected when enabled by default
- [ ] Validate that setting `GBSERVER_ARTIFACT_FILTER=false` still overrides the new default