### PR TITLE
fix: use the profile black option with isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           pip install -e ".[standalone,thirdparty,dev]"
 
       - name: Check formatting (isort)
-        run: isort --check .
+        run: isort --profile black --check .
 
       - name: Check formatting (black)
         run: black --check .

--- a/Makefile
+++ b/Makefile
@@ -187,9 +187,9 @@ check-table-prefix:
 
 .PHONY: format
 format:
-	isort . && black .
+	isort --profile black . && black .
 	# workaround for the build directory
-	isort src/gbserver/build/*
+	isort --profile black src/gbserver/build/*
 	black src/gbserver/build/*
 
 .PHONY: staticcheck


### PR DESCRIPTION
## Description

use the profile `black` option when using `isort` directly

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
