### PR TITLE
fix: honor tzinfo in humanize_iso_date for build status events

### DIFF
--- a/src/gbcli/utils/utils.py
+++ b/src/gbcli/utils/utils.py
@@ -207,11 +207,12 @@ def generate_unique_id():
 
 def humanize_iso_date(date: str) -> str:
     format = "%Y-%m-%dT%H:%M:%S.%f%z" if "." in date else "%Y-%m-%dT%H:%M:%SZ"
-    time_interval = datetime.now(timezone.utc).replace(tzinfo=None) - datetime.strptime(
-        date, format
-    ).replace(tzinfo=None)
+    parsed = datetime.strptime(date, format)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    time_interval = datetime.now(timezone.utc) - parsed
     if time_interval.days > 1:
-        return humanize.naturaldate(datetime.strptime(date, format))
+        return humanize.naturaldate(parsed)
     else:
         return humanize.naturaltime(time_interval)
 


### PR DESCRIPTION
Fixes #63.

## Summary

`gb build status --show-events` showed every event as N hours ago, where N matched the local UTC offset (e.g. 4 hours on EDT, 7 hours on PDT, even for an event that just happened). Bug was client-side in `humanize_iso_date`: it stripped tzinfo from both sides of the subtraction, so a `2026-06-04T10:03:29-04:00` timestamp got treated as `10:03:29` UTC and compared against `now_utc` (`14:03:29`), producing the offset-shaped delta.

Server-side timestamps are already tz-aware (`get_time()` returns `datetime.now().astimezone()` and the API serializes the offset), so the fix is purely client-side: keep tzinfo, default naive values to UTC, subtract two tz-aware datetimes.

## Test plan

- [x] Submitted a build in EDT, ran `gb build status <id> --show-events` immediately. Before: every event "4 hours ago". After: "a second ago" / "2 seconds ago".