### PR TITLE
docs: Remove outdated SSH comment from Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The **BuildWatcher** polls storage for pending builds and creates a **BuildRunne
 Five commands to a running build, using the bundled `standalone-quickstart` sample.
 
 ```bash
-# 1. Clone and enter the repo (use SSH; the repo is private)
+# 1. Clone and enter the repo
 git clone git@github.com:ibm-granite/granite.build.git
 cd granite.build
 


### PR DESCRIPTION
## Summary
Removes the outdated comment '(use SSH; the repo is private)' from the Quick start section in README.md.

## Reason
The repository is now public, so this comment is no longer accurate.

## Changes
- Updated line 62 in README.md to remove the SSH/private repo comment