### PR TITLE
Resolve HF resource group id dynamically from space name

### DIFF
--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -68,6 +68,7 @@ deployments:
     - GBSERVER_WANDB_API_KEY
     - GBSERVER_WANDB_ENTITY
     # OpenLineage / WandB ---
+    - GBSERVER_HF_TOKEN
   restServer:
     enable: true
     # enable: false
@@ -111,6 +112,7 @@ deployments:
     - GBSERVER_IBMID_CLIENT_ID
     - GBSERVER_IBMID_CLIENT_SECRET
     - GBSERVER_IBMID_CALLBACK_URL
+    - GBSERVER_HF_TOKEN
     # OpenLineage / WandB ---
     - GBSERVER_WANDB_API_KEY
     - GBSERVER_WANDB_ENTITY

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -68,7 +68,6 @@ deployments:
     - GBSERVER_WANDB_API_KEY
     - GBSERVER_WANDB_ENTITY
     # OpenLineage / WandB ---
-    - GBSERVER_HF_TOKEN
   restServer:
     enable: true
     # enable: false

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -22,7 +22,7 @@ from gbcli.utils.gbconstants import (
     ARTIFACT_LIST_HEADERS,
     CLIPBOARD_CHAR,
     DEFAULT_CHECKSUM_CONCURRENCY,
-    HF_RESOURCE_GROUP_ID_DEFAULT,
+    HF_ORGANIZATION_DEFAULT,
     LAKEHOUSE_FILESET_SHARED_TABLE_NAME,
     LAKEHOUSE_FILESET_TABLE_NAME,
     LAKEHOUSE_MODEL_SHARED_TABLE,
@@ -52,7 +52,12 @@ from gbcli.utils.utils import (
     validate_tags,
 )
 from gbcli.utils.versionutil import check_current_and_latest_versions
-from gbcommon.utils.hf_utils import convert_hf_uri_to_url, parse_hf_uri
+from gbcommon.uri.hf import HfURI
+from gbcommon.utils.hf_utils import (
+    convert_hf_uri_to_url,
+    lookup_hf_resource_group_id,
+    parse_hf_uri,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +163,7 @@ def cli(ctx):
 @click.option(
     "--resource-group-id",
     default=None,
-    help="Resource group ID (defaults to HF_RESOURCE_GROUP_ID from settings).",
+    help="Resource group ID. If omitted, resolved from the GB space name via the HF Enterprise API.",
 )
 @click.option(
     "--store",
@@ -244,10 +249,6 @@ def push(
             err=True,
         )
         ctx.exit(1)  # Exit with a non-zero status
-
-    # Apply default resource_group_id if not provided
-    if not resource_group_id:
-        resource_group_id = HF_RESOURCE_GROUP_ID_DEFAULT
 
     if (
         type == "model" or type == "fileset" or type == "dataset" or type == "bucket"
@@ -469,6 +470,35 @@ def push(
                 return
             if not quiet:
                 click.echo(f"HuggingFace token obtained successfully!")
+
+            # Resolve resource group id from the GB space name when not given.
+            if not resource_group_id:
+                org = hf_organization or HF_ORGANIZATION_DEFAULT
+                resolved_space_name = space
+                if not resolved_space_name:
+                    from gbcli.utils.spaceutil import resolve_space
+
+                    global_space = resolve_space(
+                        artifact_client.github_token, space, callback=echo_callback
+                    )
+                    if global_space is not None:
+                        resolved_space_name = global_space.get("name")
+                rg_name = HfURI.space_name_to_resource_group_name(resolved_space_name)
+                resource_group_id = lookup_hf_resource_group_id(
+                    organization=org,
+                    resource_group_name=rg_name,
+                    token=hf_token,
+                )
+                if not resource_group_id:
+                    click.echo(
+                        f"❌ Could not resolve HuggingFace resource group id for "
+                        f"space '{resolved_space_name}' (resource group name '{rg_name}') in "
+                        f"organization '{org}'. Pass --resource-group-id "
+                        f"explicitly, or ensure the resource group exists and "
+                        f"your HF token has access to it.",
+                        err=True,
+                    )
+                    ctx.exit(1)
 
         checksum = None
         existing_registration = None

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -38,6 +38,7 @@ from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.lh_auth import AuthException
 from gbcli.utils.lh_fileset import get_fileset_subforlder
 from gbcli.utils.lh_model import get_model_subforlder
+from gbcli.utils.spaceutil import resolve_space
 from gbcli.utils.utils import (
     check_runnable_browser,
     combine_tags,
@@ -477,13 +478,19 @@ def push(
                 org = hf_organization or HF_ORGANIZATION_DEFAULT
                 resolved_space_name = space
                 if not resolved_space_name:
-                    from gbcli.utils.spaceutil import resolve_space
-
                     global_space = resolve_space(
                         artifact_client.github_token, space, callback=echo_callback
                     )
                     if global_space is not None:
                         resolved_space_name = global_space.get("name")
+                if not resolved_space_name:
+                    click.echo(
+                        "❌ Could not determine GB space name to resolve the "
+                        "HuggingFace resource group id. Pass --space, set a "
+                        "default space, or pass --resource-group-id explicitly.",
+                        err=True,
+                    )
+                    sys.exit(1)
                 resource_group_id = lookup_hf_resource_group_id(
                     github_token=artifact_client.github_token,
                     space_name=resolved_space_name,
@@ -497,7 +504,7 @@ def push(
                         f"resource group exists.",
                         err=True,
                     )
-                    ctx.exit(1)
+                    sys.exit(1)
 
         checksum = None
         existing_registration = None

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -14,7 +14,10 @@ from tqdm import tqdm
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
 from gbcli.commands.common_options import common_options
-from gbcli.services.service_artifact import ArtifactURIError
+from gbcli.services.service_artifact import (
+    ArtifactURIError,
+    lookup_hf_resource_group_id,
+)
 from gbcli.utils.checksum import calculate_checksum_
 from gbcli.utils.gbconstants import (
     ARTIFACT_LINEAGE_DEFAULT_HEADERS,
@@ -52,10 +55,8 @@ from gbcli.utils.utils import (
     validate_tags,
 )
 from gbcli.utils.versionutil import check_current_and_latest_versions
-from gbcommon.uri.hf import HfURI
 from gbcommon.utils.hf_utils import (
     convert_hf_uri_to_url,
-    lookup_hf_resource_group_id,
     parse_hf_uri,
 )
 
@@ -483,19 +484,17 @@ def push(
                     )
                     if global_space is not None:
                         resolved_space_name = global_space.get("name")
-                rg_name = HfURI.space_name_to_resource_group_name(resolved_space_name)
                 resource_group_id = lookup_hf_resource_group_id(
+                    github_token=artifact_client.github_token,
+                    space_name=resolved_space_name,
                     organization=org,
-                    resource_group_name=rg_name,
-                    token=hf_token,
                 )
                 if not resource_group_id:
                     click.echo(
                         f"❌ Could not resolve HuggingFace resource group id for "
-                        f"space '{resolved_space_name}' (resource group name '{rg_name}') in "
-                        f"organization '{org}'. Pass --resource-group-id "
-                        f"explicitly, or ensure the resource group exists and "
-                        f"your HF token has access to it.",
+                        f"space '{resolved_space_name}' in organization '{org}'. "
+                        f"Pass --resource-group-id explicitly, or ensure the "
+                        f"resource group exists.",
                         err=True,
                     )
                     ctx.exit(1)

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -360,6 +360,29 @@ def get_artifact_uri(github_token: str, artifact_uri: str, callback=None):
         raise Exception(f"Error downloading file: {e}")
 
 
+def lookup_hf_resource_group_id(
+    github_token: str,
+    space_name: str,
+    organization: str,
+    callback=None,
+) -> Optional[str]:
+    """Resolve an HF Enterprise resource group id via gbserver."""
+    if not space_name or not organization:
+        return None
+    url = f"{GBSERVER_ARTIFACT_API}hf/resource-group"
+    try:
+        response = gb_server_request(
+            user_token=github_token,
+            url=url,
+            http_method="get",
+            body=None,
+            params={"space_name": space_name, "organization": organization},
+        )
+    except Exception:
+        return None
+    return response.get("resource_group_id") if response else None
+
+
 def get_model_lh(
     github_token: str,
     lh_token: str,

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
@@ -58,6 +59,9 @@ from gbcli.utils.utils import (
 
 if TYPE_CHECKING:
     from lakehouse.core import CopyAssetStatus
+
+
+logger = logging.getLogger(__name__)
 
 
 class ArtifactCopyResult(TypedDict):
@@ -307,6 +311,10 @@ def upload_to_hf(
         raise Exception(
             "Error: No HuggingFace organization configured. Use --hf-organization or set hf_organization in the environment config."
         )
+    if not resource_group_id:
+        raise Exception(
+            "Error: No HuggingFace resource group id provided. Pass resource_group_id explicitly or resolve it via lookup_hf_resource_group_id."
+        )
     repo_id = f"{org}/{artifact_name}"
     artifact_type_map = {
         "model": "model",
@@ -378,7 +386,13 @@ def lookup_hf_resource_group_id(
             body=None,
             params={"space_name": space_name, "organization": organization},
         )
-    except Exception:
+    except Exception as e:
+        logger.warning(
+            "Failed to look up HF resource group id for space=%s organization=%s: %s",
+            space_name,
+            organization,
+            e,
+        )
         return None
     return response.get("resource_group_id") if response else None
 

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -12,7 +12,6 @@ from gbcli.utils.gbconstants import (
     GB_DMF_USE_CLASSIC_LOADER,
     GBSERVER_ARTIFACT_API,
     HF_ORGANIZATION_DEFAULT,
-    HF_RESOURCE_GROUP_ID_DEFAULT,
     HF_REVISION_DEFAULT,
     LAKEHOUSE_FILESET_SHARED_TABLE_NAME,
     LAKEHOUSE_FILESET_TABLE_NAME,
@@ -304,7 +303,6 @@ def upload_to_hf(
     callback=None,
 ):
     org = hf_organization or HF_ORGANIZATION_DEFAULT
-    group_id = resource_group_id or HF_RESOURCE_GROUP_ID_DEFAULT
     if not org:
         raise Exception(
             "Error: No HuggingFace organization configured. Use --hf-organization or set hf_organization in the environment config."
@@ -319,7 +317,7 @@ def upload_to_hf(
     hf_type = artifact_type_map.get(type, "dataset")
     registry = HFRegistry(
         hf_token=hf_token,
-        resource_group_id=group_id,
+        resource_group_id=resource_group_id,
         organization=org,
     )
     return registry.upload_artifact(
@@ -714,9 +712,6 @@ def register_artifact_hf(
 
     if hf_organization is None:
         hf_organization = HF_ORGANIZATION_DEFAULT
-
-    if resource_group_id is None:
-        resource_group_id = HF_RESOURCE_GROUP_ID_DEFAULT
 
     payload = {
         "space_name": space_name,

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -37,7 +37,7 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "granite-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_organization": "ibm-granite",
+        "hf_organization": "ibm-research",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
                 "GBSERVER_BUILD_EVENTS", True
@@ -61,7 +61,7 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "granite-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_organization": "ibm-granite",
+        "hf_organization": "ibm-research",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
                 "GBSERVER_BUILD_EVENTS", True
@@ -85,7 +85,7 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "llm-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_organization": "ibm-granite",
+        "hf_organization": "ibm-research",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
                 "GBSERVER_BUILD_EVENTS", True
@@ -109,7 +109,7 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "llm-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_organization": "ibm-granite",
+        "hf_organization": "ibm-research",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
                 "GBSERVER_BUILD_EVENTS", True

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -37,7 +37,6 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "granite-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_resource_group_id": "69d649051d3e7b3cce6503fe",
         "hf_organization": "ibm-granite",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
@@ -62,7 +61,6 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "granite-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_resource_group_id": "69d649051d3e7b3cce6503fe",
         "hf_organization": "ibm-granite",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
@@ -87,7 +85,6 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "llm-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_resource_group_id": "69d649051d3e7b3cce6503fe",
         "hf_organization": "ibm-granite",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
@@ -112,7 +109,6 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "llm-build-prod",
         "branch_assets": "gbspace-config",
         "branch_space": "gbspace-config",
-        "hf_resource_group_id": "69d649051d3e7b3cce6503fe",
         "hf_organization": "ibm-granite",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
@@ -137,7 +133,6 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "llm-build-staging",
         "branch_assets": "gbspace-config-dev",
         "branch_space": "gbspace-config",
-        "hf_resource_group_id": "699cae1275ab75b381de01b5",
         "hf_organization": "ibm-research",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
@@ -160,7 +155,6 @@ ENVIRONMENT_CONFIGS = {
         "server_log_application_name": "llm-build-dev",
         "branch_assets": "gbspace-config-dev",
         "branch_space": "gbspace-config",
-        "hf_resource_group_id": "699cae1275ab75b381de01b5",
         "hf_organization": "ibm-research",
         "feature_flags": {
             "gbserver_build_events": getenv_boolean(
@@ -186,7 +180,6 @@ ENVIRONMENT_CONFIGS = {
         "branch_assets": "",
         "branch_space": "",
         "branch_builds": "",
-        "hf_resource_group_id": "699cae1275ab75b381de01b5",
         "hf_organization": "ibm-research",
         "feature_flags": {
             "build_start_via_github": False,
@@ -253,9 +246,6 @@ def is_standalone() -> bool:
 
 # HuggingFace defaults
 HF_ORGANIZATION_DEFAULT = gb_environment_config().get("hf_organization", "ibm-research")
-HF_RESOURCE_GROUP_ID_DEFAULT = gb_environment_config().get(
-    "hf_resource_group_id", "699cae1275ab75b381de01b5"
-)
 
 
 # gbcli
@@ -493,9 +483,6 @@ SPACE_TIMESTAMP_DELTA_HOURS = 2
 
 # HuggingFace Organization
 HF_ORGANIZATION_DEFAULT = gb_environment_config().get("hf_organization", "")
-
-# HuggingFace Resource Group ID
-HF_RESOURCE_GROUP_ID_DEFAULT = gb_environment_config().get("hf_resource_group_id", "")
 
 
 def to_int(value: str, type: str) -> str:

--- a/src/gbcli/utils/hf_registry.py
+++ b/src/gbcli/utils/hf_registry.py
@@ -46,9 +46,9 @@ class HFRegistry:
         self.resource_group_id = resource_group_id
         self.organization = organization
         logger.info(
-            "HFRegistry initialized",
-            resource_group_id=resource_group_id,
-            organization=organization,
+            "HFRegistry initialized: resource_group_id=%s organization=%s",
+            resource_group_id,
+            organization,
         )
 
     def upload_artifact(
@@ -93,11 +93,11 @@ class HFRegistry:
             )
         try:
             logger.info(
-                "uploading_to_hf",
-                repo_id=repo_id,
-                artifact_type=artifact_type,
-                local_path=str(local),
-                exist_ok=exist_ok,
+                "uploading_to_hf: repo_id=%s artifact_type=%s local_path=%s exist_ok=%s",
+                repo_id,
+                artifact_type,
+                str(local),
+                exist_ok,
             )
 
             if artifact_type == "bucket":
@@ -108,18 +108,20 @@ class HFRegistry:
                     exist_ok=exist_ok,
                 )
                 logger.info(
-                    "bucket_created_or_exists", bucket_id=repo_id, exist_ok=exist_ok
+                    "bucket_created_or_exists: bucket_id=%s exist_ok=%s",
+                    repo_id,
+                    exist_ok,
                 )
 
                 if local.is_file():
                     self.api.batch_bucket_files(
                         bucket_id=repo_id, add=[(str(local), local.name)]
                     )
-                    logger.info("bucket_file_uploaded", file=local.name)
+                    logger.info("bucket_file_uploaded: file=%s", local.name)
                 else:
                     bucket_hf_path = f"hf://buckets/{repo_id}"
                     self.api.sync_bucket(source=str(local), dest=bucket_hf_path)
-                    logger.info("bucket_folder_uploaded", folder=str(local))
+                    logger.info("bucket_folder_uploaded: folder=%s", str(local))
             else:
                 # Create repo if it doesn't exist
                 repo_url = self.api.create_repo(
@@ -130,7 +132,9 @@ class HFRegistry:
                     resource_group_id=self.resource_group_id,
                 )
                 logger.info(
-                    "repo_created_or_exists", repo_url=repo_url, exist_ok=exist_ok
+                    "repo_created_or_exists: repo_url=%s exist_ok=%s",
+                    repo_url,
+                    exist_ok,
                 )
 
                 # Ensure model card exists before uploading (for models only)
@@ -148,7 +152,9 @@ class HFRegistry:
                         commit_message=commit_message or f"Upload {local.name}",
                         revision=revision,
                     )
-                    logger.info("file_uploaded", file=local.name, revision=revision)
+                    logger.info(
+                        "file_uploaded: file=%s revision=%s", local.name, revision
+                    )
                 else:
                     # Directory upload with exclusions for .DS_Store and hidden files
                     self.api.upload_folder(

--- a/src/gbcommon/utils/hf_utils.py
+++ b/src/gbcommon/utils/hf_utils.py
@@ -1,7 +1,10 @@
 """General utility functions."""
 
-from typing import Literal
+import logging
+from typing import Literal, Optional
 from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 _ARTIFACT_TYPE_TO_SEGMENT: dict[str, str] = {
     "model": "models",
@@ -308,3 +311,27 @@ def convert_hf_uri_to_url(uri: str) -> str:
 
     else:
         raise ValueError(f"Invalid HuggingFace URI format: {uri}")
+
+
+def lookup_hf_resource_group_id(
+    organization: str, resource_group_name: str, token: Optional[str]
+) -> Optional[str]:
+    """Look up an HF Enterprise resource group id by name within an organization."""
+    if not organization or not resource_group_name:
+        return None
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils._http import get_session, hf_raise_for_status
+
+    api = HfApi(token=token)
+    try:
+        r = get_session().get(
+            f"{api.endpoint}/api/organizations/{organization}/resource-groups",
+            headers=api._build_hf_headers(),
+        )
+        hf_raise_for_status(r)
+        for group in r.json():
+            if group.get("name") == resource_group_name:
+                return group.get("id") or group.get("resourceGroupId")
+    except Exception as e:
+        logger.warning("Could not list resource groups for %s: %s", organization, e)
+    return None

--- a/src/gbcommon/utils/hf_utils.py
+++ b/src/gbcommon/utils/hf_utils.py
@@ -1,10 +1,7 @@
 """General utility functions."""
 
-import logging
-from typing import Literal, Optional
+from typing import Literal
 from urllib.parse import urlparse
-
-logger = logging.getLogger(__name__)
 
 _ARTIFACT_TYPE_TO_SEGMENT: dict[str, str] = {
     "model": "models",

--- a/src/gbcommon/utils/hf_utils.py
+++ b/src/gbcommon/utils/hf_utils.py
@@ -311,27 +311,3 @@ def convert_hf_uri_to_url(uri: str) -> str:
 
     else:
         raise ValueError(f"Invalid HuggingFace URI format: {uri}")
-
-
-def lookup_hf_resource_group_id(
-    organization: str, resource_group_name: str, token: Optional[str]
-) -> Optional[str]:
-    """Look up an HF Enterprise resource group id by name within an organization."""
-    if not organization or not resource_group_name:
-        return None
-    from huggingface_hub import HfApi
-    from huggingface_hub.utils._http import get_session, hf_raise_for_status
-
-    api = HfApi(token=token)
-    try:
-        r = get_session().get(
-            f"{api.endpoint}/api/organizations/{organization}/resource-groups",
-            headers=api._build_hf_headers(),
-        )
-        hf_raise_for_status(r)
-        for group in r.json():
-            if group.get("name") == resource_group_name:
-                return group.get("id") or group.get("resourceGroupId")
-    except Exception as e:
-        logger.warning("Could not list resource groups for %s: %s", organization, e)
-    return None


### PR DESCRIPTION
## Description

  - Removes the hardcoded hf_resource_group_id from per-environment configs and the HF_RESOURCE_GROUP_ID_DEFAULT constant.
  - On artifact push, when --resource-group-id is not provided, the CLI now resolves it from the GB space name and HF organization via a new hf/resource-group gbserver endpoint (lookup_hf_resource_group_id). Fails
  with a clear error if it can't be resolved.
  - update hf_organization form ibm-granite to ibm-research
Example:
`gb artifact push --from-local ~/Downloads/tmp/model-test  --artifact-name model-test0522 --type model --certify-no-restrictions --store hf`
<img width="929" height="230" alt="image" src="https://github.com/user-attachments/assets/95bba983-40d9-4898-82a2-3955f60a6480" />

