### PR TITLE
Fix register_artifact kwarg mismatch 

### DIFF
--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -195,7 +195,7 @@ class GBClient:
             space: Optional[str],
             table: Optional[str],
             namespace: Optional[str],
-            store: str = "lh",
+            store: str = "hf",
             hf_token: Optional[str] = None,
             hf_organization: Optional[str] = None,
             resource_group_id: Optional[str] = None,
@@ -281,7 +281,7 @@ class GBClient:
             certified_no_restrictions: bool = False,
             hf_organization: Optional[str] = None,
             resource_group_id: Optional[str] = None,
-            store: str = "lh",
+            store: str = "hf",
             callback=None,
         ):
             return (
@@ -303,7 +303,6 @@ class GBClient:
                     lh_env=lh_env,
                     origin_uris=origin_uris,
                     certified_no_restrictions=certified_no_restrictions,
-                    store=store,
                     callback=callback,
                 )
                 if store == "lh"

--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -195,7 +195,7 @@ class GBClient:
             space: Optional[str],
             table: Optional[str],
             namespace: Optional[str],
-            store: str = "hf",
+            store: str = "lh",
             hf_token: Optional[str] = None,
             hf_organization: Optional[str] = None,
             resource_group_id: Optional[str] = None,
@@ -281,7 +281,7 @@ class GBClient:
             certified_no_restrictions: bool = False,
             hf_organization: Optional[str] = None,
             resource_group_id: Optional[str] = None,
-            store: str = "hf",
+            store: str = "lh",
             callback=None,
         ):
             return (

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -162,9 +162,9 @@ def cli(ctx):
 )
 @click.option(
     "--store",
-    default="lh",
+    default="hf",
     type=click.Choice(["lh", "hf"], case_sensitive=True),
-    help="Target artifact store: lh (Lakehouse, default) or hf (HuggingFace).",
+    help="Target artifact store: hf (HuggingFace, default) or lh (Lakehouse).",
 )
 @click.option(
     "--public",
@@ -842,9 +842,9 @@ def push(
 )
 @click.option(
     "--store",
-    default="lh",
+    default="hf",
     type=click.Choice(["lh", "hf"], case_sensitive=True),
-    help="Target artifact store: lh (Lakehouse, default) or hf (HuggingFace).",
+    help="Target artifact store: hf (HuggingFace, default) or lh (Lakehouse).",
 )
 @click.option(
     "--format",

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -162,9 +162,9 @@ def cli(ctx):
 )
 @click.option(
     "--store",
-    default="hf",
+    default="lh",
     type=click.Choice(["lh", "hf"], case_sensitive=True),
-    help="Target artifact store: hf (HuggingFace, default) or lh (Lakehouse).",
+    help="Target artifact store: lh (Lakehouse, default) or hf (HuggingFace).",
 )
 @click.option(
     "--public",
@@ -842,9 +842,9 @@ def push(
 )
 @click.option(
     "--store",
-    default="hf",
+    default="lh",
     type=click.Choice(["lh", "hf"], case_sensitive=True),
-    help="Target artifact store: hf (HuggingFace, default) or lh (Lakehouse).",
+    help="Target artifact store: lh (Lakehouse, default) or hf (HuggingFace).",
 )
 @click.option(
     "--format",


### PR DESCRIPTION
   - Drop stray store=store kwarg in client.py:306 that broke --store lh with register_artifact_gbserver() got an unexpected keyword argument 'store'.

Example:
`gb artifact push --type fileset --from-local vale_test0514 --artifact-name vale_test0514 --certify-no-restrictions --store lh
`
<img width="1148" height="118" alt="image" src="https://github.com/user-attachments/assets/83ac3434-ab4e-4550-864d-613d6136e240" />


  Test plan
  - gb artifact push --store lh ... completes past step 3/5
  - gb artifact push --store hf ... still works