### PR TITLE
feat: environment-aware HF resource group names and lookup API

### DIFF
--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -281,6 +281,12 @@ class HfURI(URI):
         name = f"{_GB_RG_SPACE_NAME_PREFIX}{space_name}"
         if GB_ENVIRONMENT and GB_ENVIRONMENT.upper() not in ("PROD", ""):
             name = f"{name}-{GB_ENVIRONMENT.lower()}"
+        logger.info(
+            "Resolved resource group name '%s' from space '%s' (env=%s)",
+            name,
+            space_name,
+            GB_ENVIRONMENT,
+        )
         return name
 
     def get_artifact_type(self) -> ArtifactType:
@@ -769,6 +775,12 @@ class HfURI(URI):
                 f"id '{resolved_id}' resolved from '{effective_name}' in "
                 f"organization '{p.owner}'"
             )
+        logger.info(
+            "Resolved resource group id '%s' for name '%s' in org '%s'",
+            resolved_id,
+            effective_name,
+            p.owner,
+        )
         return resolved_id
 
     def _resolve_resource_group_id(

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -279,7 +279,7 @@ class HfURI(URI):
         if not space_name:
             return ""
         name = f"{_GB_RG_SPACE_NAME_PREFIX}{space_name}"
-        if GB_ENVIRONMENT and GB_ENVIRONMENT.upper() not in ("PROD", ""):
+        if GB_ENVIRONMENT and GB_ENVIRONMENT.upper() not in ("PROD", "STANDALONE", ""):
             name = f"{name}-{GB_ENVIRONMENT.lower()}"
         logger.debug(
             "Resolved resource group name '%s' from space '%s' (env=%s)",

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -36,6 +36,7 @@ from huggingface_hub import (
 from gbcommon.types.testing import is_hf_mocked
 from gbcommon.uri.uri import URI
 from gbserver.types.artifact import ArtifactType
+from gbserver.types.constants import GB_ENVIRONMENT
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -265,6 +266,10 @@ class HfURI(URI):
         By convention, GB space names are prefixed with ``_GB_RG_SPACE_NAME_PREFIX``
         to form the resource group name used in HuggingFace Enterprise.
 
+        For non-production environments (STAGING, DEV), a lowercase environment
+        suffix is appended to differentiate resource groups within the same HF
+        organization (e.g. ``gbspace-public-staging``).
+
         Args:
             space_name: The GB space name to convert.
 
@@ -273,7 +278,10 @@ class HfURI(URI):
         """
         if not space_name:
             return ""
-        return f"{_GB_RG_SPACE_NAME_PREFIX}{space_name}"
+        name = f"{_GB_RG_SPACE_NAME_PREFIX}{space_name}"
+        if GB_ENVIRONMENT and GB_ENVIRONMENT.upper() not in ("PROD", ""):
+            name = f"{name}-{GB_ENVIRONMENT.lower()}"
+        return name
 
     def get_artifact_type(self) -> ArtifactType:
         """Return the artifact type based on the HF resource type encoded in the URI.

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -281,7 +281,7 @@ class HfURI(URI):
         name = f"{_GB_RG_SPACE_NAME_PREFIX}{space_name}"
         if GB_ENVIRONMENT and GB_ENVIRONMENT.upper() not in ("PROD", ""):
             name = f"{name}-{GB_ENVIRONMENT.lower()}"
-        logger.info(
+        logger.debug(
             "Resolved resource group name '%s' from space '%s' (env=%s)",
             name,
             space_name,
@@ -705,14 +705,19 @@ class HfURI(URI):
         except Exception as e:
             logger.warning("Could not clean HF cache for %s: %s", repo_id, e)
 
-    def resolve_resource_group_id(
-        self: Self,
+    @classmethod
+    def resolve_resource_group_id_for_org(
+        cls,
         token: Optional[str],
+        organization: str,
         resource_group_id: Optional[str] = None,
         resource_group_name: Optional[str] = None,
         space_name: Optional[str] = None,
+        host: str = HF_HOST,
     ) -> Optional[str]:
         """Resolve an HF Enterprise resource group id from id, name, or space.
+
+        Class-level entry point that does not require an ``HfURI`` instance.
 
         Handles the full ``space_name -> resource_group_name -> resource_group_id``
         flow in one place.  Any combination of inputs is accepted as long as
@@ -732,11 +737,13 @@ class HfURI(URI):
             token: HF auth token used to build the temporary ``HfApi``.  May be
                 ``None`` for anonymous lookups, though Enterprise resource
                 groups typically require authentication.
+            organization: HF organization namespace.
             resource_group_id: Explicit resource group id (e.g. from
                 build.yaml ``store_push.config.hf.resource_group_id``).
             resource_group_name: Explicit resource group name.
             space_name: GB space name; converted to a resource group name via
                 :meth:`space_name_to_resource_group_name`.
+            host: HF host (defaults to ``huggingface.co``).
 
         Returns:
             The resolved resource group id, or ``None`` when no inputs were
@@ -749,7 +756,7 @@ class HfURI(URI):
         if not resource_group_id and not resource_group_name and not space_name:
             return None
         derived_name = (
-            self.space_name_to_resource_group_name(space_name) if space_name else None
+            cls.space_name_to_resource_group_name(space_name) if space_name else None
         )
         if resource_group_name and derived_name and derived_name != resource_group_name:
             raise ValueError(
@@ -758,33 +765,53 @@ class HfURI(URI):
             )
         effective_name = resource_group_name or derived_name
         if effective_name is None:
-            # Only resource_group_id was supplied; trust it.
             return resource_group_id
-        p = self._parts()
-        endpoint = f"https://{p.host}" if p.host != HF_HOST else None
+        endpoint = f"https://{host}" if host != HF_HOST else None
         api = HfApi(endpoint=endpoint, token=token)
-        resolved_id = self._resolve_resource_group_id(api, p.owner, effective_name)
+        resolved_id = cls._resolve_resource_group_id(api, organization, effective_name)
         if not resolved_id:
             raise ValueError(
                 f"Could not resolve resource group id for '{effective_name}' "
-                f"in organization '{p.owner}'"
+                f"in organization '{organization}'"
             )
         if resource_group_id and resource_group_id != resolved_id:
             raise ValueError(
                 f"resource group id '{resource_group_id}' does not match the "
                 f"id '{resolved_id}' resolved from '{effective_name}' in "
-                f"organization '{p.owner}'"
+                f"organization '{organization}'"
             )
         logger.info(
             "Resolved resource group id '%s' for name '%s' in org '%s'",
             resolved_id,
             effective_name,
-            p.owner,
+            organization,
         )
         return resolved_id
 
+    def resolve_resource_group_id(
+        self: Self,
+        token: Optional[str],
+        resource_group_id: Optional[str] = None,
+        resource_group_name: Optional[str] = None,
+        space_name: Optional[str] = None,
+    ) -> Optional[str]:
+        """Instance-level convenience wrapper around :meth:`resolve_resource_group_id_for_org`.
+
+        Extracts *organization* and *host* from this URI's parts.
+        """
+        p = self._parts()
+        return self.resolve_resource_group_id_for_org(
+            token=token,
+            organization=p.owner,
+            resource_group_id=resource_group_id,
+            resource_group_name=resource_group_name,
+            space_name=space_name,
+            host=p.host,
+        )
+
+    @classmethod
     def _resolve_resource_group_id(
-        self, api: HfApi, organization: str, name: str
+        cls, api: HfApi, organization: str, name: str
     ) -> Optional[str]:
         """Look up a resource group ID by name within the given organization.
 

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -435,10 +435,16 @@ def resolve_hf_resource_group(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="space_name must not be empty",
         )
-    hfuri = HfURI.from_parts(owner=organization, repo="__lookup__")
+    token = get_hf_token()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="HF token is not configured on the server",
+        )
     try:
-        resolved_id = hfuri.resolve_resource_group_id(
-            token=get_hf_token(),
+        resolved_id = HfURI.resolve_resource_group_id_for_org(
+            token=token,
+            organization=organization,
             resource_group_name=rg_name,
         )
     except ValueError as exc:

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -44,8 +44,8 @@ from gbserver.types.artifact import ArtifactType
 from gbserver.types.constants import (
     ENV_URI_SCHEME,
     GB_ENVIRONMENT,
-    GBSERVER_HF_TOKEN,
     LAKEHOUSE_ENVIRONMENT,
+    get_hf_token,
 )
 
 artifacts_api = FastAPI()
@@ -438,7 +438,7 @@ def resolve_hf_resource_group(
     hfuri = HfURI.from_parts(owner=organization, repo="__lookup__")
     try:
         resolved_id = hfuri.resolve_resource_group_id(
-            token=GBSERVER_HF_TOKEN,
+            token=get_hf_token(),
             resource_group_name=rg_name,
         )
     except ValueError as exc:

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -44,6 +44,7 @@ from gbserver.types.artifact import ArtifactType
 from gbserver.types.constants import (
     ENV_URI_SCHEME,
     GB_ENVIRONMENT,
+    GBSERVER_HF_TOKEN,
     LAKEHOUSE_ENVIRONMENT,
 )
 
@@ -415,6 +416,45 @@ def __get_hf_decoded_uri_response(hf_uri: HfURI) -> DecodedHfURIResponse:
         metadata["hf_type"] = str(metadata["hf_type"])
     response = DecodedHfURIResponse(**metadata)
     return response
+
+
+class HFResourceGroupResponse(BaseModel):
+    resource_group_name: str
+    resource_group_id: str
+
+
+@artifacts_api.get("/hf/resource-group")
+def resolve_hf_resource_group(
+    space_name: str,
+    organization: str,
+) -> HFResourceGroupResponse:
+    """Resolve an HF Enterprise resource group name and ID from a space name."""
+    rg_name = HfURI.space_name_to_resource_group_name(space_name)
+    if not rg_name:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="space_name must not be empty",
+        )
+    hfuri = HfURI.from_parts(owner=organization, repo="__lookup__")
+    try:
+        resolved_id = hfuri.resolve_resource_group_id(
+            token=GBSERVER_HF_TOKEN,
+            resource_group_name=rg_name,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        )
+    if not resolved_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Resource group '{rg_name}' not found in organization '{organization}'",
+        )
+    return HFResourceGroupResponse(
+        resource_group_name=rg_name,
+        resource_group_id=resolved_id,
+    )
 
 
 @artifacts_api.get("/decode")

--- a/src/gbserver/asset/hfstore.py
+++ b/src/gbserver/asset/hfstore.py
@@ -89,7 +89,7 @@ class Hfstore(Assetstore):
             token = self.secrets[token_key] or None
         else:
             token = os.getenv(token_key, None)
-            # Fall back to GBSERVER_HF_TOKEN if token_key is not set
+            # Fall back to get_hf_token() if token_key is not set
             if token is None:
                 token = get_hf_token()
 

--- a/src/gbserver/asset/hfstore.py
+++ b/src/gbserver/asset/hfstore.py
@@ -26,7 +26,7 @@ from gbcommon.uri.hf import HfURI
 from gbcommon.uri.uri import URI
 from gbserver.asset.assetstore import Assetstore
 from gbserver.types.artifact import ArtifactType
-from gbserver.types.constants import GBSERVER_HF_TOKEN
+from gbserver.types.constants import get_hf_token
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -91,7 +91,7 @@ class Hfstore(Assetstore):
             token = os.getenv(token_key, None)
             # Fall back to GBSERVER_HF_TOKEN if token_key is not set
             if token is None:
-                token = GBSERVER_HF_TOKEN
+                token = get_hf_token()
 
         if token is not None and token.strip() == "":
             token = None

--- a/src/gbserver/buildwatcher/buildrunner.py
+++ b/src/gbserver/buildwatcher/buildrunner.py
@@ -360,7 +360,19 @@ class BuildRunner(AbstractBuildRunner):
 
         try:
 
-            space = self.__get_build_space(stored_build)
+            try:
+                space = self.__get_build_space(stored_build)
+            except ValueError as e:
+                err_stack = traceback.format_exc()
+                logger.error("%s", err_stack)
+                self.__update_stored_build_status(
+                    status=Status.INVALID, failure_reason=str(err_stack)
+                )
+                self.build_message_logger.error(
+                    markdown=f"build `{build_id}` status `{self.stored_build.status}`, error: {e}"
+                )
+                return
+
             targets = stored_build.targets  # default: re-run all targets of the build
             force_fetch = True  # default: set to force fetch
 

--- a/src/gbserver/builtins/steps/hfpush/helm-charts/hfpush/values.yaml
+++ b/src/gbserver/builtins/steps/hfpush/helm-charts/hfpush/values.yaml
@@ -9,13 +9,3 @@ k8s:
         secretKeyRef:
           name: {{ setup_config.space.secret }}
           key: {{ config.hfpush_config.token_secretname | default("HF_TOKEN") }}
-    HF_ORGANIZATION:
-      valueFrom:
-        secretKeyRef:
-          name: {{ setup_config.space.secret }}
-          key: {{ config.hfpush_config.organization_secretname | default("HF_ORGANIZATION") }}
-    HF_RESOURCE_GROUP_ID:
-      valueFrom:
-        secretKeyRef:
-          name: {{ setup_config.space.secret }}
-          key: {{ config.hfpush_config.resource_group_secretname | default("HF_RESOURCE_GROUP_ID") }}

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -169,10 +169,6 @@ GBSERVER_RAISE_BUILD_EXCEPTIONS = (
 # Hugging Face Hub Configuration
 ENV_VAR_HF_TOKEN = ENV_VAR_PREFIX + "_HF_TOKEN"
 
-# Hugging Face Hub default values from environment
-GBSERVER_HF_TOKEN = os.getenv(ENV_VAR_HF_TOKEN, os.getenv("HF_TOKEN", None))
-
-
 def get_hf_token() -> str | None:
     # Reads env var lazily — important when the env is set after initial import (e.g. test fixtures).
     return os.getenv(ENV_VAR_HF_TOKEN, os.getenv("HF_TOKEN", None))

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -177,6 +177,7 @@ def get_hf_token() -> str | None:
     # Reads env var lazily — important when the env is set after initial import (e.g. test fixtures).
     return os.getenv(ENV_VAR_HF_TOKEN, os.getenv("HF_TOKEN", None))
 
+
 DEFAULT_GH_API_ENDPOINT = get_gh_api_base()
 # NOTE: To do multiple dmf pushes with aspera, the aspera daemon needs to be kept running.
 # This causes an issue where the LSF job doesn't end because the daemon is still running.

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -172,6 +172,11 @@ ENV_VAR_HF_TOKEN = ENV_VAR_PREFIX + "_HF_TOKEN"
 # Hugging Face Hub default values from environment
 GBSERVER_HF_TOKEN = os.getenv(ENV_VAR_HF_TOKEN, os.getenv("HF_TOKEN", None))
 
+
+def get_hf_token() -> str | None:
+    # Reads env var lazily — important when the env is set after initial import (e.g. test fixtures).
+    return os.getenv(ENV_VAR_HF_TOKEN, os.getenv("HF_TOKEN", None))
+
 DEFAULT_GH_API_ENDPOINT = get_gh_api_base()
 # NOTE: To do multiple dmf pushes with aspera, the aspera daemon needs to be kept running.
 # This causes an issue where the LSF job doesn't end because the daemon is still running.

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -169,6 +169,7 @@ GBSERVER_RAISE_BUILD_EXCEPTIONS = (
 # Hugging Face Hub Configuration
 ENV_VAR_HF_TOKEN = ENV_VAR_PREFIX + "_HF_TOKEN"
 
+
 def get_hf_token() -> str | None:
     # Reads env var lazily — important when the env is set after initial import (e.g. test fixtures).
     return os.getenv(ENV_VAR_HF_TOKEN, os.getenv("HF_TOKEN", None))

--- a/test/unit/api/test_hf_resource_group.py
+++ b/test/unit/api/test_hf_resource_group.py
@@ -131,7 +131,7 @@ class TestHFResourceGroupEndpoint:
             patch(
                 "gbserver.api.artifacts.HfURI.resolve_resource_group_id_for_org",
                 return_value="staging-id",
-            ),
+            ) as mock_resolve,
         ):
             resp = client.get(
                 "/hf/resource-group",
@@ -145,3 +145,8 @@ class TestHFResourceGroupEndpoint:
         data = resp.json()
         assert data["resource_group_name"] == "gbspace-public-staging"
         assert data["resource_group_id"] == "staging-id"
+        mock_resolve.assert_called_once_with(
+            token="fake-token",
+            organization="ibm-research",
+            resource_group_name="gbspace-public-staging",
+        )

--- a/test/unit/api/test_hf_resource_group.py
+++ b/test/unit/api/test_hf_resource_group.py
@@ -28,9 +28,7 @@ client = TestClient(artifacts_api)
 
 class TestHFResourceGroupEndpoint:
     def test_resolve_success(self):
-        with patch(
-            "gbserver.api.artifacts.HfURI.from_parts"
-        ) as mock_from_parts:
+        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
             mock_uri = mock_from_parts.return_value
             mock_uri.resolve_resource_group_id.return_value = "prod-id-123"
 
@@ -48,9 +46,7 @@ class TestHFResourceGroupEndpoint:
         assert "gbspace-public" in data["resource_group_name"]
 
     def test_resolve_not_found(self):
-        with patch(
-            "gbserver.api.artifacts.HfURI.from_parts"
-        ) as mock_from_parts:
+        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
             mock_uri = mock_from_parts.return_value
             mock_uri.resolve_resource_group_id.return_value = None
 
@@ -66,9 +62,7 @@ class TestHFResourceGroupEndpoint:
         assert "not found" in resp.json()["detail"].lower()
 
     def test_resolve_value_error(self):
-        with patch(
-            "gbserver.api.artifacts.HfURI.from_parts"
-        ) as mock_from_parts:
+        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
             mock_uri = mock_from_parts.return_value
             mock_uri.resolve_resource_group_id.side_effect = ValueError(
                 "Could not resolve resource group id"
@@ -112,9 +106,7 @@ class TestHFResourceGroupEndpoint:
 
     def test_staging_env_uses_suffixed_name(self, monkeypatch):
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
-        with patch(
-            "gbserver.api.artifacts.HfURI.from_parts"
-        ) as mock_from_parts:
+        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
             mock_uri = mock_from_parts.return_value
             mock_uri.resolve_resource_group_id.return_value = "staging-id"
 

--- a/test/unit/api/test_hf_resource_group.py
+++ b/test/unit/api/test_hf_resource_group.py
@@ -28,10 +28,13 @@ client = TestClient(artifacts_api)
 
 class TestHFResourceGroupEndpoint:
     def test_resolve_success(self):
-        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
-            mock_uri = mock_from_parts.return_value
-            mock_uri.resolve_resource_group_id.return_value = "prod-id-123"
-
+        with (
+            patch("gbserver.api.artifacts.get_hf_token", return_value="fake-token"),
+            patch(
+                "gbserver.api.artifacts.HfURI.resolve_resource_group_id_for_org",
+                return_value="prod-id-123",
+            ),
+        ):
             resp = client.get(
                 "/hf/resource-group",
                 params={
@@ -46,10 +49,13 @@ class TestHFResourceGroupEndpoint:
         assert "gbspace-public" in data["resource_group_name"]
 
     def test_resolve_not_found(self):
-        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
-            mock_uri = mock_from_parts.return_value
-            mock_uri.resolve_resource_group_id.return_value = None
-
+        with (
+            patch("gbserver.api.artifacts.get_hf_token", return_value="fake-token"),
+            patch(
+                "gbserver.api.artifacts.HfURI.resolve_resource_group_id_for_org",
+                return_value=None,
+            ),
+        ):
             resp = client.get(
                 "/hf/resource-group",
                 params={
@@ -62,12 +68,13 @@ class TestHFResourceGroupEndpoint:
         assert "not found" in resp.json()["detail"].lower()
 
     def test_resolve_value_error(self):
-        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
-            mock_uri = mock_from_parts.return_value
-            mock_uri.resolve_resource_group_id.side_effect = ValueError(
-                "Could not resolve resource group id"
-            )
-
+        with (
+            patch("gbserver.api.artifacts.get_hf_token", return_value="fake-token"),
+            patch(
+                "gbserver.api.artifacts.HfURI.resolve_resource_group_id_for_org",
+                side_effect=ValueError("Could not resolve resource group id"),
+            ),
+        ):
             resp = client.get(
                 "/hf/resource-group",
                 params={
@@ -104,12 +111,28 @@ class TestHFResourceGroupEndpoint:
         assert resp.status_code == 400
         assert "empty" in resp.json()["detail"].lower()
 
+    def test_missing_token_returns_503(self):
+        with patch("gbserver.api.artifacts.get_hf_token", return_value=None):
+            resp = client.get(
+                "/hf/resource-group",
+                params={
+                    "space_name": "public",
+                    "organization": "ibm-research",
+                },
+            )
+
+        assert resp.status_code == 503
+        assert "not configured" in resp.json()["detail"].lower()
+
     def test_staging_env_uses_suffixed_name(self, monkeypatch):
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
-        with patch("gbserver.api.artifacts.HfURI.from_parts") as mock_from_parts:
-            mock_uri = mock_from_parts.return_value
-            mock_uri.resolve_resource_group_id.return_value = "staging-id"
-
+        with (
+            patch("gbserver.api.artifacts.get_hf_token", return_value="fake-token"),
+            patch(
+                "gbserver.api.artifacts.HfURI.resolve_resource_group_id_for_org",
+                return_value="staging-id",
+            ),
+        ):
             resp = client.get(
                 "/hf/resource-group",
                 params={

--- a/test/unit/api/test_hf_resource_group.py
+++ b/test/unit/api/test_hf_resource_group.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for GET /hf/resource-group endpoint (mocked, no HF API calls)."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gbserver.api.artifacts import artifacts_api
+
+client = TestClient(artifacts_api)
+
+
+class TestHFResourceGroupEndpoint:
+    def test_resolve_success(self):
+        with patch(
+            "gbserver.api.artifacts.HfURI.from_parts"
+        ) as mock_from_parts:
+            mock_uri = mock_from_parts.return_value
+            mock_uri.resolve_resource_group_id.return_value = "prod-id-123"
+
+            resp = client.get(
+                "/hf/resource-group",
+                params={
+                    "space_name": "public",
+                    "organization": "ibm-research",
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["resource_group_id"] == "prod-id-123"
+        assert "gbspace-public" in data["resource_group_name"]
+
+    def test_resolve_not_found(self):
+        with patch(
+            "gbserver.api.artifacts.HfURI.from_parts"
+        ) as mock_from_parts:
+            mock_uri = mock_from_parts.return_value
+            mock_uri.resolve_resource_group_id.return_value = None
+
+            resp = client.get(
+                "/hf/resource-group",
+                params={
+                    "space_name": "nonexistent",
+                    "organization": "ibm-research",
+                },
+            )
+
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    def test_resolve_value_error(self):
+        with patch(
+            "gbserver.api.artifacts.HfURI.from_parts"
+        ) as mock_from_parts:
+            mock_uri = mock_from_parts.return_value
+            mock_uri.resolve_resource_group_id.side_effect = ValueError(
+                "Could not resolve resource group id"
+            )
+
+            resp = client.get(
+                "/hf/resource-group",
+                params={
+                    "space_name": "broken",
+                    "organization": "ibm-research",
+                },
+            )
+
+        assert resp.status_code == 404
+        assert "Could not resolve" in resp.json()["detail"]
+
+    def test_missing_space_name_returns_422(self):
+        resp = client.get(
+            "/hf/resource-group",
+            params={"organization": "ibm-research"},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_organization_returns_422(self):
+        resp = client.get(
+            "/hf/resource-group",
+            params={"space_name": "public"},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_space_name_returns_400(self):
+        resp = client.get(
+            "/hf/resource-group",
+            params={
+                "space_name": "",
+                "organization": "ibm-research",
+            },
+        )
+        assert resp.status_code == 400
+        assert "empty" in resp.json()["detail"].lower()
+
+    def test_staging_env_uses_suffixed_name(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        with patch(
+            "gbserver.api.artifacts.HfURI.from_parts"
+        ) as mock_from_parts:
+            mock_uri = mock_from_parts.return_value
+            mock_uri.resolve_resource_group_id.return_value = "staging-id"
+
+            resp = client.get(
+                "/hf/resource-group",
+                params={
+                    "space_name": "public",
+                    "organization": "ibm-research",
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["resource_group_name"] == "gbspace-public-staging"
+        assert data["resource_group_id"] == "staging-id"

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -787,3 +787,152 @@ class TestHfURIBucketDeleteUnit:
             result = uri.delete()
 
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# space_name_to_resource_group_name — environment suffix logic
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceNameToResourceGroupName:
+    def test_prod_no_suffix(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
+        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public"
+
+    def test_empty_env_no_suffix(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "")
+        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public"
+
+    def test_staging_suffix(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public-staging"
+
+    def test_dev_suffix(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "DEV")
+        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public-dev"
+
+    def test_empty_space_name_returns_empty(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        assert HfURI.space_name_to_resource_group_name("") == ""
+
+    def test_none_space_name_returns_empty(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "DEV")
+        assert HfURI.space_name_to_resource_group_name(None) == ""
+
+    def test_custom_space_name(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        assert HfURI.space_name_to_resource_group_name("my-team") == "gbspace-my-team-staging"
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
+        assert HfURI.space_name_to_resource_group_name("my-team") == "gbspace-my-team"
+
+
+# ---------------------------------------------------------------------------
+# resolve_resource_group_id with environment-derived names (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveResourceGroupIdWithEnvironment:
+    """Test that resolve_resource_group_id uses the environment-aware
+    resource group name when space_name is provided."""
+
+    def _mock_hf_api_response(self, groups):
+        """Patch the HF HTTP session to return the given resource groups list."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = groups
+        mock_session.get.return_value = mock_response
+        return mock_session
+
+    def test_staging_env_resolves_suffixed_name(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        uri = HfURI.from_parts(owner="ibm-research", repo="dummy")
+        groups = [{"name": "gbspace-public-staging", "id": "staging-id-123"}]
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch(
+                "huggingface_hub.utils._http.get_session",
+                return_value=self._mock_hf_api_response(groups),
+            ):
+                with patch("huggingface_hub.utils._http.hf_raise_for_status"):
+                    result = uri.resolve_resource_group_id(
+                        token="fake-token",
+                        space_name="public",
+                    )
+
+        assert result == "staging-id-123"
+
+    def test_prod_env_resolves_unsuffixed_name(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
+        uri = HfURI.from_parts(owner="ibm-research", repo="dummy")
+        groups = [{"name": "gbspace-public", "id": "prod-id-456"}]
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch(
+                "huggingface_hub.utils._http.get_session",
+                return_value=self._mock_hf_api_response(groups),
+            ):
+                with patch("huggingface_hub.utils._http.hf_raise_for_status"):
+                    result = uri.resolve_resource_group_id(
+                        token="fake-token",
+                        space_name="public",
+                    )
+
+        assert result == "prod-id-456"
+
+    def test_dev_env_resolves_suffixed_name(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "DEV")
+        uri = HfURI.from_parts(owner="ibm-research", repo="dummy")
+        groups = [{"name": "gbspace-public-dev", "id": "dev-id-789"}]
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch(
+                "huggingface_hub.utils._http.get_session",
+                return_value=self._mock_hf_api_response(groups),
+            ):
+                with patch("huggingface_hub.utils._http.hf_raise_for_status"):
+                    result = uri.resolve_resource_group_id(
+                        token="fake-token",
+                        space_name="public",
+                    )
+
+        assert result == "dev-id-789"
+
+    def test_explicit_name_ignores_environment(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        uri = HfURI.from_parts(owner="ibm-research", repo="dummy")
+        groups = [{"name": "my-custom-group", "id": "custom-id"}]
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch(
+                "huggingface_hub.utils._http.get_session",
+                return_value=self._mock_hf_api_response(groups),
+            ):
+                with patch("huggingface_hub.utils._http.hf_raise_for_status"):
+                    result = uri.resolve_resource_group_id(
+                        token="fake-token",
+                        resource_group_name="my-custom-group",
+                    )
+
+        assert result == "custom-id"
+
+    def test_raises_when_group_not_found(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        uri = HfURI.from_parts(owner="ibm-research", repo="dummy")
+        groups = [{"name": "gbspace-other", "id": "other-id"}]
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch(
+                "huggingface_hub.utils._http.get_session",
+                return_value=self._mock_hf_api_response(groups),
+            ):
+                with patch("huggingface_hub.utils._http.hf_raise_for_status"):
+                    with pytest.raises(ValueError, match="Could not resolve"):
+                        uri.resolve_resource_group_id(
+                            token="fake-token",
+                            space_name="public",
+                        )

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -805,7 +805,10 @@ class TestSpaceNameToResourceGroupName:
 
     def test_staging_suffix(self, monkeypatch):
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
-        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public-staging"
+        assert (
+            HfURI.space_name_to_resource_group_name("public")
+            == "gbspace-public-staging"
+        )
 
     def test_dev_suffix(self, monkeypatch):
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "DEV")
@@ -821,7 +824,10 @@ class TestSpaceNameToResourceGroupName:
 
     def test_custom_space_name(self, monkeypatch):
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
-        assert HfURI.space_name_to_resource_group_name("my-team") == "gbspace-my-team-staging"
+        assert (
+            HfURI.space_name_to_resource_group_name("my-team")
+            == "gbspace-my-team-staging"
+        )
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
         assert HfURI.space_name_to_resource_group_name("my-team") == "gbspace-my-team"
 

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -814,6 +814,10 @@ class TestSpaceNameToResourceGroupName:
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "DEV")
         assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public-dev"
 
+    def test_standalone_no_suffix(self, monkeypatch):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STANDALONE")
+        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public"
+
     def test_empty_space_name_returns_empty(self, monkeypatch):
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
         assert HfURI.space_name_to_resource_group_name("") == ""


### PR DESCRIPTION
## Summary

- `space_name_to_resource_group_name()` now appends a lowercase environment suffix for non-PROD environments (e.g. `gbspace-public-staging`, `gbspace-public-dev`). PROD and STANDALONE remain unsuffixed (`gbspace-public`). The environment is read internally from `GB_ENVIRONMENT`.
- New `GET /api/v1/artifacts/hf/resource-group` endpoint resolves HF resource group name and ID by space name and organization.
- `get_hf_token()` reads the HF token lazily at call time to support late env var injection (e.g. test fixtures setting the token after module import).
- Removed unused `HF_ORGANIZATION` and `HF_RESOURCE_GROUP_ID` env vars from hfpush Helm `values.yaml`.
- Added DEBUG-level logging to `space_name_to_resource_group_name()` and INFO-level logging to `resolve_resource_group_id()` for debugging resource group resolution.
- Fixed a bug where `__get_build_space()` failures (e.g. missing `space.yaml`, unknown space name) incorrectly marked the build as `FAILED` instead of `INVALID`. These are configuration errors and now correctly result in `Status.INVALID`.

## Changes

- **`src/gbcommon/uri/hf.py`** — Import `GB_ENVIRONMENT` and use it in `space_name_to_resource_group_name()` to append env suffix for STAGING/DEV. Add DEBUG logging for name derivation, INFO logging for API-based ID resolution. `resolve_resource_group_id_for_org` classmethod allows resolution without a URI instance.
- **`src/gbserver/api/artifacts.py`** — Add `HFResourceGroupResponse` model and `GET /hf/resource-group` endpoint. Use `get_hf_token()` for lazy token access.
- **`src/gbserver/types/constants.py`** — Add `get_hf_token()` for lazy env var reading.
- **`src/gbserver/asset/hfstore.py`** — Switch from `GBSERVER_HF_TOKEN` constant to `get_hf_token()`.
- **`src/gbserver/builtins/steps/hfpush/helm-charts/hfpush/values.yaml`** — Remove unused `HF_ORGANIZATION` and `HF_RESOURCE_GROUP_ID` env var injections.
- **`src/gbserver/buildwatcher/buildrunner.py`** — Catch `ValueError` from `__get_build_space()` and mark the build as `INVALID` instead of `FAILED`.
- **`test/unit/uri/test_hf.py`** — Unit tests for resource group name derivation and mocked `resolve_resource_group_id` with environment awareness.
- **`test/unit/api/test_hf_resource_group.py`** — Mocked API endpoint tests (no real HF API calls).

## Test plan

- [x] `pytest -s test/unit/uri/test_hf.py` — all existing + new tests pass
- [x] `pytest -s test/unit/api/test_hf_resource_group.py` — mocked API tests pass
- [x] `pytest -s test/unit/environment/test_lsf_hfstore.py` — existing caller tests unaffected
- [ ] Verify on a STAGING deployment that push operations resolve `gbspace-<name>-staging`
- [ ] `TestBuildWatcherInvalidBuild::test_build_watcher_run` now passes (build marked INVALID)
