### PR TITLE
fix: add error handling to subscribe endpoint

### DIFF
--- a/src/gbserver/api/event_subscribe.py
+++ b/src/gbserver/api/event_subscribe.py
@@ -93,8 +93,8 @@ async def subscribe_build_events(build_id: str, request: Request) -> SubscribeRe
         )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Event subscription service unavailable: {exc}",
-        )
+            detail="Event subscription service unavailable.",
+        ) from exc
     except httpx.ConnectError as exc:
         logger.error(
             "Cannot reach RabbitMQ management API for build %s: %s",
@@ -104,7 +104,7 @@ async def subscribe_build_events(build_id: str, request: Request) -> SubscribeRe
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Event subscription service unreachable.",
-        )
+        ) from exc
     except httpx.TimeoutException as exc:
         logger.error(
             "Timeout contacting RabbitMQ management API for build %s: %s",
@@ -114,5 +114,5 @@ async def subscribe_build_events(build_id: str, request: Request) -> SubscribeRe
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             detail="Event subscription service timed out.",
-        )
+        ) from exc
     return SubscribeResponse(**result)

--- a/src/gbserver/api/event_subscribe.py
+++ b/src/gbserver/api/event_subscribe.py
@@ -16,9 +16,11 @@
 
 """APIRouter for build event subscription."""
 
+import httpx
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
+from gbserver.messaging.rabbitmq_admin import RabbitMQAdminError
 from gbserver.messaging.subscription_service import provision_subscription
 from gbserver.storage.singleton_storage import get_admin_storage
 from gbserver.storage.stored_build import StoredBuild
@@ -80,5 +82,37 @@ async def subscribe_build_events(build_id: str, request: Request) -> SubscribeRe
     assert isinstance(build, StoredBuild)
 
     # 3. Provision credentials via messaging layer
-    result = await provision_subscription(build_id)
+    try:
+        result = await provision_subscription(build_id)
+    except RabbitMQAdminError as exc:
+        logger.error(
+            "RabbitMQ admin API error while provisioning subscription "
+            "for build %s: %s",
+            build_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Event subscription service unavailable: {exc}",
+        )
+    except httpx.ConnectError as exc:
+        logger.error(
+            "Cannot reach RabbitMQ management API for build %s: %s",
+            build_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Event subscription service unreachable.",
+        )
+    except httpx.TimeoutException as exc:
+        logger.error(
+            "Timeout contacting RabbitMQ management API for build %s: %s",
+            build_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Event subscription service timed out.",
+        )
     return SubscribeResponse(**result)

--- a/test/unit/api/test_event_subscribe.py
+++ b/test/unit/api/test_event_subscribe.py
@@ -231,9 +231,7 @@ class TestEventSubscribeEndpoint:
         )
         mock_get_storage.return_value = mock_storage
 
-        mock_provision.side_effect = httpx.ReadTimeout(
-            "Timed out reading response"
-        )
+        mock_provision.side_effect = httpx.ReadTimeout("Timed out reading response")
 
         app = _make_app()
         client = TestClient(app)

--- a/test/unit/api/test_event_subscribe.py
+++ b/test/unit/api/test_event_subscribe.py
@@ -19,6 +19,7 @@
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI, Request, status
 from fastapi.testclient import TestClient
@@ -26,6 +27,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.responses import Response
 
 from gbserver.api.event_subscribe import SubscribeResponse, event_subscribe_router
+from gbserver.messaging.rabbitmq_admin import RabbitMQAdminError
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.types.auth import User
 
@@ -167,3 +169,78 @@ class TestEventSubscribeEndpoint:
 
         assert response.status_code == 404
         assert "not found" in response.json()["detail"]
+
+    @patch("gbserver.api.event_subscribe.provision_subscription")
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_rabbitmq_admin_error_returns_503(self, mock_get_storage, mock_provision):
+        """RabbitMQAdminError during provisioning returns 503."""
+        build_id = "abc-123-def"
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = _make_stored_build(
+            build_id
+        )
+        mock_get_storage.return_value = mock_storage
+
+        mock_provision.side_effect = RabbitMQAdminError(
+            "Failed to create user tmp-build-abc-123d-xyzabc: 401 Unauthorized"
+        )
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 503
+        assert "Event subscription service unavailable" in response.json()["detail"]
+
+    @patch("gbserver.api.event_subscribe.provision_subscription")
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_connect_error_returns_503(self, mock_get_storage, mock_provision):
+        """httpx.ConnectError returns 503."""
+        build_id = "abc-123-def"
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = _make_stored_build(
+            build_id
+        )
+        mock_get_storage.return_value = mock_storage
+
+        mock_provision.side_effect = httpx.ConnectError(
+            "Connection refused: localhost:15672"
+        )
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 503
+        assert "unreachable" in response.json()["detail"]
+
+    @patch("gbserver.api.event_subscribe.provision_subscription")
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_timeout_error_returns_504(self, mock_get_storage, mock_provision):
+        """httpx.TimeoutException returns 504."""
+        build_id = "abc-123-def"
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = _make_stored_build(
+            build_id
+        )
+        mock_get_storage.return_value = mock_storage
+
+        mock_provision.side_effect = httpx.ReadTimeout(
+            "Timed out reading response"
+        )
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 504
+        assert "timed out" in response.json()["detail"]


### PR DESCRIPTION
## Summary

- Catch RabbitMQAdminError, httpx.ConnectError, and httpx.TimeoutException in the subscribe endpoint, returning 503/504 with generic error messages instead of a bare 500 Internal Server Error.
- Add from exc exception chaining to all three handlers.
- Remove internal detail leak from error responses (details stay in logs only).
- Unit tests for all three error scenarios.

## Context

Discovered while investigating a 500 error when calling POST /api/v1/builds/{build_id}/events/subscribe in DEV. Root cause was the RabbitMQ Management API being unreachable (issue #117, now resolved via PR #118). This fix ensures future connectivity or auth failures surface useful diagnostics rather than opaque 500s.

## Test plan

- [x] Unit tests pass (pytest test/unit/api/test_event_subscribe.py)
- [x] Verify endpoint returns 503 with generic detail when RabbitMQ mgmt API is misconfigured
- [x] Verify endpoint returns 200 with credentials when properly configured

## Note

TLS support, event publishing enablement, and Helm config changes have been split into a separate PR (feat/rabbitmq-tls-config) per review feedback.