### PR TITLE
Replace the static version in pyproject.toml with dynamic versioning via setuptools-scm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ WORKDIR /app
 RUN mkdir -p /opt/app-root/src/.pip
 RUN echo "[global]" >> /opt/app-root/src/.pip/pip.conf
 RUN echo "extra-index-url = https://${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}@na.artifactory.swg-devops.com/artifactory/api/pypi/res-data-model-factory-team-pypi-local/simple" >> /opt/app-root/src/.pip/pip.conf
-# Copy the pyproject.toml to install dependencies
+# Copy the pyproject.toml and .git (needed by setuptools-scm for versioning)
 COPY pyproject.toml pyproject.toml
+COPY .git .git
 RUN pip install ".[all]"
 # Copy the source code and install in editable mode
 COPY . .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "granite.build"
-version = "0.3.0"
+dynamic = ["version"]
 authors = [
     { name = "Akash Nayak", email = "akash.nayak1@ibm.com" },
     { name = "Alexei Karve", email = "karve@us.ibm.com" },
@@ -131,6 +131,9 @@ Issues = "https://github.com/ibm-granite/granite.build/issues"
 [build-system]
 requires = ["setuptools", "setuptools_scm", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 where = ["src", "test"]


### PR DESCRIPTION
## Summary

Replace the static `version = "0.3.0"` in `pyproject.toml` with automatic git-tag-based versioning via [setuptools-scm](https://setuptools-scm.readthedocs.io/). This eliminates manual version bumps — the version is now derived from git tags at build time.

## Motivation

After tagging `v0.3.0`, we had to manually bump `pyproject.toml` to `0.3.1`. This is error-prone and easy to forget. With `setuptools-scm`, the version is always in sync with git tags.

## How it works

- On a tagged commit (e.g. `v0.3.1`) → version is `0.3.1`
- On commits after a tag → version is `0.3.2.dev<N>+g<hash>` (auto-incremented)
- No `.git` directory available → falls back to `0.0.0`

The existing runtime version lookup via `importlib.metadata.version("granite.build")` in `src/gbserver/__init__.py` and `src/gbcli/utils/versionutil.py` works with this out of the box — no changes needed there.

## Changes

### `pyproject.toml`
- Removed static `version = "0.3.0"`
- Added `dynamic = ["version"]` to `[project]`
- Added `[tool.setuptools_scm]` section with `fallback_version = "0.0.0"`
- (`setuptools_scm` was already listed in `[build-system] requires`)

### `Dockerfile`
- Added `COPY .git .git` before `pip install ".[all]"` so setuptools-scm can resolve the version during container builds (`.git` is already not excluded by `.dockerignore`)

## Test plan

- [ ] `python -c "from setuptools_scm import get_version; print(get_version())"` prints `0.3.1.dev<N>+g<hash>`
- [ ] `pip install -e . && python -c "from gbserver import __version__; print(__version__)"` matches
- [ ] `make image` / Docker build succeeds with correct version baked in
- [ ] `gb version` CLI command reports the correct version