### PR TITLE
Fix WandB lineage store skipping jobstats for skipped retry targets

### DIFF
--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -327,9 +327,7 @@ class WandBLineageStore(ILineageStore):
         count = 0
         for target in targets:
             assert isinstance(target, StoredTargetRun)
-            events, _ = self._build_events_for_target(storage, build, target)
-            for event in events:
-                self._service.emit_event(event)
+            self.__add_jobstats_for_target(storage, build, target)
             count += 1
         if count == 0:
             raise ValueError(f"Zero targets found in build with id {build_id}")
@@ -348,12 +346,20 @@ class WandBLineageStore(ILineageStore):
         count = 0
         for target in targets:
             assert isinstance(target, StoredTargetRun)
-            events, _ = self._build_events_for_target(storage, build, target)
-            for event in events:
-                self._service.emit_event(event)
+            self.__add_jobstats_for_target(storage, build, target)
             count += 1
         if count == 0:
             raise ValueError(f"Zero targets found in build with id {build_id}")
+
+    def __add_jobstats_for_target(
+        self,
+        storage: SingletonAdminStorage,
+        build: StoredBuild,
+        targetrun: StoredTargetRun,
+    ) -> None:
+        events, _ = self.create_jobstats_for_target(storage, targetrun, build)
+        for event in events:
+            self._service.emit_event(event)
 
     def add_jobstats_for_original_artifact(
         self,


### PR DESCRIPTION
On retry builds, skipped targets were not producing any jobstats. The integration test
  expected 3, got 0.

  WandBLineageStore.add_jobstats_for_build and add_jobstats_for_build_target called
  _build_events_for_target directly, which bypassed the skipped_for_prerun_target_id
  substitution that lives in create_jobstats_for_target. Skipped retry targets carry
  empty input_artifacts and output_artifacts dicts (the real artifacts belong to the
  original run), so _build_events_for_target emitted zero events for them.

  LakehouseLineageStore already handled this correctly by routing through
  create_jobstats_for_target, which swaps in a model_copy of the original target while
  keeping the retry's uuid and build_id. This PR aligns WandB with that pattern: both
  public entry points now delegate to a new private __add_jobstats_for_target helper that
   calls create_jobstats_for_target.

  After the fix, both backends produce the same number of jobstats for a skipped retry
  target as for the original successful run, tagged with the retry's build_id and
  target_id.

  Test plan
  - Run test/integration/ibm/buildwatcher/test_buildrunner_retry.py::TestBuildRunnerRetry
  ::test_buildrunner_retry
  - Existing WandB unit tests in test/integration/ibm/lineage/test_wandb_jobstats.py
  still pass (non-skipped path is unchanged)