### PR TITLE
Allow HF artifacts in PROD by scoping prod gate to env-aware URIs

### DIFF
--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -247,6 +247,14 @@ class HfURI(URI):
     def is_accessible(self: Self) -> bool:
         return self.exists()
 
+    def is_prod_safe(self: Self) -> bool:
+        """HF artifacts are always prod-safe.
+
+        HF URIs use the same host (huggingface.co) across all environments, so
+        they carry no prod/non-prod distinction and may register in PROD.
+        """
+        return True
+
     def get_revision(self) -> str:
         """Return the branch/tag/ref of the repo."""
         return self._parts().revision

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -350,17 +350,6 @@ class HfURI(URI):
         # Always include host in the output
         return f"{HF_URI_SCHEME}://{p.host}{path}"
 
-    def is_prod(self) -> bool:
-        """Return True if this URI is production-safe.
-
-        Since all GB environments use the canonical HuggingFace host (huggingface.co),
-        production status is determined solely by the GB_ENVIRONMENT, not the host
-        or the URI format. In PROD and STANDALONE environments, HF artifacts are
-        production-safe; in non-PROD environments (DEV, STAGING) they are not.
-        """
-        env_upper = GB_ENVIRONMENT.upper() if GB_ENVIRONMENT else ""
-        return env_upper in ("PROD", "STANDALONE")
-
     @staticmethod
     def parse(uri_str: str) -> "HfURI":
         """Factory method from a raw URI string"""

--- a/src/gbcommon/uri/lh.py
+++ b/src/gbcommon/uri/lh.py
@@ -303,6 +303,10 @@ class LhURI(URI):
         """Return True if this URI points to the production Lakehouse environment."""
         return self.get_lh_environment() == PRODUCTION_HOST
 
+    def is_prod_safe(self: Self) -> bool:
+        """LhURI is prod-safe only when it points at the production Lakehouse host."""
+        return self.is_prod()
+
     @staticmethod
     def __get_lh_type(uri_path: str) -> Optional[LhType]:
         splits = uri_path.split("/")

--- a/src/gbcommon/uri/uri.py
+++ b/src/gbcommon/uri/uri.py
@@ -69,6 +69,15 @@ class URI(ABC):
     def get_secrets(self: Self) -> Optional[dict]:
         return self.secrets
 
+    def is_prod_safe(self: Self) -> bool:
+        """Whether this URI may be registered in the PROD environment.
+
+        Default-deny: URI types with no production-safety notion are rejected
+        in PROD. Subclasses that are always safe (HfURI) or conditionally safe
+        (LhURI) override this.
+        """
+        return False
+
     def __str__(self: Self) -> str:
         return self.get_uristr(self)
 

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -300,12 +300,12 @@ def register_artifact(
 ) -> RegisterArtifactResponse:
     new_artifact = artifact
 
-    # Block non-prod uris in PROD only for URI types that encode an environment
-    # (e.g. LhURI). URI types without an environment notion (HfURI, etc.) carry no
-    # prod/non-prod information and are always allowed.
+    # Only allow artifacts whose URI type is production-safe in the PROD env.
+    # HfURI is always safe (HF host is env-independent); LhURI is safe only when
+    # it points at the production Lakehouse host; all other URI types are rejected.
     if GB_ENVIRONMENT == "PROD":
         uri_obj = URI.get_uri(new_artifact.uri)
-        if hasattr(uri_obj, "is_prod") and not uri_obj.is_prod():
+        if not uri_obj.is_prod_safe():
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Non-production artifacts are not allowed!",

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -300,10 +300,12 @@ def register_artifact(
 ) -> RegisterArtifactResponse:
     new_artifact = artifact
 
-    # Make sure we can't register non-prod uris in the PROD environment
+    # Block non-prod uris in PROD only for URI types that encode an environment
+    # (e.g. LhURI). URI types without an environment notion (HfURI, etc.) carry no
+    # prod/non-prod information and are always allowed.
     if GB_ENVIRONMENT == "PROD":
         uri_obj = URI.get_uri(new_artifact.uri)
-        if not hasattr(uri_obj, "is_prod") or not uri_obj.is_prod():
+        if hasattr(uri_obj, "is_prod") and not uri_obj.is_prod():
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Non-production artifacts are not allowed!",

--- a/test/unit/api/test_artifact_prod_gate.py
+++ b/test/unit/api/test_artifact_prod_gate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the PROD artifact-registration gate in ``register_artifact``.
+
+The gate admits an artifact in the PROD environment iff its URI type is
+production-safe (``URI.is_prod_safe()``). HfURI is always safe; LhURI is safe
+only when it points at the production Lakehouse host; all other URI types are
+rejected. These tests exercise the gate directly without any storage or secret
+infrastructure — rejection paths raise before storage is touched, and the one
+allow path mocks the downstream storage.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from gbserver.api import artifacts as artifacts_module
+from gbserver.api.artifacts import register_artifact
+from gbserver.storage.artifact_registration import ArtifactRegistration
+from gbserver.types.artifact import ArtifactType
+
+
+def _registration(uri: str, art_type: ArtifactType = ArtifactType.MODEL):
+    return ArtifactRegistration(
+        type=art_type,
+        uri=uri,
+        space_name="sn",
+        username="un",
+    )
+
+
+def _call_gate(uri: str, art_type: ArtifactType = ArtifactType.MODEL):
+    """Invoke register_artifact in a PROD environment with a dummy request."""
+    request = MagicMock()
+    with patch.object(artifacts_module, "GB_ENVIRONMENT", "PROD"):
+        return register_artifact(request, _registration(uri, art_type))
+
+
+class TestRegisterArtifactProdGate:
+    def test_hf_uri_allowed_in_prod(self):
+        """HF artifacts register in PROD (the feature this gate enables)."""
+        with patch.object(artifacts_module, "is_super_admin", return_value=True):
+            with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
+                mock_storage.return_value.artifact_registry.add = MagicMock()
+                resp = _call_gate("hf://huggingface.co/models/ibm-granite/granite")
+
+        assert resp.registered.uri == "hf://huggingface.co/models/ibm-granite/granite"
+
+    def test_lh_uri_prod_host_allowed_in_prod(self):
+        """LhURI pointing at the production Lakehouse host is allowed in PROD."""
+        with patch.object(artifacts_module, "is_super_admin", return_value=True):
+            with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
+                mock_storage.return_value.artifact_registry.add = MagicMock()
+                resp = _call_gate("lh://prod/namespace0/models/table0/label0/rev0")
+
+        assert resp.registered.uri.startswith("lh://prod/")
+
+    def test_lh_uri_non_prod_host_rejected_in_prod(self):
+        """LhURI at a non-prod host is rejected in PROD (regression guard)."""
+        with pytest.raises(HTTPException) as exc:
+            _call_gate("lh://staging/namespace0/models/table0/label0/rev0")
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_file_uri_rejected_in_prod(self):
+        """A file:// artifact has no prod-safety notion and is rejected in PROD.
+
+        Pins the default-deny behavior: only explicitly prod-safe URI types are
+        admitted, so non-environment URI types stay blocked in PROD.
+        """
+        with pytest.raises(HTTPException) as exc:
+            _call_gate("file:///tmp/some/artifact")
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -388,14 +388,14 @@ class TestHfURIPartsUnit:
             ),
         )
 
-    def test_hf_uri_has_no_is_prod(self):
+    def test_hf_uri_is_prod_safe(self):
         """HF URIs carry no environment information (all envs use huggingface.co),
-        so HfURI must not expose is_prod(). The artifact registration gate relies
-        on this absence to allow HF artifacts in every environment, including PROD.
+        so HfURI is always prod-safe. The artifact registration gate relies on
+        this to allow HF artifacts in every environment, including PROD.
         """
         uri = URI.get_uri("hf://huggingface.co/datasets/owner/repo_name")
         assert isinstance(uri, HfURI)
-        assert not hasattr(uri, "is_prod")
+        assert uri.is_prod_safe() is True
 
     def _helper(self, hfuri: str, expectations: ExistsExpection) -> None:
         uri = URI.get_uri(hfuri)

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -388,6 +388,15 @@ class TestHfURIPartsUnit:
             ),
         )
 
+    def test_hf_uri_has_no_is_prod(self):
+        """HF URIs carry no environment information (all envs use huggingface.co),
+        so HfURI must not expose is_prod(). The artifact registration gate relies
+        on this absence to allow HF artifacts in every environment, including PROD.
+        """
+        uri = URI.get_uri("hf://huggingface.co/datasets/owner/repo_name")
+        assert isinstance(uri, HfURI)
+        assert not hasattr(uri, "is_prod")
+
     def _helper(self, hfuri: str, expectations: ExistsExpection) -> None:
         uri = URI.get_uri(hfuri)
         assert isinstance(uri, HfURI)


### PR DESCRIPTION
The artifact registration gate previously rejected any URI lacking an is_prod() method when GB_ENVIRONMENT == PROD. Remove HfURI.is_prod() (HF URIs carry no environment info since all envs use huggingface.co) and invert the gate to only block URI types that expose is_prod() and report non-prod (e.g. LhURI).

## Summary
- Remove `HfURI.is_prod()` — HF URIs carry no environment information since all
  GB environments use the canonical `huggingface.co` host, so the method only
  echoed the global `GB_ENVIRONMENT` redundantly.
- Invert the artifact-registration prod gate in `register_artifact`: instead of
  rejecting any URI lacking `is_prod()`, it now blocks only URI types that
  expose `is_prod()` and report non-prod (e.g. `LhURI`). HF artifacts are now
  allowed in every environment, including PROD.
- Add a unit test asserting `HfURI` exposes no `is_prod` attribute, documenting
  that the gate relies on its absence.

## Test plan
- [x] `pytest test/unit/uri/test_hf.py::TestHfURIPartsUnit::test_hf_uri_has_no_is_prod` passes
- [x] `isort` + `black` clean on all changed files

