### PR TITLE
Fixes duplicate launches of retried builds.

### DIFF
--- a/configurations/assets/environments/bash/steps/command/bash_scripts/command/command.sh
+++ b/configurations/assets/environments/bash/steps/command/bash_scripts/command/command.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Run an arbitrary command supplied via the build.yaml step config
+# (config.bash.env.LLMB_COMMAND). The step's exit status is the command's exit
+# status, so a failing command (e.g. "exit 1") hard-FAILS the target.
+echo "command step start: ${LLMB_COMMAND:-<no LLMB_COMMAND set>}"
+exec sh -c "${LLMB_COMMAND}"

--- a/configurations/assets/environments/bash/steps/command/step.yaml
+++ b/configurations/assets/environments/bash/steps/command/step.yaml
@@ -1,0 +1,34 @@
+name: command
+version: v1
+type: custom
+# A general-purpose Bash step that runs an arbitrary shell command supplied by
+# the build.yaml under `config.bash_config.command` — mirroring how the docker
+# `image` step takes `config.image_config.command`.  The step exits with that
+# command's status, so e.g. `command: "exit 1"` hard-FAILS the target.  Useful
+# for tests and quick experiments that need a controllable bash workload.
+config:
+  bash_config:
+    command: ""    # shell command to execute on the launcher node
+environment_configs:
+  Bash:
+    launchers:
+      command:
+        type: nohup
+        monitors:
+        - log_monitor
+        # The build.yaml's command is templated into the launcher env; command.sh
+        # exec's $LLMB_COMMAND so the step's exit status is the command's status.
+        config:
+          env:
+            LLMB_COMMAND: '{{ config.bash_config.command }}'
+    monitors:
+      log_monitor:
+        type: log_monitor
+        config:
+          event_configs:
+          - event_type: MESSAGE_EVENT
+            line_regex: .*
+            is_json: false
+            event_fields:
+            - field_name: msg
+              field_regex: .*

--- a/docs/features/build-retry.md
+++ b/docs/features/build-retry.md
@@ -31,15 +31,46 @@ from scratch on every retry, even if they succeeded in an earlier attempt.
 When a build finishes with status `FAILED` and `retry_count < retries.max_retries`, gbserver:
 
 1. Creates a new `StoredBuild` with the same configuration (`build_archive`, targets, tags,
-   etc.) and status `PENDING`.
+   etc.) and status `RETRY`.
 2. Sets `retry_count` on the new build to `original.retry_count + 1`.
 3. Sets `retry_of_build_id` on the new build to the UUID of the original (first) build — this
    field always points to the root of the retry chain, not just the previous attempt.
 4. Updates `retry_build_id` on the failed build to point to the new retry build.
 5. Runs the new build immediately in the same `BuildRunner` session.
 
+The retry build is created with status `RETRY` rather than `PENDING` on purpose: the
+`BuildWatcher` only dispatches `PENDING` builds, so a distinct status keeps it from launching
+a *second* runner for a retry that the in-process loop is already running. The `RETRY` build
+transitions to `RUNNING` as it executes, just like any other in-flight build.
+
 Retries are only triggered for the `FAILED` status. Builds that end with `CANCELLED` or
 `INVALID` are never retried.
+
+## Cancellation
+
+Cancelling a build with `max_retries > 0` cancels the **entire retry chain**, not just one
+attempt. Because the whole chain is run by a single `BuildRunner`, cancelling any member of
+the chain stops the work that is actually running and marks every build in the chain
+`CANCELLED`.
+
+How a cancellation request is handled (`POST /builds/{id}/cancel`):
+
+- If the targeted build is **still in flight** (`PENDING`, `RUNNING`, or `RETRY`), it is set to
+  `CANCEL_REQUESTED` (or directly `CANCELLED` if it had not started yet).
+- If the targeted build is **already finished** (for example the original, which is now
+  `FAILED`) **but its retry chain still has an active member**, the request is accepted — the
+  failed build is itself set to `CANCEL_REQUESTED`. This is a durable signal on a build that is
+  not being re-run, so it cannot be clobbered by a concurrent status update. (Cancelling a
+  finished build whose chain has **no** active member is still rejected with `412`.)
+
+The `BuildRunner` checks the whole retry chain for a cancellation request after each attempt
+(and while a step is running, where the environment supports interrupting it). As soon as any
+member is `CANCEL_REQUESTED`/`CANCELLED`, it stops the active workload, **marks every build in
+the chain `CANCELLED`**, and does not create any further retries. Earlier attempts that had
+already failed are relabelled `CANCELLED` so the whole chain reflects the cancellation.
+
+This means you can cancel a retrying build using the original build id you submitted, even
+after that first attempt has failed and the chain has moved on to a later retry.
 
 ## Storage fields
 

--- a/docs/features/build-retry.md
+++ b/docs/features/build-retry.md
@@ -31,16 +31,16 @@ from scratch on every retry, even if they succeeded in an earlier attempt.
 When a build finishes with status `FAILED` and `retry_count < retries.max_retries`, gbserver:
 
 1. Creates a new `StoredBuild` with the same configuration (`build_archive`, targets, tags,
-   etc.) and status `RETRY`.
+   etc.) and status `RETRY_PENDING`.
 2. Sets `retry_count` on the new build to `original.retry_count + 1`.
 3. Sets `retry_of_build_id` on the new build to the UUID of the original (first) build — this
    field always points to the root of the retry chain, not just the previous attempt.
 4. Updates `retry_build_id` on the failed build to point to the new retry build.
 5. Runs the new build immediately in the same `BuildRunner` session.
 
-The retry build is created with status `RETRY` rather than `PENDING` on purpose: the
+The retry build is created with status `RETRY_PENDING` rather than `PENDING` on purpose: the
 `BuildWatcher` only dispatches `PENDING` builds, so a distinct status keeps it from launching
-a *second* runner for a retry that the in-process loop is already running. The `RETRY` build
+a *second* runner for a retry that the in-process loop is already running. The `RETRY_PENDING` build
 transitions to `RUNNING` as it executes, just like any other in-flight build.
 
 Retries are only triggered for the `FAILED` status. Builds that end with `CANCELLED` or
@@ -55,7 +55,7 @@ the chain stops the work that is actually running and marks every build in the c
 
 How a cancellation request is handled (`POST /builds/{id}/cancel`):
 
-- If the targeted build is **still in flight** (`PENDING`, `RUNNING`, or `RETRY`), it is set to
+- If the targeted build is **still in flight** (`PENDING`, `RUNNING`, or `RETRY_PENDING`), it is set to
   `CANCEL_REQUESTED` (or directly `CANCELLED` if it had not started yet).
 - If the targeted build is **already finished** (for example the original, which is now
   `FAILED`) **but its retry chain still has an active member**, the request is accepted — the

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -75,7 +75,7 @@ def get_status_emoji(status: str) -> str:
             return "🔵"
         case "running":
             return "⚡"
-        case "retry":
+        case "retry_pending":
             return "🔁"
         case "failed":
             return "❌"

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -75,6 +75,8 @@ def get_status_emoji(status: str) -> str:
             return "🔵"
         case "running":
             return "⚡"
+        case "retry":
+            return "🔁"
         case "failed":
             return "❌"
         case "invalid":

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -822,7 +822,7 @@ def build_list(
             return
     status = None
     if not show_done and not show_all:
-        status = ["pending", "running", "submitted"]
+        status = ["pending", "running", "submitted", "retry"]
     sort = ["created_time:desc"]
     gbserver_builds = make_gbserver_call(
         lambda: get_builds(

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -822,7 +822,7 @@ def build_list(
             return
     status = None
     if not show_done and not show_all:
-        status = ["pending", "running", "submitted", "retry"]
+        status = ["pending", "running", "submitted", "retry_pending"]
     sort = ["created_time:desc"]
     gbserver_builds = make_gbserver_call(
         lambda: get_builds(

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -501,7 +501,7 @@ def request_cancellation(
             )
         target_status: Optional[Status] = Status.CANCEL_REQUESTED
     # RETRY is treated like RUNNING: an in-flight build the runner must stop.
-    elif current_status in (Status.RUNNING, Status.RETRY):
+    elif current_status in (Status.RUNNING, Status.RETRY_PENDING):
         target_status = Status.CANCEL_REQUESTED
     elif current_status in (Status.SUBMITTED, Status.PENDING):
         target_status = Status.CANCELLED

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -37,7 +37,7 @@ from gbserver.storage.artifact_registration import ArtifactRegistration
 from gbserver.storage.build_storage import IStoredBuildStorage
 from gbserver.storage.singleton_storage import SingletonAdminStorage, get_admin_storage
 from gbserver.storage.space_storage import IStoredSpaceStorage
-from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_build import StoredBuild, get_retry_chain_members
 from gbserver.storage.stored_event import StoredEvent
 from gbserver.storage.stored_step_run import StoredStepRun
 from gbserver.storage.stored_target_run import StoredTargetRun
@@ -444,39 +444,85 @@ async def cancel_build(build_id: str, request: Request) -> CancelBuildResponse:
             detail="You are not the owner or admin of this build.",
         )
 
-    # Determine the target status based on current status
-    current_status = build.status
-    if not current_status.is_cancellable():
-        raise HTTPException(
-            status_code=status.HTTP_412_PRECONDITION_FAILED,
-            detail=f"Build {build.uuid} has status {current_status} and therefore can not be canceled.",
-        )
-    elif current_status == Status.RUNNING:
-        target_status = Status.CANCEL_REQUESTED
-    elif current_status == Status.SUBMITTED or current_status == Status.PENDING:
-        target_status = Status.CANCELLED
-    elif current_status == Status.CANCEL_REQUESTED:
-        target_status = None  # Already requested, no update needed
-    else:
-        target_status = None
-
-    if target_status is not None:
-        # Use callback to ensure status hasn't changed (fixes race condition)
-        updated_build = storage.build_storage.update_fields(
-            build.uuid,
-            {"status": target_status},
-            should_update=lambda item: item.status == current_status,
-        )
-        if updated_build is None:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Build {build.uuid} status changed during update.  Try again?.",
-            )
-        build = updated_build
+    build = request_cancellation(storage.build_storage, build)
 
     build.build_archive = ""
     response: CancelBuildResponse = CancelBuildResponse(canceled=build)
     return response
+
+
+def _find_active_chain_member(
+    build_storage: IStoredBuildStorage, build: StoredBuild
+) -> Optional[StoredBuild]:
+    """Return the single non-finished member of ``build``'s retry chain, if any.
+
+    A retry chain is linear, so at most one member is in flight at a time.
+    """
+    for member in get_retry_chain_members(build_storage, build):
+        if not member.status.is_finished():
+            return member
+    return None
+
+
+def request_cancellation(
+    build_storage: IStoredBuildStorage, build: StoredBuild
+) -> StoredBuild:
+    """Apply a cancellation request to a build, routing into its retry chain.
+
+    If the targeted build itself is in flight, it is set to CANCEL_REQUESTED (or
+    CANCELLED for SUBMITTED/PENDING). If the targeted build is already finished
+    (e.g. a FAILED original) but its retry chain still has an active member, the
+    request is routed to that active member instead — so cancelling a failed build
+    cancels the retry that is actually running.
+
+    Args:
+        build_storage: storage used to read/update builds.
+        build: the build the cancellation was requested for.
+
+    Returns:
+        The build whose status was updated (the active chain member when routed),
+        or the unchanged build if no update was needed.
+
+    Raises:
+        HTTPException: 412 if nothing in the chain is cancellable; 409 if the
+            status changed concurrently.
+    """
+    current_status = build.status
+    if not current_status.is_cancellable():
+        # The build itself is finished (e.g. a FAILED original). Allow cancelling
+        # it only if its retry chain still has an active member, and set
+        # CANCEL_REQUESTED on THIS build — a durable signal on a build that is not
+        # being re-run (so it can't be clobbered by a concurrent FAILED update).
+        # The runner detects it chain-wide and cancels the whole chain.
+        if _find_active_chain_member(build_storage, build) is None:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail=f"Build {build.uuid} has status {current_status} and therefore can not be canceled.",
+            )
+        target_status: Optional[Status] = Status.CANCEL_REQUESTED
+    # RETRY is treated like RUNNING: an in-flight build the runner must stop.
+    elif current_status in (Status.RUNNING, Status.RETRY):
+        target_status = Status.CANCEL_REQUESTED
+    elif current_status in (Status.SUBMITTED, Status.PENDING):
+        target_status = Status.CANCELLED
+    else:  # CANCEL_REQUESTED (already requested) or anything else: no update
+        target_status = None
+
+    if target_status is None:
+        return build
+
+    # Use a callback to ensure the status hasn't changed (fixes race condition).
+    updated_build = build_storage.update_fields(
+        build.uuid,
+        {"status": target_status},
+        should_update=lambda item: item.status == current_status,
+    )
+    if updated_build is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Build {build.uuid} status changed during update.  Try again?.",
+        )
+    return updated_build
 
 
 class BuildUpdateRequest(BaseModel):

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -245,7 +245,10 @@ class BuildRunner(AbstractBuildRunner):
             source_uri="",
             username=latest.username,
             build_archive=latest.build_archive,
-            status=Status.PENDING,
+            # RETRY (not PENDING): this build is run by the in-process retry loop
+            # below; a distinct status keeps the BuildWatcher (which polls PENDING)
+            # from dispatching a duplicate runner for it. See Status.RETRY.
+            status=Status.RETRY,
             targets=latest.targets,
             description=latest.description,
             tags=latest.tags,
@@ -524,7 +527,9 @@ class BuildRunner(AbstractBuildRunner):
         update = self.storage.build_storage.update_fields(
             self.stored_build.uuid,
             updates,
-            should_update=lambda item: item.status == Status.PENDING,
+            # PENDING for a first run, RETRY for a build-level retry run.
+            should_update=lambda item: item.status
+            in (Status.PENDING, Status.RETRY),
         )
         if update is not None:  # Build had pending status, all good.
             self.stored_build = update
@@ -543,11 +548,14 @@ class BuildRunner(AbstractBuildRunner):
             self.stored_build = _build_result
             success = False
             logger.warning(
-                "Build update failed.  Likely as the status was not %s (currently %s).",
+                "Build update failed.  Likely as the status was not %s/%s (currently %s).",
                 Status.PENDING,
+                Status.RETRY,
                 self.stored_build.status,
             )
-            push_failed_status_update_metric(self.stored_build.uuid, [Status.PENDING])
+            push_failed_status_update_metric(
+                self.stored_build.uuid, [Status.PENDING, Status.RETRY]
+            )
         return success
 
     def __get_build_space(self: Self, stored_build: StoredBuild) -> Optional[Space]:
@@ -1331,7 +1339,8 @@ Download : {download_msg}
             )
 
         # Update the build status as the last thing so JobStats and PR are updated before declaring the build complete - tests expect this.
-        valid_status_values = [Status.PENDING, Status.RUNNING]
+        # RETRY is included so a build-level retry run can transition RETRY->RUNNING/FAILED.
+        valid_status_values = [Status.PENDING, Status.RUNNING, Status.RETRY]
         valid_status = lambda item: item.status in valid_status_values
         updated = self.__update_stored_build_status(
             status, failure_reason=failure_reason, unfinished_should_update=valid_status

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -148,6 +148,13 @@ class BuildRunner(AbstractBuildRunner):
             build, _BUILD_EVENT_SOURCE_NAME
         )  # To be recreated later.
         self.event_storage = get_admin_storage().event_storage
+        # In-memory list of the uuids of every build in this retry chain. The
+        # runner creates the whole chain, so membership is tracked here rather than
+        # walked from the DB on the hot cancellation-check path. Seeded in
+        # start_and_wait and appended in __prepare_retry; guarded by a lock since
+        # __cancel_build_run may run on the BuildWatcher thread via stop().
+        self._retry_chain_build_ids: List[str] = []
+        self._retry_chain_lock = threading.Lock()
 
     def stop(self: Self) -> None:
         """Stop the building thread if it was started."""
@@ -177,6 +184,14 @@ class BuildRunner(AbstractBuildRunner):
             if item is None:
                 raise ValueError("Storage of build failed without error.")
             logger.info("Build successfuly stored build: %s", build_id)
+
+        # Seed the in-memory retry-chain id list once (one DB walk, not on the hot
+        # path). Covers a runner resumed onto an already-existing chain; for a
+        # fresh build this is just [build_id] and grows via __prepare_retry.
+        for member in get_retry_chain_members(
+            self.storage.build_storage, self.stored_build
+        ):
+            self.__track_retry_chain_build(member.uuid)
         try:
             buildrunner_resume: bool = self.enable_resume and self.__should_resume()
 
@@ -238,6 +253,16 @@ class BuildRunner(AbstractBuildRunner):
         """
         return self.stored_build.status == Status.RUNNING
 
+    def __track_retry_chain_build(self: Self, build_id: str) -> None:
+        """Append a build id to the in-memory retry-chain list (thread-safe, deduped).
+
+        Args:
+            build_id: UUID of a build belonging to this runner's retry chain.
+        """
+        with self._retry_chain_lock:
+            if build_id not in self._retry_chain_build_ids:
+                self._retry_chain_build_ids.append(build_id)
+
     def __prepare_retry(self: Self) -> Optional[StoredBuild]:
         """If the finished build is eligible for retry, create, store, and return a new PENDING build.
 
@@ -271,6 +296,9 @@ class BuildRunner(AbstractBuildRunner):
         self.storage.build_storage.add(retry_build)
         latest.retry_build_id = retry_build.uuid
         self.storage.build_storage.update(latest)
+        # Track the new chain member in memory so cancellation checks and the
+        # mark-all in __cancel_build_run never have to walk the DB for membership.
+        self.__track_retry_chain_build(retry_build.uuid)
         logger.info(
             "Build %s failed; retrying as build %s (attempt %d of %d)",
             latest.uuid,
@@ -590,31 +618,38 @@ class BuildRunner(AbstractBuildRunner):
         return space
 
     def __is_build_cancelled(self) -> bool:
-        # See if something else has signalled us to stop the build. We check the
-        # whole retry chain, not just the current build, so a cancellation
-        # requested on any member (e.g. the FAILED original) also stops the
-        # active retry that is running here.
-        build_id = self.stored_build.uuid
+        """Return True if a cancellation was requested for any build in this chain.
+
+        A cancellation can be requested on any chain member (e.g. the FAILED
+        original), so all members are checked. Membership comes from the in-memory
+        ``_retry_chain_build_ids`` (no DB walk); only the per-build *status* is read
+        from storage, since cancellation is set externally. Callers on the hot path
+        (the worker loop) rate-limit how often they invoke this.
+        """
+        with self._retry_chain_lock:
+            build_ids = list(self._retry_chain_build_ids)
         try:
-            members = get_retry_chain_members(
-                self.storage.build_storage, self.stored_build
-            )
-            return any(
-                member.status in (Status.CANCEL_REQUESTED, Status.CANCELLED)
-                for member in members
-            )
+            for build_id in build_ids:
+                build = self.storage.build_storage.get_by_uuid(build_id)
+                if isinstance(build, StoredBuild) and build.status in (
+                    Status.CANCEL_REQUESTED,
+                    Status.CANCELLED,
+                ):
+                    return True
         except Exception as e:
             logger.warning(
                 "Exception checking if build %s is cancelled: %s. Assuming not cancelled.",
-                build_id,
+                self.stored_build.uuid,
                 e,
             )
-            return False
+        return False
 
     async def __worker_task(self: Self, event_q: Queue[Event], build_id: str) -> None:
         logger.debug("BuildRunner.__worker_task start build_id: %s", build_id)
         build_finished = False
-        # last_cancel_check_time = time.time()
+        # Rate-limit the cancellation check below: 0.0 means "check on the first
+        # iteration", then at most once per monitoring_interval thereafter.
+        last_cancel_check_time = 0.0
         while not self.stop_event.is_set():
             try:
                 logger.info("build %s waiting for events...", build_id)
@@ -662,10 +697,14 @@ class BuildRunner(AbstractBuildRunner):
                     self.__cancel_and_fail_build(failure_reason=msg)
                     raise e
             finally:
-                # Check for cancellation, every time through the loop to minimize time when
-                # CANCEL_REQUESTED can be ignored via  a builds status event that sets to RUNNING.
-                if self.__is_build_cancelled():
-                    break  # and call cancel_build_run() below
+                # Check for cancellation, but at most once per monitoring_interval
+                # so a build emitting events rapidly doesn't read the chain's
+                # statuses from storage on every iteration.
+                now = time.time()
+                if now - last_cancel_check_time >= self.monitoring_interval:
+                    last_cancel_check_time = now
+                    if self.__is_build_cancelled():
+                        break  # and call cancel_build_run() below
         if self.stop_event.is_set():
             logger.warning("stop event has been set, stopping event monitoring...")
 
@@ -724,21 +763,31 @@ class BuildRunner(AbstractBuildRunner):
         if not update_status:
             return
 
-        # Finalize the current build's child entities (targets/steps/artifacts)
-        # to CANCELLED when it hasn't already reached a terminal state.
+        # Distinguish a real cancellation (a cancel was requested for some chain
+        # member) from a cleanup stop() of a build that already finished (e.g. the
+        # test harness / BuildWatcher shutdown calls stop() after SUCCESS). Compute
+        # this BEFORE changing any status below.
+        cancellation_requested = self.__is_build_cancelled()
+
+        # Cancel the current build if it is still in flight (stop() semantics).
         if not self.stored_build.status.is_finished():
             self.__update_stored_build_status(Status.CANCELLED)
 
-        # Force every build in the retry chain to CANCELLED. update_fields is
-        # unconditional (unlike finalize_build_status, which skips a build already
-        # in a different finished state), so an attempt that just failed is still
-        # flipped to CANCELLED — cancelling any member cancels the whole chain.
-        for member in get_retry_chain_members(
-            self.storage.build_storage, self.stored_build
-        ):
-            if member.status != Status.CANCELLED:
+        # On a real cancellation, force every other build in the retry chain to
+        # CANCELLED, using the in-memory chain id list (no DB walk). update_fields
+        # is unconditional (unlike finalize_build_status, which skips a build in a
+        # different finished state), so an attempt that just failed is still
+        # flipped to CANCELLED. A SUCCESS build is never overwritten, and when no
+        # cancellation was requested nothing in the chain is touched.
+        if cancellation_requested:
+            with self._retry_chain_lock:
+                build_ids = list(self._retry_chain_build_ids)
+            for build_id in build_ids:
                 self.storage.build_storage.update_fields(
-                    member.uuid, {"status": Status.CANCELLED}
+                    build_id,
+                    {"status": Status.CANCELLED},
+                    should_update=lambda item: item.status
+                    not in (Status.CANCELLED, Status.SUCCESS),
                 )
 
     def __process_workload_status_event(self: Self, event: BuildEvent) -> None:

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -281,8 +281,8 @@ class BuildRunner(AbstractBuildRunner):
             build_archive=latest.build_archive,
             # RETRY (not PENDING): this build is run by the in-process retry loop
             # below; a distinct status keeps the BuildWatcher (which polls PENDING)
-            # from dispatching a duplicate runner for it. See Status.RETRY.
-            status=Status.RETRY,
+            # from dispatching a duplicate runner for it. See Status.RETRY_PENDING.
+            status=Status.RETRY_PENDING,
             targets=latest.targets,
             description=latest.description,
             tags=latest.tags,
@@ -565,7 +565,7 @@ class BuildRunner(AbstractBuildRunner):
             self.stored_build.uuid,
             updates,
             # PENDING for a first run, RETRY for a build-level retry run.
-            should_update=lambda item: item.status in (Status.PENDING, Status.RETRY),
+            should_update=lambda item: item.status in (Status.PENDING, Status.RETRY_PENDING),
         )
         if update is not None:  # Build had pending status, all good.
             self.stored_build = update
@@ -586,11 +586,11 @@ class BuildRunner(AbstractBuildRunner):
             logger.warning(
                 "Build update failed.  Likely as the status was not %s/%s (currently %s).",
                 Status.PENDING,
-                Status.RETRY,
+                Status.RETRY_PENDING,
                 self.stored_build.status,
             )
             push_failed_status_update_metric(
-                self.stored_build.uuid, [Status.PENDING, Status.RETRY]
+                self.stored_build.uuid, [Status.PENDING, Status.RETRY_PENDING]
             )
         return success
 
@@ -1414,7 +1414,7 @@ Download : {download_msg}
 
         # Update the build status as the last thing so JobStats and PR are updated before declaring the build complete - tests expect this.
         # RETRY is included so a build-level retry run can transition RETRY->RUNNING/FAILED.
-        valid_status_values = [Status.PENDING, Status.RUNNING, Status.RETRY]
+        valid_status_values = [Status.PENDING, Status.RUNNING, Status.RETRY_PENDING]
         valid_status = lambda item: item.status in valid_status_values
         updated = self.__update_stored_build_status(
             status, failure_reason=failure_reason, unfinished_should_update=valid_status

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -565,7 +565,8 @@ class BuildRunner(AbstractBuildRunner):
             self.stored_build.uuid,
             updates,
             # PENDING for a first run, RETRY for a build-level retry run.
-            should_update=lambda item: item.status in (Status.PENDING, Status.RETRY_PENDING),
+            should_update=lambda item: item.status
+            in (Status.PENDING, Status.RETRY_PENDING),
         )
         if update is not None:  # Build had pending status, all good.
             self.stored_build = update

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -57,7 +57,7 @@ from gbserver.storage.artifact_registration import (
     ArtifactRegistrationStatus,
 )
 from gbserver.storage.singleton_storage import get_admin_storage
-from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_build import StoredBuild, get_retry_chain_members
 from gbserver.storage.stored_event import StoredEvent
 from gbserver.storage.stored_step_run import StoredStepRun
 from gbserver.storage.stored_target_run import StoredTargetRun
@@ -207,6 +207,15 @@ class BuildRunner(AbstractBuildRunner):
                         self.stored_build.uuid,
                         buildrunner_resume,
                     )
+
+                # Stop the chain if a cancellation was requested for any member of
+                # the retry chain (e.g. the FAILED original). This runs after every
+                # attempt regardless of how it finished — including the exception
+                # path that bypasses the worker task — so the whole chain is marked
+                # CANCELLED and no further retry is created.
+                if self.__is_build_cancelled():
+                    self.__cancel_build_run()
+                    break
 
                 retry_build = self.__prepare_retry()
                 if retry_build is None:
@@ -581,17 +590,19 @@ class BuildRunner(AbstractBuildRunner):
         return space
 
     def __is_build_cancelled(self) -> bool:
-        # See if something else has signalled us to stop the build.
+        # See if something else has signalled us to stop the build. We check the
+        # whole retry chain, not just the current build, so a cancellation
+        # requested on any member (e.g. the FAILED original) also stops the
+        # active retry that is running here.
         build_id = self.stored_build.uuid
         try:
-            build: StoredBuild = self.storage.build_storage.get_by_uuid(build_id)  # type: ignore
-            if build is None:
-                logger.warning(
-                    "Build id %s unexpectedly not found on cancellation request check. Ignoring.",
-                    build_id,
-                )
-                return False
-            return build.status in (Status.CANCEL_REQUESTED, Status.CANCELLED)
+            members = get_retry_chain_members(
+                self.storage.build_storage, self.stored_build
+            )
+            return any(
+                member.status in (Status.CANCEL_REQUESTED, Status.CANCELLED)
+                for member in members
+            )
         except Exception as e:
             logger.warning(
                 "Exception checking if build %s is cancelled: %s. Assuming not cancelled.",
@@ -687,19 +698,16 @@ class BuildRunner(AbstractBuildRunner):
             logger.error("Could not mark build %s as failed", self.stored_build.uuid)
 
     def __cancel_build_run(self: Self, update_status: bool = True) -> None:
-        """Cancel an inprogress build_run and mark the stored build as CANCELLED, unless it has finished."""
+        """Cancel the in-progress build_run and mark the whole retry chain CANCELLED.
+
+        Marking every build in the retry chain (not just the current one) means a
+        cancellation requested on any member — including the FAILED original —
+        cancels the active retry running here and stops the chain.
+        """
 
         self.stop_event.set()
 
-        # This can be called both from the worker thread and stop(), so try and avoid duplication.
-        if self.stored_build.status == Status.CANCELLED:
-            if update_status:
-                # Re-run entity finalization to catch any targets/steps stored concurrently
-                # with a previous finalize_build_status() call (race between the BuildWatcher
-                # monitoring thread and the build runner's event loop).
-                finalize_build_status(self.stored_build.uuid, Status.CANCELLED)
-            return
-
+        # Cancel the in-progress workload for the current build, if still running.
         if self.build_run is not None:
             status = self.build_run.status
             if status is Status.PENDING or status is Status.RUNNING:
@@ -707,13 +715,31 @@ class BuildRunner(AbstractBuildRunner):
                 self.build_run.cancel()
             else:
                 logger.info(
-                    "Not marking finished build as cancelled:  build id = %s",
+                    "Not cancelling already-finished build_run:  build id = %s",
                     self.stored_build.uuid,
                 )
         else:
             logger.warning("self.build_run is None")
-        if update_status and not self.stored_build.status.is_finished():
+
+        if not update_status:
+            return
+
+        # Finalize the current build's child entities (targets/steps/artifacts)
+        # to CANCELLED when it hasn't already reached a terminal state.
+        if not self.stored_build.status.is_finished():
             self.__update_stored_build_status(Status.CANCELLED)
+
+        # Force every build in the retry chain to CANCELLED. update_fields is
+        # unconditional (unlike finalize_build_status, which skips a build already
+        # in a different finished state), so an attempt that just failed is still
+        # flipped to CANCELLED — cancelling any member cancels the whole chain.
+        for member in get_retry_chain_members(
+            self.storage.build_storage, self.stored_build
+        ):
+            if member.status != Status.CANCELLED:
+                self.storage.build_storage.update_fields(
+                    member.uuid, {"status": Status.CANCELLED}
+                )
 
     def __process_workload_status_event(self: Self, event: BuildEvent) -> None:
         payload = event.payload

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -565,8 +565,7 @@ class BuildRunner(AbstractBuildRunner):
             self.stored_build.uuid,
             updates,
             # PENDING for a first run, RETRY for a build-level retry run.
-            should_update=lambda item: item.status
-            in (Status.PENDING, Status.RETRY),
+            should_update=lambda item: item.status in (Status.PENDING, Status.RETRY),
         )
         if update is not None:  # Build had pending status, all good.
             self.stored_build = update

--- a/src/gbserver/storage/stored_build.py
+++ b/src/gbserver/storage/stored_build.py
@@ -23,8 +23,11 @@ import shutil
 import tempfile
 from base64 import b64decode, b64encode
 from pathlib import Path
-from typing import Dict, List, Optional, Self, Tuple, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Self, Tuple, Type
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from gbserver.storage.build_storage import IStoredBuildStorage
 
 from pydantic import Field
 
@@ -228,3 +231,34 @@ class StoredBuild(BaseStoredItem, TaggedItem):
             and self.created_time == other.created_time
             and self.updated_time == other.updated_time
         )
+
+
+def get_retry_chain_members(
+    build_storage: "IStoredBuildStorage", build: StoredBuild
+) -> List[StoredBuild]:
+    """Return all builds in ``build``'s retry chain, root first.
+
+    The chain is walked with repeated point reads (``get_by_uuid``) rather than a
+    column query, since ``retry_of_build_id``/``retry_build_id`` are not indexed
+    columns on gb_builds. The root is resolved via ``retry_of_build_id`` (a retry
+    points at the original), then the chain is followed forward via
+    ``retry_build_id`` (each build points at the build retrying it).
+
+    Args:
+        build_storage: storage used to read builds by uuid.
+        build: any member of the chain (the original or a retry).
+
+    Returns:
+        The chain members ordered from root to the most recent retry. Returns just
+        ``build`` if it cannot be re-read from storage.
+    """
+    root_id = build.retry_of_build_id or build.uuid
+    members: List[StoredBuild] = []
+    seen: set[str] = set()
+    current = build_storage.get_by_uuid(root_id)
+    while isinstance(current, StoredBuild) and current.uuid not in seen:
+        members.append(current)
+        seen.add(current.uuid)
+        next_id = current.retry_build_id
+        current = build_storage.get_by_uuid(next_id) if next_id else None
+    return members or [build]

--- a/src/gbserver/types/status.py
+++ b/src/gbserver/types/status.py
@@ -27,11 +27,16 @@ class Status(StrEnum):
     INVALID = auto()
     CANCELLED = auto()
     CANCEL_REQUESTED = auto()
+    # A build that is queued for a build-level retry. It is owned and run by the
+    # in-process BuildRunner retry loop, NOT dispatched by the BuildWatcher (which
+    # polls only PENDING/SUBMITTED/CANCEL_REQUESTED). Using a distinct status keeps
+    # the watcher from double-dispatching a retry the runner is already handling.
+    RETRY = auto()
 
     def is_finished(self) -> bool:
         """Determine of the status (of a build) indicates the job is no longer running.
         This includes SUCCESS, FAILED, INVALID or CANCELLED states.
-        If status PENDING, RUNNING, or CANCEL_REQUESTED, then the build is assumed to either not have started or currently is running.
+        If status PENDING, RUNNING, RETRY, or CANCEL_REQUESTED, then the build is assumed to either not have started or currently is running.
         """
         return self in (Status.SUCCESS, Status.FAILED, Status.INVALID, Status.CANCELLED)
 
@@ -51,4 +56,5 @@ STATUS_TO_ICON = {
     Status.INVALID: "❌",
     Status.CANCELLED: "⚠️",
     Status.CANCEL_REQUESTED: "⚠️",
+    Status.RETRY: "🔁",
 }

--- a/src/gbserver/types/status.py
+++ b/src/gbserver/types/status.py
@@ -27,16 +27,17 @@ class Status(StrEnum):
     INVALID = auto()
     CANCELLED = auto()
     CANCEL_REQUESTED = auto()
-    # A build that is queued for a build-level retry. It is owned and run by the
-    # in-process BuildRunner retry loop, NOT dispatched by the BuildWatcher (which
-    # polls only PENDING/SUBMITTED/CANCEL_REQUESTED). Using a distinct status keeps
-    # the watcher from double-dispatching a retry the runner is already handling.
-    RETRY = auto()
+    # A build that is queued for a build-level retry but not yet running. It is
+    # owned and run by the in-process BuildRunner retry loop, NOT dispatched by the
+    # BuildWatcher (which polls only PENDING/SUBMITTED/CANCEL_REQUESTED). Using a
+    # distinct status keeps the watcher from double-dispatching a retry the runner
+    # is already handling.
+    RETRY_PENDING = auto()
 
     def is_finished(self) -> bool:
         """Determine of the status (of a build) indicates the job is no longer running.
         This includes SUCCESS, FAILED, INVALID or CANCELLED states.
-        If status PENDING, RUNNING, RETRY, or CANCEL_REQUESTED, then the build is assumed to either not have started or currently is running.
+        If status PENDING, RUNNING, RETRY_PENDING, or CANCEL_REQUESTED, then the build is assumed to either not have started or currently is running.
         """
         return self in (Status.SUCCESS, Status.FAILED, Status.INVALID, Status.CANCELLED)
 
@@ -56,5 +57,5 @@ STATUS_TO_ICON = {
     Status.INVALID: "❌",
     Status.CANCELLED: "⚠️",
     Status.CANCEL_REQUESTED: "⚠️",
-    Status.RETRY: "🔁",
+    Status.RETRY_PENDING: "🔁",
 }

--- a/test-data/integration/standalone/buildrunner/local/retry-cancel/build.yaml
+++ b/test-data/integration/standalone/buildrunner/local/retry-cancel/build.yaml
@@ -1,0 +1,18 @@
+granite.build:
+  name: bash-retry-cancel-test
+  # Every attempt lingers briefly then fails, giving the test a window to cancel
+  # the build while a retry is in flight. max_retries has headroom so the chain
+  # would keep retrying if cancellation didn't stop it.
+  retries:
+    max_retries: 5
+  targets:
+    fail-target:
+      allow_unknown: true
+      environment_uri: space://environments/bash
+      steps:
+        - step_uri: space://steps/command
+          config:
+            bash_config:
+              command: "sleep 5; exit 1"
+            compute_config:
+              num_nodes: 1

--- a/test-data/integration/standalone/buildrunner/local/retry-cancel/buildtest.yaml
+++ b/test-data/integration/standalone/buildrunner/local/retry-cancel/buildtest.yaml
@@ -1,0 +1,9 @@
+# Fixture for the build-level retry cancellation test
+# (test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py).
+#
+# build_yaml defaults to ./build.yaml (sibling) when omitted.
+expected_status: cancelled
+simulate_step_failure: false
+space_uri: ../../../../../../configurations/spaces/local
+target_expectations: []
+timeout_minutes: 10

--- a/test-data/integration/standalone/buildrunner/local/retry-exhaust/build.yaml
+++ b/test-data/integration/standalone/buildrunner/local/retry-exhaust/build.yaml
@@ -1,0 +1,23 @@
+granite.build:
+  name: bash-retry-exhaust-test
+  # Build-level retry: when the whole build FAILS, the BuildRunner creates a new
+  # build record and retries the entire build, up to max_retries times.  This
+  # fixture's single target always fails, so the chain is expected to be exactly
+  # 1 original + max_retries retries = 3 build records, all FAILED.
+  retries:
+    max_retries: 2
+  targets:
+    fail-target:
+      allow_unknown: true
+      environment_uri: space://environments/bash
+      steps:
+        # The general-purpose `command` bash step runs an arbitrary shell command
+        # from config.bash_config.command.  `exit 1` hard-FAILS the target; the
+        # Bash environment does not wrap steps in a RetryHandler, so the failure
+        # is not absorbed and build-level retry is exercised.
+        - step_uri: space://steps/command
+          config:
+            bash_config:
+              command: "exit 1"
+            compute_config:
+              num_nodes: 1

--- a/test-data/integration/standalone/buildrunner/local/retry-exhaust/buildtest.yaml
+++ b/test-data/integration/standalone/buildrunner/local/retry-exhaust/buildtest.yaml
@@ -1,0 +1,17 @@
+# Fixture for the build-level retry-exhaustion regression test
+# (test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py).
+#
+# build_yaml defaults to ./build.yaml (sibling) when omitted.  The build's single
+# target always fails, so the expected end state is a FAILED build.
+expected_status: failed
+# This test exercises build-level retry, NOT step-level failure simulation.
+simulate_step_failure: false
+# Use the shared standalone space at <repo>/configurations/spaces/local so the
+# BuildRunner resolves space:// URIs (the bash environment and the command step)
+# without cloning from GitHub.  Relative path resolves against this YAML's
+# directory and is returned as an absolute file:// URI by from_yaml.
+space_uri: ../../../../../../configurations/spaces/local
+# No per-target expectations are asserted by this test (it counts build records
+# instead), but the field is required by BuildTestSpecification.
+target_expectations: []
+timeout_minutes: 10

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
@@ -21,6 +21,7 @@ must stop the active retry and mark every build in the chain CANCELLED, and the
 chain must not spawn further retries.
 """
 
+import threading
 from pathlib import Path
 from time import sleep, time
 
@@ -34,6 +35,7 @@ from libgbtest.buildrunner.utils import ExceptionRaisingThread
 from libgbtest.constants import GBTEST_SPACE_NAME, GBTEST_USER_NAME
 
 from gbserver.api.builds import request_cancellation
+from gbserver.buildrunner.buildrunner import BuildRunner
 from gbserver.buildwatcher.buildwatcher import BuildWatcher
 from gbserver.storage.stored_build import StoredBuild, get_retry_chain_members
 from gbserver.types.status import Status
@@ -73,6 +75,31 @@ class TestRetryChainCancellation(AbstractBuildTest):
             retry_count=retry_count,
             retry_of_build_id=retry_of_build_id,
         )
+
+    def _bare_runner(self, build: StoredBuild) -> BuildRunner:
+        """A BuildRunner wired just enough to exercise __cancel_build_run / stop()."""
+        runner = object.__new__(BuildRunner)
+        runner.stored_build = build
+        runner.storage = self.storage
+        runner.build_run = None
+        runner.stop_event = threading.Event()
+        runner._retry_chain_build_ids = [build.uuid]
+        runner._retry_chain_lock = threading.Lock()
+        return runner
+
+    def test_stop_after_success_does_not_cancel(self):
+        """Stopping the runner as cleanup must not flip a finished build.
+
+        The harness (and BuildWatcher shutdown) call runner.stop() after a build
+        completes. With no cancellation requested, a SUCCESS build must stay
+        SUCCESS — __cancel_build_run must not relabel finished builds.
+        """
+        build = self._make_build(Status.SUCCESS, 0)
+        self.storage.build_storage.add(build)
+        self._bare_runner(build).stop()
+        assert (
+            self.storage.build_storage.get_by_uuid(build.uuid).status == Status.SUCCESS
+        ), "A cleanup stop() must not cancel a build that already succeeded"
 
     def test_cancel_failed_root_is_accepted_when_chain_active(self):
         """Deterministic: a FAILED root with an active retry can be cancelled.

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cancellation of a build-level retry chain.
+
+Cancelling any member of a retry chain — including the already-FAILED original —
+must stop the active retry and mark every build in the chain CANCELLED, and the
+chain must not spawn further retries.
+"""
+
+from pathlib import Path
+from time import sleep, time
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractBuildTest,
+    BuildTestSpecification,
+    get_test_data_dir_for,
+)
+from libgbtest.buildrunner.utils import ExceptionRaisingThread
+from libgbtest.constants import GBTEST_SPACE_NAME, GBTEST_USER_NAME
+
+from gbserver.api.builds import request_cancellation
+from gbserver.buildwatcher.buildwatcher import BuildWatcher
+from gbserver.storage.stored_build import StoredBuild, get_retry_chain_members
+from gbserver.types.status import Status
+
+pytestmark = pytest.mark.standalone
+
+_IN_FLIGHT = {
+    Status.SUBMITTED,
+    Status.PENDING,
+    Status.RUNNING,
+    Status.CANCEL_REQUESTED,
+    Status.RETRY,
+}
+
+
+@pytest.mark.xdist_group(name="buildwatcher_bash_cancel")
+class TestRetryChainCancellation(AbstractBuildTest):
+    """Cancelling a retry chain stops it and marks all members CANCELLED."""
+
+    def setup_method(self, method):
+        self.run_locally = True
+        super().setup_method(method)
+
+    def _get_spec(self) -> BuildTestSpecification:
+        return BuildTestSpecification.from_yaml(
+            get_test_data_dir_for(__file__) / "retry-cancel" / "buildtest.yaml"
+        )
+
+    def _make_build(self, status, retry_count, retry_of_build_id=None) -> StoredBuild:
+        """Create a bare StoredBuild for chain-routing assertions (not executed)."""
+        return StoredBuild(
+            name="test",
+            space_name=GBTEST_SPACE_NAME,
+            source_uri="",
+            username=GBTEST_USER_NAME,
+            status=status,
+            retry_count=retry_count,
+            retry_of_build_id=retry_of_build_id,
+        )
+
+    def test_cancel_failed_root_is_accepted_when_chain_active(self):
+        """Deterministic: a FAILED root with an active retry can be cancelled.
+
+        The request sets CANCEL_REQUESTED on the root itself (a durable signal the
+        runner detects chain-wide); the active retry is left for the runner to act
+        on. With no active member, cancellation is rejected.
+        """
+        root = self._make_build(Status.FAILED, 0)
+        retry1 = self._make_build(Status.FAILED, 1, retry_of_build_id=root.uuid)
+        retry2 = self._make_build(Status.RUNNING, 2, retry_of_build_id=root.uuid)
+        root.retry_build_id = retry1.uuid
+        retry1.retry_build_id = retry2.uuid
+        for b in (root, retry1, retry2):
+            self.storage.build_storage.add(b)
+
+        members = get_retry_chain_members(self.storage.build_storage, root)
+        assert [m.uuid for m in members] == [root.uuid, retry1.uuid, retry2.uuid]
+
+        # Cancelling the FAILED root is accepted because retry2 is still active.
+        updated = request_cancellation(self.storage.build_storage, root)
+        assert updated.uuid == root.uuid
+        assert updated.status == Status.CANCEL_REQUESTED
+
+        # With every member finished (no active retry), cancellation is rejected.
+        self.storage.build_storage.update_fields(root.uuid, {"status": Status.FAILED})
+        self.storage.build_storage.update_fields(
+            retry2.uuid, {"status": Status.FAILED}
+        )
+        done_root = self.storage.build_storage.get_by_uuid(root.uuid)
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            request_cancellation(self.storage.build_storage, done_root)
+
+    def test_cancel_stops_retry_chain(self):
+        """E2E: cancel the FAILED root mid-chain; all chain builds end CANCELLED."""
+        spec = self._get_spec()
+        space = self._check_and_setup_space(spec)
+
+        stored_build = StoredBuild.create(
+            name="test",
+            space_name=space.name,
+            source_uri="",
+            username=GBTEST_USER_NAME,
+            build_yaml_path=spec.build_yaml,
+            status=Status.SUBMITTED,
+        )
+        root_id = stored_build.uuid
+        self.storage.build_storage.add(stored_build)
+
+        watcher = BuildWatcher(gh_token="", all_build_space_uri=spec.space_uri)
+        watcher.config.buildrunner_type = "thread"
+        watcher.config.monitoring_interval = 1
+
+        thread = ExceptionRaisingThread(
+            name="BuildWatcher", target=watcher.start_and_wait, args=()
+        )
+        thread.start()
+        try:
+            timeout = spec.timeout_minutes * 60
+            # Wait until the first attempt has failed and a retry is in flight.
+            self._wait_for_active_retry(timeout)
+            # Cancel via the FAILED root — routes to the active retry.
+            root = self.storage.build_storage.get_by_uuid(root_id)
+            request_cancellation(self.storage.build_storage, root)
+            self._wait_until_chain_settles(timeout)
+        finally:
+            watcher.stop()
+            thread.join(timeout=60)
+
+        builds = self.storage.build_storage.get_by_uuid(None) or []
+        statuses = [b.status for b in builds]
+        assert all(s == Status.CANCELLED for s in statuses), (
+            f"Every build in the chain should be CANCELLED after cancellation, "
+            f"got {statuses}"
+        )
+        # The chain stopped well short of exhausting max_retries (5).
+        assert max(b.retry_count for b in builds) < 5, (
+            f"Chain kept retrying after cancellation: retry_counts="
+            f"{sorted(b.retry_count for b in builds)}"
+        )
+
+    def _wait_for_active_retry(self, timeout_seconds: float) -> None:
+        """Block until a build with retry_count >= 1 is in flight (a retry is running)."""
+        start = time()
+        while time() - start <= timeout_seconds:
+            builds = self.storage.build_storage.get_by_uuid(None) or []
+            if any(b.retry_count >= 1 and b.status in _IN_FLIGHT for b in builds):
+                return
+            sleep(1)
+        assert False, f"No active retry appeared within {timeout_seconds}s."
+
+    def _wait_until_chain_settles(self, timeout_seconds: float) -> None:
+        """Block until no build is in flight and the count is stable across two polls."""
+        poll = 2.0
+        prev_count = -1
+        start = time()
+        while time() - start <= timeout_seconds:
+            builds = self.storage.build_storage.get_by_uuid(None) or []
+            in_flight = [b for b in builds if b.status in _IN_FLIGHT]
+            if builds and not in_flight and len(builds) == prev_count:
+                return
+            prev_count = len(builds)
+            sleep(poll)
+        assert False, f"Retry chain did not settle within {timeout_seconds}s."

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
@@ -47,7 +47,7 @@ _IN_FLIGHT = {
     Status.PENDING,
     Status.RUNNING,
     Status.CANCEL_REQUESTED,
-    Status.RETRY,
+    Status.RETRY_PENDING,
 }
 
 

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_cancellation.py
@@ -126,9 +126,7 @@ class TestRetryChainCancellation(AbstractBuildTest):
 
         # With every member finished (no active retry), cancellation is rejected.
         self.storage.build_storage.update_fields(root.uuid, {"status": Status.FAILED})
-        self.storage.build_storage.update_fields(
-            retry2.uuid, {"status": Status.FAILED}
-        )
+        self.storage.build_storage.update_fields(retry2.uuid, {"status": Status.FAILED})
         done_root = self.storage.build_storage.get_by_uuid(root.uuid)
         from fastapi import HTTPException
 

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py
@@ -123,9 +123,9 @@ class TestBuildWatcherRetryExhaustion(AbstractBuildTest):
             f"with retry_counts={retry_counts}. More than expected indicates the "
             f"BuildWatcher is double-dispatching PENDING retry builds."
         )
-        assert all(s == Status.FAILED for s in statuses), (
-            f"Every build in the chain should be FAILED, got statuses={statuses}"
-        )
+        assert all(
+            s == Status.FAILED for s in statuses
+        ), f"Every build in the chain should be FAILED, got statuses={statuses}"
         assert retry_counts == list(range(0, max_retries + 1)), (
             f"Retry chain should have one build per retry_count 0..{max_retries}, "
             f"got {retry_counts}"

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py
@@ -57,7 +57,7 @@ _IN_FLIGHT = {
     Status.PENDING,
     Status.RUNNING,
     Status.CANCEL_REQUESTED,
-    Status.RETRY,
+    Status.RETRY_PENDING,
 }
 
 

--- a/test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py
+++ b/test/integration/standalone/buildrunner/local/test_buildrunner_retry_exhaustion.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for build-level retry exhaustion under the BuildWatcher.
+
+A build whose only target hard-fails should be retried exactly ``max_retries``
+times — producing ``1 + max_retries`` build records total, all FAILED — and then
+stop.
+
+This must run through the *BuildWatcher* (not a directly-driven BuildRunner):
+the bug being guarded against is that ``BuildRunner.__prepare_retry`` persists
+each retry build as PENDING, while the BuildRunner's in-process retry loop *also*
+runs it.  The watcher polls for PENDING builds and dispatches a *second* runner
+for that same retry build, so each failure spawns more than one next-level retry
+— a branching tree of retries instead of a linear chain.  Driving the build
+directly via a BuildRunner would never expose this, because no watcher is polling.
+
+The build runs in the local Bash environment, so no Docker/cluster is required.
+"""
+
+from pathlib import Path
+from time import sleep, time
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractBuildTest,
+    BuildTestSpecification,
+    get_test_data_dir_for,
+)
+from libgbtest.buildrunner.utils import ExceptionRaisingThread
+from libgbtest.constants import GBTEST_USER_NAME
+
+from gbserver.buildwatcher.buildwatcher import BuildWatcher
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.types.status import Status
+
+pytestmark = pytest.mark.standalone
+
+# Statuses that mean a build (or its retry) is still in flight; the retry chain
+# has "settled" only once no build is in any of these. RETRY is in-flight: it is
+# a retry build the in-process loop is about to run.
+_IN_FLIGHT = {
+    Status.SUBMITTED,
+    Status.PENDING,
+    Status.RUNNING,
+    Status.CANCEL_REQUESTED,
+    Status.RETRY,
+}
+
+
+@pytest.mark.xdist_group(name="buildwatcher_bash_retry")
+class TestBuildWatcherRetryExhaustion(AbstractBuildTest):
+    """The BuildWatcher must retry a failing build exactly ``max_retries`` times."""
+
+    def setup_method(self, method):
+        # Always run locally via the thread BuildRunner — no cluster login.
+        self.run_locally = True
+        super().setup_method(method)
+
+    def _get_spec(self) -> BuildTestSpecification:
+        return BuildTestSpecification.from_yaml(
+            get_test_data_dir_for(__file__) / "retry-exhaust" / "buildtest.yaml"
+        )
+
+    def test_build_watcher_stops_after_max_retries(self):
+        """Submit a build whose target always fails and let the BuildWatcher run it.
+
+        Expectation: exactly ``1 + max_retries`` build records exist, all FAILED,
+        with retry_count values 0..max_retries (a linear chain).  The bug produces
+        *more* than that because the watcher double-dispatches each PENDING retry.
+        """
+        spec = self._get_spec()
+        space = self._check_and_setup_space(spec)
+
+        stored_build = StoredBuild.create(
+            name="test",
+            space_name=space.name,
+            source_uri="",
+            username=GBTEST_USER_NAME,
+            build_yaml_path=spec.build_yaml,
+            status=Status.SUBMITTED,
+        )
+        max_retries = stored_build.get_build_config().retries.max_retries
+        assert max_retries > 0, "fixture must set retries.max_retries > 0"
+        self.storage.build_storage.add(stored_build)
+
+        watcher = BuildWatcher(gh_token="", all_build_space_uri=spec.space_uri)
+        # Thread runner (no cluster) and continuous polling so the watcher reliably
+        # observes retry builds during their brief PENDING window.
+        watcher.config.buildrunner_type = "thread"
+        watcher.config.monitoring_interval = 0
+
+        thread = ExceptionRaisingThread(
+            name="BuildWatcher", target=watcher.start_and_wait, args=()
+        )
+        thread.start()
+        try:
+            self._wait_until_chain_settles(timeout_seconds=spec.timeout_minutes * 60)
+        finally:
+            watcher.stop()
+            thread.join(timeout=60)
+
+        builds = self.storage.build_storage.get_by_uuid(None) or []
+        retry_counts = sorted(b.retry_count for b in builds)
+        statuses = [b.status for b in builds]
+
+        assert len(builds) == 1 + max_retries, (
+            f"Expected a linear retry chain of {1 + max_retries} builds "
+            f"(1 original + {max_retries} retries), but found {len(builds)} "
+            f"with retry_counts={retry_counts}. More than expected indicates the "
+            f"BuildWatcher is double-dispatching PENDING retry builds."
+        )
+        assert all(s == Status.FAILED for s in statuses), (
+            f"Every build in the chain should be FAILED, got statuses={statuses}"
+        )
+        assert retry_counts == list(range(0, max_retries + 1)), (
+            f"Retry chain should have one build per retry_count 0..{max_retries}, "
+            f"got {retry_counts}"
+        )
+
+    def _wait_until_chain_settles(self, timeout_seconds: float) -> None:
+        """Block until no build is in flight and the build count is stable.
+
+        Settled means: at least one build exists, none are in an in-flight status,
+        and the total count has not changed across two consecutive polls (so a
+        late duplicate dispatch has a chance to appear before we assert).
+
+        Args:
+            timeout_seconds: Maximum time to wait for the chain to settle.
+
+        Raises:
+            AssertionError: if the chain has not settled before the timeout.
+        """
+        poll = 2.0
+        prev_count = -1
+        start = time()
+        while time() - start <= timeout_seconds:
+            builds = self.storage.build_storage.get_by_uuid(None) or []
+            in_flight = [b for b in builds if b.status in _IN_FLIGHT]
+            if builds and not in_flight and len(builds) == prev_count:
+                return
+            prev_count = len(builds)
+            sleep(poll)
+        assert False, (
+            f"Retry chain did not settle within {timeout_seconds}s; "
+            f"last seen {prev_count} build(s)."
+        )


### PR DESCRIPTION
## Description

This fixes issue #114 

We add a new build RETRY status and use that instead of PENDING status when creating a new StoredBuild for retry inside the BuildRunner.
We also allow cancellation of the build by cancelling any build in the retry chain.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
