### PR TITLE
Fixes hfuri to use HF_TOKEN and adds artifact existence test to buildtests

### DIFF
--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -210,7 +210,7 @@ class HfURI(URI):
         try:
             p = self._parts()
             repo_id = f"{p.owner}/{p.repo}"
-            token = self.secrets.get("HF_TOKEN") if self.secrets else None
+            token = self._resolve_token()
 
             if p.hf_type == HfType.BUCKET:
                 endpoint = f"https://{p.host}" if p.host != HF_HOST else None

--- a/test/lib/buildwatcher/buildtest.py
+++ b/test/lib/buildwatcher/buildtest.py
@@ -918,10 +918,12 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
                 build_id,
                 f"Artifact status is {artifact.status}, but expected one of {status_list}",
             )
-            uri = URI.get_uri(artifact.uri)
-            assert (
-                uri is not None
-            ), f"Could not resovle artifact uri {artifact.uri} to an object"
+            try:
+                uri = URI.get_uri(artifact.uri)
+            except Exception as e:
+                raise AssertionError(
+                    f"Could not resolve artifact uri {artifact.uri} to an object: {e}"
+                ) from e
             assert (
                 uri.exists()
             ), f"URI {artifact.uri} does not exist in artifact storage"

--- a/test/lib/buildwatcher/buildtest.py
+++ b/test/lib/buildwatcher/buildtest.py
@@ -136,13 +136,12 @@ class ClassTestedEnum(Enum):
 
 class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
 
-
     def setup_method(self: Self, method):
         # breakpoint()
-        # Only use real HF calls when extended testing is enabled. 
+        # Only use real HF calls when extended testing is enabled.
         if not is_extended_testing_enabled:
             self._enable_artifact_mocks()
-            
+
         self.class_tested = None
         run_locally = getattr(self, "run_locally", False)
         logger.info(f"Test to be run locally: {run_locally}")
@@ -167,7 +166,6 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
         )
 
         super().setup_method(method)
-
 
     def teardown_method(self: Self, method):
         if not is_extended_testing_enabled:
@@ -921,8 +919,12 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
                 f"Artifact status is {artifact.status}, but expected one of {status_list}",
             )
             uri = URI.get_uri(artifact.uri)
-            assert uri is not None, f"Could not resovle artifact uri {artifact.uri} to an object"
-            assert uri.exists(), f"URI {artifact.uri} does not exist in artifact storage"
+            assert (
+                uri is not None
+            ), f"Could not resovle artifact uri {artifact.uri} to an object"
+            assert (
+                uri.exists()
+            ), f"URI {artifact.uri} does not exist in artifact storage"
 
     def _verify_skipped_target_and_steps(
         self: Self,

--- a/test/lib/buildwatcher/buildtest.py
+++ b/test/lib/buildwatcher/buildtest.py
@@ -920,6 +920,9 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
                 build_id,
                 f"Artifact status is {artifact.status}, but expected one of {status_list}",
             )
+            uri = URI.get_uri(artifact.uri)
+            assert uri is not None, f"Could not resovle artifact uri {artifact.uri} to an object"
+            assert uri.exists(), f"URI {artifact.uri} does not exist in artifact storage"
 
     def _verify_skipped_target_and_steps(
         self: Self,


### PR DESCRIPTION
## Description

Fixes hfuri to use HF_TOKEN and adds artifact existence test to buildtests

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
