### PR TITLE
Add RabbitMQ management env vars to rest-server chart values

### DIFF
--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -112,6 +112,10 @@ deployments:
     - GBSERVER_IBMID_CLIENT_SECRET
     - GBSERVER_IBMID_CALLBACK_URL
     - GBSERVER_HF_TOKEN
+    # RabbitMQ for notification subscription
+    - GBSERVER_RABBITMQ_MGMT_URL
+    - GBSERVER_RABBITMQ_MGMT_USER
+    - GBSERVER_RABBITMQ_MGMT_PASSWORD
     # OpenLineage / WandB ---
     - GBSERVER_WANDB_API_KEY
     - GBSERVER_WANDB_ENTITY
@@ -190,3 +194,7 @@ secrets:
       # OpenLineage / WandB
       GBSERVER_WANDB_API_KEY: xxxx
       GBSERVER_WANDB_ENTITY: granite-lineage
+      # RabbitMQ for notification subscription
+      GBSERVER_RABBITMQ_MGMT_URL: xxxx
+      GBSERVER_RABBITMQ_MGMT_USER: xxxx
+      GBSERVER_RABBITMQ_MGMT_PASSWORD: xxxx


### PR DESCRIPTION
## Summary
Wire the RabbitMQ management credentials into the Helm chart so the rest-server can reach the RabbitMQ management API for the notification subscription service.

- Add `GBSERVER_RABBITMQ_MGMT_URL`, `GBSERVER_RABBITMQ_MGMT_USER`, and `GBSERVER_RABBITMQ_MGMT_PASSWORD` to `deployments.restServer.envFromMainSecret`.
- Add the same three keys to `secrets.mainSecret.stringData` as the chart-template/dev path.

These env vars are defined in `src/gbserver/types/constants.py` and consumed by `messaging/subscription_service.py` and `messaging/credential_cleanup.py` via the REST API (`api/event_subscribe.py`, `api/root_api.py`). Placed under `restServer` only, since the build-watcher does not use the subscription service.

## Notes
- In prod/staging, `secrets.enable` is `false` and the deployment references an external secret (`mainSecretName`), so the `stringData` template here does not render there. The three RabbitMQ keys must be added to those external secrets manually — this will be handled out-of-band.

## Testing
- Verified env var names match the constants registry and the messaging consumers.
- Confirmed env-specific overrides (`values-{dev,staging,prod}.yaml`) do not redefine the edited lists.