### PR TITLE
Handle 0-sized files pushed to HF

### DIFF
--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -865,6 +865,31 @@ class HfURI(URI):
             logger.warning("Could not list resource groups for %s: %s", organization, e)
         return None
 
+    @staticmethod
+    def _validate_non_empty_src(src: Path) -> None:
+        """Ensure ``src`` has uploadable, non-zero-length content.
+
+        HuggingFace silently skips an upload that would produce an empty commit
+        (e.g. a single 0-byte file), so a push of empty content appears to
+        succeed while creating nothing on the Hub.  Fail fast instead.
+
+        Args:
+            src: Local file or directory path being pushed.
+
+        Raises:
+            ValueError: If ``src`` is a zero-length file, or a directory whose
+                regular files are all zero-length (or which contains none).
+        """
+        if src.is_file():
+            if src.stat().st_size == 0:
+                raise ValueError(f"refusing to push zero-length file: {src}")
+            return
+        # Directory: require at least one non-empty regular file.
+        if not any(f.is_file() and f.stat().st_size > 0 for f in src.rglob("*")):
+            raise ValueError(
+                f"refusing to push directory with no non-empty files: {src}"
+            )
+
     def push(
         self: Self,
         src: Path,
@@ -898,7 +923,9 @@ class HfURI(URI):
             space_name: GB space name used to derive the resource group name.
 
         Raises:
-            ValueError: If ``src`` does not exist.
+            ValueError: If ``src`` does not exist, or is a zero-length file or a
+                directory with no non-empty files (HuggingFace would skip the
+                resulting empty commit, leaving the push a silent no-op).
             Exception: Any error from the HuggingFace Hub API is re-raised.
         """
         if is_hf_mocked(HF_OP_PUSH):
@@ -911,6 +938,7 @@ class HfURI(URI):
         src = Path(src)
         if not src.exists():
             raise ValueError(f"{src} does not exist")
+        self._validate_non_empty_src(src)
 
         resource_group_id = self.resolve_resource_group_id(
             token=self._resolve_token(),

--- a/test-data/integration/standalone/buildrunner/docker/docker-hf/build.yaml
+++ b/test-data/integration/standalone/buildrunner/docker/docker-hf/build.yaml
@@ -22,9 +22,9 @@ granite.build:
               image: quay.io/fedora/fedora-minimal:42
               command: >-
                 mkdir /gb-workspace/outputs;
-                file=/gb-workspace/outputs/foo1a.json; touch $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
-                file=/gb-workspace/outputs/foo1b.json; touch $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
-                file=/gb-workspace/outputs/foo2.json; touch $file; echo "LLMB_ARTIFACT_ID:output_model2 LLMB_ARTIFACT_PATH:$file"
+                file=/gb-workspace/outputs/foo1a.json; echo '{"artifact": "output_model1", "file": "foo1a"}' > $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
+                file=/gb-workspace/outputs/foo1b.json; echo '{"artifact": "output_model1", "file": "foo1b"}' > $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
+                file=/gb-workspace/outputs/foo2.json; echo '{"artifact": "output_model2", "file": "foo2"}' > $file; echo "LLMB_ARTIFACT_ID:output_model2 LLMB_ARTIFACT_PATH:$file"
             compute_config:
               num_gpus_per_node: 0
               total_memory_per_node: 1Gi

--- a/test-data/integration/standalone/buildrunner/skypilot_slurm/native/build.yaml
+++ b/test-data/integration/standalone/buildrunner/skypilot_slurm/native/build.yaml
@@ -16,8 +16,8 @@ granite.build:
           config:
             bash_config:
               command: >-
-                file=foo1a.json; touch $file;                 echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
-                file=foo1b.json; touch $file;                 echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
+                file=foo1a.json; echo '{"artifact": "output_model1", "file": "foo1a"}' > $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
+                file=foo1b.json; echo '{"artifact": "output_model1", "file": "foo1b"}' > $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
                 file={{ bindings.input_model.binding.path }}; echo "LLMB_ARTIFACT_ID:output_model2 LLMB_ARTIFACT_PATH:$file"
             compute_config:
               num_gpus_per_node: 0

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -203,6 +203,7 @@ class TestHfURIPushUnit:
         """push() calls upload_folder for a directory source."""
         src_dir = tmp_path / "checkpoint"
         src_dir.mkdir()
+        (src_dir / "f.bin").write_bytes(b"x")
         uri = HfURI.from_parts(owner="org", repo="my-model", hf_type=HfType.MODEL)
 
         with patch("gbcommon.uri.hf.HfApi") as MockApi:
@@ -238,6 +239,7 @@ class TestHfURIPushUnit:
         """path_in_repo encoded in the URI is used as the folder prefix."""
         src_dir = tmp_path / "ckpt"
         src_dir.mkdir()
+        (src_dir / "f.bin").write_bytes(b"x")
         uri = HfURI.from_parts(
             owner="org",
             repo="my-model",
@@ -267,6 +269,7 @@ class TestHfURIPushUnit:
         """HfType.DATASET is passed as repo_type='dataset'."""
         src_dir = tmp_path / "data"
         src_dir.mkdir()
+        (src_dir / "f.bin").write_bytes(b"x")
         uri = HfURI.from_parts(owner="org", repo="my-dataset", hf_type=HfType.DATASET)
 
         with patch("gbcommon.uri.hf.HfApi") as MockApi:
@@ -311,6 +314,29 @@ class TestHfURIPushUnit:
             MockApi.return_value.upload_file.side_effect = RuntimeError("network error")
             with pytest.raises(RuntimeError, match="network error"):
                 uri.push(src)
+
+    def test_push_rejects_zero_length_file(self, tmp_path):
+        """A zero-length file is rejected before any Hub API call."""
+        src = tmp_path / "empty.json"
+        src.touch()  # 0 bytes
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            with pytest.raises(ValueError, match="zero-length file"):
+                uri.push(src)
+        MockApi.return_value.upload_file.assert_not_called()
+
+    def test_push_rejects_directory_with_only_empty_files(self, tmp_path):
+        """A directory whose files are all zero-length is rejected."""
+        src_dir = tmp_path / "ckpt"
+        src_dir.mkdir()
+        (src_dir / "empty.bin").touch()  # 0 bytes
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            with pytest.raises(ValueError, match="no non-empty files"):
+                uri.push(src_dir)
+        MockApi.return_value.upload_folder.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -644,6 +670,7 @@ class TestHfURIBucketPushUnit:
     def test_folder_calls_sync_bucket(self, tmp_path):
         src_dir = tmp_path / "output"
         src_dir.mkdir()
+        (src_dir / "f.bin").write_bytes(b"x")
         uri = HfURI.from_parts(owner="org", repo="my-bucket", hf_type=HfType.BUCKET)
 
         with patch("gbcommon.uri.hf.HfApi") as MockApi:
@@ -657,6 +684,7 @@ class TestHfURIBucketPushUnit:
     def test_folder_with_path_in_repo(self, tmp_path):
         src_dir = tmp_path / "output"
         src_dir.mkdir()
+        (src_dir / "f.bin").write_bytes(b"x")
         uri = HfURI.from_parts(
             owner="org",
             repo="my-bucket",


### PR DESCRIPTION
## Description

The nightly build tests (docker and skypilot/slurm) were [failing the build test ](https://github.com/ibm-granite/granite.build/actions/runs/27927681121/job/82633279973#step:5:3028).  The hf delete was failing because the artifact did not exist.  The artifact did not exist because the tests were pushing zero-length artifacts, which HF did not bother to store. Since the artifacts did not exist, the delete failed.

Note also that the [existance test also failed ](https://github.com/ibm-granite/granite.build/actions/runs/27927681121/job/82633279973#step:5:15387)so that the test would have been marked failed even if the delete did not raise an error.

We've changed the HfUri.push() function to raise an error on 0-length files and empty dirs.
## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
