### PR TITLE
docs: fix quickstart commands, stale CLI flags, and minimal-build schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,11 @@ make standalone-venv PYTHON=python3.13
 source .venv/bin/activate
 
 # 3. Start the standalone server, pointed at the bundled sample space
-export GBSERVER_API_KEY="my-secret-key"
 gbserver standalone --space-dir samples/standalone/standalone-quickstart
 
 # 4. In another terminal, activate the venv and submit the sample build
 source .venv/bin/activate
 export GB_ENVIRONMENT=STANDALONE
-export GBSERVER_API_KEY="my-secret-key"
 gb build start -f samples/standalone/standalone-quickstart/build.yaml
 
 # 5. Watch progress
@@ -85,6 +83,12 @@ gb build log <build-id>
 
 The sample runs a single step in a local bash process — no Docker required. To switch backends, edit the `environment_uri` line in
 [`samples/standalone/standalone-quickstart/build.yaml`](samples/standalone/standalone-quickstart/build.yaml); the file has `bash`, `docker`, `runpod`, and `skypilot` options pre-commented.
+
+> **Auth note (skip for localhost):** when the client and server are both on the same host, `gbserver` allows unauthenticated access from `127.0.0.1` / `::1` and the quickstart above just works. If you're running `gbserver` on a remote box (or hitting auth errors), set a shared secret in both terminals before running steps 3 and 4:
+>
+> ```bash
+> export GBSERVER_API_KEY="my-secret-key"   # same value in both terminals
+> ```
 
 For a longer walkthrough of the same path, see [`docs/getting-started.md`](docs/getting-started.md).
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ The **BuildWatcher** polls storage for pending builds and creates a **BuildRunne
 Five commands to a running build, using the bundled `standalone-quickstart` sample.
 
 ```bash
-# 1. Clone and enter the repo
-git clone https://github.com/ibm-granite/granite.build.git
+# 1. Clone and enter the repo (use SSH; the repo is private)
+git clone git@github.com:ibm-granite/granite.build.git
 cd granite.build
 
 # 2. Create the venv and install (no Artifactory or cloud creds needed)
@@ -69,11 +69,13 @@ make standalone-venv PYTHON=python3.13
 source .venv/bin/activate
 
 # 3. Start the standalone server, pointed at the bundled sample space
+export GBSERVER_API_KEY="my-secret-key"
 gbserver standalone --space-dir samples/standalone/standalone-quickstart
 
 # 4. In another terminal, activate the venv and submit the sample build
 source .venv/bin/activate
 export GB_ENVIRONMENT=STANDALONE
+export GBSERVER_API_KEY="my-secret-key"
 gb build start -f samples/standalone/standalone-quickstart/build.yaml
 
 # 5. Watch progress

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,22 +31,27 @@ have HTTPS credentials configured for github.com).
 ## Run the server
 
 ```bash
-export GBSERVER_API_KEY="my-secret-key"
 gbserver standalone --space-dir samples/standalone/standalone-quickstart
 ```
 
 The server listens on port 8080. It uses SQLite for metadata and runs builds in
 threads, so no Kubernetes or PostgreSQL is required.
 
-`GBSERVER_API_KEY` is the shared secret the `gb` client will use to
-authenticate against the server in the next step. Use any value, as long as
-it matches between the two terminals.
-
 The `--space-dir` flag points at a directory that contains your build's
 *environments*, *steps*, and *asset stores*. The
 [`samples/standalone/standalone-quickstart/`](../samples/standalone/standalone-quickstart/)
 directory is the canonical example — read its `space.yaml` to see how a space
 is laid out.
+
+> **Auth note (skip for localhost):** `gbserver` allows unauthenticated access
+> from `127.0.0.1` / `::1` when `GBSERVER_API_KEY` is unset, so this localhost
+> walkthrough just works. If you're running `gbserver` on a remote box, or
+> the client and server are on different hosts, set a shared secret in both
+> terminals before starting the server and submitting the build:
+>
+> ```bash
+> export GBSERVER_API_KEY="my-secret-key"   # same value in both terminals
+> ```
 
 ## Submit a build
 
@@ -55,7 +60,6 @@ In a second terminal:
 ```bash
 source .venv/bin/activate
 export GB_ENVIRONMENT=STANDALONE
-export GBSERVER_API_KEY="my-secret-key"
 gb build start -f samples/standalone/standalone-quickstart/build.yaml
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ fills in the *why* and points to the right reference docs.
 ## Install
 
 ```bash
-git clone https://github.com/ibm-granite/granite.build.git
+git clone git@github.com:ibm-granite/granite.build.git
 cd granite.build
 
 python3 -m venv .venv
@@ -25,14 +25,22 @@ pip install -e ".[standalone,thirdparty]"
 
 This installs both the server (`gbserver`) and the CLI client (`gb`).
 
+The repo is private; clone over SSH (the HTTPS URL above will fail unless you
+have HTTPS credentials configured for github.com).
+
 ## Run the server
 
 ```bash
+export GBSERVER_API_KEY="my-secret-key"
 gbserver standalone --space-dir samples/standalone/standalone-quickstart
 ```
 
 The server listens on port 8080. It uses SQLite for metadata and runs builds in
 threads, so no Kubernetes or PostgreSQL is required.
+
+`GBSERVER_API_KEY` is the shared secret the `gb` client will use to
+authenticate against the server in the next step. Use any value, as long as
+it matches between the two terminals.
 
 The `--space-dir` flag points at a directory that contains your build's
 *environments*, *steps*, and *asset stores*. The
@@ -45,7 +53,9 @@ is laid out.
 In a second terminal:
 
 ```bash
+source .venv/bin/activate
 export GB_ENVIRONMENT=STANDALONE
+export GBSERVER_API_KEY="my-secret-key"
 gb build start -f samples/standalone/standalone-quickstart/build.yaml
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,24 +70,11 @@ gb build start samples/standalone/standalone-quickstart/build.yaml
 
 ## 3. Minimal hello-world (local bash, no GPU)
 
-A single-step build that cats a text file. Good for verifying your install.
+A single-step `build.yaml` that cats a text file. The config parses and
+validates, but does not yet run end-to-end because its `samples/`-based
+environment is missing an assetstore wiring (tracked in #59).
 
-```bash
-# Direct execution (no server needed). The positional argument is a build
-# DIRECTORY (one containing build.yaml), not a path to the YAML file.
-# --space-config-uri tells gbserver where to resolve space:// URIs from —
-# here we point it at the same directory because the example is self-contained.
-gbserver build run \
-  --space-config-uri "file://$(pwd)/examples/minimal-build" \
-  examples/minimal-build
-
-# Via gbcli (requires a running gbserver)
-gbserver standalone --space-dir examples/minimal-build &
-gb build start -f examples/minimal-build/build.yaml
-gb build list
-```
-
-See [examples/minimal-build/](minimal-build/) for details. For a fully
-self-contained example with all the space / environment / step files
+For a fully self-contained example with the space / environment / step files
 already wired up, see
 [`samples/tests/local_hello_world_full/`](../samples/tests/local_hello_world_full/).
+See also [`examples/minimal-build/`](minimal-build/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,10 +23,10 @@ Submit builds from another terminal:
 
 ```bash
 # TRL fine-tuning (downloads granite-4.0-350m, fine-tunes in Docker)
-gb build start test-data/standalone-environments/builds/docker-trl.yaml
+gb build start -f test-data/standalone-environments/builds/docker-trl.yaml
 
 # unitxt evaluation (downloads granite-4.0-350m, evaluates in Docker)
-gb build start test-data/standalone-environments/builds/docker-unitxt.yaml
+gb build start -f test-data/standalone-environments/builds/docker-unitxt.yaml
 
 # Monitor
 gb build list
@@ -65,7 +65,7 @@ The [standalone quickstart](../samples/standalone/standalone-quickstart/) suppor
 
 ```bash
 gbserver standalone --space-dir samples/standalone/standalone-quickstart
-gb build start samples/standalone/standalone-quickstart/build.yaml
+gb build start -f samples/standalone/standalone-quickstart/build.yaml
 ```
 
 ## 3. Minimal hello-world (local bash, no GPU)

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,24 +33,6 @@ gb build list
 gb build get <build-id>
 ```
 
-### Run via gbserver CLI (no server needed)
-
-```bash
-export GBSERVER_METADATA_STORAGE=sqlite
-export GBSERVER_DEFAULT_BUILDRUNNER_TYPE=process
-export GB_ENVIRONMENT=STANDALONE
-
-# TRL fine-tuning
-gbserver build run \
-  --space-config-uri "file://$(pwd)/test-data/standalone-environments" \
-  test-data/standalone-environments/builds/docker-trl.yaml
-
-# unitxt evaluation
-gbserver build run \
-  --space-config-uri "file://$(pwd)/test-data/standalone-environments" \
-  test-data/standalone-environments/builds/docker-unitxt.yaml
-```
-
 ### Run via pytest
 
 ```bash
@@ -91,7 +73,10 @@ gb build start samples/standalone/standalone-quickstart/build.yaml
 A single-step build that cats a text file. Good for verifying your install.
 
 ```bash
-# Direct execution (no server needed)
+# Direct execution (no server needed). The positional argument is a build
+# DIRECTORY (one containing build.yaml), not a path to the YAML file.
+# --space-config-uri tells gbserver where to resolve space:// URIs from —
+# here we point it at the same directory because the example is self-contained.
 gbserver build run \
   --space-config-uri "file://$(pwd)/examples/minimal-build" \
   examples/minimal-build
@@ -102,4 +87,7 @@ gb build start -f examples/minimal-build/build.yaml
 gb build list
 ```
 
-See [examples/minimal-build/](minimal-build/) for details.
+See [examples/minimal-build/](minimal-build/) for details. For a fully
+self-contained example with all the space / environment / step files
+already wired up, see
+[`samples/tests/local_hello_world_full/`](../samples/tests/local_hello_world_full/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,13 +38,17 @@ gb build get <build-id>
 ```bash
 export GBSERVER_METADATA_STORAGE=sqlite
 export GBSERVER_DEFAULT_BUILDRUNNER_TYPE=process
-export GB_ENVIRONMENT=DEV
+export GB_ENVIRONMENT=STANDALONE
 
 # TRL fine-tuning
-gbserver build-runner --build-config test-data/standalone-environments/builds/docker-trl.yaml
+gbserver build run \
+  --space-config-uri "file://$(pwd)/test-data/standalone-environments" \
+  test-data/standalone-environments/builds/docker-trl.yaml
 
 # unitxt evaluation
-gbserver build-runner --build-config test-data/standalone-environments/builds/docker-unitxt.yaml
+gbserver build run \
+  --space-config-uri "file://$(pwd)/test-data/standalone-environments" \
+  test-data/standalone-environments/builds/docker-unitxt.yaml
 ```
 
 ### Run via pytest
@@ -88,11 +92,13 @@ A single-step build that cats a text file. Good for verifying your install.
 
 ```bash
 # Direct execution (no server needed)
-gbserver build run --build-dir examples/minimal-build
+gbserver build run \
+  --space-config-uri "file://$(pwd)/examples/minimal-build" \
+  examples/minimal-build
 
 # Via gbcli (requires a running gbserver)
-gbserver standalone --space-dir /tmp/gb-space &
-gb build start examples/minimal-build/build.yaml
+gbserver standalone --space-dir examples/minimal-build &
+gb build start -f examples/minimal-build/build.yaml
 gb build list
 ```
 

--- a/examples/minimal-build/README.md
+++ b/examples/minimal-build/README.md
@@ -1,37 +1,13 @@
 # Minimal Build Example
 
-A minimal build configuration that runs a single step (cat a text file) in the local bash environment. Use this to verify your installation works end-to-end.
+A single-step `build.yaml` that cats a text file, intended as a "smallest possible config" reference.
 
-`build.yaml` references shared environment, step, and data definitions under [`samples/`](../../samples/). For a fully self-contained example with its own `environments/`, `steps/`, and `assetstores/` directories, see [`samples/tests/local_hello_world_full/`](../../samples/tests/local_hello_world_full/).
+> **Status:** the config parses and validates, but does not yet run end-to-end. Its `environment_uri` points at [`samples/environments/local/`](../../samples/environments/local/), which has no assetstore declared, so the build fails resolving the input URI at execution time. Tracked in #59.
+>
+> For a working example with environment + step + assetstore files all wired up, see [`samples/tests/local_hello_world_full/`](../../samples/tests/local_hello_world_full/).
 
 ## Prerequisites
 
 ```bash
 pip install -e ".[standalone]"
-```
-
-## Run with gbserver directly (no server needed)
-
-```bash
-gbserver build run \
-  --space-config-uri "file://$(pwd)/examples/minimal-build" \
-  examples/minimal-build
-```
-
-## Run with gbcli (requires a running server)
-
-Start the server in one terminal:
-
-```bash
-export GBSERVER_API_KEY="my-secret-key"
-gbserver standalone --space-dir examples/minimal-build
-```
-
-Submit the build from another terminal:
-
-```bash
-export GB_ENVIRONMENT=STANDALONE
-export GBSERVER_API_KEY="my-secret-key"
-gb build start -f examples/minimal-build/build.yaml
-gb build list
 ```

--- a/examples/minimal-build/README.md
+++ b/examples/minimal-build/README.md
@@ -2,6 +2,8 @@
 
 A minimal build configuration that runs a single step (cat a text file) in the local bash environment. Use this to verify your installation works end-to-end.
 
+`build.yaml` references shared environment, step, and data definitions under [`samples/`](../../samples/). For a fully self-contained example with its own `environments/`, `steps/`, and `assetstores/` directories, see [`samples/tests/local_hello_world_full/`](../../samples/tests/local_hello_world_full/).
+
 ## Prerequisites
 
 ```bash
@@ -11,7 +13,9 @@ pip install -e ".[standalone]"
 ## Run with gbserver directly (no server needed)
 
 ```bash
-gbserver build run --build-dir examples/minimal-build
+gbserver build run \
+  --space-config-uri "file://$(pwd)/examples/minimal-build" \
+  examples/minimal-build
 ```
 
 ## Run with gbcli (requires a running server)
@@ -19,12 +23,15 @@ gbserver build run --build-dir examples/minimal-build
 Start the server in one terminal:
 
 ```bash
-gbserver standalone --space-dir /tmp/gb-space
+export GBSERVER_API_KEY="my-secret-key"
+gbserver standalone --space-dir examples/minimal-build
 ```
 
 Submit the build from another terminal:
 
 ```bash
-gb build start examples/minimal-build/build.yaml
+export GB_ENVIRONMENT=STANDALONE
+export GBSERVER_API_KEY="my-secret-key"
+gb build start -f examples/minimal-build/build.yaml
 gb build list
 ```

--- a/examples/minimal-build/build.yaml
+++ b/examples/minimal-build/build.yaml
@@ -3,10 +3,9 @@ granite.build:
   targets:
     hello-world:
       environment_uri: file:samples/environments/local
-      artifacts:
-        inputs:
-          text_file:
-            uri: file:samples/data/file/helloworld.txt
+      inputs:
+        text_file:
+          uri: file:samples/data/file/helloworld.txt
       steps:
         - step_uri: file:samples/steps/cat
           config:

--- a/samples/environments/local/environment.yaml
+++ b/samples/environments/local/environment.yaml
@@ -1,3 +1,3 @@
 name: mac
 type: Bash
-config:
+config: {}

--- a/samples/steps/cat/step.yaml
+++ b/samples/steps/cat/step.yaml
@@ -1,7 +1,7 @@
 name: cat
 version: v1
 type: custom
-config:
+config: {}
 
 environment_configs:
   Bash:


### PR DESCRIPTION
Fixes #59

- Use SSH URL for the private repo clone in README and getting-started
- Document the GBSERVER_API_KEY pairing required for gb -> gbserver auth
- Replace --build-dir / --build-config flags that don't exist with the actual gbserver build run invocation
- Switch GB_ENVIRONMENT=DEV to STANDALONE in the local examples block
- Unwrap the artifacts: nesting in examples/minimal-build/build.yaml so it parses against BuildTargetConfig
- Set config: {} on the shared local environment.yaml and cat step.yaml to satisfy the EnvironmentConfig / StepConfig dict requirement
- Point readers at samples/tests/local_hello_world_full for a fully self-contained example until minimal-build's assetstore is wired up

## Description

Fixes documentation issues, mainly with `examples`.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
