### PR TITLE
Default standalone space secrets to a writable local backend

### DIFF
--- a/configurations/spaces/local/space.yaml
+++ b/configurations/spaces/local/space.yaml
@@ -4,7 +4,7 @@
 # the shared assets directory.
 name: public
 secret_manager:
-  type: env
+  type: local
   config: {}
 base_uris:
   # Pull assetstores, environments, and steps from configurations/assets/.

--- a/src/gbserver/build/space.py
+++ b/src/gbserver/build/space.py
@@ -181,13 +181,17 @@ class Space:
         if sm.type != "local":
             return False
 
-        assert (
-            "secrets_dir" in sm.config
-        ), "Local secret manager requires 'secrets_dir' in config"
-
-        # Remote sync must be explicitly enabled
+        # Remote sync must be explicitly enabled. Check this before requiring
+        # secrets_dir: without remote sync there is nothing to sync into, and the
+        # local manager resolves its own default dir (<gb_home>/space_secrets) when
+        # secrets_dir is omitted (the standalone `config: {}` case).
         if not sm.config.get("do_remote_sync", False):
             return False
+
+        # secrets_dir is only required to locate the local file to sync into.
+        assert (
+            "secrets_dir" in sm.config
+        ), "Local secret manager requires 'secrets_dir' in config when do_remote_sync is set"
 
         # Validate remote sync config
         assert (

--- a/src/gbserver/spacesecretmanager/localspacesecretmanager.py
+++ b/src/gbserver/spacesecretmanager/localspacesecretmanager.py
@@ -18,9 +18,11 @@
 Secret manager from local directory.
 """
 
+import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Self
+from typing import Any, Dict, Optional, Self, Union
 
+from gbcommon.types.constants import get_gb_home_dir
 from gbserver.spacesecretmanager.spacesecretmanager import SpaceSecretManager
 from gbserver.utils.logger import get_logger
 from gbserver.utils.secretfile import (
@@ -48,9 +50,21 @@ class LocalSpaceSecretManager(SpaceSecretManager):
 
     SUPPORTED_EXTENSIONS = SUPPORTED_SECRET_FILE_EXTENSIONS
 
-    def __init__(self: Self, uri: str, secrets_dir: Path, **kwargs) -> None:
+    def __init__(
+        self: Self, uri: str, secrets_dir: Optional[Union[str, Path]] = None, **kwargs
+    ) -> None:
         super().__init__(uri=uri, **kwargs)
-        self.dir = Path(secrets_dir)
+        # secrets_dir is optional: when omitted (e.g. a space.yaml with `config: {}`),
+        # default to <gb_home>/space_secrets — the sibling of the per-user secrets dir
+        # (see usersecretmanager.factory). Resolved at call time via get_gb_home_dir()
+        # so a GB_HOME_DIR override is honored. ~ and ${ENV} in an explicit value are
+        # expanded so a committed space.yaml can carry a portable path.
+        raw_dir = (
+            os.path.join(get_gb_home_dir(), "space_secrets")
+            if secrets_dir is None
+            else str(secrets_dir)
+        )
+        self.dir = Path(os.path.expanduser(os.path.expandvars(raw_dir)))
 
     def get_secret(
         self: Self,

--- a/test/unit/api/test_space_secrets_standalone.py
+++ b/test/unit/api/test_space_secrets_standalone.py
@@ -34,6 +34,10 @@ def _build_client(monkeypatch, space_dir):
 
     import gbserver.api.secrets as secrets_module
 
+    # The manager cache is a module-global keyed by (name, uri); clear it so each
+    # test's space.yaml is re-read rather than served from a prior test's instance.
+    secrets_module._space_secret_manager_cache.clear()
+
     # The space-secret handlers resolve the space via _get_space_for_admin; return a
     # standalone space dict whose git_repo_uri points at our space.yaml dir.
     space = {
@@ -77,6 +81,22 @@ def env_client(tmp_path, monkeypatch):
     space_dir = tmp_path / "space"
     _write_space_yaml(space_dir, "secret_manager:\n  type: env\n  config: {}\n")
     return _build_client(monkeypatch, space_dir)
+
+
+@pytest.fixture
+def local_default_client(tmp_path, monkeypatch):
+    """A `type: local` space.yaml with `config: {}` and no secrets_dir.
+
+    Mirrors configurations/spaces/local/space.yaml: LocalSpaceSecretManager should
+    default secrets_dir to <gb_home>/space_secrets. GB_HOME_DIR is pointed at a temp
+    dir so the default location is isolated and assertable.
+    """
+    gb_home = tmp_path / "gb_home"
+    monkeypatch.setenv("GB_HOME_DIR", str(gb_home))
+    space_dir = tmp_path / "space"
+    _write_space_yaml(space_dir, "secret_manager:\n  type: local\n  config: {}\n")
+    client = _build_client(monkeypatch, space_dir)
+    return client, gb_home
 
 
 def _decode(resp_json):
@@ -146,3 +166,25 @@ def test_env_space_secret_read_only(env_client, monkeypatch):
 
 def test_get_missing_space_secret_returns_404(local_client):
     assert local_client.get("/space_secrets/standalone/NOPE").status_code == 404
+
+
+def test_local_default_secrets_dir_crud(local_default_client):
+    """`type: local` with no secrets_dir defaults to <gb_home>/space_secrets and is writable."""
+    client, gb_home = local_default_client
+    base = "/space_secrets/standalone"
+
+    r = client.post(
+        base,
+        json={"secret_name": "API_KEY", "secret_value": "hunter2", "encoding": "plain"},
+    )
+    assert r.status_code == 200, r.text
+
+    # The secret file landed under the defaulted <gb_home>/space_secrets dir.
+    default_dir = gb_home / "space_secrets"
+    assert default_dir.is_dir()
+    assert any(default_dir.iterdir()), "expected a secret file under the default dir"
+
+    # Round-trips via the API.
+    assert client.get(base).json()["secrets"] == ["API_KEY"]
+    assert _decode(client.get(f"{base}/API_KEY").json()) == "hunter2"
+    assert client.delete(f"{base}/API_KEY").status_code == 200

--- a/test/unit/space/test_space_config.py
+++ b/test/unit/space/test_space_config.py
@@ -60,7 +60,12 @@ class TestStandalonePublicSpaceYaml:
     def test_secret_manager(self):
         with open(LOCAL_SPACE_DIR / "space.yaml") as f:
             data = yaml.safe_load(f)
-        assert data["secret_manager"]["type"] == "env"
+        # The standalone space uses the writable `local` backend so that
+        # `gb secret create` works (the `env` backend is read-only). No
+        # secrets_dir is configured, so LocalSpaceSecretManager defaults it
+        # to <gb_home>/space_secrets.
+        assert data["secret_manager"]["type"] == "local"
+        assert data["secret_manager"]["config"] == {}
 
     def test_default_environment_variable(self):
         with open(LOCAL_SPACE_DIR / "space.yaml") as f:

--- a/test/unit/space/test_space_secrets_build_path.py
+++ b/test/unit/space/test_space_secrets_build_path.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build-path coverage for a `type: local` space with no secrets_dir.
+
+The standalone space.yaml uses `type: local` / `config: {}` (LocalSpaceSecretManager
+defaults secrets_dir to <gb_home>/space_secrets). Besides the API path, that same
+config is consumed by the build path via Space._fetch_secrets -> _is_first_local_sync.
+This guards that the empty config does not trip the local-secrets assertions there.
+"""
+
+from gbserver.build.space import Space
+from gbserver.types.spaceconfig import SpaceConfig, SpaceSecretManagerConfig
+
+
+def _space_with_config(secret_manager: SpaceSecretManagerConfig) -> Space:
+    """A Space instance whose space_config we control, without running __init__.
+
+    __init__ pulls a URI and globs space.yaml; we only need _is_first_local_sync to
+    see a chosen secret_manager config, so build the instance directly.
+    """
+    space = Space.__new__(Space)
+    space.space_config = SpaceConfig(name="public", secret_manager=secret_manager)
+    return space
+
+
+def test_first_local_sync_local_empty_config_does_not_assert():
+    """`type: local` / `config: {}` must not raise; with no remote sync -> False."""
+    space = _space_with_config(SpaceSecretManagerConfig(type="local", config={}))
+
+    # Pre-fix this raised AssertionError("...requires 'secrets_dir' in config").
+    assert space._is_first_local_sync() is False
+
+
+def test_first_local_sync_env_type_returns_false():
+    space = _space_with_config(SpaceSecretManagerConfig(type="env", config={}))
+    assert space._is_first_local_sync() is False
+
+
+def test_first_local_sync_requires_secrets_dir_only_when_remote_sync():
+    """secrets_dir is still required, but only once remote sync is requested."""
+    import pytest
+
+    space = _space_with_config(
+        SpaceSecretManagerConfig(type="local", config={"do_remote_sync": True})
+    )
+    with pytest.raises(AssertionError, match="secrets_dir"):
+        space._is_first_local_sync()

--- a/test/unit/spacesecretmanager/test_localspacesecretmanager_dir.py
+++ b/test/unit/spacesecretmanager/test_localspacesecretmanager_dir.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for LocalSpaceSecretManager secrets_dir resolution.
+
+Covers the optional/defaulted/expanded `secrets_dir` behavior that lets a
+standalone space.yaml use `type: local` with `config: {}` (no secrets_dir) and
+land at <gb_home>/space_secrets.
+"""
+
+from pathlib import Path
+
+from gbserver.spacesecretmanager.localspacesecretmanager import LocalSpaceSecretManager
+
+
+def test_default_secrets_dir_uses_gb_home(tmp_path, monkeypatch):
+    """No secrets_dir -> <gb_home>/space_secrets, resolved from GB_HOME_DIR at call time."""
+    gb_home = tmp_path / "gbhome"
+    monkeypatch.setenv("GB_HOME_DIR", str(gb_home))
+
+    manager = LocalSpaceSecretManager(uri="local")
+
+    assert manager.dir == gb_home / "space_secrets"
+
+
+def test_explicit_secrets_dir_is_expanded(tmp_path, monkeypatch):
+    """~ and ${ENV} in an explicit secrets_dir are expanded."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MY_SECRETS_BASE", str(tmp_path / "base"))
+
+    tilde = LocalSpaceSecretManager(uri="local", secrets_dir="~/space_secrets")
+    assert tilde.dir == tmp_path / "space_secrets"
+
+    envvar = LocalSpaceSecretManager(uri="local", secrets_dir="${MY_SECRETS_BASE}/s")
+    assert envvar.dir == tmp_path / "base" / "s"
+
+
+def test_explicit_path_object_preserved(tmp_path):
+    """A plain absolute Path is used as-is."""
+    manager = LocalSpaceSecretManager(uri="local", secrets_dir=tmp_path / "secrets")
+    assert manager.dir == tmp_path / "secrets"
+
+
+def test_default_dir_is_writable_crud(tmp_path, monkeypatch):
+    """The defaulted dir supports a create/read round-trip."""
+    monkeypatch.setenv("GB_HOME_DIR", str(tmp_path / "gbhome"))
+    manager = LocalSpaceSecretManager(uri="local")
+
+    manager.create_secret(
+        secret_name="API_KEY", secret_value="hunter2", secret_group_name="group1"
+    )
+
+    assert (Path(manager.dir) / "group1.yaml").exists()
+    assert manager.get_secrets()["API_KEY"] == "hunter2"


### PR DESCRIPTION
## Description

In standalone mode, `gb secret create --personal` (user secrets) works and writes to `~/.granite.build/user_secrets`, but `gb secret create` for **space** secrets failed: the local space (`configurations/spaces/local/space.yaml`) used the read-only `env` backend, whose `create_secret` raises `NotImplementedError`.

This switches the standalone space to the existing, writable `LocalSpaceSecretManager`, defaulting its storage to `~/.granite.build/space_secrets` — the sibling of `user_secrets` — so space-secret CRUD works out of the box in standalone, consistently with user secrets.

### Changes

- **`configurations/spaces/local/space.yaml`**: `secret_manager.type` `env` → `local`, keeping `config: {}`.
- **`LocalSpaceSecretManager`**: `secrets_dir` is now optional. When omitted (i.e. `config: {}`), it defaults to `<gb_home>/space_secrets` via `get_gb_home_dir()`, resolved at call time so a `GB_HOME_DIR` override is honored. An explicit value has `~` and `${ENV}` expanded so a committed `space.yaml` can carry a portable path. Both existing construction sites (`api/secrets.py`, `build/space.py`) already pass `**config`, so no call-site changes were needed.
- **No space config model change**; `SpaceConfig` / `SpaceSecretManagerConfig` are untouched.

### Scope notes

- **User secret management is intentionally unchanged.** It stays space-independent and resolves via the existing `usersecretmanager` factory. The `/user_secrets` API path has no space context; the build path has one, but reusing the space's `secret_manager.type` there would split a user's personal secrets across backends by space — so it's deliberately left alone.

### Tests

- `test/unit/spacesecretmanager/test_localspacesecretmanager_dir.py` (new): default-dir resolution, `~`/`${ENV}` expansion, explicit-Path passthrough, and a write/read round-trip under the defaulted dir.
- `test/unit/api/test_space_secrets_standalone.py`: added a `type: local` / `config: {}` fixture and a CRUD test asserting files land under `<gb_home>/space_secrets`; cleared the module-global manager cache between fixtures.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)