### PR TITLE
Fix standalone bash builds: create, register, and locate output artifacts

### DIFF
--- a/samples/standalone/inference/README.md
+++ b/samples/standalone/inference/README.md
@@ -6,15 +6,25 @@ GPU, no container, no cloud credentials. Uses the
 
 ## Run it
 
-From the repo root, with the venv active (`make venv && source .venv/bin/activate`):
+From the repo root, with the venv active (`make venv && source .venv/bin/activate`). Start the
+standalone server in one terminal, then submit the build with `gb` (gbcli) in another:
 
 ```bash
-GBSERVER_METADATA_STORAGE=sqlite \
-GBSERVER_DEFAULT_BUILDRUNNER_TYPE=process \
-GB_ENVIRONMENT=STANDALONE \
-gbserver build run \
-  --space-config-uri "file://$(pwd)/configurations/spaces/local" \
-  samples/standalone/inference
+# Terminal 1 — start the server
+gbserver standalone --space-dir configurations/spaces/local
+```
+
+```bash
+# Terminal 2 — submit the build
+export GB_ENVIRONMENT=STANDALONE
+gb build start -f samples/standalone/inference/build.yaml
+```
+
+`gb build start` returns a build ID; use it to check status and logs:
+
+```bash
+gb build status <build-id>
+gb build log <build-id>
 ```
 
 On first run the step `pip install`s `torch`/`transformers` into the venv (CPU-only), so it
@@ -35,5 +45,22 @@ The model arrives in the step as `$LLMB_BASH_INPUT_MODEL` automatically (see
 ## Output
 
 The step writes `inference_result.json` (model type, prompt, response, timing) and
-`response.txt`, and registers them as the `generation` artifact (→
-`file:outputs/inference/`). Success is logged as `INFERENCE_SUCCESS`.
+`response.txt`, and registers them as the `generation` artifact. Success is logged as
+`INFERENCE_SUCCESS`.
+
+A successful run creates an **`outputs/` folder** (relative to where you started
+`gbserver standalone` — typically the repo root) and writes the result under it. The output
+URI is defined in `build.yaml` as `file:outputs/inference_{{ binding.path | short_hash }}/`,
+where `{{ binding.path | short_hash }}` makes the location **unique per run** (keyed on the
+model), so repeated runs don't overwrite each other. For example:
+
+```
+outputs/inference_a1b2c3d4/
+```
+
+The registered artifact records the resolved absolute path. Inspect it with:
+
+```bash
+gb build status <build-id>              # shows each target's output artifacts (id + uri)
+gb artifact list --build-id <build-id>  # lists the individual artifact entries
+```

--- a/samples/standalone/inference/build.yaml
+++ b/samples/standalone/inference/build.yaml
@@ -17,7 +17,7 @@ granite.build:
         # registers it as the "generation" artifact (name must match the
         # LLMB_ARTIFACT_ID the step emits).
         generation:
-          uri: file:outputs/inference/
+          uri: file:outputs/inference_{{ binding.path | short_hash }}/
       steps:
         - step_uri: space://steps/inference
           config:

--- a/samples/standalone/lora-finetune/README.md
+++ b/samples/standalone/lora-finetune/README.md
@@ -13,15 +13,25 @@ steps:
 
 ## Run it
 
-From the repo root, with the venv active:
+From the repo root, with the venv active. Start the standalone server in one terminal, then
+submit the build with `gb` (gbcli) in another:
 
 ```bash
-GBSERVER_METADATA_STORAGE=sqlite \
-GBSERVER_DEFAULT_BUILDRUNNER_TYPE=process \
-GB_ENVIRONMENT=STANDALONE \
-gbserver build run \
-  --space-config-uri "file://$(pwd)/configurations/spaces/local" \
-  samples/standalone/lora-finetune
+# Terminal 1 — start the server
+gbserver standalone --space-dir configurations/spaces/local
+```
+
+```bash
+# Terminal 2 — submit the build
+export GB_ENVIRONMENT=STANDALONE
+gb build start -f samples/standalone/lora-finetune/build.yaml
+```
+
+`gb build start` returns a build ID; use it to check status and logs:
+
+```bash
+gb build status <build-id>
+gb build log <build-id>
 ```
 
 First run installs `torch`/`transformers`/`trl`/`peft` (CPU) and trains for `MAX_STEPS`
@@ -53,9 +63,26 @@ adapter to a directory keyed on `$LLMB_BASH_TARGET_RUN_ID` (shared by both steps
 
 ## Output
 
-- Stage 1 registers the `adapter` artifact (→ `file:outputs/lora-finetune/adapter/`);
-  success `LORA_FINETUNE_SUCCESS`.
+- Stage 1 registers the `adapter` artifact; success `LORA_FINETUNE_SUCCESS`.
 - Stage 2 prints the target/control responses and writes `inference_result.json` under its
   step output directory; success `LORA_INFERENCE_SUCCESS`. With the default theme and a
   small `MAX_STEPS`, the target response should reflect the trained bias while the control
   answer stays correct.
+
+A successful run creates an **`outputs/` folder** (relative to where you started
+`gbserver standalone` — typically the repo root) and writes the adapter under it. The output
+URI is defined in `build.yaml` as
+`file:outputs/lora-finetune/adapter_{{ binding.path | short_hash }}/`, where
+`{{ binding.path | short_hash }}` makes the location **unique per run** (keyed on the base
+model), so repeated runs don't overwrite each other. For example:
+
+```
+outputs/lora-finetune/adapter_fppv8qwd/
+```
+
+The registered artifact records the resolved absolute path. Inspect it with:
+
+```bash
+gb build status <build-id>              # shows each target's output artifacts (id + uri)
+gb artifact list --build-id <build-id>  # lists the individual artifact entries
+```

--- a/samples/standalone/lora-finetune/build.yaml
+++ b/samples/standalone/lora-finetune/build.yaml
@@ -23,7 +23,7 @@ granite.build:
         # printed to the log and written under the step's output dir; it isn't
         # registered as a separate target output here.
         adapter:
-          uri: file:outputs/lora-finetune/adapter/
+          uri: file:outputs/lora-finetune/adapter_{{ binding.path | short_hash }}/
       steps:
         # ── Step 1: train the adapter ──────────────────────────────────
         - step_uri: space://steps/lora-finetune

--- a/src/gbcommon/uri/file.py
+++ b/src/gbcommon/uri/file.py
@@ -18,10 +18,11 @@
 URI for files/folders in the local filesystem.
 """
 
+import os
 import shutil
 from pathlib import Path
 from typing import Dict, List, Optional, Self
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from gbcommon.uri.uri import URI
 from gbserver.types.constants import FILE_SCHEME
@@ -77,3 +78,30 @@ class FileURI(URI):
             return True
         except Exception:
             return False
+
+
+def absolutize_file_uri(uri: URI) -> URI:
+    """Resolve a relative ``file:`` URI to an absolute one against the cwd.
+
+    A relative ``file:outputs/...`` URI is physically read/written relative to
+    the process working directory (e.g. an artifact push shells out to rsync
+    from ``os.getcwd()``), but it would otherwise be *registered* verbatim as a
+    relative URI — meaningless to any later consumer (e.g. ``gb artifact
+    download``) that runs from a different directory. Rewriting it to
+    ``file:///<cwd>/outputs/...`` makes the URI match the file's real on-disk
+    location.
+
+    Absolute ``file:`` URIs and all non-``file:`` schemes (``hf:``, ``lh:``,
+    ``cos:``, ``env:``, ...) are returned unchanged.
+    """
+    if uri.uri is None or uri.uri.scheme != FILE_SCHEME:
+        return uri
+    path = uri.uri.path
+    if Path(path).is_absolute():
+        return uri
+    abs_path = os.path.normpath(os.path.join(os.getcwd(), path))
+    # normpath strips a trailing slash; restore it for directory URIs so the
+    # round-tripped URI keeps its original (dir vs file) shape.
+    if path.endswith("/") and not abs_path.endswith("/"):
+        abs_path += "/"
+    return URI.get_uri(urlunparse((FILE_SCHEME, "", abs_path, "", "", "")))

--- a/src/gbserver/builtins/steps/gbstep/bash_scripts/{{ step.name | default(run_metadata.target_name) }}/llmb_bash_wrapper.sh
+++ b/src/gbserver/builtins/steps/gbstep/bash_scripts/{{ step.name | default(run_metadata.target_name) }}/llmb_bash_wrapper.sh
@@ -111,12 +111,12 @@ LLMB_BASH_JOB_EXIT_CODE="${PIPESTATUS[0]}"
 
 {%- if cbash.skip_finding_output_artifacts is defined and cbash.skip_finding_output_artifacts %}
 
-echo "${LLMB_BASH_JOB_NAME}: skip making artifacts out of ${LLMB_BASH_OUTPUT_DIR}"
+echo "${LLMB_BASH_JOB_NAME}: skip making artifacts out of ${LLMB_BASH_OUTPUT_DIR}" | tee -a "${LLMB_BASH_LOG_FILE_COMBINED}"
 
 {%- elif cbash.single_output_artifact is defined and cbash.single_output_artifact %}
 
 echo "${LLMB_BASH_JOB_NAME}: making a single artifact out of ${LLMB_BASH_OUTPUT_DIR}"
-echo "LLMB_ARTIFACT_ID:${LLMB_BASH_OUTPUT_DIR##*/} LLMB_ARTIFACT_PATH:${LLMB_BASH_OUTPUT_DIR}"
+echo "LLMB_ARTIFACT_ID:${LLMB_BASH_OUTPUT_DIR##*/} LLMB_ARTIFACT_PATH:${LLMB_BASH_OUTPUT_DIR}" | tee -a "${LLMB_BASH_LOG_FILE_COMBINED}"
 
 {%- else %}
 

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -299,20 +299,28 @@ class Bash(Environment):
     ) -> Any:
         if uri is None and base_uri is None:
             return None
+        # The binding is the artifact location, either a {"path": ...} dict or a
+        # bare path string. rsync needs the path, not the dict (a stringified
+        # dict is parsed by rsync as a remote spec and fails). raise_errors=True
+        # so a failed copy surfaces as a push failure instead of the artifact
+        # being silently marked successful.
+        source_path = (
+            binding.get("path", "") if isinstance(binding, dict) else str(binding)
+        )
         if uri is not None:
             uriobj = uri
             if isinstance(uri, str):
                 uriobj = URI.get_uri(uri)
             assert uriobj.uri is not None, "the URI is None"
-            sync_or_copy(binding, uriobj.uri.path)
+            sync_or_copy(source_path, uriobj.uri.path, raise_errors=True)
             return uri
         elif base_uri is not None:
             uriobj = base_uri
             if isinstance(base_uri, str):
                 uriobj = URI.get_uri(base_uri)
             assert uriobj.uri is not None, "the URI is None"
-            sync_or_copy(binding, uriobj.uri.path)
-            return URI.get_uristr(base_uri) + "/" + os.path.basename(binding)
+            sync_or_copy(source_path, uriobj.uri.path, raise_errors=True)
+            return URI.get_uristr(base_uri) + "/" + os.path.basename(source_path)
         else:
             return None
 

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -32,11 +32,13 @@ from gbserver.environment.environment import (
     EventLogLineParserConfig,
 )
 from gbserver.environment.local_assets import get_hf_cache_dir, pull_asset_hfstore
+from gbserver.monitoring.logfile_monitor import LogFileMonitor
+from gbserver.monitoring.streams.stream_factory import make_stream
 from gbserver.types.buildconfig import BuildTargetStepConfig
 from gbserver.types.buildevent import EntityRunMetadata
 from gbserver.types.environmentconfig import EnvironmentConfig
+from gbserver.types.errors import LogMonitoringFailedException
 from gbserver.utils.filesystem import sync_or_copy
-from gbserver.utils.launch import launch_command_and_raise_errors
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -53,10 +55,12 @@ class Bash(Environment):
 
     _launched_processes: Dict[str, Process]
     _env: dict[str, Any]
+    log_paths: Dict[str, str]  # launch_id -> combined job.log path
 
     def __init__(self: Self, event_q: asyncio.Queue, **kwargs) -> None:
         self._launched_processes = {}
         self._env = {}
+        self.log_paths = {}
         super().__init__(event_q=event_q, **kwargs)
 
     async def setup_nohup(self: Self, **kwargs):
@@ -165,6 +169,7 @@ class Bash(Environment):
             assert isinstance(
                 run_metadata, dict
             ), f"invalid run_metadata: {run_metadata}"
+            build_id = run_metadata.get("build_id", "")
             final_asset_dir = await self._copy_assets(
                 launch_id=launch_id,
                 asset_dir=targetsteprun_asset_dir,  # type: ignore[arg-type]
@@ -172,16 +177,25 @@ class Bash(Environment):
             )
             final_asset_output_dir = Path(final_asset_dir) / "outputs"
             logger.info("final_asset_output_dir: %s", final_asset_output_dir)
-            self.log_paths = {launch_id: str(Path(final_asset_output_dir) / "job.log")}
+            # The wrapper tees all workload output (incl. LLMB_ARTIFACT_ID lines)
+            # to this combined log file; monitor_log_monitor tails it for events.
+            self.log_paths[launch_id] = str(Path(final_asset_output_dir) / "job.log")
             env["LLMB_BASH_OUTPUT_DIR"] = str(final_asset_output_dir)
-            process, _, _ = await launch_command_and_raise_errors(
-                command_list=command_list,
-                launch_id=launch_id,
+            # Launch non-blocking: do NOT drain the pipes here (that would consume
+            # and close them before the monitor can read, and the real output goes
+            # to job.log anyway). stdout/stderr -> DEVNULL avoids a full-pipe
+            # deadlock since nothing reads them.
+            process = await asyncio.create_subprocess_exec(
+                *command_list,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
                 start_new_session=True,
-                cwd=cwd,  # type: ignore[arg-type]
+                cwd=str(cwd) if cwd else ".",
                 env=env,
             )
             self._launched_processes[launch_id] = process
+            # Release monitors BEFORE awaiting the process so the log_monitor tails
+            # job.log concurrently while the workload runs.
             self._release_monitors(launch_id)
         except FileNotFoundError as fe:
             # logger.error("Command not found: %s", command_list)
@@ -189,6 +203,20 @@ class Bash(Environment):
         except Exception as e:
             # logger.error("Error launching process: %s", e)
             raise ValueError("Error launching process") from e
+
+        # Wait for the job outside the setup try/except so the failure below is
+        # not re-wrapped as a ValueError. Setting the stop event transitions the
+        # concurrent log_monitor's LocalFileStream into its drain phase so any
+        # final lines (artifact markers) are still captured; the sleep(0) yields
+        # to let that drain run before a nonzero exit aborts the task group.
+        returncode = await process.wait()
+        self._get_launch_stopped_event(launch_id).set()
+        await asyncio.sleep(0)
+        if returncode != 0:
+            raise LogMonitoringFailedException(
+                f"bash launch {launch_id} exited with code {returncode}",
+                build_id=build_id,
+            )
 
     async def monitor_log_monitor(
         self: Self,
@@ -207,12 +235,22 @@ class Bash(Environment):
             ]
         assert event_q is not None, "the event_q is None"
         assert entityrun_metadata is not None, "the entityrun_metadata is None"
-        await self._monitor_logs_of_async_subprocess_all(
-            self._launched_processes[launch_id],
-            event_q,
-            event_log_parser_configs,
-            entityrun_metadata,
+        # Tail the combined job.log file (where the wrapper tees all workload
+        # output) rather than the launched process's stdout pipe. The launch task
+        # sets the stop event when the workload exits, which transitions the
+        # stream into its drain phase and ends monitoring.
+        log_path = self.log_paths[launch_id]
+        log_stream_source = make_stream(use_ssh=False, path=log_path)
+        logfile_monitor = LogFileMonitor(
+            step_id=launch_id,
+            stream_source=log_stream_source,
+            event_configs=event_log_parser_configs,
+            launch_id=launch_id,
+            entityrun_metadata=entityrun_metadata,
+            event_queue=event_q,
+            stop_event=self._get_launch_stopped_event(launch_id),
         )
+        await logfile_monitor.monitor()
 
     async def pullasset_filestore(
         self: Self,

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Self, Tuple, Union
 from urllib.parse import urlparse
 
+from gbcommon.types.constants import get_gb_home_dir
 from gbcommon.uri.uri import URI
 from gbserver.environment.environment import (
     BINDING_KEY,
@@ -42,7 +43,6 @@ from gbserver.utils.filesystem import sync_or_copy
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
-DEFAULT_OUTPUT_DIR = "~/.gbcli/logs"
 BASH_SCRIPTS = "bash_scripts"
 JOB_SUB_SH = "llmb_bash_jobsub.sh"
 
@@ -164,7 +164,11 @@ class Bash(Environment):
                     os.path.expandvars(os.path.expanduser(self.output_dir))
                 )
             else:
-                self.output_dir = Path(DEFAULT_OUTPUT_DIR).expanduser()
+                # Default server-side working dir under the GB home
+                # (~/.granite.build by default, overridable via GB_HOME_DIR),
+                # aligning with the rest of the server's per-user state instead
+                # of the CLI's ~/.gbcli tree.
+                self.output_dir = Path(get_gb_home_dir()) / "workdir"
             run_metadata = kwargs.get("run_metadata")
             assert isinstance(
                 run_metadata, dict

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 from pydantic import Field
 
 from gbcommon.types.testing import is_failure_simulated
+from gbcommon.uri.file import absolutize_file_uri
 from gbcommon.uri.uri import URI
 from gbserver.asset.asset import Asset
 from gbserver.asset.assetstore import Assetstore
@@ -1017,6 +1018,9 @@ class Environment(ABC):
         if space_variables is not None:
             config = config | space_variables
         uri = URI.get_uri(fill_template(uristr, config, strict=True))
+        # Register a relative file: output URI as an absolute path so the stored
+        # artifact URI matches where the push physically writes it (cwd-relative).
+        uri = absolutize_file_uri(uri)
         assetstore, assetstoreenv_config = self._get_storeconfig(
             uri=uri, raise_exceptions=True
         )

--- a/test/unit/environment/test_bash_log_monitor.py
+++ b/test/unit/environment/test_bash_log_monitor.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Bash environment's log_monitor.
+
+Regression coverage for the bug where the Bash log_monitor read the launched
+process's (already drained) stdout pipe instead of the job.log file the wrapper
+tees workload output to. The artifact marker (LLMB_ARTIFACT_ID) is written to
+job.log, so the monitor must tail that file and emit a
+NEWARTIFACT_IN_ENVIRONMENT_EVENT.
+"""
+
+import asyncio
+
+import pytest
+
+from gbserver.types.buildevent import BuildEventType, EntityRunMetadata
+
+# Mirrors the lora-finetune step.yaml log_monitor config: matches
+# "LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>" lines.
+ARTIFACT_EVENT_CONFIGS = [
+    {
+        "event_type": "NEWARTIFACT_IN_ENVIRONMENT_EVENT",
+        "line_regex": "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_PATH:.*",
+        "is_json": False,
+        "event_fields": [
+            {"field_name": "binding_id", "field_regex": "(?<=LLMB_ARTIFACT_ID:)[^ ]+"},
+            {
+                "field_name": "path",
+                "field_regex": "(?<=LLMB_ARTIFACT_PATH:).*",
+                "is_data": True,
+            },
+            {
+                "field_name": "binding",
+                "field_value_template": '{ "path": "{{ fields.data.path }}" }',
+                "is_json": True,
+            },
+        ],
+    },
+]
+
+
+def _make_bash():
+    from gbserver.environment.bash import Bash
+
+    return Bash(event_q=asyncio.Queue())
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_monitor_log_monitor_emits_newartifact_event_from_job_log(tmp_path):
+    """monitor_log_monitor tails job.log and emits a NEWARTIFACT event for the
+    artifact marker line written there (not to the process stdout pipe)."""
+    bash = _make_bash()
+    launch_id = "launch-test-1"
+
+    artifact_path = tmp_path / "outputs" / "adapter"
+    job_log = tmp_path / "job.log"
+    job_log.write_text(
+        "some training output\n"
+        f"LLMB_ARTIFACT_ID:adapter LLMB_ARTIFACT_PATH:{artifact_path}\n"
+        "workload script finished successfully\n"
+    )
+    bash.log_paths[launch_id] = str(job_log)
+
+    event_q: asyncio.Queue = asyncio.Queue()
+    # The launch task normally sets this when the workload exits; set it up front
+    # so the stream reads the existing (complete) file and then ends.
+    bash._get_launch_stopped_event(launch_id).set()
+
+    await asyncio.wait_for(
+        bash.monitor_log_monitor(
+            launch_id=launch_id,
+            event_q=event_q,
+            entityrun_metadata=EntityRunMetadata(build_id="b1", target_name="t1"),
+            event_configs=ARTIFACT_EVENT_CONFIGS,
+        ),
+        timeout=30,
+    )
+
+    events = []
+    while not event_q.empty():
+        events.append(event_q.get_nowait())
+
+    artifact_events = [
+        e for e in events if e.type is BuildEventType.NEWARTIFACT_IN_ENVIRONMENT_EVENT
+    ]
+    assert len(artifact_events) == 1, f"expected one NEWARTIFACT event, got {events}"
+    assert artifact_events[0].payload.binding_id == "adapter"
+    assert artifact_events[0].payload.binding == {"path": str(artifact_path)}
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_monitor_log_monitor_no_event_without_marker(tmp_path):
+    """A job.log with no artifact marker yields no NEWARTIFACT event."""
+    bash = _make_bash()
+    launch_id = "launch-test-2"
+
+    job_log = tmp_path / "job.log"
+    job_log.write_text("just some output\nno markers here\n")
+    bash.log_paths[launch_id] = str(job_log)
+
+    event_q: asyncio.Queue = asyncio.Queue()
+    bash._get_launch_stopped_event(launch_id).set()
+
+    await asyncio.wait_for(
+        bash.monitor_log_monitor(
+            launch_id=launch_id,
+            event_q=event_q,
+            entityrun_metadata=EntityRunMetadata(build_id="b2", target_name="t2"),
+            event_configs=ARTIFACT_EVENT_CONFIGS,
+        ),
+        timeout=30,
+    )
+
+    events = []
+    while not event_q.empty():
+        events.append(event_q.get_nowait())
+    artifact_events = [
+        e for e in events if e.type is BuildEventType.NEWARTIFACT_IN_ENVIRONMENT_EVENT
+    ]
+    assert artifact_events == []

--- a/test/unit/environment/test_bash_log_monitor.py
+++ b/test/unit/environment/test_bash_log_monitor.py
@@ -24,6 +24,7 @@ NEWARTIFACT_IN_ENVIRONMENT_EVENT.
 """
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -134,3 +135,50 @@ async def test_monitor_log_monitor_no_event_without_marker(tmp_path):
         e for e in events if e.type is BuildEventType.NEWARTIFACT_IN_ENVIRONMENT_EVENT
     ]
     assert artifact_events == []
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_pushasset_filestore_copies_binding_path_to_uri(tmp_path):
+    """A {"path": ...} binding has its path (not the dict) copied to the file
+    URI destination, and the artifact lands at the resolved location."""
+    from gbcommon.uri.uri import URI
+
+    bash = _make_bash()
+
+    src_dir = tmp_path / "step-outputs" / "adapter"
+    src_dir.mkdir(parents=True)
+    (src_dir / "adapter_model.safetensors").write_text("weights")
+    dest_dir = tmp_path / "outputs" / "lora-finetune" / "adapter_abcd1234"
+
+    binding = {"path": str(src_dir)}
+    uri = URI.get_uri(f"file:{dest_dir}")
+
+    result = await bash.pushasset_filestore(binding=binding, uri=uri)
+
+    assert result is uri
+    # The source path (not the {"path": ...} dict) was copied into the dest.
+    assert (dest_dir / "adapter" / "adapter_model.safetensors").read_text() == "weights"
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_pushasset_filestore_raises_on_copy_failure():
+    """A failed copy raises (instead of silently marking the artifact pushed)."""
+    from gbcommon.uri.uri import URI
+
+    bash = _make_bash()
+    binding = {"path": "/some/source/adapter"}
+    uri = URI.get_uri("file:outputs/lora-finetune/adapter_abcd1234/")
+
+    with patch(
+        "gbserver.environment.bash.sync_or_copy",
+        side_effect=ValueError("rsync failed"),
+    ) as mock_copy:
+        with pytest.raises(ValueError, match="rsync failed"):
+            await bash.pushasset_filestore(binding=binding, uri=uri)
+
+    # The path (not the dict) is passed as the rsync source, with raise_errors=True.
+    args, kwargs = mock_copy.call_args
+    assert args[0] == "/some/source/adapter"
+    assert kwargs.get("raise_errors") is True

--- a/test/unit/uri/test_absolutize_file_uri.py
+++ b/test/unit/uri/test_absolutize_file_uri.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for absolutize_file_uri.
+
+A relative ``file:`` URI is physically read/written relative to the process cwd,
+so a registered artifact URI must be absolutized to match the on-disk location.
+Absolute ``file:`` URIs and other schemes (hf:, lh:, cos:, env:) are unchanged.
+"""
+
+import pytest
+
+from gbcommon.uri.file import absolutize_file_uri
+from gbcommon.uri.uri import URI
+
+FIXED_CWD = "/work/space"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_cwd(monkeypatch):
+    monkeypatch.setattr("gbcommon.uri.file.os.getcwd", lambda: FIXED_CWD)
+
+
+@pytest.mark.standalone
+def test_relative_file_dir_uri_is_absolutized():
+    uri = absolutize_file_uri(URI.get_uri("file:outputs/lora-finetune/adapter_x/"))
+    assert URI.get_uristr(uri) == f"file://{FIXED_CWD}/outputs/lora-finetune/adapter_x/"
+
+
+@pytest.mark.standalone
+def test_relative_file_uri_without_trailing_slash():
+    uri = absolutize_file_uri(URI.get_uri("file:outputs/result.txt"))
+    # No spurious trailing slash added for a non-directory URI.
+    assert URI.get_uristr(uri) == f"file://{FIXED_CWD}/outputs/result.txt"
+
+
+@pytest.mark.standalone
+def test_absolute_file_uri_unchanged():
+    original = "file:///abs/outputs/adapter_x/"
+    uri = absolutize_file_uri(URI.get_uri(original))
+    assert URI.get_uristr(uri) == original
+
+
+@pytest.mark.standalone
+def test_non_file_scheme_unchanged():
+    # hf: is normalized by its own URI handler in get_uri; absolutize_file_uri
+    # must not further alter it. Compare against get_uri's own output.
+    parsed = URI.get_uri("hf:///ibm-granite/granite-4.0-h-350m")
+    result = absolutize_file_uri(parsed)
+    assert result is parsed
+    assert URI.get_uristr(result) == URI.get_uristr(parsed)


### PR DESCRIPTION
## Summary

Fixes standalone (bash environment) builds so output artifacts are actually created, registered with a usable URI, and stored under the project's GB home. Previously a successful standalone build (e.g. the `lora-finetune` / `inference` samples) reported SUCCESS but produced **no output artifact**.

## What was broken & fixed

**1. Output artifacts were never registered.** The bash launcher ran the job via `launch_command_and_raise_errors`, which calls `process.communicate()` — blocking until the job finished and draining/closing the stdout pipe before the `log_monitor` started. The monitor then read an already-closed pipe and never saw the workload's `LLMB_ARTIFACT_ID:` markers (which the wrapper `tee`s to `job.log`), so no `NEWARTIFACT_IN_ENVIRONMENT_EVENT` fired. Now the launcher is non-blocking (Docker/LSF-style): it releases monitors early, the `log_monitor` tails `job.log` via the existing `LogFileMonitor` + `LocalFileStream`, and the launch task awaits the process, sets the stop event, and raises `LogMonitoringFailedException` on a nonzero exit. The wrapper also tees the remaining artifact-marker cases to `job.log` so it's the single source of truth. Also initializes `self.log_paths` in `__init__` (was replaced wholesale per launch, clobbering earlier steps in multi-step targets).

**2. The `file://` push silently failed.** `pushasset_filestore` passed the whole `{"path": ...}` binding dict to rsync (parsed as a remote host spec → `hostname contains invalid characters`, exit 255), and `sync_or_copy` was called with `raise_errors=False`, so the artifact was marked SUCCESS even though nothing was copied. Now it extracts the path (matching the Docker filestore push) and uses `raise_errors=True` so a failed copy surfaces as a push failure.

**3. Registered `file:` URIs were relative (meaningless later).** A relative `file:outputs/...` output URI was recorded verbatim, but the file physically lands relative to the server's cwd — so the stored URI couldn't be resolved by later consumers (e.g. `gb artifact download`). Now relative `file:` URIs are normalized to absolute (`file:///<cwd>/...`) at registration time, against the same cwd the push uses. Guarded by the `file:` scheme — `env://` (environment-internal) and `hf:`/`lh:`/`cos:` are untouched.

**4. Default working dir aligned to the GB home.** The bash environment's default output directory was hardcoded to `~/.gbcli/logs` (the CLI's tree) while the rest of the server's per-user state lives under the GB home. It now defaults to `~/.granite.build/workdir` via `get_gb_home_dir()` (honoring `GB_HOME_DIR`). An explicit `workspace.output_dir` still takes precedence.

## Samples & docs

- `samples/standalone/{lora-finetune,inference}/build.yaml`: make the output URI unique per run via `file:outputs/.../<name>_{{ binding.path | short_hash }}/` so repeated runs don't overwrite each other.
- `samples/standalone/{lora-finetune,inference}/README.md`: switch run instructions to the simpler gbcli flow (`gbserver standalone` + `gb build start -f <build.yaml>`), and document that a successful run creates an `outputs/` folder with the per-run unique artifact, inspectable via `gb build status <id>` / `gb artifact list --build-id <id>`.

## Testing

- New unit tests: bash `log_monitor` emits a NEWARTIFACT event from a `job.log` marker; `pushasset_filestore` copies the binding path and raises on failure; `_absolutize_file_uri` (relative→absolute, absolute unchanged, non-file scheme unchanged).
- `test/unit/environment`, `test/unit/uri`, `test/unit/monitoring` suites pass (the one `test_git.py` error is a pre-existing local `LAKEHOUSE_TOKEN` env requirement, unrelated).
- Verified end-to-end with `gbserver standalone` + `gb build start` on both samples: the artifact is created on disk and registered with an absolute URI.
