### PR TITLE
Show 'gb' as the representative CLI command; fix standalone DB path in docs

### DIFF
--- a/docs/operators/setup/skypilot-kubernetes-setup.md
+++ b/docs/operators/setup/skypilot-kubernetes-setup.md
@@ -485,7 +485,7 @@ If automatic labeling fails or doesn't apply all labels:
 | **Setup Script Fails** | Error during `setup-skypilot.sh` | Ensure `kubectl` is configured and cluster is reachable. Check that required env vars are set: `source .env.skypilot && env \| grep -E 'SKYPILOT\|IMAGE_PULL\|S3_\|RITS\|PVC'` |
 | **Sky Config Not Generated** | `~/.sky/config.yaml` missing after script | Check Python 3 is available: `python3 --version`. Check script output for `[ERROR]` lines. Ensure PyYAML is installed: `python3 -c "import yaml"` |
 | **S3 Input Validation Fails** | Error: "input URI ... doesn't exist" with s3:// URIs | Known limitation: `CosURI.exists()` is not yet implemented and always returns False. Remove `inputs`/`outputs` blocks with s3:// URIs from build.yaml — data is accessed via `file_mounts` or step config instead |
-| **Stale Space Registration** | Build uses wrong space directory or old config | Delete the old space from SQLite: `sqlite3 ~/.llmb/llmb-server.db "DELETE FROM gb_spaces WHERE name='public';"` then restart `gbserver standalone` |
+| **Stale Space Registration** | Build uses wrong space directory or old config | Delete the old space from SQLite: `sqlite3 ~/.granite.build/llmb-server.db "DELETE FROM gb_spaces WHERE name='public';"` then restart `gbserver standalone` |
 
 ## Additional Resources
 

--- a/docs/operators/troubleshooting.md
+++ b/docs/operators/troubleshooting.md
@@ -135,7 +135,7 @@ target/step state at the moment the assertion fired.
   watcher, build runner. Requires admin auth.
 - For SQL-storage debugging: connect to the gbserver Postgres directly and
   read `gb_builds`, `gb_targets`, `gb_steps`, `gb_artifacts`.
-- For SQLite (standalone): the database file is at `~/.llmb/llmb-server.db`.
+- For SQLite (standalone): the database file is at `~/.granite.build/llmb-server.db`.
 - Runner-environment specifics:
   - K8s: `kubectl logs -n <ns> <pod>` for the launcher pod.
   - SkyPilot: `sky logs <cluster>`.

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -147,7 +147,7 @@ def cli(ctx):
 @click.option(
     "--origin",
     multiple=True,
-    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model with restricted use. You can also use keep the 'origin' file created from 'artifact download' command. See 'llmb artifact download --help' for more details.""",
+    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model with restricted use. You can also use keep the 'origin' file created from 'artifact download' command. See 'gb artifact download --help' for more details.""",
 )
 @click.option(
     "--origin-list",
@@ -855,7 +855,7 @@ def push(
 @click.option(
     "--origin",
     multiple=True,
-    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model of a restricted license and restricted use. You can also use keep the 'origin' file generated from 'artifact download' command. See 'llmb artifact download --help' for more details.""",
+    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model of a restricted license and restricted use. You can also use keep the 'origin' file generated from 'artifact download' command. See 'gb artifact download --help' for more details.""",
 )
 @click.option(
     "--origin-list",

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -697,21 +697,21 @@ def start(
             markdown_str = f"""
 {'Once the build is running, you can find the build ID of the above issue:' if show_build_id == 'BUILD_ID' else ''}
 ```
-llmb build list | grep {requested_build_url}
-llmb build list --show-all # See all your builds, including old ones.
+gb build list | grep {requested_build_url}
+gb build list --show-all # See all your builds, including old ones.
 ```
 To get the build status:
 ```
-llmb build status {show_build_id}
+gb build status {show_build_id}
 ```
 To get the last 10k lines of the logs:
 ```
-llmb build log --all {show_build_id}
+gb build log --all {show_build_id}
 ```
 By default this gives you the logs of the last step in the build.
 To get the logs of a particular step you can use:
 ```
-llmb build log --all {show_build_id} --build-step-id <step id>
+gb build log --all {show_build_id} --build-step-id <step id>
 ```
         """
             if not quiet:

--- a/src/gbcli/commands/command_dataset.py
+++ b/src/gbcli/commands/command_dataset.py
@@ -6,7 +6,7 @@ import click
 def cli(ctx):
     """
     Operate datasets.
-    In this version, please use 'llmb artifact' for dataset operations.
+    In this version, please use 'gb artifact' for dataset operations.
     """
     pass
 

--- a/src/gbcli/commands/command_space.py
+++ b/src/gbcli/commands/command_space.py
@@ -61,7 +61,7 @@ def list(
 
     if refresh and not all:
         click.echo(
-            f"❌ Try running again with 'llmb space list --all --refresh", err=True
+            f"❌ Try running again with 'gb space list --all --refresh", err=True
         )
         ctx.exit(1)  # Exit with a non-zero status
 
@@ -167,7 +167,7 @@ def list(
 @click.option(
     "--default",
     is_flag=True,
-    help="WARNING Command line option '--default' has been deprecated and will be removed from a future update. Just run 'llmb space set' without this option to set the default space",
+    help="WARNING Command line option '--default' has been deprecated and will be removed from a future update. Just run 'gb space set' without this option to set the default space",
 )
 @click.option(
     "--name",
@@ -204,7 +204,7 @@ def set(ctx, space_name, default, name, format, skip_version_check, quiet):
 
         if default:
             click.echo(
-                "Warning: Command line option '--default' has been deprecated and will be removed from a future update. Just run 'llmb space set' without this option to set the default space"
+                "Warning: Command line option '--default' has been deprecated and will be removed from a future update. Just run 'gb space set' without this option to set the default space"
             )
 
         # always set space to be default

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -98,7 +98,7 @@ def upload_to_lh(
     )
     if namespace == None:
         raise Exception(
-            f"Error: Lakehouse namespace of space='{space}' does not exist. Please check the 'llmb space list --all' or check if it is a valid space name and try again."
+            f"Error: Lakehouse namespace of space='{space}' does not exist. Please check the 'gb space list --all' or check if it is a valid space name and try again."
         )
     public = global_space.get("name") == "public"
 
@@ -1257,7 +1257,7 @@ def artifact_copy(
     target_namespace = global_space.get("lakehouse_namespace")
     if target_namespace == None:
         raise Exception(
-            f"Error: Lakehouse namespace of space='{space_to}' does not exist. Please check the 'llmb space list --all' or check if it is a valid space name and try again."
+            f"Error: Lakehouse namespace of space='{space_to}' does not exist. Please check the 'gb space list --all' or check if it is a valid space name and try again."
         )
     public = global_space.get("name") == "public"
     target_table = LAKEHOUSE_MODEL_SHARED_TABLE if public else LAKEHOUSE_MODEL_TABLE

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -171,7 +171,7 @@ def build_init(
                 callback(
                     callback_event="error",
                     callback_args={
-                        "reason": f"Space '{space}' provided could not be resolved. Please run 'llmb space list --all --refresh' to see your latest available spaces."
+                        "reason": f"Space '{space}' provided could not be resolved. Please run 'gb space list --all --refresh' to see your latest available spaces."
                     },
                 )
             return None
@@ -1374,7 +1374,7 @@ def build_describe(
                     callback(
                         callback_event="error",
                         callback_args={
-                            "reason": f"Space '{space}' provided could not be resolved. Please run 'llmb space list --all --refresh' to see your latest available spaces."
+                            "reason": f"Space '{space}' provided could not be resolved. Please run 'gb space list --all --refresh' to see your latest available spaces."
                         },
                     )
                 return None

--- a/src/gbcli/services/service_model.py
+++ b/src/gbcli/services/service_model.py
@@ -30,7 +30,7 @@ def lookup_model_url(rits_api_key: str, model: str, callback=None):
 
     if len(matching_models) == 0:
         raise Exception(
-            f"No models matching {model} found in RITS. Use 'llmb model list' to view available models."
+            f"No models matching {model} found in RITS. Use 'gb model list' to view available models."
         )
 
     return matching_models

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -160,7 +160,7 @@ ORIGIN_CERTIFY_MESSAGE = f"""🚨 New Requirement: To track artifacts from model
 2. If the artifact was created using a model under restricted use: Use --origin or --origin-list
 3. If the artifact was created using a model under non-restricted use: Use --certify-no-restrictions (this will log your certification)
 View the list of both unrestricted use and restricted-use models in the project documentation.
-For any help on how to use each option in more details see `llmb artifact push --help`. For more information, ask a question in the `#llm-dot-build-users` channel."""
+For any help on how to use each option in more details see `gb artifact push --help`. For more information, ask a question in the `#llm-dot-build-users` channel."""
 
 
 WEB_UI_URL = gb_environment_config().web_ui_url
@@ -229,7 +229,7 @@ BUILD_DESCRIBE_STEPS_HEADERS = ["URI", "CONFIG"]
 MODEL_LIST_HEADERS = ["MODEL", "FULL MODEL ID"]
 MODEL_LIST_URI_HEADERS = ["MODEL", "RITS BASE URI"]
 
-SECRET_SPACE_ADMIN_ERROR = "Only space admin can perform this operation. Run 'llmb space list --all --refresh' if the space role was recently updated."
+SECRET_SPACE_ADMIN_ERROR = "Only space admin can perform this operation. Run 'gb space list --all --refresh' if the space role was recently updated."
 
 # time delta for comparison against saved timestamp
 SPACE_TIMESTAMP_DELTA_HOURS = 2

--- a/src/gbcli/utils/gbcredentials.py
+++ b/src/gbcli/utils/gbcredentials.py
@@ -101,7 +101,7 @@ class GBCredentials(GBTomlConfig):
             super().__init__(credential_path)
         except TomlDecodeError as e:
             sys.exit(
-                f"❌ Error: {credential_path} can't be parsed: {str(e)}\nPlease run 'llmb cleanup --credentials' and try again."
+                f"❌ Error: {credential_path} can't be parsed: {str(e)}\nPlease run 'gb cleanup --credentials' and try again."
             )
 
     def check_permissions(self):
@@ -111,7 +111,7 @@ class GBCredentials(GBTomlConfig):
 
             if int(oct_perm) > 600:
                 logger.warning(
-                    f"Warning: the permissions of the LLM.build credentials file are too open. Run 'chmod 600 {self._config_path}', or redo 'llmb login auth'."
+                    f"Warning: the permissions of the LLM.build credentials file are too open. Run 'chmod 600 {self._config_path}', or redo 'gb login auth'."
                 )
 
     def check_gbserver_values(self):
@@ -243,5 +243,5 @@ class GBConfig(GBTomlConfig):
             super().__init__(credential_path)
         except TomlDecodeError as e:
             sys.exit(
-                f"❌ Error: {credential_path} can't be parsed: {str(e)}\nPlease run 'llmb cleanup --config' and try again."
+                f"❌ Error: {credential_path} can't be parsed: {str(e)}\nPlease run 'gb cleanup --config' and try again."
             )

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -563,19 +563,19 @@ Once the build is running, you can use the `gb` CLI to get more information.
 To get the build status:
 
 ```shell
-llmb build status {build_id}
+gb build status {build_id}
 ```
 
 To get all of the lines from the logs:
 
 ```shell
-llmb build log --all {build_id}
+gb build log --all {build_id}
 ```
 
 To only get the last 10k lines of the logs:
 
 ```shell
-llmb build log --tail 10000 {build_id}
+gb build log --tail 10000 {build_id}
 ```
 
 By default this gives you the logs from all the steps in the build.
@@ -583,13 +583,13 @@ By default this gives you the logs from all the steps in the build.
 To only get the logs of a particular step you can use:
 
 ```shell
-llmb build log --all {build_id} --build-step-id <step id>
+gb build log --all {build_id} --build-step-id <step id>
 ```
 
 If you have admin access, you can access the build-runner logs as well:
 
 ```shell
-llmb admin log gbserver-build-runner --all --build-id {build_id}
+gb admin log gbserver-build-runner --all --build-id {build_id}
 ```
 """
 


### PR DESCRIPTION
## Summary

Two related display/documentation fixes. No behavior change.

### 1. `gb` as the representative CLI command in user-facing messages

Wherever a message, help string, or error told the user to run `llmb <subcommand>`, it now shows `gb <subcommand>`. `gb` is already a real entry point (alongside the `llmb`/`llmbuild`/`lamb` aliases), so this is purely a display change.

26 string replacements across 10 files:
- `gbserver/types/constants.py` — build help text (`build status`, `build log`, `admin log`); this block already referred to the `gb` CLI in prose, so the commands now match.
- `gbcli/commands/` — `command_build.py` (build list/status/log block), `command_space.py` (`space list`/`space set`), `command_dataset.py` (`gb artifact`), `command_artifact.py` (`artifact download --help`).
- `gbcli/services/` — `service_artifact.py`, `service_build.py`, `service_model.py` (`space list`, `model list` hints in error messages).
- `gbcli/utils/` — `gbconstants.py` (`artifact push --help`, `space list`), `gbcredentials.py` (`cleanup`, `login auth`).

### 2. Docs: standalone SQLite path `~/.llmb` → `~/.granite.build`

The standalone metadata DB directory was changed from `~/.llmb` to the consolidated GB home dir (`~/.granite.build`, default from `get_gb_home_dir()`) in earlier commits; `~/.llmb` is now only a legacy/migration source. Updated the two operator docs that still pointed users at the old path:
- `docs/operators/troubleshooting.md`
- `docs/operators/setup/skypilot-kubernetes-setup.md`

The DB **filename** (`llmb-server.db`) is unchanged in code, so only the directory portion was updated — the current path is `~/.granite.build/llmb-server.db`.

## What was intentionally NOT changed

`llmb` is also a set of real identifiers in the codebase. These were left as-is because renaming the *reference* without renaming the underlying thing would make them wrong:

- **CLI alias entry points** in `pyproject.toml` — `llmb`, `llmbuild`, `lamb` still resolve the binary. `gb` is already one of them; this PR doesn't remove the aliases.
- **Script filenames** — `llmb_bash_jobsub.sh`, `llmb_lsf_jobsub.sh`, `llmb_bash_wrapper.sh`, `llmb_lsf_wrapper.sh`, `llmb_resolve_dir_script.py`, etc.
- **Environment variables** — `LLMB_BASH_*`, `LLMB_LSF_*`.
- **The DB filename** — `llmb-server.db` (only the containing directory changed, in code, in prior commits).
- **Other paths / dirs / files** — `llmb-targetsteprun-assets`, `.llmbpull.lock`/`.llmbpull.state`, and the legacy `~/.llmb` references in migration code (which must keep pointing at the old location to migrate from it).
- **Comments / proper nouns** — references to `llmbuild` and `llmb-lite` as names.
- **Remaining docs** — other `llmb` references in docs are these internal identifiers (script names, env vars), not representative commands or stale paths, so they're left unchanged to stay accurate against the code.

## Test plan

- `isort --profile black` + `black` on all 10 changed Python files — no changes (string-literal edits only).
- `pylint` shows only pre-existing warnings; none on the lines touched.
- Changes are display-string and documentation only — no control flow, no behavior change.

Generated with [Claude Code](https://claude.com/claude-code)