### PR TITLE
bug fix for artifact push with tags for hg .. also show a warning whe…

### DIFF
--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -477,6 +477,9 @@ def push(
                 click.echo(f"(2/{total_steps}) Obtaining HuggingFace token.")
             hf_token = GBClient.Auth().hf_token()
             if not hf_token:
+                click.echo("❌ HuggingFace authentication failed. Please check your HuggingFace credentials and try again.",
+                    err=True,
+                )
                 return
             if not quiet:
                 click.echo(f"HuggingFace token obtained successfully!")

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -477,7 +477,8 @@ def push(
                 click.echo(f"(2/{total_steps}) Obtaining HuggingFace token.")
             hf_token = GBClient.Auth().hf_token()
             if not hf_token:
-                click.echo("❌ HuggingFace authentication failed. Please check your HuggingFace credentials and try again.",
+                click.echo(
+                    "❌ HuggingFace authentication failed. Please check your HuggingFace credentials and try again.",
                     err=True,
                 )
                 return

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -761,7 +761,7 @@ def register_artifact_hf(
         "description": description,
         "checksum": checksum,
         "status": status,
-        "tags": format_artifact_tags(tags),
+        "tags": tags,
     }
 
     if type == "model":


### PR DESCRIPTION
#109 

## Description

bug fix for artifact push with tags for hg .. also show a warning when hf_token is unavlable instead of silent exit

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
