### PR TITLE
Split tests into quick and extended and enable extended on pr merge.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,38 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install quick test dependencies
         run: |
           python -m pip install --upgrade pip
-          make test-git-cicd-pr-setup
+          make quick-tests-setup
 
-      - name: Run tests (standalone + thirdparty)
-        run: make test-git-cicd-pr
+      - name: Run quick tests
+        run: make quick-tests
+
+  extended-test:
+    # Run the heavier, live extended test suite only when a PR is merged
+    # into main (the push event), not on every pull request.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install extended test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make extended-tests-setup
+
+      - name: Run extended tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: make extended-tests
 
   demo-cpu:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
   extended-test:
     # Run the heavier, live extended test suite only when a PR is merged
     # into main (the push event), not on every pull request.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-comment.yml
+++ b/.github/workflows/test-comment.yml
@@ -96,10 +96,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          make test-git-cicd-pr-setup
+          make quick-tests-setup
 
       - name: Run tests (standalone + thirdparty)
-        run: make test-git-cicd-pr
+        run: make quick-tests
 
   demo-cpu:
     needs: trigger-check

--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,8 @@ quick-tests-setup:
 
 # Setup does not setup slurm, so the skypilot/slurm tests are skipped 
 # Mock most of HF since the action does not have the HF_TOKEN secret on PRs
-.PHONY: quick-tests 
-quick-tests: 
+.PHONY: quick-tests
+quick-tests:
 	export GB_ENVIRONMENT=STANDALONE &&			\
 	$(MAKE) GBTEST_ENABLE_EXTENDED_TESTS=false 		\
 		GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group \
@@ -239,8 +239,8 @@ extended-tests-setup:
 	$(MAKE) slurm-setup
 
 # For now we mock the HF calls since we can't provide the HF_TOKEN as a git secret on forked PRs.
-.PHONY: extended-tests 
-extended-tests: 
+.PHONY: extended-tests
+extended-tests:
 	export GB_ENVIRONMENT=STANDALONE &&			\
 	$(MAKE) GBTEST_ENABLE_EXTENDED_TESTS=true 		\
 		GBTEST_MODE=live				\

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ VENV_INSTALL_TARGET='.[dev]'
 ARTIFACTORY_DESTINATION=https://na.artifactory.swg-devops.com/artifactory/api/pypi/res-data-engineering-team-pypi-local
 # Eventually this number (a percentage over all the code) needs to be bumped up.
 MIN_COVERAGE?=20
+PYTEST_TEST_TARGETS ?= test
 
 GB_ENVIRONMENT_LOWER ?= dev
 
@@ -219,7 +220,6 @@ cicd-pr-test:
 quick-tests-setup:
 	$(MAKE) g4os-skypilot-venv
 
-PYTEST_TEST_TARGETS ?= test
 # Setup does not setup slurm, so the skypilot/slurm tests are skipped 
 # Mock most of HF since the action does not have the HF_TOKEN secret on PRs
 .PHONY: quick-tests 

--- a/Makefile
+++ b/Makefile
@@ -215,21 +215,37 @@ cicd-pr-test:
 	$(MAKE) cicd-venv
 	$(MAKE) test-pr 
 
-.PHONY: test-git-cicd-pr-setup
-test-git-cicd-pr-setup:
+.PHONY: quick-tests-setup
+quick-tests-setup:
+	$(MAKE) g4os-skypilot-venv
+
+PYTEST_TEST_TARGETS ?= test
+# Setup does not setup slurm, so the skypilot/slurm tests are skipped 
+# Mock most of HF since the action does not have the HF_TOKEN secret on PRs
+.PHONY: quick-tests 
+quick-tests: 
+	export GB_ENVIRONMENT=STANDALONE &&			\
+	$(MAKE) GBTEST_ENABLE_EXTENDED_TESTS=FALSE 		\
+		GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group \
+		GBTEST_MODE=mock				\
+		PYTEST_MARKERS="not ibm" 			\
+		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\
+		.test
+
+.PHONY: extended-tests-setup
+extended-tests-setup:
 	$(MAKE) g4os-skypilot-venv
 	$(MAKE) minio-setup 
 	$(MAKE) slurm-setup
 
 # For now we mock the HF calls since we can't provide the HF_TOKEN as a git secret on forked PRs.
-.PHONY: test-git-cicd-pr 
-test-git-cicd-pr: 
+.PHONY: extended-tests 
+extended-tests: 
 	export GB_ENVIRONMENT=STANDALONE &&			\
 	$(MAKE) GBTEST_ENABLE_EXTENDED_TESTS=true 		\
-		GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group	\
 		GBTEST_MODE=live				\
 		PYTEST_MARKERS="not ibm" 			\
-		PYTEST_TEST_TARGETS="test"			\
+		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\
 		.test
 
 .PHONY: test-pr 

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ PYTEST_TEST_TARGETS ?= test
 .PHONY: quick-tests 
 quick-tests: 
 	export GB_ENVIRONMENT=STANDALONE &&			\
-	$(MAKE) GBTEST_ENABLE_EXTENDED_TESTS=FALSE 		\
+	$(MAKE) GBTEST_ENABLE_EXTENDED_TESTS=false 		\
 		GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group \
 		GBTEST_MODE=mock				\
 		PYTEST_MARKERS="not ibm" 			\

--- a/test/unit/standalone/test_noop_lineage.py
+++ b/test/unit/standalone/test_noop_lineage.py
@@ -43,6 +43,12 @@ class TestStandaloneLineageProviderDefault:
             importlib.reload(constants)
 
 
+# These tests exercise the real get_lineage_store() backend selection, so they
+# must opt out of the autouse _mock_lineage fixture (which otherwise replaces
+# get_lineage_store with a MagicMock in mock mode). The "lakehouse" service key
+# matches that fixture's should_use_live() guard. Provider "none" only
+# instantiates NoopLineageStore, so no real lakehouse connection is made.
+@pytest.mark.live("lakehouse")
 class TestGetLineageStoreStandalone:
     """Verify get_lineage_store() returns NoopLineageStore when provider is 'none'."""
 

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -34,7 +34,7 @@ def _disable_hf_op_mocking(monkeypatch):
 
     These unit tests exercise the *real* HfURI methods (pull/push/exists/delete
     and resource-group resolution) against a mocked HfApi / snapshot_download.
-    A suite-level GBTEST_MOCKED_HF_OPS (e.g. exported by ``make test-git-cicd-pr``)
+    A suite-level GBTEST_MOCKED_HF_OPS (e.g. exported by ``make quick-tests``)
     would otherwise short-circuit those methods before they call the mocked Hub,
     so clear it here; monkeypatch restores the prior value after each test.
     """


### PR DESCRIPTION
## Description

We want two levels of testing - quick and extended.  

1.  Add and rename targets in the `Mak`efile 
2. Call quick test targets on PR check and extended tests on merge in` ci.yml`

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
