### PR TITLE
fix pass ctx to wrapped callback in pass_context_and_reject_standalone

### DIFF
--- a/src/gbcli/commands/command_admin.py
+++ b/src/gbcli/commands/command_admin.py
@@ -8,7 +8,7 @@ from tabulate import tabulate
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import common_options, exit_if_standalone
 from gbcli.utils.gbconstants import (
     BUILD_LOG_DEFAULT_QUERY_RANGE,
     BUILD_LOG_MAX_LOG_LIFESPAN,
@@ -31,7 +31,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 @click.pass_context
 def cli(ctx):
     """Functions for admin users"""
-    pass
+    if ctx.invoked_subcommand is not None:
+        exit_if_standalone("admin")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_admin.py
+++ b/src/gbcli/commands/command_admin.py
@@ -8,7 +8,7 @@ from tabulate import tabulate
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, exit_if_standalone
+from gbcli.commands.common_options import common_options, unsupported_in_standalone
 from gbcli.utils.gbconstants import (
     BUILD_LOG_DEFAULT_QUERY_RANGE,
     BUILD_LOG_MAX_LOG_LIFESPAN,
@@ -28,11 +28,9 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("admin")
-@click.pass_context
-def cli(ctx):
+@unsupported_in_standalone("admin")
+def cli():
     """Functions for admin users"""
-    if ctx.invoked_subcommand is not None:
-        exit_if_standalone("admin")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_admin.py
+++ b/src/gbcli/commands/command_admin.py
@@ -8,7 +8,10 @@ from tabulate import tabulate
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, unsupported_in_standalone
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.utils.gbconstants import (
     BUILD_LOG_DEFAULT_QUERY_RANGE,
     BUILD_LOG_MAX_LOG_LIFESPAN,
@@ -28,8 +31,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("admin")
-@unsupported_in_standalone("admin")
-def cli():
+@pass_context_and_reject_standalone
+def cli(ctx):
     """Functions for admin users"""
 
 

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import common_options, exit_if_standalone
 from gbcli.services.service_artifact import (
     ArtifactURIError,
     lookup_hf_resource_group_id,
@@ -69,7 +69,8 @@ logger = logging.getLogger(__name__)
 def cli(ctx):
     """Work with artifacts"""
     ctx.ensure_object(dict)  # Ensures `ctx.obj` is a dictionary
-    pass
+    if ctx.invoked_subcommand is not None:
+        exit_if_standalone("artifact")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options, exit_if_standalone
+from gbcli.commands.common_options import common_options, unsupported_in_standalone
 from gbcli.services.service_artifact import (
     ArtifactURIError,
     lookup_hf_resource_group_id,
@@ -65,12 +65,11 @@ logger = logging.getLogger(__name__)
 
 
 @click.group("artifact")
+@unsupported_in_standalone("artifact")
 @click.pass_context
 def cli(ctx):
     """Work with artifacts"""
     ctx.ensure_object(dict)  # Ensures `ctx.obj` is a dictionary
-    if ctx.invoked_subcommand is not None:
-        exit_if_standalone("artifact")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -13,7 +13,10 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options, unsupported_in_standalone
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.services.service_artifact import (
     ArtifactURIError,
     lookup_hf_resource_group_id,
@@ -65,8 +68,7 @@ logger = logging.getLogger(__name__)
 
 
 @click.group("artifact")
-@unsupported_in_standalone("artifact")
-@click.pass_context
+@pass_context_and_reject_standalone
 def cli(ctx):
     """Work with artifacts"""
     ctx.ensure_object(dict)  # Ensures `ctx.obj` is a dictionary

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -15,7 +15,10 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.utils.click_utils import validation_formatting
 from gbcli.utils.gbconstants import (
     ASSETS_REPO_NAME,
@@ -266,6 +269,17 @@ def init(
     if not from_template and not from_build:
         click.echo(
             f"❌ Error: Please specify a template with --from-template option or a build with --from-build.",
+            err=True,
+        )
+        ctx.exit(1)  # Exit with a non-zero status
+
+    if from_template and is_standalone():
+        # --from-template clones the template from GitHub Enterprise, which is
+        # unavailable in standalone mode. Use --from-build instead.
+        click.echo(
+            "❌ Error: 'build init --from-template' is currently not supported in "
+            "standalone mode (templates are fetched from GitHub). Use --from-build "
+            "instead.",
             err=True,
         )
         ctx.exit(1)  # Exit with a non-zero status
@@ -1057,7 +1071,7 @@ def cancel(ctx, space, build_id, format, skip_version_check, quiet):
 
 
 @cli.command()
-@click.pass_context
+@pass_context_and_reject_standalone("build lineage")
 @click.argument("build_id", required=True)
 @click.option(
     "--format",
@@ -2724,7 +2738,7 @@ def monitor(ctx, build_id, show_events, fetch_pr, skip_version_check, quiet):
 
 
 @cli.command()
-@click.pass_context
+@pass_context_and_reject_standalone("build notification")
 @click.argument("status", nargs=-1)
 @click.option("--space", help="Space name.")
 @click.option(

--- a/src/gbcli/commands/command_model.py
+++ b/src/gbcli/commands/command_model.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import common_options, exit_if_standalone
 from gbcli.services.service_auth import verify_rits_api_key
 from gbcli.utils.gbconstants import (
     MODEL_LIST_HEADERS,
@@ -30,7 +30,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 @click.pass_context
 def cli(ctx):
     """Work with deployed models"""
-    pass
+    if ctx.invoked_subcommand is not None:
+        exit_if_standalone("model")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_model.py
+++ b/src/gbcli/commands/command_model.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options, exit_if_standalone
+from gbcli.commands.common_options import common_options, unsupported_in_standalone
 from gbcli.services.service_auth import verify_rits_api_key
 from gbcli.utils.gbconstants import (
     MODEL_LIST_HEADERS,
@@ -27,11 +27,9 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("model")
-@click.pass_context
-def cli(ctx):
+@unsupported_in_standalone("model")
+def cli():
     """Work with deployed models"""
-    if ctx.invoked_subcommand is not None:
-        exit_if_standalone("model")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_model.py
+++ b/src/gbcli/commands/command_model.py
@@ -10,7 +10,10 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
-from gbcli.commands.common_options import common_options, unsupported_in_standalone
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.services.service_auth import verify_rits_api_key
 from gbcli.utils.gbconstants import (
     MODEL_LIST_HEADERS,
@@ -27,8 +30,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("model")
-@unsupported_in_standalone("model")
-def cli():
+@pass_context_and_reject_standalone
+def cli(ctx):
     """Work with deployed models"""
 
 

--- a/src/gbcli/commands/command_secret.py
+++ b/src/gbcli/commands/command_secret.py
@@ -8,15 +8,18 @@ from tabulate import tabulate
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, unsupported_in_standalone
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.utils.gbconstants import CLIPBOARD_CHAR, PROJECT_NAME
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("secret")
-@unsupported_in_standalone("secret")
-def cli():
+@pass_context_and_reject_standalone
+def cli(ctx):
     """Work with secrets"""
 
 

--- a/src/gbcli/commands/command_secret.py
+++ b/src/gbcli/commands/command_secret.py
@@ -8,18 +8,16 @@ from tabulate import tabulate
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, exit_if_standalone
+from gbcli.commands.common_options import common_options, unsupported_in_standalone
 from gbcli.utils.gbconstants import CLIPBOARD_CHAR, PROJECT_NAME
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("secret")
-@click.pass_context
-def cli(ctx):
+@unsupported_in_standalone("secret")
+def cli():
     """Work with secrets"""
-    if ctx.invoked_subcommand is not None:
-        exit_if_standalone("secret")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_secret.py
+++ b/src/gbcli/commands/command_secret.py
@@ -8,7 +8,7 @@ from tabulate import tabulate
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import common_options, exit_if_standalone
 from gbcli.utils.gbconstants import CLIPBOARD_CHAR, PROJECT_NAME
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.versionutil import check_current_and_latest_versions
@@ -18,7 +18,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 @click.pass_context
 def cli(ctx):
     """Work with secrets"""
-    pass
+    if ctx.invoked_subcommand is not None:
+        exit_if_standalone("secret")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_space.py
+++ b/src/gbcli/commands/command_space.py
@@ -8,7 +8,10 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.utils.gbconstants import CLIPBOARD_CHAR, PROJECT_NAME, SPACE_LIST_HEADERS
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.spaceutil import get_spaces
@@ -67,7 +70,7 @@ def list(
         # also corrupt ~/.gbcli/config because the standalone config has no spaces
         # section). Block the flag with a clear message instead.
         click.echo(
-            "⚠️  Warning: '--refresh' is not supported in standalone mode "
+            "❌ Error: '--refresh' is currently not supported in standalone mode "
             "(spaces are always fetched fresh from the local gbserver).",
             err=True,
         )
@@ -156,7 +159,7 @@ def list(
 
 
 @cli.command()
-@click.pass_context
+@pass_context_and_reject_standalone("space set")
 @click.argument("space_name", required=True)
 @click.option(
     "--default",

--- a/src/gbcli/commands/command_space.py
+++ b/src/gbcli/commands/command_space.py
@@ -13,6 +13,7 @@ from gbcli.utils.gbconstants import CLIPBOARD_CHAR, PROJECT_NAME, SPACE_LIST_HEA
 from gbcli.utils.gbcredentials import get_user_token
 from gbcli.utils.spaceutil import get_spaces
 from gbcli.utils.versionutil import check_current_and_latest_versions
+from gbcommon.types.gbenvconfig import is_standalone
 
 
 @click.group("space")
@@ -57,6 +58,18 @@ def list(
     if refresh and not all:
         click.echo(
             f"❌ Try running again with 'llmb space list --all --refresh", err=True
+        )
+        ctx.exit(1)  # Exit with a non-zero status
+
+    if refresh and is_standalone():
+        # In standalone mode spaces are always fetched fresh from the local gbserver,
+        # and the local cache/profile that --refresh repopulates is never used (it would
+        # also corrupt ~/.gbcli/config because the standalone config has no spaces
+        # section). Block the flag with a clear message instead.
+        click.echo(
+            "⚠️  Warning: '--refresh' is not supported in standalone mode "
+            "(spaces are always fetched fresh from the local gbserver).",
+            err=True,
         )
         ctx.exit(1)  # Exit with a non-zero status
 

--- a/src/gbcli/commands/command_step.py
+++ b/src/gbcli/commands/command_step.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, exit_if_standalone
+from gbcli.commands.common_options import common_options, unsupported_in_standalone
 from gbcli.utils.gbconstants import (
     CLIPBOARD_CHAR,
     PROJECT_NAME,
@@ -22,11 +22,9 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("step")
-@click.pass_context
-def cli(ctx):
+@unsupported_in_standalone("step")
+def cli():
     """Work with steps"""
-    if ctx.invoked_subcommand is not None:
-        exit_if_standalone("step")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_step.py
+++ b/src/gbcli/commands/command_step.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import common_options, exit_if_standalone
 from gbcli.utils.gbconstants import (
     CLIPBOARD_CHAR,
     PROJECT_NAME,
@@ -25,7 +25,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 @click.pass_context
 def cli(ctx):
     """Work with steps"""
-    pass
+    if ctx.invoked_subcommand is not None:
+        exit_if_standalone("step")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_step.py
+++ b/src/gbcli/commands/command_step.py
@@ -9,7 +9,10 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, unsupported_in_standalone
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.utils.gbconstants import (
     CLIPBOARD_CHAR,
     PROJECT_NAME,
@@ -22,8 +25,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("step")
-@unsupported_in_standalone("step")
-def cli():
+@pass_context_and_reject_standalone
+def cli(ctx):
     """Work with steps"""
 
 

--- a/src/gbcli/commands/command_template.py
+++ b/src/gbcli/commands/command_template.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options
+from gbcli.commands.common_options import common_options, exit_if_standalone
 from gbcli.utils.gbconstants import (
     BUILD_DESCRIBE_ARTIFACTS_HEADERS,
     BUILD_DESCRIBE_STEPS_HEADERS,
@@ -24,7 +24,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 @click.pass_context
 def cli(ctx):
     """Work with templates"""
-    pass
+    if ctx.invoked_subcommand is not None:
+        exit_if_standalone("template")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_template.py
+++ b/src/gbcli/commands/command_template.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, exit_if_standalone
+from gbcli.commands.common_options import common_options, unsupported_in_standalone
 from gbcli.utils.gbconstants import (
     BUILD_DESCRIBE_ARTIFACTS_HEADERS,
     BUILD_DESCRIBE_STEPS_HEADERS,
@@ -21,11 +21,9 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("template")
-@click.pass_context
-def cli(ctx):
+@unsupported_in_standalone("template")
+def cli():
     """Work with templates"""
-    if ctx.invoked_subcommand is not None:
-        exit_if_standalone("template")
 
 
 @cli.command()

--- a/src/gbcli/commands/command_template.py
+++ b/src/gbcli/commands/command_template.py
@@ -8,7 +8,10 @@ from tqdm import tqdm
 
 from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import str_exc_chain
-from gbcli.commands.common_options import common_options, unsupported_in_standalone
+from gbcli.commands.common_options import (
+    common_options,
+    pass_context_and_reject_standalone,
+)
 from gbcli.utils.gbconstants import (
     BUILD_DESCRIBE_ARTIFACTS_HEADERS,
     BUILD_DESCRIBE_STEPS_HEADERS,
@@ -21,8 +24,8 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 
 
 @click.group("template")
-@unsupported_in_standalone("template")
-def cli():
+@pass_context_and_reject_standalone
+def cli(ctx):
     """Work with templates"""
 
 

--- a/src/gbcli/commands/common_options.py
+++ b/src/gbcli/commands/common_options.py
@@ -16,18 +16,38 @@ def exit_if_standalone(command_name: str) -> None:
     """
     if is_standalone():
         click.echo(
-            f"⚠️  Warning: '{command_name}' is not supported in standalone mode "
+            f"❌ Error: '{command_name}' is currently not supported in standalone mode "
             f"(GB_ENVIRONMENT=STANDALONE).",
             err=True,
         )
         sys.exit(1)
 
 
-def unsupported_in_standalone(command_name: str):
-    """Decorator that guards a Click command or group against standalone mode.
+def pass_context_and_reject_standalone(command_name=None):
+    """Decorator that passes the Click context and guards against standalone mode.
 
-    Apply below ``@click.group(...)`` / ``@cli.command(...)`` to warn and exit non-zero
-    when the command is invoked in standalone mode (see :func:`exit_if_standalone`).
+    Combines ``@click.pass_context`` with a standalone-mode guard: apply it below
+    ``@click.group(...)`` / ``@cli.command(...)`` (in place of ``@click.pass_context``)
+    to warn and exit non-zero when the command is invoked in standalone mode (see
+    :func:`exit_if_standalone`). The wrapped callback still receives ``ctx`` as its first
+    argument, so callbacks that need the context keep their ``ctx`` parameter and do not
+    declare their own ``@click.pass_context``.
+
+    The command name shown in the warning defaults to ``ctx.info_name`` (the Click
+    command name as invoked), so group-level guards need no argument::
+
+        @click.group("secret")
+        @pass_context_and_reject_standalone
+        def cli(ctx):
+            ...
+
+    Pass an explicit name when the default would lose context -- e.g. a leaf subcommand
+    whose ``info_name`` is just ``"set"`` but should read ``"space set"``::
+
+        @cli.command()
+        @pass_context_and_reject_standalone("space set")
+        def set(ctx, ...):
+            ...
 
     Works on both groups and leaf commands:
 
@@ -35,13 +55,6 @@ def unsupported_in_standalone(command_name: str):
       being invoked, so ``<group> --help`` (and bare ``<group>``) still work.
     * On a leaf command the guard fires whenever the command runs; Click handles
       ``--help`` before the callback, so help is unaffected.
-
-    Example::
-
-        @cli.command()
-        @unsupported_in_standalone("model list")
-        def list(...):
-            ...
     """
 
     def decorator(f):
@@ -53,10 +66,16 @@ def unsupported_in_standalone(command_name: str):
             # is always None, so the guard fires as expected.
             is_group = isinstance(ctx.command, click.Group)
             if not is_group or ctx.invoked_subcommand is not None:
-                exit_if_standalone(command_name)
+                exit_if_standalone(command_name or ctx.info_name)
             return ctx.invoke(f, *args, **kwargs)
 
         return wrapper
+
+    # Allow usage as a bare decorator (@pass_context_and_reject_standalone) in addition
+    # to the called forms (@pass_context_and_reject_standalone() / (...("name")).
+    if callable(command_name):
+        f, command_name = command_name, None
+        return decorator(f)
 
     return decorator
 

--- a/src/gbcli/commands/common_options.py
+++ b/src/gbcli/commands/common_options.py
@@ -23,6 +23,44 @@ def exit_if_standalone(command_name: str) -> None:
         sys.exit(1)
 
 
+def unsupported_in_standalone(command_name: str):
+    """Decorator that guards a Click command or group against standalone mode.
+
+    Apply below ``@click.group(...)`` / ``@cli.command(...)`` to warn and exit non-zero
+    when the command is invoked in standalone mode (see :func:`exit_if_standalone`).
+
+    Works on both groups and leaf commands:
+
+    * On a ``@click.group`` callback the guard only fires when a subcommand is actually
+      being invoked, so ``<group> --help`` (and bare ``<group>``) still work.
+    * On a leaf command the guard fires whenever the command runs; Click handles
+      ``--help`` before the callback, so help is unaffected.
+
+    Example::
+
+        @cli.command()
+        @unsupported_in_standalone("model list")
+        def list(...):
+            ...
+    """
+
+    def decorator(f):
+        @wraps(f)
+        @click.pass_context
+        def wrapper(ctx: click.Context, *args, **kwargs):
+            # For a group, ctx.invoked_subcommand is set when a subcommand is being
+            # dispatched and None for bare/`--help` invocations. For a leaf command it
+            # is always None, so the guard fires as expected.
+            is_group = isinstance(ctx.command, click.Group)
+            if not is_group or ctx.invoked_subcommand is not None:
+                exit_if_standalone(command_name)
+            return ctx.invoke(f, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def common_options(f):
     @wraps(f)
     @click.option(

--- a/src/gbcli/commands/common_options.py
+++ b/src/gbcli/commands/common_options.py
@@ -67,7 +67,10 @@ def pass_context_and_reject_standalone(command_name=None):
             is_group = isinstance(ctx.command, click.Group)
             if not is_group or ctx.invoked_subcommand is not None:
                 exit_if_standalone(command_name or ctx.info_name)
-            return ctx.invoke(f, *args, **kwargs)
+            # ``f`` is the bare callback (its own ``@click.pass_context`` was replaced
+            # by this decorator), so ``ctx.invoke`` will not auto-inject the context --
+            # pass it explicitly as the first positional argument.
+            return ctx.invoke(f, ctx, *args, **kwargs)
 
         return wrapper
 

--- a/src/gbcli/commands/common_options.py
+++ b/src/gbcli/commands/common_options.py
@@ -1,6 +1,26 @@
+import sys
 from functools import wraps
 
 import click
+
+from gbcommon.types.gbenvconfig import is_standalone
+
+
+def exit_if_standalone(command_name: str) -> None:
+    """Warn and exit non-zero if an unsupported command is run in standalone mode.
+
+    Commands that depend on cloud-only services (Lakehouse, GitHub Enterprise, the
+    gbserver secret/admin backends) cannot work when GB_ENVIRONMENT=STANDALONE. Calling
+    this at the start of such a command surfaces a clear warning instead of letting it
+    fail later with a confusing auth/network error.
+    """
+    if is_standalone():
+        click.echo(
+            f"⚠️  Warning: '{command_name}' is not supported in standalone mode "
+            f"(GB_ENVIRONMENT=STANDALONE).",
+            err=True,
+        )
+        sys.exit(1)
 
 
 def common_options(f):

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -2885,7 +2885,10 @@ def update_build(
             )
 
     username = get_user(github_token).login
-    if not username or not github_token:
+    # In standalone mode an empty token is legitimate (the local gbserver allows
+    # localhost access when no GBSERVER_API_KEY is configured), so only require a
+    # non-empty token outside standalone mode.
+    if not username or (not github_token and not is_standalone()):
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)
 
     gbserver_artifact = update_build_gserver(

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -1083,7 +1083,10 @@ def build_log(
     skip_id_check: Optional[bool] = False,
     callback=None,
 ):
-    if not github_token:
+    # In standalone mode an empty token is legitimate: the local gbserver allows
+    # localhost access when no GBSERVER_API_KEY is configured. Only require a non-empty
+    # token outside standalone mode.
+    if not github_token and not is_standalone():
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)
 
     resolved_space = (

--- a/src/gbcli/services/service_version.py
+++ b/src/gbcli/services/service_version.py
@@ -1,9 +1,13 @@
 from gbcli.utils.gbconstants import GBSERVER_INSTANCE, USER_NOT_LOGGED_IN_ERROR_MESSAGE
 from gbcli.utils.gbserver import get_server_version, make_gbserver_call
+from gbcommon.types.gbenvconfig import is_standalone
 
 
 def get_gbserver_version(github_token: str, quiet: bool, callback=None) -> str:
-    if not github_token:
+    # In standalone mode an empty token is legitimate (the local gbserver allows
+    # localhost access when no GBSERVER_API_KEY is configured), so only require a
+    # non-empty token outside standalone mode.
+    if not github_token and not is_standalone():
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)
 
     if callback and not quiet:

--- a/src/gbcli/utils/gbserver.py
+++ b/src/gbcli/utils/gbserver.py
@@ -764,7 +764,10 @@ def update_build_gserver(
     tags: Optional[list[str]] = None,
     append: bool = False,
 ):
-    if server_api and user_token:
+    # In standalone mode an empty token is legitimate (the local gbserver allows
+    # localhost access when no GBSERVER_API_KEY is configured). Without this, an empty
+    # token would silently skip the update and the change would never be sent.
+    if server_api and (user_token or is_standalone()):
         put_url = f"{server_api}{build_id}/update"
         try:
 

--- a/src/gbcli/utils/log_query.py
+++ b/src/gbcli/utils/log_query.py
@@ -12,6 +12,7 @@ from gbcli.utils.gbconstants import (
 from gbcli.utils.gbserver import gbserver_post
 from gbcli.utils.gh_auth import get_user
 from gbcli.utils.utils import convert_seconds_to_milliseconds
+from gbcommon.types.gbenvconfig import is_standalone
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,10 @@ def run_logquery(
     is_admin: Optional[bool] = None,
 ):
     username = get_user(github_token).login
-    if not username or not github_token:
+    # In standalone mode an empty token is legitimate (the local gbserver allows
+    # localhost access when no GBSERVER_API_KEY is configured), so only require a
+    # non-empty token outside standalone mode.
+    if not username or (not github_token and not is_standalone()):
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)
 
     url = f"{GBSERVER_LOGS_API}logquery"

--- a/src/gbcli/utils/versionutil.py
+++ b/src/gbcli/utils/versionutil.py
@@ -11,6 +11,7 @@ from gbcli.utils.gbconstants import (
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.gh_clone import get_repo_tags, run_github_command
 from gbcommon.types.constants import get_gh_credentials_section
+from gbcommon.types.gbenvconfig import is_standalone
 
 
 def get_latest_version(user_token: str, repo_org: str, repo_name: str) -> str:
@@ -33,6 +34,12 @@ def get_current_version(package_name: str) -> str:
 
 
 def check_current_and_latest_versions() -> str:
+    # The version check queries GitHub Enterprise (and so requires GitHub auth), which is
+    # unavailable in standalone mode. Skip it there so standalone commands don't fail
+    # with "user not logged in" just for the update check.
+    if is_standalone():
+        return ""
+
     credentials = GBCredentials()
     if not credentials.check_values():
         raise Exception(USER_NOT_LOGGED_IN_ERROR_MESSAGE)

--- a/test/unit/standalone/test_gbcli_standalone_guards.py
+++ b/test/unit/standalone/test_gbcli_standalone_guards.py
@@ -63,9 +63,12 @@ class TestGbcliStandaloneGuards:
             f"'{group_name} {' '.join(subcommand)}' should exit non-zero in standalone "
             f"mode, got {result.exit_code}"
         )
-        assert WARNING_FRAGMENT in result.stderr, (
-            f"expected standalone warning in stderr for '{group_name}', "
-            f"got: {result.stderr!r}"
+        # Assert against result.output (combined stdout+stderr) rather than
+        # result.stderr: CliRunner mixes the streams by default on Click 8.1.x, where
+        # accessing result.stderr raises "stderr not separately captured".
+        assert WARNING_FRAGMENT in result.output, (
+            f"expected standalone warning for '{group_name}', "
+            f"got: {result.output!r}"
         )
 
     @pytest.mark.parametrize("module_path,group_name,subcommand", GUARDED_COMMANDS)
@@ -79,7 +82,7 @@ class TestGbcliStandaloneGuards:
 
         assert result.exit_code == 0, (
             f"'{group_name} --help' should succeed in standalone mode, "
-            f"got {result.exit_code}: {result.stderr}"
+            f"got {result.exit_code}: {result.output}"
         )
         assert WARNING_FRAGMENT not in result.output
 
@@ -94,7 +97,7 @@ class TestGbcliStandaloneGuards:
         # still fail later (no credentials), but it must not emit the standalone warning.
         result = runner.invoke(cli, subcommand, env={"GB_ENVIRONMENT": "PROD"})
 
-        assert WARNING_FRAGMENT not in result.stderr, (
+        assert WARNING_FRAGMENT not in result.output, (
             f"standalone warning should not appear for '{group_name}' outside "
-            f"standalone mode, got: {result.stderr!r}"
+            f"standalone mode, got: {result.output!r}"
         )

--- a/test/unit/standalone/test_gbcli_standalone_guards.py
+++ b/test/unit/standalone/test_gbcli_standalone_guards.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify that cloud-only gbcli commands are guarded in standalone mode.
+
+The ``admin`` and ``secret`` command groups depend on cloud-only backends and cannot
+work when ``GB_ENVIRONMENT=STANDALONE``. Invoking any of their subcommands in standalone
+mode should warn and exit non-zero *before* hitting an auth/network error, while plain
+``--help`` should still work.
+"""
+
+import importlib
+
+import pytest
+from click.testing import CliRunner
+
+STANDALONE_ENV = {"GB_ENVIRONMENT": "STANDALONE"}
+WARNING_FRAGMENT = "not supported in standalone mode"
+
+# (module path, group name, a representative subcommand invocation)
+GUARDED_COMMANDS = [
+    ("gbcli.commands.command_secret", "secret", ["list"]),
+    ("gbcli.commands.command_admin", "admin", ["log", "gbserver-rest-server"]),
+    ("gbcli.commands.command_template", "template", ["list"]),
+    ("gbcli.commands.command_step", "step", ["list"]),
+    ("gbcli.commands.command_artifact", "artifact", ["list"]),
+]
+
+
+def _load_cli(module_path: str):
+    """Import a command module fresh and return its ``cli`` group."""
+    module = importlib.import_module(module_path)
+    return module.cli
+
+
+class TestGbcliStandaloneGuards:
+    """The admin and secret groups must refuse to run subcommands in standalone mode."""
+
+    @pytest.mark.parametrize("module_path,group_name,subcommand", GUARDED_COMMANDS)
+    def test_subcommand_blocked_in_standalone(
+        self, module_path: str, group_name: str, subcommand: list
+    ):
+        """A guarded subcommand should warn and exit non-zero in standalone mode."""
+        cli = _load_cli(module_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, subcommand, env=STANDALONE_ENV)
+
+        assert result.exit_code != 0, (
+            f"'{group_name} {' '.join(subcommand)}' should exit non-zero in standalone "
+            f"mode, got {result.exit_code}"
+        )
+        assert WARNING_FRAGMENT in result.stderr, (
+            f"expected standalone warning in stderr for '{group_name}', "
+            f"got: {result.stderr!r}"
+        )
+
+    @pytest.mark.parametrize("module_path,group_name,subcommand", GUARDED_COMMANDS)
+    def test_group_help_works_in_standalone(
+        self, module_path: str, group_name: str, subcommand: list
+    ):
+        """Group-level --help must still work in standalone mode (no guard)."""
+        cli = _load_cli(module_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"], env=STANDALONE_ENV)
+
+        assert result.exit_code == 0, (
+            f"'{group_name} --help' should succeed in standalone mode, "
+            f"got {result.exit_code}: {result.stderr}"
+        )
+        assert WARNING_FRAGMENT not in result.output
+
+    @pytest.mark.parametrize("module_path,group_name,subcommand", GUARDED_COMMANDS)
+    def test_subcommand_not_blocked_outside_standalone(
+        self, module_path: str, group_name: str, subcommand: list
+    ):
+        """Outside standalone mode the guard must not fire (no warning)."""
+        cli = _load_cli(module_path)
+        runner = CliRunner()
+        # Force a non-standalone environment so the guard is a no-op. The command may
+        # still fail later (no credentials), but it must not emit the standalone warning.
+        result = runner.invoke(cli, subcommand, env={"GB_ENVIRONMENT": "PROD"})
+
+        assert WARNING_FRAGMENT not in result.stderr, (
+            f"standalone warning should not appear for '{group_name}' outside "
+            f"standalone mode, got: {result.stderr!r}"
+        )

--- a/test/unit/standalone/test_gbcli_standalone_guards.py
+++ b/test/unit/standalone/test_gbcli_standalone_guards.py
@@ -37,6 +37,7 @@ GUARDED_COMMANDS = [
     ("gbcli.commands.command_template", "template", ["list"]),
     ("gbcli.commands.command_step", "step", ["list"]),
     ("gbcli.commands.command_artifact", "artifact", ["list"]),
+    ("gbcli.commands.command_model", "model", ["list"]),
 ]
 
 

--- a/test/unit/standalone/test_gbcli_subcommand_guards.py
+++ b/test/unit/standalone/test_gbcli_subcommand_guards.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-subcommand / per-flag standalone guards in the ``gb`` CLI.
+
+Unlike the whole-group guards (admin, secret, template, ...), these block individual
+subcommands of otherwise-supported groups, or a specific flag:
+
+* ``space set``                  — whole subcommand
+* ``build lineage``              — whole subcommand
+* ``build notification``         — whole subcommand
+* ``build init --from-template`` — flag only (``--from-build`` stays allowed)
+
+All assert against ``result.output`` (combined stdout+stderr): CliRunner mixes the
+streams by default on Click 8.1.x, where accessing ``result.stderr`` raises.
+"""
+
+import importlib
+
+import pytest
+from click.testing import CliRunner
+
+WARNING_FRAGMENT = "not supported in standalone mode"
+
+# (module path, argv) for whole-subcommand blocks.
+GUARDED_SUBCOMMANDS = [
+    ("gbcli.commands.command_space", ["set", "myspace", "--skip-version-check"]),
+    ("gbcli.commands.command_build", ["lineage", "someid", "--skip-version-check"]),
+    ("gbcli.commands.command_build", ["notification", "on", "--skip-version-check"]),
+]
+
+
+def _cli(module_path: str):
+    return importlib.import_module(module_path).cli
+
+
+class TestSubcommandStandaloneGuards:
+    @pytest.mark.parametrize("module_path,argv", GUARDED_SUBCOMMANDS)
+    def test_blocked_in_standalone(self, module_path: str, argv: list):
+        result = CliRunner().invoke(
+            _cli(module_path), argv, env={"GB_ENVIRONMENT": "STANDALONE"}
+        )
+        assert result.exit_code != 0, f"{argv} should exit non-zero in standalone"
+        assert (
+            WARNING_FRAGMENT in result.output
+        ), f"expected standalone warning for {argv}, got: {result.output!r}"
+
+    @pytest.mark.parametrize("module_path,argv", GUARDED_SUBCOMMANDS)
+    def test_not_blocked_outside_standalone(self, module_path: str, argv: list):
+        result = CliRunner().invoke(
+            _cli(module_path), argv, env={"GB_ENVIRONMENT": "PROD"}
+        )
+        assert WARNING_FRAGMENT not in result.output, (
+            f"standalone warning should not appear for {argv} outside standalone, "
+            f"got: {result.output!r}"
+        )
+
+
+class TestBuildInitFromTemplateGuard:
+    """`build init --from-template` is blocked in standalone; --from-build is not."""
+
+    def test_from_template_blocked_in_standalone(self):
+        result = CliRunner().invoke(
+            _cli("gbcli.commands.command_build"),
+            ["init", "myb", "--from-template", "hello", "--skip-version-check"],
+            env={"GB_ENVIRONMENT": "STANDALONE"},
+        )
+        assert result.exit_code != 0
+        assert "build init --from-template" in result.output
+
+    def test_from_build_not_blocked_in_standalone(self):
+        """--from-build must NOT trigger the --from-template standalone guard."""
+        result = CliRunner().invoke(
+            _cli("gbcli.commands.command_build"),
+            [
+                "init",
+                "myb",
+                "--from-build",
+                "00000000-0000-0000-0000-000000000000",
+                "--skip-version-check",
+            ],
+            env={"GB_ENVIRONMENT": "STANDALONE"},
+        )
+        assert "currently not supported in standalone" not in result.output

--- a/test/unit/standalone/test_space_refresh_standalone.py
+++ b/test/unit/standalone/test_space_refresh_standalone.py
@@ -27,7 +27,7 @@ from click.testing import CliRunner
 
 # Assert against result.output (combined stdout+stderr): CliRunner mixes the streams by
 # default on Click 8.1.x, where accessing result.stderr raises.
-WARNING_FRAGMENT = "'--refresh' is not supported in standalone mode"
+WARNING_FRAGMENT = "'--refresh' is currently not supported in standalone mode"
 
 
 def _space_cli():

--- a/test/unit/standalone/test_space_refresh_standalone.py
+++ b/test/unit/standalone/test_space_refresh_standalone.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``gb space list --refresh`` is blocked in standalone mode.
+
+In standalone mode spaces are always fetched fresh from the local gbserver and the local
+cache/profile that ``--refresh`` repopulates is never used (writing it would also corrupt
+~/.gbcli/config). The flag should warn and exit non-zero instead.
+"""
+
+import importlib
+
+from click.testing import CliRunner
+
+# Assert against result.output (combined stdout+stderr): CliRunner mixes the streams by
+# default on Click 8.1.x, where accessing result.stderr raises.
+WARNING_FRAGMENT = "'--refresh' is not supported in standalone mode"
+
+
+def _space_cli():
+    module = importlib.import_module("gbcli.commands.command_space")
+    return module.cli
+
+
+class TestSpaceRefreshStandalone:
+    def test_refresh_blocked_in_standalone(self):
+        """`space list --all --refresh` should warn and exit non-zero in standalone."""
+        runner = CliRunner()
+        result = runner.invoke(
+            _space_cli(),
+            ["list", "--all", "--refresh", "--skip-version-check"],
+            env={"GB_ENVIRONMENT": "STANDALONE"},
+        )
+
+        assert result.exit_code != 0, (
+            f"'space list --all --refresh' should exit non-zero in standalone mode, "
+            f"got {result.exit_code}"
+        )
+        assert (
+            WARNING_FRAGMENT in result.output
+        ), f"expected --refresh standalone warning, got: {result.output!r}"
+
+    def test_refresh_not_blocked_outside_standalone(self):
+        """Outside standalone the --refresh guard must not fire (no warning)."""
+        runner = CliRunner()
+        # The command may fail later (no gbserver/credentials), but it must not emit the
+        # standalone --refresh warning.
+        result = runner.invoke(
+            _space_cli(),
+            ["list", "--all", "--refresh", "--skip-version-check"],
+            env={"GB_ENVIRONMENT": "PROD"},
+        )
+
+        assert WARNING_FRAGMENT not in result.output, (
+            f"--refresh standalone warning should not appear outside standalone mode, "
+            f"got: {result.output!r}"
+        )

--- a/test/unit/utils/test_log_query_standalone.py
+++ b/test/unit/utils/test_log_query_standalone.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone-mode token handling for ``build log`` (run_logquery).
+
+In standalone mode the gbserver log query should work with an empty user token: the
+local gbserver allows localhost access when no GBSERVER_API_KEY is configured. Outside
+standalone mode an empty token must still be rejected as "not logged in".
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gbcli.utils import log_query
+from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE
+
+
+@pytest.fixture
+def fake_user(monkeypatch):
+    """get_user() returns a synthetic standalone user (as it does in standalone mode)."""
+    monkeypatch.setattr(
+        log_query, "get_user", lambda token: SimpleNamespace(login="standalone")
+    )
+
+
+@pytest.fixture
+def captured_post(monkeypatch):
+    """Replace gbserver_post so no network call is made; record that it was reached."""
+    calls = {}
+
+    def _fake_post(token, url, payload):
+        calls["token"] = token
+        calls["url"] = url
+        return {"status": 200, "result": []}
+
+    monkeypatch.setattr(log_query, "gbserver_post", _fake_post)
+    return calls
+
+
+class TestRunLogqueryStandaloneToken:
+    def test_empty_token_allowed_in_standalone(
+        self, monkeypatch, fake_user, captured_post
+    ):
+        """An empty token must NOT raise in standalone mode; the query proceeds."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "STANDALONE")
+
+        result = log_query.run_logquery(
+            github_token="",
+            start_epoch_in_s=0,
+            end_epoch_in_s=1,
+            callback=lambda **kwargs: None,
+        )
+
+        assert result == {"status": 200, "result": []}
+        assert captured_post["token"] == ""  # forwarded as-is to the local gbserver
+
+    def test_empty_token_rejected_outside_standalone(
+        self, monkeypatch, fake_user, captured_post
+    ):
+        """An empty token must still raise 'not logged in' outside standalone mode."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        with pytest.raises(Exception) as exc_info:
+            log_query.run_logquery(
+                github_token="",
+                start_epoch_in_s=0,
+                end_epoch_in_s=1,
+                callback=lambda **kwargs: None,
+            )
+
+        assert USER_NOT_LOGGED_IN_ERROR_MESSAGE in str(exc_info.value)
+        assert "token" not in captured_post  # never reached the request
+
+    def test_nonempty_token_works_outside_standalone(
+        self, monkeypatch, fake_user, captured_post
+    ):
+        """A normal (non-empty) token still works outside standalone mode."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        result = log_query.run_logquery(
+            github_token="some-token",
+            start_epoch_in_s=0,
+            end_epoch_in_s=1,
+            callback=lambda **kwargs: None,
+        )
+
+        assert result == {"status": 200, "result": []}
+        assert captured_post["token"] == "some-token"

--- a/test/unit/utils/test_service_build_update_standalone.py
+++ b/test/unit/utils/test_service_build_update_standalone.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone-mode token handling for ``gb build update`` (update_build).
+
+In standalone mode an empty user token is legitimate (the local gbserver allows localhost
+access when no GBSERVER_API_KEY is configured), so update_build must not reject it.
+Outside standalone mode an empty token still raises "user not logged in".
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gbcli.services import service_build
+from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Stub get_user (synthetic standalone user) and the gbserver update call."""
+    calls = {}
+
+    monkeypatch.setattr(
+        service_build, "get_user", lambda token: SimpleNamespace(login="standalone")
+    )
+
+    def _fake_update(build_id, server_api, user_token, description, tags, append):
+        calls["token"] = user_token
+        return {"build_id": build_id, "description": description}
+
+    monkeypatch.setattr(service_build, "update_build_gserver", _fake_update)
+    return calls
+
+
+class TestUpdateBuildStandaloneToken:
+    def test_empty_token_allowed_in_standalone(self, monkeypatch, patched):
+        monkeypatch.setenv("GB_ENVIRONMENT", "STANDALONE")
+
+        result = service_build.update_build("", "bid", description="hi")
+
+        assert result == {"build_id": "bid", "description": "hi"}
+        assert patched["token"] == ""
+
+    def test_empty_token_rejected_outside_standalone(self, monkeypatch, patched):
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        with pytest.raises(Exception) as exc_info:
+            service_build.update_build("", "bid", description="hi")
+
+        assert USER_NOT_LOGGED_IN_ERROR_MESSAGE in str(exc_info.value)
+        assert "token" not in patched  # never reached the gbserver call
+
+    def test_nonempty_token_works_outside_standalone(self, monkeypatch, patched):
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        result = service_build.update_build("real-token", "bid", description="hi")
+
+        assert result == {"build_id": "bid", "description": "hi"}
+        assert patched["token"] == "real-token"
+
+
+class TestUpdateBuildGserverStandaloneGuard:
+    """update_build_gserver must still issue the PUT with an empty token in standalone.
+
+    The old ``if server_api and user_token:`` guard silently skipped the request (and
+    returned None) when the token was empty -- so an update appeared to succeed but never
+    reached gbserver. In standalone an empty token must still send the request.
+    """
+
+    def test_empty_token_still_sends_request_in_standalone(self, monkeypatch):
+        from gbcli.utils import gbserver
+
+        sent = {}
+
+        def _fake_put(token, url, body):
+            sent["url"] = url
+            sent["body"] = body
+            return {"build": {"build_id": "bid", "tags": body.get("tags")}}
+
+        monkeypatch.setenv("GB_ENVIRONMENT", "STANDALONE")
+        monkeypatch.setattr(gbserver, "gbserver_put", _fake_put)
+
+        result = gbserver.update_build_gserver(
+            build_id="bid",
+            server_api="http://localhost:8080/api/v1/builds/",
+            user_token="",
+            tags=["tagA"],
+        )
+
+        assert sent, "PUT should be issued even with an empty token in standalone"
+        assert sent["body"]["tags"] == {"set": ["tagA"]}
+        assert result == {"build_id": "bid", "tags": {"set": ["tagA"]}}
+
+    def test_empty_token_skips_request_outside_standalone(self, monkeypatch):
+        from gbcli.utils import gbserver
+
+        sent = {}
+
+        def _fake_put(token, url, body):
+            sent["url"] = url
+            return {"build": {}}
+
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+        monkeypatch.setattr(gbserver, "gbserver_put", _fake_put)
+
+        result = gbserver.update_build_gserver(
+            build_id="bid",
+            server_api="http://host/api/v1/builds/",
+            user_token="",
+            tags=["tagA"],
+        )
+
+        # Outside standalone an empty token still short-circuits (no request, None).
+        assert not sent
+        assert result is None

--- a/test/unit/utils/test_service_version_standalone.py
+++ b/test/unit/utils/test_service_version_standalone.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone-mode token handling for ``gb version`` (get_gbserver_version).
+
+In standalone mode the gbserver version query should work with an empty user token: the
+local gbserver allows localhost access when no GBSERVER_API_KEY is configured. Outside
+standalone mode an empty token must still be rejected as "not logged in".
+"""
+
+import pytest
+
+from gbcli.services import service_version
+from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE
+
+
+@pytest.fixture
+def captured_call(monkeypatch):
+    """Replace get_server_version so no network call is made; record the token used."""
+    calls = {}
+
+    def _fake_get_server_version(user_token, gbserver_instance):
+        calls["token"] = user_token
+        return {"git_commit": "abc1234"}
+
+    monkeypatch.setattr(service_version, "get_server_version", _fake_get_server_version)
+    # make_gbserver_call just invokes the thunk; keep it simple and deterministic.
+    monkeypatch.setattr(
+        service_version, "make_gbserver_call", lambda fn, callback: fn()
+    )
+    return calls
+
+
+class TestGetGbserverVersionStandaloneToken:
+    def test_empty_token_allowed_in_standalone(self, monkeypatch, captured_call):
+        """An empty token must NOT raise in standalone mode; the query proceeds."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "STANDALONE")
+
+        result = service_version.get_gbserver_version("", quiet=True, callback=None)
+
+        assert result == "abc1234"
+        assert captured_call["token"] == ""
+
+    def test_empty_token_rejected_outside_standalone(self, monkeypatch, captured_call):
+        """An empty token must still raise 'not logged in' outside standalone mode."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        with pytest.raises(Exception) as exc_info:
+            service_version.get_gbserver_version("", quiet=True, callback=None)
+
+        assert USER_NOT_LOGGED_IN_ERROR_MESSAGE in str(exc_info.value)
+        assert "token" not in captured_call  # never reached the request
+
+    def test_nonempty_token_works_outside_standalone(self, monkeypatch, captured_call):
+        """A normal (non-empty) token still works outside standalone mode."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        result = service_version.get_gbserver_version(
+            "some-token", quiet=True, callback=None
+        )
+
+        assert result == "abc1234"
+        assert captured_call["token"] == "some-token"

--- a/test/unit/utils/test_versionutil_standalone.py
+++ b/test/unit/utils/test_versionutil_standalone.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone-mode behavior of the CLI version check.
+
+``check_current_and_latest_versions()`` runs at the top of most ``gb`` commands and
+queries GitHub Enterprise (requiring GitHub auth). In standalone mode that auth is
+unavailable, so the check must be skipped (return "") rather than raising
+"user not logged in".
+"""
+
+import pytest
+
+from gbcli.utils import versionutil
+from gbcli.utils.gbconstants import USER_NOT_LOGGED_IN_ERROR_MESSAGE
+
+
+class TestVersionCheckStandalone:
+    def test_skipped_in_standalone(self, monkeypatch):
+        """In standalone mode the check returns '' without touching credentials/network."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "STANDALONE")
+
+        # Guard: if the check did NOT short-circuit, these would be reached and blow up,
+        # making the test fail loudly rather than silently passing for the wrong reason.
+        def _boom(*args, **kwargs):
+            raise AssertionError("version check should not reach credentials/network")
+
+        monkeypatch.setattr(versionutil, "GBCredentials", _boom)
+        monkeypatch.setattr(versionutil, "get_latest_version", _boom)
+
+        assert versionutil.check_current_and_latest_versions() == ""
+
+    def test_requires_login_outside_standalone(self, monkeypatch):
+        """Outside standalone, missing credentials still raise 'user not logged in'."""
+        monkeypatch.setenv("GB_ENVIRONMENT", "PROD")
+
+        class _FakeCreds:
+            def check_values(self):
+                return False
+
+        monkeypatch.setattr(versionutil, "GBCredentials", lambda: _FakeCreds())
+
+        with pytest.raises(Exception) as exc_info:
+            versionutil.check_current_and_latest_versions()
+
+        assert USER_NOT_LOGGED_IN_ERROR_MESSAGE in str(exc_info.value)


### PR DESCRIPTION
introduced error (through guard decorator) in PR #69 for any non-standalone mode. This error was a result of not passing ctx.
