### PR TITLE
update toml to make black focus on py311

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,9 @@ where = ["src", "test"]
 [tool.isort]
 profile = "black"
 
+[tool.black]
+target-version = ["py311"]
+
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"


### PR DESCRIPTION
## Description

Brief description of what this PR does and why.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
