### PR TITLE
Unify environment configuration into gbcommon

### DIFF
--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -90,8 +90,8 @@ from gbcli.services.service_version import get_gbserver_version
 from gbcli.utils.gbconstants import (
     USER_NOT_LOGGED_IN_ERROR_MESSAGE,
     hf_token,
-    is_standalone,
 )
+from gbcommon.types.gbenvconfig import is_standalone
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.gh_auth import get_user
 

--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -91,9 +91,9 @@ from gbcli.utils.gbconstants import (
     USER_NOT_LOGGED_IN_ERROR_MESSAGE,
     hf_token,
 )
-from gbcommon.types.gbenvconfig import is_standalone
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.gh_auth import get_user
+from gbcommon.types.gbenvconfig import is_standalone
 
 
 class GBClient:

--- a/src/gbcli/commands/command_auth.py
+++ b/src/gbcli/commands/command_auth.py
@@ -9,7 +9,8 @@ from requests.exceptions import ConnectionError
 
 from gbcli.client import GBClient
 from gbcli.utils.click_utils import FileOrStringParamType
-from gbcli.utils.gbconstants import PROJECT_NAME, is_standalone
+from gbcli.utils.gbconstants import PROJECT_NAME
+from gbcommon.types.gbenvconfig import is_standalone
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.utils import check_runnable_browser
 from gbcommon.types.constants import get_gh_credentials_section

--- a/src/gbcli/commands/command_auth.py
+++ b/src/gbcli/commands/command_auth.py
@@ -10,10 +10,10 @@ from requests.exceptions import ConnectionError
 from gbcli.client import GBClient
 from gbcli.utils.click_utils import FileOrStringParamType
 from gbcli.utils.gbconstants import PROJECT_NAME
-from gbcommon.types.gbenvconfig import is_standalone
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.utils import check_runnable_browser
 from gbcommon.types.constants import get_gh_credentials_section
+from gbcommon.types.gbenvconfig import is_standalone
 
 # Maps user-facing provider names to internal credential keys.
 # Multiple synonyms may map to the same internal value.

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -34,8 +34,8 @@ from gbcli.utils.gbconstants import (
     CLIPBOARD_CHAR,
     DMF_URL,
     PROJECT_NAME,
-    is_standalone,
 )
+from gbcommon.types.gbenvconfig import is_standalone
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.lh_auth import AuthException
 from gbcli.utils.utils import (

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -35,7 +35,6 @@ from gbcli.utils.gbconstants import (
     DMF_URL,
     PROJECT_NAME,
 )
-from gbcommon.types.gbenvconfig import is_standalone
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.lh_auth import AuthException
 from gbcli.utils.utils import (
@@ -54,6 +53,7 @@ from gbcli.utils.utils import (
     validate_tags,
 )
 from gbcli.utils.versionutil import check_current_and_latest_versions
+from gbcommon.types.gbenvconfig import is_standalone
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/services/service_admin.py
+++ b/src/gbcli/services/service_admin.py
@@ -8,8 +8,8 @@ from gbcli.utils.gbconstants import (
     BUILD_LOGALL_PAGE_SIZE,
     GBSERVER_BUILD_API,
     PROJECT_NAME,
-    gb_environment_config,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gbserver import get_builds, make_gbserver_call
 from gbcli.utils.log_query import run_logquery
 from gbcli.utils.spaceutil import resolve_space
@@ -91,7 +91,7 @@ def server_log(
             },
         )
 
-    application_name = gb_environment_config()["server_log_application_name"]
+    application_name = gb_environment_config().server_log_application_name
 
     if not all or follow:
         if all:

--- a/src/gbcli/services/service_admin.py
+++ b/src/gbcli/services/service_admin.py
@@ -9,7 +9,6 @@ from gbcli.utils.gbconstants import (
     GBSERVER_BUILD_API,
     PROJECT_NAME,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gbserver import get_builds, make_gbserver_call
 from gbcli.utils.log_query import run_logquery
 from gbcli.utils.spaceutil import resolve_space
@@ -19,6 +18,7 @@ from gbcli.utils.utils import (
     convert_milliseconds_to_seconds,
     get_current_epoch,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -22,8 +22,8 @@ from gbcli.utils.gbconstants import (
     REVISION_DEFAULT,
     SPACE_DEFAULT_NAME,
     USER_NOT_LOGGED_IN_ERROR_MESSAGE,
-    gb_environment_config,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gbserver import (
     archive_artifact,
     gb_server_request,
@@ -818,7 +818,7 @@ def register_artifact_gbserver_hf(
     if not github_token:
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)
 
-    env = env if env else str(gb_environment_config()["lakehouse_environment"]).lower()
+    env = env if env else str(gb_environment_config().lakehouse_environment).lower()
 
     if revision is None:
         revision = HF_REVISION_DEFAULT
@@ -879,7 +879,7 @@ def register_artifact_gbserver(
     lh_env = (
         lh_env
         if lh_env
-        else str(gb_environment_config()["lakehouse_environment"]).lower()
+        else str(gb_environment_config().lakehouse_environment).lower()
     )
 
     if namespace is None:
@@ -1028,7 +1028,7 @@ def artifact_list(
         )
 
     gbserver_username = None if list_all else username
-    gbserver_artifact_filter = gb_environment_config()["feature_flags"][
+    gbserver_artifact_filter = gb_environment_config().feature_flags[
         "gbserver_artifact_filter"
     ]
     if gbserver_artifact_filter:

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -23,7 +23,6 @@ from gbcli.utils.gbconstants import (
     SPACE_DEFAULT_NAME,
     USER_NOT_LOGGED_IN_ERROR_MESSAGE,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gbserver import (
     archive_artifact,
     gb_server_request,
@@ -56,6 +55,7 @@ from gbcli.utils.utils import (
     read_lines,
     remove_suffix,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 
 if TYPE_CHECKING:
     from lakehouse.core import CopyAssetStatus
@@ -877,9 +877,7 @@ def register_artifact_gbserver(
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)
 
     lh_env = (
-        lh_env
-        if lh_env
-        else str(gb_environment_config().lakehouse_environment).lower()
+        lh_env if lh_env else str(gb_environment_config().lakehouse_environment).lower()
     )
 
     if namespace is None:

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -47,9 +47,8 @@ from gbcli.utils.gbconstants import (
     USER_NOT_LOGGED_IN_ERROR_MESSAGE,
     VPN_CONNECTION_ERROR_MESSAGE,
     gb_environment,
-    gb_environment_config,
-    is_standalone,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config, is_standalone
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.gbserver import (
     cancel_build,
@@ -208,7 +207,7 @@ def build_init(
 
     else:
         # from a template
-        branch_name = gb_environment_config()["branch_space"]
+        branch_name = gb_environment_config().space_config_branch_name
         if space:
             template_repo = resolved_space.get("git_repo_uri")
         elif template_repo != None:
@@ -228,7 +227,7 @@ def build_init(
                     branch_name = template_repo_split[1]
         else:
             template_repo = ASSETS_REPO_URL
-            branch_name = gb_environment_config()["branch_assets"]
+            branch_name = gb_environment_config().branch_assets
 
         if callback:
             time.sleep(1)
@@ -282,7 +281,7 @@ def build_start(
     validation_type: str = "static",
 ) -> str:
 
-    gbserver_build_update = gb_environment_config()["feature_flags"][
+    gbserver_build_update = gb_environment_config().feature_flags[
         "gbserver_build_update"
     ]
     if gbserver_build_update == False:
@@ -891,7 +890,7 @@ def build_list(
 
     gbserver_username = None if list_all else username
 
-    gbserver_build_update = gb_environment_config()["feature_flags"][
+    gbserver_build_update = gb_environment_config().feature_flags[
         "gbserver_build_update"
     ]
     if gbserver_build_update == False:
@@ -1178,7 +1177,7 @@ def build_log(
         )
 
     application_name = (
-        gb_environment_config()["server_log_application_name"] if runner else None
+        gb_environment_config().server_log_application_name if runner else None
     )
 
     if not all or follow:
@@ -1298,7 +1297,7 @@ def build_status(
     result_format: str,
     callback=None,
 ) -> List[Any]:
-    gbserver_build_events = gb_environment_config()["feature_flags"][
+    gbserver_build_events = gb_environment_config().feature_flags[
         "gbserver_build_events"
     ]
 
@@ -1654,7 +1653,7 @@ def build_monitor(
     id_format: Optional[str] = None,
     callback=None,
 ) -> Tuple[Any, List[Any], List[Any], List[Any]]:
-    gbserver_build_events = gb_environment_config()["feature_flags"][
+    gbserver_build_events = gb_environment_config().feature_flags[
         "gbserver_build_events"
     ]
 
@@ -2870,7 +2869,7 @@ def update_build(
     if append and tags is not None and len(tags) == 0:
         raise ValueError("--append cannot be used with empty tags")
 
-    gbserver_build_update = gb_environment_config()["feature_flags"][
+    gbserver_build_update = gb_environment_config().feature_flags[
         "gbserver_build_update"
     ]
     if gbserver_build_update == False:

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -48,7 +48,6 @@ from gbcli.utils.gbconstants import (
     VPN_CONNECTION_ERROR_MESSAGE,
     gb_environment,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config, is_standalone
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.gbserver import (
     cancel_build,
@@ -90,6 +89,7 @@ from gbcli.utils.utils import (
 )
 from gbcommon.types.buildconfig import BuildConfig
 from gbcommon.types.constants import BUILD_YAML_BASE_KEYS, DEFAULT_GH_DOMAIN
+from gbcommon.types.gbenvconfig import gb_environment_config, is_standalone
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/services/service_step.py
+++ b/src/gbcli/services/service_step.py
@@ -10,8 +10,8 @@ from gbcli.utils.gbconstants import (
     STEP_FILENAME,
     STEP_README_FILENAME,
     STEPS_REPO_FOLDER,
-    gb_environment_config,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gh_clone import download_repo_file, list_repo_tree
 from gbcli.utils.spaceutil import resolve_space
 from gbcli.utils.utils import parse_markdown_str, remove_suffix
@@ -33,7 +33,7 @@ def list_steps(
     callback=None,
 ) -> List[Any]:
 
-    branch_name = gb_environment_config()["branch_space"]
+    branch_name = gb_environment_config().space_config_branch_name
     if space:
         s = resolve_space(github_token, space, callback)
         step_repo = s["git_repo_uri"] if s is not None else None
@@ -55,7 +55,7 @@ def list_steps(
                 branch_name = step_repo_split[1]
     else:
         step_repo = ASSETS_REPO_URL
-        branch_name = gb_environment_config()["branch_assets"]
+        branch_name = gb_environment_config().branch_assets
 
     if callback is not None:
         callback(
@@ -146,7 +146,7 @@ def describe_step(
     space: Optional[str] = None,
     callback=None,
 ) -> Any:
-    branch_name = gb_environment_config()["branch_space"]
+    branch_name = gb_environment_config().space_config_branch_name
     if space:
         s = resolve_space(github_token, space, callback)
         step_repo = s["git_repo_uri"] if s is not None else None
@@ -168,7 +168,7 @@ def describe_step(
                 branch_name = step_repo_split[1]
     else:
         step_repo = ASSETS_REPO_URL
-        branch_name = gb_environment_config()["branch_assets"]
+        branch_name = gb_environment_config().branch_assets
 
     steps_org, steps_name = step_repo.split("/")[3:]
     steps_name = remove_suffix(steps_name, ".git")

--- a/src/gbcli/services/service_step.py
+++ b/src/gbcli/services/service_step.py
@@ -11,11 +11,11 @@ from gbcli.utils.gbconstants import (
     STEP_README_FILENAME,
     STEPS_REPO_FOLDER,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gh_clone import download_repo_file, list_repo_tree
 from gbcli.utils.spaceutil import resolve_space
 from gbcli.utils.utils import parse_markdown_str, remove_suffix
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcommon.types.stepconfig import (
     StepConfig,
     StepEnvironmentTypeConfig,

--- a/src/gbcli/services/service_template.py
+++ b/src/gbcli/services/service_template.py
@@ -10,11 +10,11 @@ from gbcli.utils.gbconstants import (
     BUILD_FILENAME,
     TEMPLATES_REPO_FOLDER,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gh_clone import download_repo_file, list_repo_tree
 from gbcli.utils.spaceutil import resolve_space
 from gbcli.utils.utils import remove_suffix
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN
+from gbcommon.types.gbenvconfig import gb_environment_config
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/services/service_template.py
+++ b/src/gbcli/services/service_template.py
@@ -9,8 +9,8 @@ from gbcli.utils.gbconstants import (
     ASSETS_REPO_URL,
     BUILD_FILENAME,
     TEMPLATES_REPO_FOLDER,
-    gb_environment_config,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gh_clone import download_repo_file, list_repo_tree
 from gbcli.utils.spaceutil import resolve_space
 from gbcli.utils.utils import remove_suffix
@@ -38,9 +38,9 @@ def list_templates(
                 )
             return None
         template_repo = global_space.get("git_repo_uri")
-        branch_name = gb_environment_config()["branch_space"]
+        branch_name = gb_environment_config().space_config_branch_name
     elif template_repo != None:
-        branch_name = gb_environment_config()["branch_space"]
+        branch_name = gb_environment_config().space_config_branch_name
         if "@" in template_repo:
             template_repo_split = template_repo.split("@", 1)
             template_repo = template_repo_split[0]
@@ -48,7 +48,7 @@ def list_templates(
                 branch_name = template_repo_split[1]
     else:
         template_repo = ASSETS_REPO_URL
-        branch_name = gb_environment_config()["branch_assets"]
+        branch_name = gb_environment_config().branch_assets
 
     if callback is not None:
         callback(
@@ -112,9 +112,9 @@ def describe_template(
                 )
             return None
         template_repo = global_space.get("git_repo_uri")
-        branch_name = gb_environment_config()["branch_space"]
+        branch_name = gb_environment_config().space_config_branch_name
     elif template_repo != None:
-        branch_name = gb_environment_config()["branch_space"]
+        branch_name = gb_environment_config().space_config_branch_name
         if "@" in template_repo:
             template_repo_split = template_repo.split("@", 1)
             template_repo = template_repo_split[0]
@@ -122,7 +122,7 @@ def describe_template(
                 branch_name = template_repo_split[1]
     else:
         template_repo = ASSETS_REPO_URL
-        branch_name = gb_environment_config()["branch_assets"]
+        branch_name = gb_environment_config().branch_assets
 
     assets_org, assets_name = template_repo.split("/")[3:]
     assets_name = remove_suffix(assets_name, ".git")

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -8,213 +8,27 @@ import sys
 from sys import platform
 
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN, is_public_github
+from gbcommon.types.gbenvconfig import (
+    gb_env_normalize,
+    gb_environment_config,
+    getenv_boolean,
+)
 
 logger = logging.getLogger(__name__)
 
 PROJECT_NAME = "LLM.build"
 
 
-def getenv_boolean(envname: str, default: bool = False) -> bool:
-    """Evaluate the environment variable and return as a boolean value"""
-    value = os.getenv(envname)
-    if value is None:
-        return default
-    value_normalized = str(value).lower()
-    return not value_normalized in ["false", "null", "undefined", "no", "0", ""]
-
-
 # environments
 GB_ENVIRONMENT_DEFAULT = "PROD"
-ENVIRONMENT_CONFIGS = {
-    "PROD_OLD": {
-        "env": "PROD_OLD",
-        "lakehouse_environment": "PROD",
-        "gbserver_host": "https://granite-build-prod.bx.cloud9.ibm.com",
-        "default_space": "public",
-        "dmf_ui": "https://ui.dmf.vpc-int.res.ibm.com",
-        "config_spaces": "gb.spaces",
-        "config_profile": "gb.spaces.profiles",
-        "server_log_application_name": "granite-build-prod",
-        "branch_assets": "gbspace-config",
-        "branch_space": "gbspace-config",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "gbserver_build_events": getenv_boolean(
-                "GBSERVER_BUILD_EVENTS", True
-            ),  # Default false
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean(
-                "GBSERVER_BUILD_UPDATE", True
-            ),  # Default false
-        },
-    },
-    "PROD_INTERNAL_OLD": {
-        "env": "PROD_INTERNAL_OLD",
-        "lakehouse_environment": "PROD",
-        "gbserver_host": "https://granite-build-prod.ris3-int-dal12-ocp-9ca4d14d48413d18ce61b80811ba4308-0000.us-south.containers.appdomain.cloud",
-        "default_space": "public",
-        "dmf_ui": "https://ui.dmf.vpc-int.res.ibm.com",
-        "config_spaces": "gb.spaces",
-        "config_profile": "gb.spaces.profiles",
-        "server_log_application_name": "granite-build-prod",
-        "branch_assets": "gbspace-config",
-        "branch_space": "gbspace-config",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "gbserver_build_events": getenv_boolean(
-                "GBSERVER_BUILD_EVENTS", True
-            ),  # Default false
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean(
-                "GBSERVER_BUILD_UPDATE", True
-            ),  # Default false
-        },
-    },
-    "PROD": {
-        "env": "PROD",
-        "lakehouse_environment": "PROD",
-        "gbserver_host": "https://api.llm-build-prod.vpc-int.res.ibm.com",
-        "default_space": "public",
-        "dmf_ui": "https://ui.dmf.vpc-int.res.ibm.com",
-        "config_spaces": "gb.spaces",
-        "config_profile": "gb.spaces.profiles",
-        "server_log_application_name": "llm-build-prod",
-        "branch_assets": "gbspace-config",
-        "branch_space": "gbspace-config",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "gbserver_build_events": getenv_boolean(
-                "GBSERVER_BUILD_EVENTS", True
-            ),  # Default false
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean(
-                "GBSERVER_BUILD_UPDATE", True
-            ),  # Default false
-        },
-    },
-    "PROD_INTERNAL": {
-        "env": "PROD_INTERNAL",
-        "lakehouse_environment": "PROD",
-        "gbserver_host": "https://api.llm-build-prod.vpc-int.res.ibm.com",
-        "default_space": "public",
-        "dmf_ui": "https://ui.dmf.vpc-int.res.ibm.com",
-        "config_spaces": "gb.spaces",
-        "config_profile": "gb.spaces.profiles",
-        "server_log_application_name": "llm-build-prod",
-        "branch_assets": "gbspace-config",
-        "branch_space": "gbspace-config",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "gbserver_build_events": getenv_boolean(
-                "GBSERVER_BUILD_EVENTS", True
-            ),  # Default false
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean(
-                "GBSERVER_BUILD_UPDATE", True
-            ),  # Default false
-        },
-    },
-    "STAGING": {
-        "env": "STAGING",
-        "lakehouse_environment": "STAGING",
-        "gbserver_host": "https://api.llm-build-staging.vpc-int.res.ibm.com",
-        "default_space": "public",
-        "dmf_ui": "https://ui.dmf-staging.vpc-int.res.ibm.com",
-        "config_spaces": "staging.gb.spaces",
-        "config_profile": "staging.gb.spaces.profiles",
-        "server_log_application_name": "llm-build-staging",
-        "branch_assets": "gbspace-config-dev",
-        "branch_space": "gbspace-config",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "gbserver_build_events": getenv_boolean(
-                "GBSERVER_BUILD_EVENTS", True
-            ),  # Default false
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
-        },
-    },
-    "DEV": {
-        "env": "DEV",
-        "lakehouse_environment": "STAGING",
-        "gbserver_host": "https://api.llm-build-dev.vpc-int.res.ibm.com",
-        "default_space": "public",
-        "dmf_ui": "https://ui2.dmf-staging.vpc-int.res.ibm.com",
-        "config_spaces": "dev.gb.spaces",
-        "config_profile": "dev.gb.spaces.profiles",
-        "server_log_application_name": "llm-build-dev",
-        "branch_assets": "gbspace-config-dev",
-        "branch_space": "gbspace-config",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "gbserver_build_events": getenv_boolean(
-                "GBSERVER_BUILD_EVENTS", True
-            ),  # Default false
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),  # Default false
-            "gbserver_build_update": getenv_boolean(
-                "GBSERVER_BUILD_UPDATE", True
-            ),  # Default false
-        },
-    },
-    "STANDALONE": {
-        "env": "STANDALONE",
-        "lakehouse_environment": "",
-        "gbserver_host": os.environ.get("GBSERVER_HOST", "http://localhost:8080"),
-        "default_space": "standalone",
-        "dmf_ui": "",
-        "config_spaces": "",
-        "config_profile": "",
-        "server_log_application_name": "gbserver-standalone",
-        "branch_assets": "",
-        "branch_space": "",
-        "branch_builds": "",
-        "hf_organization": "ibm-research",
-        "feature_flags": {
-            "build_start_via_github": False,
-            "gbserver_build_events": True,
-            "gbserver_artifact_filter": False,
-            "gbserver_build_update": True,
-        },
-    },
-}
 
 
 def gb_env_formating(value: str, type: str) -> str:
-    if value:
-        if value.lower() == "prod" or value.lower() == "production":
-            return "PROD"
-        elif value.lower() == "prod_internal" or value.lower() == "production_internal":
-            return "PROD_INTERNAL"
-        elif value.lower() == "staging":
-            return "STAGING"
-        elif value.lower() == "dev" or value.lower() == "development":
-            return "DEV"
-        elif value.lower() == "prod_old" or value.lower() == "production_old":
-            return "PROD_OLD"
-        elif (
-            value.lower() == "prod_internal_old"
-            or value.lower() == "production_internal_old"
-        ):
-            return "PROD_INTERNAL_OLD"
-        elif value.lower() == "standalone" or value.lower() == "local":
-            return "STANDALONE"
-
-        else:
-            sys.exit(f"Error: {type} has invalid value '{value}'")
-
-    return None
+    """Normalize env name with sys.exit on invalid input (CLI behavior)."""
+    try:
+        return gb_env_normalize(value, type)
+    except ValueError as e:
+        sys.exit(str(e))
 
 
 def gb_environment() -> str:
@@ -234,19 +48,8 @@ def hf_token() -> str:
     return HF_TOKEN
 
 
-def gb_environment_config(gb_env=None):
-    if gb_env is None:
-        gb_env = gb_environment()
-    return ENVIRONMENT_CONFIGS[gb_env]
-
-
-def is_standalone() -> bool:
-    return gb_environment() == "STANDALONE"
-
-
 # HuggingFace defaults
-HF_ORGANIZATION_DEFAULT = gb_environment_config().get("hf_organization", "ibm-research")
-
+HF_ORGANIZATION_DEFAULT = gb_environment_config().hf_organization or "ibm-research"
 
 # gbcli
 _GBCLI_REPO_ORG = "ibm-granite" if is_public_github() else "granite-dot-build"
@@ -312,14 +115,13 @@ RITS_TEMP = 1.0
 RITS_TOP_P = 0.7
 
 # Lakehouse
-LAKEHOUSE_ENVIRONMENT = gb_environment_config()["lakehouse_environment"]
+LAKEHOUSE_ENVIRONMENT = gb_environment_config().lakehouse_environment
 LAKEHOUSE_NAMESPACE = "granite_dot_build.public"
 LAKEHOUSE_MODEL_SHARED_TABLE = "model_shared"
 LAKEHOUSE_MODEL_TABLE = "model"
 LAKEHOUSE_FILESET_SHARED_TABLE_NAME = "fileset_shared"
 LAKEHOUSE_FILESET_TABLE_NAME = "fileset"
 REVISION_DEFAULT = "granite-dot-build"
-LAKEHOUSE_FILESET_TABLE_NAME = "fileset"
 HF_REVISION_DEFAULT = "main"
 GB_DMF_USE_CLASSIC_LOADER = getenv_boolean(
     "GB_DMF_USE_CLASSIC_LOADER", False
@@ -329,7 +131,7 @@ GB_DMF_LOADER_SIZE_LIMIT = 1073741824  # 1GB limit
 
 # GBServer
 GBSERVER_INSTANCE = os.environ.get(
-    "GBSERVER_HOST", gb_environment_config()["gbserver_host"]
+    "GBSERVER_HOST", gb_environment_config().gbserver_host
 )
 GBSERVER_BUILD_API = f"{GBSERVER_INSTANCE}/api/v1/builds/"
 GBSERVER_ARTIFACT_API = f"{GBSERVER_INSTANCE}/api/v1/artifacts/"
@@ -362,7 +164,7 @@ For any help on how to use each option in more details see `llmb artifact push -
 
 
 # DMF
-DMF_URL = gb_environment_config()["dmf_ui"]
+DMF_URL = gb_environment_config().dmf_ui
 
 # for tabulate
 ARTIFACT_LINEAGE_DEFAULT_HEADERS = [
@@ -398,20 +200,6 @@ ARTIFACT_LINEAGE_FULL_HEADERS = [
     "JOB_OUTPUT_STATS",
 ]
 
-# ARTIFACT_LIST_HEADERS = [
-#     "UUID",
-#     "NAME",
-#     "URI",
-#     "TYPE",
-#     "CREATED_BY_BUILD_ID",
-#     "CREATED_BY_STEP_ID",
-#     "SPACE_NAME",
-#     "USERNAME",
-#     "LINEAGE_HASH",
-#     "CREATED_AT",
-#     "METADATA",
-#     "TAGS",
-# ]
 ARTIFACT_LIST_HEADERS = [
     "UUID",
     "NAME",
@@ -480,9 +268,6 @@ SECRET_SPACE_ADMIN_ERROR = "Only space admin can perform this operation. Run 'll
 
 # time delta for comparison against saved timestamp
 SPACE_TIMESTAMP_DELTA_HOURS = 2
-
-# HuggingFace Organization
-HF_ORGANIZATION_DEFAULT = gb_environment_config().get("hf_organization", "")
 
 
 def to_int(value: str, type: str) -> str:

--- a/src/gbcli/utils/gbcredentials.py
+++ b/src/gbcli/utils/gbcredentials.py
@@ -11,8 +11,8 @@ from toml import TomlDecodeError
 
 from gbcli.utils.cli_config import get_local_gb_config
 from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE
-from gbcommon.types.gbenvconfig import is_standalone
 from gbcommon.types.constants import get_gh_api_base, get_gh_credentials_section
+from gbcommon.types.gbenvconfig import is_standalone
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/utils/gbcredentials.py
+++ b/src/gbcli/utils/gbcredentials.py
@@ -10,7 +10,8 @@ from requests.exceptions import ConnectionError
 from toml import TomlDecodeError
 
 from gbcli.utils.cli_config import get_local_gb_config
-from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE, is_standalone
+from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE
+from gbcommon.types.gbenvconfig import is_standalone
 from gbcommon.types.constants import get_gh_api_base, get_gh_credentials_section
 
 logger = logging.getLogger(__name__)

--- a/src/gbcli/utils/gbserver.py
+++ b/src/gbcli/utils/gbserver.py
@@ -8,8 +8,8 @@ from requests.exceptions import ConnectionError
 from gbcli.utils.gbconstants import (
     GBSERVER_SPACES_API,
     VPN_CONNECTION_ERROR_MESSAGE,
-    is_standalone,
 )
+from gbcommon.types.gbenvconfig import is_standalone
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/utils/gh_auth.py
+++ b/src/gbcli/utils/gh_auth.py
@@ -117,7 +117,7 @@ def get_token_using_device_code(
 def get_user(token: str) -> UserInfoResponse:
     import os
 
-    from gbcli.utils.gbconstants import is_standalone
+    from gbcommon.types.gbenvconfig import is_standalone
     from gbcli.utils.gbcredentials import GBCredentials
 
     if is_standalone():

--- a/src/gbcli/utils/gh_auth.py
+++ b/src/gbcli/utils/gh_auth.py
@@ -117,8 +117,8 @@ def get_token_using_device_code(
 def get_user(token: str) -> UserInfoResponse:
     import os
 
-    from gbcommon.types.gbenvconfig import is_standalone
     from gbcli.utils.gbcredentials import GBCredentials
+    from gbcommon.types.gbenvconfig import is_standalone
 
     if is_standalone():
         creds = GBCredentials()

--- a/src/gbcli/utils/spaceutil.py
+++ b/src/gbcli/utils/spaceutil.py
@@ -4,9 +4,8 @@ from datetime import datetime, timedelta
 from gbcli.utils.gbconstants import (
     SPACE_TIMESTAMP_DELTA_HOURS,
     gb_environment,
-    gb_environment_config,
-    is_standalone,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config, is_standalone
 from gbcli.utils.gbcredentials import (
     ConfigLockException,
     GBConfig,
@@ -75,7 +74,7 @@ def resolve_space(github_token: str, space=None, callback=None):
     # Resolve space by name without going through the profile layer.
     if is_standalone():
         space_name = (
-            gb_environment_config()["default_space"]
+            gb_environment_config().default_space
             if (not space or space == "default")
             else space
         )
@@ -92,7 +91,7 @@ def resolve_space(github_token: str, space=None, callback=None):
             )
         return found_space
 
-    config_profile_name = gb_environment_config()["config_profile"]
+    config_profile_name = gb_environment_config().config_profile
     if config_profile_name:
         gbconfig = GBConfig()
         config_profile = gbconfig.get_section(config_profile_name)
@@ -169,7 +168,7 @@ def save_new_spaces(remote_spaces, callback=None):
     # Saving the remote space list in the config file
     gbconfig = GBConfig()
 
-    space_section = gb_environment_config()["config_spaces"]
+    space_section = gb_environment_config().config_spaces
     gbconfig.set(
         "expiration_timestamp",
         expiration_timestamp,
@@ -207,7 +206,7 @@ def get_spaces(github_token: str, callback=None):
 
     try:
         gbconfig = GBConfig()
-        config_spaces_name = gb_environment_config()["config_spaces"]
+        config_spaces_name = gb_environment_config().config_spaces
         spaces = gbconfig.get("spaces", config_spaces_name)
         expiration_timestamp = gbconfig.get("expiration_timestamp", config_spaces_name)
         if not spaces:
@@ -236,7 +235,7 @@ def get_profile(profile_name="default"):
     try:
         format_profile_check()
         gbconfig = GBConfig()
-        config_profile_name = gb_environment_config()["config_profile"]
+        config_profile_name = gb_environment_config().config_profile
         profile_arr = gbconfig.get_section(config_profile_name)
         profile = next(
             (profile for profile in profile_arr if profile.get("name") == profile_name),
@@ -255,7 +254,7 @@ def save_profile(space_key: str, space_name: str, profile_name="default"):
     format_profile_check()
     profile_space = "profiles"
     gbconfig = GBConfig()
-    config_spaces = gb_environment_config()["config_spaces"]
+    config_spaces = gb_environment_config().config_spaces
     space_profiles = gbconfig.get(profile_space, config_spaces)
     for profile in space_profiles:
         if profile.get("name") == profile_name:
@@ -269,7 +268,7 @@ def save_profile(space_key: str, space_name: str, profile_name="default"):
 def format_profile_check():
     profile_space = "profiles"
     gbconfig = GBConfig()
-    config_section = gb_environment_config()["config_spaces"]
+    config_section = gb_environment_config().config_spaces
     space_profiles = gbconfig.get(profile_space, config_section)
 
     # confirm if existing_space_profiles is an array or does not exist

--- a/src/gbcli/utils/spaceutil.py
+++ b/src/gbcli/utils/spaceutil.py
@@ -5,12 +5,12 @@ from gbcli.utils.gbconstants import (
     SPACE_TIMESTAMP_DELTA_HOURS,
     gb_environment,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config, is_standalone
 from gbcli.utils.gbcredentials import (
     ConfigLockException,
     GBConfig,
 )
 from gbcli.utils.gbserver import get_remote_spaces
+from gbcommon.types.gbenvconfig import gb_environment_config, is_standalone
 
 logger = logging.getLogger(__name__)
 

--- a/src/gbcli/utils/utils.py
+++ b/src/gbcli/utils/utils.py
@@ -42,8 +42,8 @@ from gbcli.utils.gbconstants import (
     GBSERVER_ARTIFACT_API,
     SPACE_REPO_NAME,
     SPACE_REPO_ORG,
-    gb_environment_config,
 )
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gbserver import get_artifacts, make_gbserver_call
 from gbcli.utils.gh_auth import get_user
 from gbcli.utils.spaceutil import resolve_space
@@ -344,7 +344,7 @@ def decode_uri(
 def compare_env_uri(uri: str):
     return (
         uri.split("/")[2],
-        str(gb_environment_config()["lakehouse_environment"]).lower(),
+        str(gb_environment_config().lakehouse_environment).lower(),
     )
 
 
@@ -628,7 +628,7 @@ def get_artifact_uuid(github_token: str, uri: str, callback=None):
 def get_build_lineage_url(build_id: str):
     url = f"{DMF_URL}/gb/builds/{build_id}"
 
-    if gb_environment_config()["env"] == "DEV":
+    if gb_environment_config().env == "DEV":
         url = url + "?gb_environment=DEV"
 
     return url

--- a/src/gbcli/utils/utils.py
+++ b/src/gbcli/utils/utils.py
@@ -43,11 +43,11 @@ from gbcli.utils.gbconstants import (
     SPACE_REPO_NAME,
     SPACE_REPO_ORG,
 )
-from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcli.utils.gbserver import get_artifacts, make_gbserver_call
 from gbcli.utils.gh_auth import get_user
 from gbcli.utils.spaceutil import resolve_space
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN
+from gbcommon.types.gbenvconfig import gb_environment_config
 from gbcommon.uri.lh import LhURI
 from gbcommon.uri.uri import URI
 

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -117,7 +117,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         hf_organization="ibm-research",
         feature_flags={
             "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
-            "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+            "gbserver_artifact_filter": getenv_boolean(
+                "GBSERVER_ARTIFACT_FILTER", True
+            ),
             "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
         },
         # gbserver
@@ -125,7 +127,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public",
         public_space_lh_subnamespace="public",
         buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=os.getenv("GBSERVER_BACKEND_SERVER_NAMESPACE_PROD", "llm-build-prod"),
+        default_pod_namespace=os.getenv(
+            "GBSERVER_BACKEND_SERVER_NAMESPACE_PROD", "llm-build-prod"
+        ),
         default_sql_schema="granite_dot_build_prod",
     ),
     "STAGING": GBEnvConfig(
@@ -143,7 +147,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         hf_organization="ibm-research",
         feature_flags={
             "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
-            "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+            "gbserver_artifact_filter": getenv_boolean(
+                "GBSERVER_ARTIFACT_FILTER", True
+            ),
             "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
         },
         # gbserver
@@ -151,7 +157,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gb-test",
         public_space_lh_subnamespace="public",
         buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=os.getenv("GBSERVER_BACKEND_SERVER_NAMESPACE_STAGING", "llm-build-staging"),
+        default_pod_namespace=os.getenv(
+            "GBSERVER_BACKEND_SERVER_NAMESPACE_STAGING", "llm-build-staging"
+        ),
         default_sql_schema="granite_dot_build_staging",
     ),
     "DEV": GBEnvConfig(
@@ -169,7 +177,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         hf_organization="ibm-research",
         feature_flags={
             "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
-            "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+            "gbserver_artifact_filter": getenv_boolean(
+                "GBSERVER_ARTIFACT_FILTER", True
+            ),
             "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
         },
         # gbserver
@@ -177,7 +187,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public-dev",
         public_space_lh_subnamespace="public_dev",
         buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=os.getenv("GBSERVER_BACKEND_SERVER_NAMESPACE_DEV", "llm-build-dev"),
+        default_pod_namespace=os.getenv(
+            "GBSERVER_BACKEND_SERVER_NAMESPACE_DEV", "llm-build-dev"
+        ),
         default_sql_schema="granite_dot_build_dev",
     ),
     "STANDALONE": GBEnvConfig(
@@ -243,7 +255,9 @@ def gb_environment_config(gb_env: Optional[str] = None) -> GBEnvConfig:
         gb_env = gb_environment()
     if gb_env not in _GB_ENVIRONMENT_CONFIGS:
         valid_keys = list(_GB_ENVIRONMENT_CONFIGS.keys())
-        raise ValueError(f"unknown GB environment: {gb_env}, expected one of {valid_keys}")
+        raise ValueError(
+            f"unknown GB environment: {gb_env}, expected one of {valid_keys}"
+        )
     return _GB_ENVIRONMENT_CONFIGS[gb_env]
 
 

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified environment configuration for GB (gbcli + gbserver)."""
+
+import os
+from typing import Any, Dict, Optional, Self
+
+from pydantic import BaseModel
+
+from gbcommon.types.constants import DEFAULT_GH_DOMAIN
+
+
+def getenv_boolean(envname: str, default: bool = False) -> bool:
+    """Evaluate the environment variable and return as a boolean value."""
+    value = os.getenv(envname)
+    if value is None:
+        return default
+    value_normalized = str(value).lower()
+    return value_normalized not in ["false", "null", "undefined", "no", "0", ""]
+
+
+class GBEnvConfig(BaseModel):
+    """Unified environment configuration for gbcli and gbserver."""
+
+    env: str
+    """The GB env name. One of PROD, STAGING, DEV, or STANDALONE."""
+
+    lakehouse_environment: str
+    """The lakehouse environment to use. One of PROD or STAGING."""
+
+    feature_flags: Dict[str, bool] = {}
+    """Feature flags for this environment."""
+
+    space_config_branch_name: str = ""
+    """The branch in a space repo holding steps, assetstores, etc."""
+
+    # --- gbcli-origin fields ---
+
+    gbserver_host: str = ""
+    """The gbserver API endpoint URL."""
+
+    default_space: str = ""
+    """The default space name."""
+
+    dmf_ui: str = ""
+    """The full DMF UI base URL (e.g. https://ui.dmf.vpc-int.res.ibm.com)."""
+
+    config_spaces: str = ""
+    """Config section name for spaces."""
+
+    config_profile: str = ""
+    """Config section name for profiles."""
+
+    server_log_application_name: str = ""
+    """Application name for logging."""
+
+    branch_assets: str = ""
+    """Git branch name for assets."""
+
+    hf_organization: str = ""
+    """HuggingFace organization."""
+
+    # --- gbserver-origin fields ---
+
+    dashboard_instance: str = ""
+    """The dashboard URL for build status."""
+
+    public_space_git_uri: str = ""
+    """The URI of the public space git repo."""
+
+    public_space_lh_subnamespace: str = ""
+    """The child name of the Lakehouse namespace under the main GB namespace."""
+
+    buildwatcher_deployment_yaml: str = ""
+    """The location of the buildwatcher's deployment yaml."""
+
+    default_pod_namespace: str = ""
+    """The default K8s namespace for servers."""
+
+    default_sql_schema: str = ""
+    """The default schema to use in SQL storage."""
+
+    def model_post_init(self: Self, context: Any, /) -> None:
+        if self.env == "":
+            raise ValueError("field env cannot be empty")
+
+
+DEFAULT_GB_ENVIRONMENT = "PROD"
+
+_GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
+    "PROD": GBEnvConfig(
+        env="PROD",
+        lakehouse_environment="PROD",
+        space_config_branch_name="gbspace-config",
+        # gbcli
+        gbserver_host="https://api.llm-build-prod.vpc-int.res.ibm.com",
+        default_space="public",
+        dmf_ui="https://ui.dmf.vpc-int.res.ibm.com",
+        config_spaces="gb.spaces",
+        config_profile="gb.spaces.profiles",
+        server_log_application_name="llm-build-prod",
+        branch_assets="gbspace-config",
+        hf_organization="ibm-research",
+        feature_flags={
+            "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
+            "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
+        },
+        # gbserver
+        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
+        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public",
+        public_space_lh_subnamespace="public",
+        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
+        default_pod_namespace=os.getenv("GBSERVER_BACKEND_SERVER_NAMESPACE_PROD", "llm-build-prod"),
+        default_sql_schema="granite_dot_build_prod",
+    ),
+    "STAGING": GBEnvConfig(
+        env="STAGING",
+        lakehouse_environment="STAGING",
+        space_config_branch_name="gbspace-config",
+        # gbcli
+        gbserver_host="https://api.llm-build-staging.vpc-int.res.ibm.com",
+        default_space="public",
+        dmf_ui="https://ui.dmf-staging.vpc-int.res.ibm.com",
+        config_spaces="staging.gb.spaces",
+        config_profile="staging.gb.spaces.profiles",
+        server_log_application_name="llm-build-staging",
+        branch_assets="gbspace-config-dev",
+        hf_organization="ibm-research",
+        feature_flags={
+            "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
+            "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
+        },
+        # gbserver
+        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
+        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gb-test",
+        public_space_lh_subnamespace="public",
+        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
+        default_pod_namespace=os.getenv("GBSERVER_BACKEND_SERVER_NAMESPACE_STAGING", "llm-build-staging"),
+        default_sql_schema="granite_dot_build_staging",
+    ),
+    "DEV": GBEnvConfig(
+        env="DEV",
+        lakehouse_environment="STAGING",
+        space_config_branch_name="gbspace-config",
+        # gbcli
+        gbserver_host="https://api.llm-build-dev.vpc-int.res.ibm.com",
+        default_space="public",
+        dmf_ui="https://ui2.dmf-staging.vpc-int.res.ibm.com",
+        config_spaces="dev.gb.spaces",
+        config_profile="dev.gb.spaces.profiles",
+        server_log_application_name="llm-build-dev",
+        branch_assets="gbspace-config-dev",
+        hf_organization="ibm-research",
+        feature_flags={
+            "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
+            "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
+        },
+        # gbserver
+        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
+        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public-dev",
+        public_space_lh_subnamespace="public_dev",
+        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
+        default_pod_namespace=os.getenv("GBSERVER_BACKEND_SERVER_NAMESPACE_DEV", "llm-build-dev"),
+        default_sql_schema="granite_dot_build_dev",
+    ),
+    "STANDALONE": GBEnvConfig(
+        env="STANDALONE",
+        lakehouse_environment="",
+        space_config_branch_name="main",
+        # gbcli
+        gbserver_host="http://localhost:8080",
+        default_space="standalone",
+        dmf_ui="",
+        config_spaces="",
+        config_profile="",
+        server_log_application_name="gbserver-standalone",
+        branch_assets="",
+        hf_organization="ibm-research",
+        feature_flags={
+            "build_start_via_github": False,
+            "gbserver_build_events": True,
+            "gbserver_artifact_filter": False,
+            "gbserver_build_update": True,
+        },
+        # gbserver
+        dashboard_instance="",
+        public_space_git_uri="",
+        public_space_lh_subnamespace="",
+        buildwatcher_deployment_yaml="",
+        default_pod_namespace="default",
+        default_sql_schema="standalone",
+    ),
+}
+
+
+def gb_env_normalize(value: Optional[str], source: str = "input") -> Optional[str]:
+    """Normalize user-facing env name to canonical form.
+
+    Returns None if value is None/empty. Raises ValueError on invalid input.
+    """
+    if not value:
+        return None
+    v = value.lower()
+    if v in ("prod", "production"):
+        return "PROD"
+    elif v in ("staging",):
+        return "STAGING"
+    elif v in ("dev", "development"):
+        return "DEV"
+    elif v in ("standalone", "local"):
+        return "STANDALONE"
+    else:
+        raise ValueError(f"Error: {source} has invalid value '{value}'")
+
+
+def gb_environment() -> str:
+    """Read GB_ENVIRONMENT env var, normalize, default to PROD."""
+    raw = os.environ.get("GB_ENVIRONMENT")
+    normalized = gb_env_normalize(raw, "Environment variable GB_ENVIRONMENT")
+    return normalized if normalized else DEFAULT_GB_ENVIRONMENT
+
+
+def gb_environment_config(gb_env: Optional[str] = None) -> GBEnvConfig:
+    """Get the config for the given env. If gb_env is None or empty, uses gb_environment()."""
+    if not gb_env:
+        gb_env = gb_environment()
+    if gb_env not in _GB_ENVIRONMENT_CONFIGS:
+        valid_keys = list(_GB_ENVIRONMENT_CONFIGS.keys())
+        raise ValueError(f"unknown GB environment: {gb_env}, expected one of {valid_keys}")
+    return _GB_ENVIRONMENT_CONFIGS[gb_env]
+
+
+def is_standalone() -> bool:
+    """Return True if the current environment is STANDALONE."""
+    return gb_environment() == "STANDALONE"
+
+
+def add_environment_config(config_dict: Dict) -> GBEnvConfig:
+    """Add or overwrite a runtime config entry. Used by gbserver for --server-runtime-config."""
+    config = GBEnvConfig.model_validate(config_dict)
+    if config.env in _GB_ENVIRONMENT_CONFIGS:
+        old = _GB_ENVIRONMENT_CONFIGS[config.env]
+        print(
+            f"[WARNING] the environment config '{config.env}'"
+            + f" already exists: {old} , overwriting with {config}"
+        )
+    _GB_ENVIRONMENT_CONFIGS[config.env] = config
+    return config

--- a/src/gbserver/types/constants_base.py
+++ b/src/gbserver/types/constants_base.py
@@ -21,7 +21,6 @@ import os
 from gbcommon.types.gbenvconfig import DEFAULT_GB_ENVIRONMENT  # noqa: F401
 from gbcommon.types.gbenvconfig import getenv_boolean  # noqa: F401
 
-
 ENV_VAR_PREFIX = "GBSERVER"
 
 ENV_VAR_GBSERVER_BACKEND_SERVER_NAMESPACE_PROD = (

--- a/src/gbserver/types/constants_base.py
+++ b/src/gbserver/types/constants_base.py
@@ -18,14 +18,8 @@
 
 import os
 
-
-def getenv_boolean(envname: str, default: bool = False) -> bool:
-    """Evaluate the environment variable and return as a boolean value"""
-    value = os.getenv(envname)
-    if value is None:
-        return default
-    value_normalized = str(value).lower()
-    return value_normalized not in ["false", "null", "undefined", "no", "0", ""]
+from gbcommon.types.gbenvconfig import DEFAULT_GB_ENVIRONMENT  # noqa: F401
+from gbcommon.types.gbenvconfig import getenv_boolean  # noqa: F401
 
 
 ENV_VAR_PREFIX = "GBSERVER"
@@ -40,7 +34,6 @@ ENV_VAR_GBSERVER_BACKEND_SERVER_NAMESPACE_DEV = (
     ENV_VAR_PREFIX + "_BACKEND_SERVER_NAMESPACE_DEV"
 )
 
-DEFAULT_GB_ENVIRONMENT = "PROD"
 BACKEND_SERVER_NAMESPACE_PROD = os.getenv(
     ENV_VAR_GBSERVER_BACKEND_SERVER_NAMESPACE_PROD, "llm-build-prod"
 )

--- a/src/gbserver/types/gbserverenvconfig.py
+++ b/src/gbserver/types/gbserverenvconfig.py
@@ -14,154 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Environment specific config."""
+"""Environment specific config — thin wrapper over gbcommon.types.gbenvconfig."""
 
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Self
+from typing import Dict, Optional
 
 import yaml
-from pydantic import BaseModel
 
-from gbcommon.types.constants import DEFAULT_GH_DOMAIN
-from gbserver.types.constants_base import (
-    BACKEND_SERVER_NAMESPACE_DEV,
-    BACKEND_SERVER_NAMESPACE_PROD,
-    BACKEND_SERVER_NAMESPACE_STAGING,
+from gbcommon.types.gbenvconfig import (
     DEFAULT_GB_ENVIRONMENT,
-    getenv_boolean,
+    GBEnvConfig,
+    add_environment_config,
+)
+from gbcommon.types.gbenvconfig import (
+    gb_environment_config as _common_gb_environment_config,
 )
 
-
-class GBServerEnvConfig(BaseModel):
-    """
-    The server runtime config.
-    """
-
-    env: str
-    """The GB env name. One of PROD, STAGING or DEV."""
-
-    lakehouse_environment: str
-    """The lakehouse environment to use.  One of PROD or STAGING """
-
-    dashboard_instance: str = ""
-    """The portion of the dashboard url specific to DMF PROD, STAGING or STAGING2."""
-
-    dmf_instance: str
-    """The portion of the lineage url specific to DMF PROD, STAGING or STAGING2."""
-
-    public_space_git_uri: str
-    """The uri of the public space git repo (https://...) """
-
-    public_space_lh_subnamespace: str
-    """The child name of the Lakehouse namespace under the main GB name space (i.e. granite_dot_build). For example, public. """
-
-    buildwatcher_deployment_yaml: str
-    """The location of the buildwatcher's deployment yaml for use by the BuildRunnerJob"""
-
-    default_pod_namespace: str
-    """The default namespace in which our servers are run in the cluster
-       And used for testing when not running buildwatcher in the cluster.
-    """
-
-    default_sql_schema: str
-    """The default schema to use in SQL storage."""
-
-    space_config_branch_name: str
-    """The name of the branch in a space repo holding the steps, assetstores, etc.
-    Usually one of gspace-cofig, gbspace-config-staging or gbspace-config-dev
-    """
-
-    feature_flags: Dict[str, bool] = {}
-    """Feature flags for this environment. Each flag is a string key mapped to a boolean value.
-    Values are evaluated at startup via getenv_boolean() so they can be overridden by env vars.
-    """
-
-    def model_post_init(self: Self, context: Any, /) -> None:
-        if self.env == "":
-            raise ValueError("field env cannot be empty")
-
-
-_GBSERVER_ENVIRONMENT_CONFIGS = {
-    "PROD": GBServerEnvConfig(
-        env="PROD",
-        lakehouse_environment="PROD",
-        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        dmf_instance="ui.dmf",
-        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public",
-        public_space_lh_subnamespace="public",
-        # buildwatcher_deployment_yaml="k8s/prod/dep-gbserver-build-runner.yaml",
-        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=BACKEND_SERVER_NAMESPACE_PROD,
-        default_sql_schema="granite_dot_build_prod",
-        space_config_branch_name="gbspace-config",
-        feature_flags={},
-    ),
-    "STAGING": GBServerEnvConfig(
-        env="STAGING",
-        lakehouse_environment="STAGING",
-        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        dmf_instance="ui.dmf-staging",
-        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gb-test",
-        public_space_lh_subnamespace="public",
-        # buildwatcher_deployment_yaml="k8s/staging/dep-gbserver-build-runner.yaml",
-        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=BACKEND_SERVER_NAMESPACE_STAGING,
-        default_sql_schema="granite_dot_build_staging",
-        space_config_branch_name="gbspace-config",
-        feature_flags={},
-    ),
-    "DEV": GBServerEnvConfig(
-        env="DEV",
-        lakehouse_environment="STAGING",
-        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        dmf_instance="ui2.dmf-staging",
-        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public-dev",
-        public_space_lh_subnamespace="public_dev",
-        # buildwatcher_deployment_yaml="k8s/dev/dep-gbserver-build-runner.yaml",
-        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=BACKEND_SERVER_NAMESPACE_DEV,
-        default_sql_schema="granite_dot_build_dev",
-        # For now this is the same as staging and prod, but when we have a CI/CD with a dev environtment,
-        # we will likely want to change this to be something like gbspace-config-dev.
-        space_config_branch_name="gbspace-config",
-        feature_flags={},
-    ),
-    "STANDALONE": GBServerEnvConfig(
-        env="STANDALONE",
-        lakehouse_environment="",
-        dmf_instance="",
-        public_space_git_uri="",
-        public_space_lh_subnamespace="",
-        buildwatcher_deployment_yaml="",
-        default_pod_namespace="default",
-        default_sql_schema="standalone",
-        space_config_branch_name="main",
-        feature_flags={},
-    ),
-}
-
-
-def add_server_runtime_config(config_dict: Dict) -> GBServerEnvConfig:
-    """Add another server runtime config to the dict of built-in ones."""
-    print("[INFO] add_server_runtime_config config_dict:", config_dict)
-    config = GBServerEnvConfig.model_validate(config_dict)
-    print("[INFO] add_server_runtime_config config:", config)
-    if config.env in _GBSERVER_ENVIRONMENT_CONFIGS:
-        old = _GBSERVER_ENVIRONMENT_CONFIGS[config.env]
-        print(
-            f"[WARNING] the server runtime config '{config.env}'"
-            + f" already exists: {old} , overwriting with {config}"
-        )
-    _GBSERVER_ENVIRONMENT_CONFIGS[config.env] = config
-    return config
+# Backwards-compatible alias
+GBServerEnvConfig = GBEnvConfig
 
 
 _LOADED_EXTRA_SERVER_RUNTIME_CONFIGS = False
 
 
-def load_extra_server_runtime_configs() -> Optional[GBServerEnvConfig]:
+def load_extra_server_runtime_configs() -> Optional[GBEnvConfig]:
     """
     Parse the CLI args and add another server runtime config
     to the dict of built-in ones.
@@ -173,9 +51,7 @@ def load_extra_server_runtime_configs() -> Optional[GBServerEnvConfig]:
         return None
     _LOADED_EXTRA_SERVER_RUNTIME_CONFIGS = True
 
-    # print("[INFO] sys.argv:", sys.argv)
-
-    parser = argparse.ArgumentParser(add_help=False)  # avoid usage info
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
         "--server-runtime-config",
         dest="server_runtime_config",
@@ -184,31 +60,18 @@ def load_extra_server_runtime_configs() -> Optional[GBServerEnvConfig]:
         default=None,
         help="Path to a server runtime config file.",
     )
-    # NOTE: there is a danger of sub-commands being treated as file path if the user forgets to give a path
-    # This will throw usage errors because there are unknown flags and commands
-    # args = parser.parse_args()
     known_args = None
-    unknown_args = None
     try:
         known_args, unknown_args = parser.parse_known_args()
     except SystemExit as e:
-        # Could also be triggered by the --help flag which prints usage and exits.
-        # add_help=False does stop this, but keep it just in case.
         print("[ERROR] parse_known_args caught SystemExit, error:", e)
         return None
     except Exception as e:
         print("[ERROR] parse_known_args failed to parse, error:", e)
         return None
-    # print(
-    #     "[DEBUG] parse_known_args known_args:",
-    #     known_args,
-    #     "unknown_args:",
-    #     unknown_args,
-    # )
+
     server_runtime_config_path = known_args.server_runtime_config
-    # print("[INFO] server_runtime_config_path:", server_runtime_config_path)
     if server_runtime_config_path is None:
-        # print("[INFO] server_runtime_config_path is None")
         return None
     assert isinstance(
         server_runtime_config_path, Path
@@ -218,19 +81,13 @@ def load_extra_server_runtime_configs() -> Optional[GBServerEnvConfig]:
     ), f"expected server runtime config to be a file: '{server_runtime_config_path}'"
     with open(server_runtime_config_path, "r", encoding="utf-8") as f:
         config_dict = yaml.safe_load(f)
-    config = add_server_runtime_config(config_dict=config_dict)
+    config = add_environment_config(config_dict=config_dict)
     return config
 
 
-def gb_environment_config(gb_env: str) -> GBServerEnvConfig:
-    """Get the config for the llm.build environment. and raise exception if bad env name is given
-    Currently supported values include DEV, STAGING and PROD.
-    """
+def gb_environment_config(gb_env: str = "") -> GBEnvConfig:
+    """Server-specific wrapper that loads extra runtime configs first."""
     loaded_config = load_extra_server_runtime_configs()
     if gb_env == "":
-        gb_env = loaded_config.env if loaded_config else DEFAULT_GB_ENVIRONMENT
-    valid_keys = list(_GBSERVER_ENVIRONMENT_CONFIGS.keys())
-    assert (
-        gb_env in _GBSERVER_ENVIRONMENT_CONFIGS
-    ), f"unknown GB environment: {gb_env} , expected one of {valid_keys}"
-    return _GBSERVER_ENVIRONMENT_CONFIGS[gb_env]
+        gb_env = loaded_config.env if loaded_config else None
+    return _common_gb_environment_config(gb_env)

--- a/src/gbserver/utils/utils.py
+++ b/src/gbserver/utils/utils.py
@@ -109,12 +109,10 @@ def random_string(length: int = 8):
 
 def get_build_status_link(build_id: str) -> str:
     """Get the link to the build status/lineage given the build ID."""
-    dmf_instance = GB_ENVIRONMENT_CONFIG.dmf_instance
-    if not dmf_instance:
+    dmf_ui = GB_ENVIRONMENT_CONFIG.dmf_ui
+    if not dmf_ui:
         return "(lineage is not available in standalone mode)"
-    dmf_url = f"https://{dmf_instance}.vpc-int.res.ibm.com"
-    build_lineage_url = f"{dmf_url}/gb/builds/{build_id}"
-    return build_lineage_url
+    return f"{dmf_ui}/gb/builds/{build_id}"
 
 
 def get_dashboard_link(build_id: str) -> str:

--- a/test/unit/standalone/test_regression_smoke.py
+++ b/test/unit/standalone/test_regression_smoke.py
@@ -271,7 +271,7 @@ class TestEnvironmentConfig:
         assert config.default_sql_schema == "standalone"
         assert config.default_pod_namespace == "default"
         assert config.lakehouse_environment == ""
-        assert config.dmf_instance == ""
+        assert config.dmf_ui == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Create a single `GBEnvConfig` Pydantic model in `src/gbcommon/types/gbenvconfig.py` that merges environment-specific settings from both gbcli and gbserver
- Remove deprecated environments (`PROD_OLD`, `PROD_INTERNAL_OLD`, `PROD_INTERNAL`) from gbcli
- Unify `dmf_ui`/`dmf_instance` into a single `dmf_ui` field (full URL)
- Rename `branch_space` → `space_config_branch_name` (use gbserver's more descriptive name)
- Deduplicate `getenv_boolean()` into gbcommon
- All gbcli consumers import `gb_environment_config` and `is_standalone` directly from `gbcommon.types.gbenvconfig`
- gbserver retains a thin wrapper in `gbserverenvconfig.py` for `--server-runtime-config` support

## Test plan

- [ ] Verify `python -c "from gbcommon.types.gbenvconfig import gb_environment_config; print(gb_environment_config())"` works for all envs (PROD, STAGING, DEV, STANDALONE)
- [ ] Verify gbserver wrapper: `from gbserver.types.gbserverenvconfig import gb_environment_config` still works
- [ ] Run `pytest test/unit/standalone/test_regression_smoke.py::TestEnvironmentConfig`
- [ ] Run `make xcheck` (pylint + mypy on changed files)
- [ ] Run `make cicd-pr-test`