### PR TITLE
fix: repair Dockerfile install and pyproject.toml self-reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,10 @@ WORKDIR /app
 RUN mkdir -p /opt/app-root/src/.pip
 RUN echo "[global]" >> /opt/app-root/src/.pip/pip.conf
 RUN echo "extra-index-url = https://${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}@na.artifactory.swg-devops.com/artifactory/api/pypi/res-data-model-factory-team-pypi-local/simple" >> /opt/app-root/src/.pip/pip.conf
-# Copy the pyproject.toml and .git (needed by setuptools-scm for versioning)
-COPY pyproject.toml pyproject.toml
-COPY .git .git
-RUN pip install ".[all]"
+
 # Copy the source code and install in editable mode
 COPY . .
-RUN pip install --no-deps -e .
+RUN pip install --upgrade -e ".[all]"
 # Patch aiohttp and kubernetes_asyncio
 RUN patch -i connector.py.patch /opt/app-root/lib/python3.12/site-packages/aiohttp/connector.py
 RUN patch -i api_client.py.patch /opt/app-root/lib/python3.12/site-packages/kubernetes_asyncio/client/api_client.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ibm = [
 ]
 # All optional dependencies
 all = [
-    "granite-build-tools[standalone,thirdparty,ibm]",
+    "granite.build[standalone,thirdparty,ibm]",
 ]
 # Development tools
 dev = [


### PR DESCRIPTION
The setuptools-scm change broke the Docker build with a two-stage install that copied .git into the image. Revert to a single editable install from the full source copy. Also fix the `all` extras self-reference from `granite-build-tools` to `granite.build`.

### Summary

- **Dockerfile**: Remove the two-stage install introduced by the setuptools-scm change (#31), which copied `.git` into the image for versioning but broke the build flow. Revert to a single `pip install --upgrade -e
  ".[all]"` after copying the full source tree.
- **pyproject.toml**: Fix the `all` extras self-reference from `granite-build-tools` (old package name) to `granite.build` (current package name), which caused the extras resolution to fail.

### Context

  PR #31 introduced setuptools-scm for git-tag-based versioning. A side effect was a Dockerfile refactor that split the install into two stages — first installing dependencies via `pip install ".[all]"` with only
  `pyproject.toml` and `.git` copied, then doing a `--no-deps -e .` install after copying the full source. This broke because the editable install still needed the full source for the first stage.

  Separately, the `all` extras group referenced the old distribution name `granite-build-tools` instead of `granite.build`, preventing `pip install ".[all]"` from resolving correctly.

### Test plan

- [ ] `pip install -e ".[all]"` resolves successfully in a local venv
- [ ] `make image` / `make imagex` builds the container image without errors
- [ ] Existing CI tests pass