### PR TITLE
Allow gbserver-backed artifact commands in standalone mode

### DIFF
--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -75,6 +75,11 @@ def cli(ctx):
     # (list, describe, checksum, archive, unarchive, update) work in standalone mode.
     # Subcommands that depend on Lakehouse/HuggingFace (push, register, download, copy,
     # lineage) are guarded individually with @reject_standalone below.
+    #
+    # Unlike the secret/admin/template/step/model groups (guarded once at the group level),
+    # artifact is deliberately guarded per-subcommand because only *some* of its commands
+    # need cloud services. Accepted tradeoff: a new cloud-dependent artifact subcommand
+    # must remember its own @reject_standalone -- there is no group-level safety net.
     ctx.ensure_object(dict)  # Ensures `ctx.obj` is a dictionary
 
 

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -15,7 +15,7 @@ from gbcli.client.client import GBClient
 from gbcli.commands.command_auth import execute_with_spinner, str_exc_chain
 from gbcli.commands.common_options import (
     common_options,
-    pass_context_and_reject_standalone,
+    reject_standalone,
 )
 from gbcli.services.service_artifact import (
     ArtifactURIError,
@@ -68,14 +68,19 @@ logger = logging.getLogger(__name__)
 
 
 @click.group("artifact")
-@pass_context_and_reject_standalone
+@click.pass_context
 def cli(ctx):
     """Work with artifacts"""
+    # The group itself is not standalone-guarded: gbserver-backed metadata commands
+    # (list, describe, checksum, archive, unarchive, update) work in standalone mode.
+    # Subcommands that depend on Lakehouse/HuggingFace (push, register, download, copy,
+    # lineage) are guarded individually with @reject_standalone below.
     ctx.ensure_object(dict)  # Ensures `ctx.obj` is a dictionary
 
 
 @cli.command()
 @click.pass_context
+@reject_standalone
 @click.option(
     "--from-local",
     required=True,
@@ -783,6 +788,7 @@ def push(
 
 @cli.command()
 @click.pass_context
+@reject_standalone
 @click.option(
     "--artifact-name",
     required=True,
@@ -1539,6 +1545,7 @@ def _lineage_hf(ctx, artifact_client, artifact, format, quiet):
 
 @cli.command()
 @click.pass_context
+@reject_standalone
 @click.argument("artifact-id", required=True)
 @click.option(
     "--format",
@@ -2017,6 +2024,7 @@ def list(
     help="Git revision/branch name for HuggingFace artifacts (default: main)",
 )
 @click.pass_context
+@reject_standalone
 @common_options
 def download(
     ctx,
@@ -2577,6 +2585,7 @@ def unarchive(
 
 @cli.command()
 @click.pass_context
+@reject_standalone
 @click.argument("artifact_id")
 @click.option("--space-to", required=True, help="Destination space name.")
 @click.option(

--- a/src/gbcli/commands/common_options.py
+++ b/src/gbcli/commands/common_options.py
@@ -24,23 +24,19 @@ def exit_if_standalone(command_name: str) -> None:
 
 
 def _command_name_from_context(ctx: click.Context) -> str:
-    """Build a qualified command name (e.g. ``"artifact register"``) from a context.
+    """Return the qualified command name (e.g. ``"artifact register"``) for a context.
 
-    Walks the parent chain collecting each ``info_name`` and drops the root (the program
-    name, e.g. ``gb``), so the standalone warning reads ``'artifact register'`` rather than
-    just ``'register'`` -- without callers having to spell the name out.
+    Click already tracks the full invocation as ``ctx.command_path`` (e.g.
+    ``"gb artifact register"``); we just drop the leading program name so the standalone
+    warning reads ``'artifact register'`` rather than the full ``'gb artifact register'``,
+    without callers having to spell the name out.
     """
-    names = []
-    cur: click.Context | None = ctx
-    while cur is not None and cur.parent is not None:
-        if cur.info_name:
-            names.append(cur.info_name)
-        cur = cur.parent
-    return " ".join(reversed(names)) or (ctx.info_name or "")
+    _prog, _, qualified = ctx.command_path.partition(" ")
+    return qualified or ctx.command_path
 
 
 def reject_standalone(f):
-    """Decorator that guards a single command against standalone mode.
+    """Decorator that guards a single *leaf* command against standalone mode.
 
     Unlike :func:`pass_context_and_reject_standalone`, this does *not* inject the Click
     context -- it reads the active context via ``click.get_current_context`` and leaves the
@@ -58,11 +54,28 @@ def reject_standalone(f):
     Click handles ``--help`` before the callback, so help is unaffected. The name shown in
     the warning is derived from the active context (e.g. ``"artifact register"``), so no
     argument is needed.
+
+    The guard fires at callback time, i.e. *after* Click validates required args/options.
+    So ``gb artifact register`` with no args reports a missing-option error rather than the
+    standalone message. We accept this: the standalone guard is expected to be temporary
+    (these commands will eventually work standalone), so it is not worth the extra
+    complexity of an eager pre-parse hook to reorder the messages.
+
+    This is leaf-only by design: applied to a ``click.Group`` callback it would fire for
+    *every* subcommand once one is dispatched, silently re-introducing the blanket guard we
+    are trying to avoid. Guard against that misuse with a clear programming error; use
+    :func:`pass_context_and_reject_standalone` (which has the group/leaf handling) on a
+    group instead.
     """
 
     @wraps(f)
     def wrapper(*args, **kwargs):
         ctx = click.get_current_context()
+        if isinstance(ctx.command, click.Group):
+            raise RuntimeError(
+                "@reject_standalone is leaf-only; it would block every subcommand if "
+                "applied to a group. Use @pass_context_and_reject_standalone on groups."
+            )
         exit_if_standalone(_command_name_from_context(ctx))
         return f(*args, **kwargs)
 

--- a/src/gbcli/commands/common_options.py
+++ b/src/gbcli/commands/common_options.py
@@ -23,6 +23,52 @@ def exit_if_standalone(command_name: str) -> None:
         sys.exit(1)
 
 
+def _command_name_from_context(ctx: click.Context) -> str:
+    """Build a qualified command name (e.g. ``"artifact register"``) from a context.
+
+    Walks the parent chain collecting each ``info_name`` and drops the root (the program
+    name, e.g. ``gb``), so the standalone warning reads ``'artifact register'`` rather than
+    just ``'register'`` -- without callers having to spell the name out.
+    """
+    names = []
+    cur: click.Context | None = ctx
+    while cur is not None and cur.parent is not None:
+        if cur.info_name:
+            names.append(cur.info_name)
+        cur = cur.parent
+    return " ".join(reversed(names)) or (ctx.info_name or "")
+
+
+def reject_standalone(f):
+    """Decorator that guards a single command against standalone mode.
+
+    Unlike :func:`pass_context_and_reject_standalone`, this does *not* inject the Click
+    context -- it reads the active context via ``click.get_current_context`` and leaves the
+    wrapped callback's signature untouched, so it composes with a command's own
+    ``@click.pass_context`` (and other option decorators) without consuming an argument.
+    Use it as a bare decorator to gate the cloud-only subcommands of a group whose other
+    subcommands work in standalone mode, so the group itself stays unguarded::
+
+        @cli.command()
+        @click.pass_context
+        @reject_standalone
+        def register(ctx, ...):
+            ...
+
+    Click handles ``--help`` before the callback, so help is unaffected. The name shown in
+    the warning is derived from the active context (e.g. ``"artifact register"``), so no
+    argument is needed.
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        ctx = click.get_current_context()
+        exit_if_standalone(_command_name_from_context(ctx))
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
 def pass_context_and_reject_standalone(command_name=None):
     """Decorator that passes the Click context and guards against standalone mode.
 

--- a/test/unit/standalone/test_gbcli_standalone_guards.py
+++ b/test/unit/standalone/test_gbcli_standalone_guards.py
@@ -166,6 +166,35 @@ class TestArtifactStandaloneGuards:
             f"got: {result.output!r}"
         )
 
+    def test_warning_uses_qualified_command_name(self):
+        """The warning must name the command as ``artifact register``, not just ``register``.
+
+        ``reject_standalone`` derives the name from ``ctx.command_path`` minus the program
+        name, so it only reads correctly when the artifact group is mounted under a root
+        (as it is under the real ``gb`` CLI). Mount it that way here so the qualified-name
+        logic is actually exercised -- invoking the group as its own root would collapse
+        the name back to the bare leaf and silently pass.
+        """
+        import click
+
+        artifact_cli = _load_cli("gbcli.commands.command_artifact")
+        root = click.Group("gb")
+        root.add_command(artifact_cli)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            root,
+            ["artifact", "register", "--artifact-name", "a"],
+            env=STANDALONE_ENV,
+            prog_name="gb",
+        )
+
+        assert result.exit_code != 0
+        assert "'artifact register'" in result.output, (
+            f"expected qualified command name 'artifact register' in warning, "
+            f"got: {result.output!r}"
+        )
+
     @pytest.mark.parametrize(
         "module_path,group_name,subcommand", ARTIFACT_UNGUARDED_SUBCOMMANDS
     )

--- a/test/unit/standalone/test_gbcli_standalone_guards.py
+++ b/test/unit/standalone/test_gbcli_standalone_guards.py
@@ -36,8 +36,44 @@ GUARDED_COMMANDS = [
     ("gbcli.commands.command_admin", "admin", ["log", "gbserver-rest-server"]),
     ("gbcli.commands.command_template", "template", ["list"]),
     ("gbcli.commands.command_step", "step", ["list"]),
-    ("gbcli.commands.command_artifact", "artifact", ["list"]),
     ("gbcli.commands.command_model", "model", ["list"]),
+]
+
+# The artifact group is *not* guarded as a whole: gbserver-backed metadata commands work
+# in standalone mode, while only the Lakehouse/HuggingFace-dependent subcommands are
+# guarded individually. The guard fires at callback time, so each invocation must satisfy
+# Click's required-argument validation (which runs first) for the guard to be reached.
+# (module path, group name, subcommand invocation)
+ARTIFACT_GUARDED_SUBCOMMANDS = [
+    (
+        "gbcli.commands.command_artifact",
+        "artifact",
+        ["push", "--from-local", ".", "--artifact-name", "a", "--type", "model"],
+    ),
+    (
+        "gbcli.commands.command_artifact",
+        "artifact",
+        ["register", "--artifact-name", "a"],
+    ),
+    ("gbcli.commands.command_artifact", "artifact", ["download", "some-id"]),
+    (
+        "gbcli.commands.command_artifact",
+        "artifact",
+        ["copy", "some-id", "--space-to", "s"],
+    ),
+    ("gbcli.commands.command_artifact", "artifact", ["lineage", "some-id"]),
+]
+
+# Artifact subcommands that must remain runnable in standalone mode (they only talk to the
+# local gbserver). They may still fail later for other reasons, but must not emit the
+# standalone warning.
+ARTIFACT_UNGUARDED_SUBCOMMANDS = [
+    ("gbcli.commands.command_artifact", "artifact", ["list"]),
+    ("gbcli.commands.command_artifact", "artifact", ["describe", "some-id"]),
+    ("gbcli.commands.command_artifact", "artifact", ["checksum", "some-id"]),
+    ("gbcli.commands.command_artifact", "artifact", ["archive", "some-id"]),
+    ("gbcli.commands.command_artifact", "artifact", ["unarchive", "some-id"]),
+    ("gbcli.commands.command_artifact", "artifact", ["update", "some-id"]),
 ]
 
 
@@ -101,3 +137,59 @@ class TestGbcliStandaloneGuards:
             f"standalone warning should not appear for '{group_name}' outside "
             f"standalone mode, got: {result.output!r}"
         )
+
+
+class TestArtifactStandaloneGuards:
+    """The artifact group is guarded per-subcommand, not at the group level.
+
+    Cloud-only subcommands (push/register/download/copy/lineage) must refuse to run in
+    standalone mode, while gbserver-backed metadata subcommands (list/describe/...) must
+    not emit the standalone warning -- ``artifact list`` in particular must just work.
+    """
+
+    @pytest.mark.parametrize(
+        "module_path,group_name,subcommand", ARTIFACT_GUARDED_SUBCOMMANDS
+    )
+    def test_cloud_subcommand_blocked_in_standalone(
+        self, module_path: str, group_name: str, subcommand: list
+    ):
+        cli = _load_cli(module_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, subcommand, env=STANDALONE_ENV)
+
+        assert result.exit_code != 0, (
+            f"'{group_name} {' '.join(subcommand)}' should exit non-zero in standalone "
+            f"mode, got {result.exit_code}"
+        )
+        assert WARNING_FRAGMENT in result.output, (
+            f"expected standalone warning for '{group_name} {' '.join(subcommand)}', "
+            f"got: {result.output!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "module_path,group_name,subcommand", ARTIFACT_UNGUARDED_SUBCOMMANDS
+    )
+    def test_metadata_subcommand_not_blocked_in_standalone(
+        self, module_path: str, group_name: str, subcommand: list
+    ):
+        cli = _load_cli(module_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, subcommand, env=STANDALONE_ENV)
+
+        # The command may fail later (e.g. no local gbserver), but it must not be rejected
+        # by the standalone guard.
+        assert WARNING_FRAGMENT not in result.output, (
+            f"standalone warning should not appear for '{group_name} "
+            f"{' '.join(subcommand)}' in standalone mode, got: {result.output!r}"
+        )
+
+    def test_group_help_works_in_standalone(self):
+        cli = _load_cli("gbcli.commands.command_artifact")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"], env=STANDALONE_ENV)
+
+        assert result.exit_code == 0, (
+            f"'artifact --help' should succeed in standalone mode, "
+            f"got {result.exit_code}: {result.output}"
+        )
+        assert WARNING_FRAGMENT not in result.output


### PR DESCRIPTION
## Summary

`gb artifact list` (and other read-only artifact metadata commands) failed under `GB_ENVIRONMENT=STANDALONE`. The entire `artifact` command group was guarded with `@pass_context_and_reject_standalone`, which rejected **every** subcommand in standalone mode — even though the gbserver `/artifacts/` endpoint and the CLI's list path already support standalone.

This PR removes the blanket group-level guard and instead guards only the subcommands that genuinely depend on Lakehouse/HuggingFace/cloud services.

## Changes

- **`command_artifact.py`**
  - Removed the group-level `@pass_context_and_reject_standalone`; the `artifact` group is now unguarded.
  - Guard only the cloud-dependent subcommands with a bare `@reject_standalone`: `push`, `register`, `download`, `copy`, `lineage`.
  - Now work in standalone (gbserver-backed only): `list`, `describe`, `checksum`, `archive`, `unarchive`, `update`.
- **`common_options.py`**
  - Added a `reject_standalone` decorator. It reads the active Click context (rather than injecting it) so it composes with each command's own `@click.pass_context`, and derives the qualified command name (e.g. `"artifact register"`) from the context — so it's used bare, with no argument at call sites.
- **`test_gbcli_standalone_guards.py`**
  - Removed `artifact` from the group-guarded set; added a `TestArtifactStandaloneGuards` class asserting the cloud-only subcommands stay blocked while the metadata subcommands (incl. `list`) are not.

## Verification

- All 102 standalone unit tests pass (27 guard tests).
- `GB_ENVIRONMENT=STANDALONE gb artifact list` runs against the local gbserver (no rejection).
- `register` / `download` / `copy` / `push` / `lineage` correctly emit `❌ Error: 'artifact <cmd>' is currently not supported in standalone mode` and exit non-zero.
- `common_options.py`: pylint 10/10, no new mypy errors.