### PR TITLE
Standalone LoRA sample: Apple Silicon acceleration + multi-target pipeline

### DIFF
--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
@@ -145,12 +145,19 @@ def main():
         and os.path.isdir(adapter_path)
         and not os.path.isfile(os.path.join(adapter_path, "adapter_config.json"))
     ):
+        descended = False
         for entry in sorted(os.listdir(adapter_path)):
             nested = os.path.join(adapter_path, entry)
             if os.path.isfile(os.path.join(nested, "adapter_config.json")):
                 print(f"Descending into nested adapter dir: {nested}")
                 adapter_path = nested
+                descended = True
                 break
+        if not descended:
+            print(
+                f"WARNING: no adapter_config.json in {adapter_path!r} or any "
+                "immediate subdir; from_pretrained will likely fail to load it."
+            )
     os.makedirs(output_dir, exist_ok=True)
 
     import torch

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
@@ -15,8 +15,26 @@ import subprocess
 import sys
 import time
 
+# Let unimplemented MPS (Apple Silicon) ops fall back to CPU instead of erroring.
+# Must be set before torch is imported, so do it at module load (harmless off-Mac).
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
 # Must match the output name declared in build.yaml (outputs.generation).
 ARTIFACT_ID = "generation"
+
+
+def pick_device(torch):
+    """Best available torch device: CUDA, then Apple Silicon (MPS), else CPU.
+
+    MPS is PyTorch's Metal backend — it accelerates inference on Mac M-series
+    GPUs. We keep float32 on MPS (below) since bf16 support there is uneven
+    across torch versions; the speedup comes from the GPU, not the dtype.
+    """
+    if torch.cuda.is_available():
+        return "cuda"
+    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
 
 def shared_adapter_dir():
@@ -109,12 +127,13 @@ def main():
     import torch
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = pick_device(torch)
     print(f"Using device: {device}")
     print(f"Base model: {model_path}")
     print(f"Adapter: {adapter_path or '(none — base model only)'}")
 
     tokenizer = AutoTokenizer.from_pretrained(adapter_path or model_path)
+    # bf16 only on CUDA; CPU and MPS (Apple Silicon) stay in float32 for stability.
     model = AutoModelForCausalLM.from_pretrained(
         model_path,
         torch_dtype=torch.bfloat16 if device == "cuda" else torch.float32,

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
@@ -32,7 +32,10 @@ def pick_device(torch):
     """
     if torch.cuda.is_available():
         return "cuda"
-    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+    if (
+        getattr(torch.backends, "mps", None) is not None
+        and torch.backends.mps.is_available()
+    ):
         return "mps"
     return "cpu"
 
@@ -53,7 +56,9 @@ def shared_adapter_dir():
 
 def ensure_deps():
     try:
+        import google.protobuf  # noqa: F401
         import peft  # noqa: F401
+        import sentencepiece  # noqa: F401
         import torch  # noqa: F401
         import transformers  # noqa: F401
 
@@ -61,6 +66,8 @@ def ensure_deps():
     except ImportError:
         pass
     print("Installing inference dependencies (torch, transformers, peft)...")
+    # sentencepiece + protobuf are required to load the Granite tokenizer (the
+    # slow->fast conversion needs them); transformers does NOT pull them in.
     subprocess.check_call(
         [
             sys.executable,
@@ -72,6 +79,8 @@ def ensure_deps():
             "transformers>=4.55",
             "peft>=0.13",
             "accelerate",
+            "sentencepiece",
+            "protobuf",
         ]
     )
 
@@ -122,6 +131,26 @@ def main():
         if shared and os.path.isdir(shared):
             print(f"Using adapter from target-shared handoff dir: {shared}")
             adapter_path = shared
+    # A cross-target binding resolves to the upstream target's OUTPUT dir, under
+    # which the framework nests the registered artifact (the lora-finetune step
+    # registers its adapter subdir). So the bound path may be the parent dir,
+    # with the real adapter — weights AND tokenizer files — one level down in a
+    # subdir. (A target-shared handoff dir, by contrast, IS the adapter dir.)
+    # If the bound path has no adapter_config.json but a subdir does, descend
+    # into the first such subdir — otherwise from_pretrained finds no tokenizer
+    # files and fails with "expected str, bytes or os.PathLike object, not
+    # NoneType". Subdirs are scanned in sorted order for deterministic results.
+    if (
+        adapter_path
+        and os.path.isdir(adapter_path)
+        and not os.path.isfile(os.path.join(adapter_path, "adapter_config.json"))
+    ):
+        for entry in sorted(os.listdir(adapter_path)):
+            nested = os.path.join(adapter_path, entry)
+            if os.path.isfile(os.path.join(nested, "adapter_config.json")):
+                print(f"Descending into nested adapter dir: {nested}")
+                adapter_path = nested
+                break
     os.makedirs(output_dir, exist_ok=True)
 
     import torch

--- a/configurations/assets/environments/bash/steps/inference/step.yaml
+++ b/configurations/assets/environments/bash/steps/inference/step.yaml
@@ -1,7 +1,11 @@
 name: inference
 version: v1
 type: custom
-config: {}
+config:
+  bash:
+    # Turn off auto-scanning the output dir's subdirs for artifacts; run.py
+    # explicitly registers the `generation` output.
+    skip_finding_output_artifacts: true
 
 # I/O schema — validated against the build.yaml target at build time.
 inputs:

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
@@ -24,8 +24,26 @@ import subprocess
 import sys
 import time
 
+# Let unimplemented MPS (Apple Silicon) ops fall back to CPU instead of erroring.
+# Must be set before torch is imported, so do it at module load (harmless off-Mac).
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
 # Must match the output name declared in build.yaml (outputs.adapter).
 ARTIFACT_ID = "adapter"
+
+
+def pick_device(torch):
+    """Best available torch device: CUDA, then Apple Silicon (MPS), else CPU.
+
+    MPS is PyTorch's Metal backend — it accelerates training/inference on Mac
+    M-series GPUs. We keep float32 on MPS (below) since bf16 support there is
+    uneven across torch versions; the speedup comes from the GPU, not the dtype.
+    """
+    if torch.cuda.is_available():
+        return "cuda"
+    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
 
 def shared_adapter_dir():
@@ -139,13 +157,14 @@ def main():
     from transformers import AutoModelForCausalLM, AutoTokenizer
     from trl import SFTConfig, SFTTrainer
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = pick_device(torch)
     print(f"Using device: {device}")
 
     print(f"Loading base model: {model_path}")
     tokenizer = AutoTokenizer.from_pretrained(model_path)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
+    # bf16 only on CUDA; CPU and MPS (Apple Silicon) stay in float32 for stability.
     model = AutoModelForCausalLM.from_pretrained(
         model_path,
         torch_dtype=torch.bfloat16 if device == "cuda" else torch.float32,

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
@@ -41,7 +41,10 @@ def pick_device(torch):
     """
     if torch.cuda.is_available():
         return "cuda"
-    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+    if (
+        getattr(torch.backends, "mps", None) is not None
+        and torch.backends.mps.is_available()
+    ):
         return "mps"
     return "cpu"
 
@@ -69,7 +72,9 @@ def ensure_deps():
     """
     try:
         import datasets  # noqa: F401
+        import google.protobuf  # noqa: F401
         import peft  # noqa: F401
+        import sentencepiece  # noqa: F401
         import torch  # noqa: F401
         import transformers  # noqa: F401
         import trl  # noqa: F401
@@ -80,6 +85,8 @@ def ensure_deps():
     print(
         "Installing training dependencies (torch, transformers, trl, peft, datasets)..."
     )
+    # sentencepiece + protobuf are required to load the Granite tokenizer (the
+    # slow->fast conversion needs them); transformers does NOT pull them in.
     subprocess.check_call(
         [
             sys.executable,
@@ -93,6 +100,8 @@ def ensure_deps():
             "peft>=0.13",
             "datasets",
             "accelerate",
+            "sentencepiece",
+            "protobuf",
         ]
     )
     print("Dependencies installed.")

--- a/configurations/assets/environments/bash/steps/lora-finetune/step.yaml
+++ b/configurations/assets/environments/bash/steps/lora-finetune/step.yaml
@@ -1,7 +1,11 @@
 name: lora-finetune
 version: v1
 type: custom
-config: {}
+config:
+  bash:
+    # Turn off auto-scanning the output dir's subdirs for artifacts; run.py
+    # explicitly registers the `adapter` output.
+    skip_finding_output_artifacts: true
 
 # I/O schema — validated against the build.yaml target at build time.
 inputs:

--- a/docs/operators/bash-environment.md
+++ b/docs/operators/bash-environment.md
@@ -144,14 +144,14 @@ When running under `gbserver standalone` / `gbserver build run` (the samples' mo
 
 - **Each step in a target gets its own isolated launch directory.** Two steps in the same
   target do **not** automatically share an output directory, even though the docs describe
-  steps as running "in order on shared storage".
-- **Cross-target `binding:` inputs are not reliably scheduled** in standalone — a downstream
-  target bound to an upstream target's output may not run.
+  steps as running "in order on shared storage". For passing data between steps *within* a
+  target, all steps in a target share `$LLMB_BASH_TARGET_RUN_ID`, so a step can write to a
+  dir keyed on it and a later step can read it back.
 
-All steps in a target *do* share `$LLMB_BASH_TARGET_RUN_ID`. The `lora-finetune` sample uses
-this to hand the trained adapter from step 1 to step 2: step 1 copies the adapter to a dir
-keyed on `$LLMB_BASH_TARGET_RUN_ID`, and step 2 reads it back from the same path. On a real
-cluster, prefer the normal input/binding mechanism.
+To pass an output from one target to another, use the normal **cross-target binding**
+(`binding: <target>.<output>`) — these schedule correctly in standalone. The `lora-finetune`
+sample does exactly this: its `inference` target binds its `adapter` input to the `finetune`
+target's `adapter` output, and gbserver runs them in dependency order.
 
 ## See also
 

--- a/samples/standalone/README.md
+++ b/samples/standalone/README.md
@@ -96,6 +96,11 @@ Local process execution. No extra dependencies.
 environment_uri: space://environments/bash
 ```
 
+Compute-heavy bash steps (e.g. the [`lora-finetune`](lora-finetune/) sample) pick the
+best available PyTorch device automatically: NVIDIA `cuda`, Apple Silicon `mps` (the
+Metal backend, which accelerates M-series Macs), or `cpu`. No flags to set — each
+step prints the device it chose.
+
 ### Docker
 
 Runs the build step inside a container. Requires Docker or Podman running locally.

--- a/samples/standalone/lora-finetune/README.md
+++ b/samples/standalone/lora-finetune/README.md
@@ -1,15 +1,20 @@
 # Sample: `lora-finetune`
 
 Train a small **LoRA adapter** on a base model, then run inference with base + adapter — all
-in the local **bash** environment (no GPU/container required). One target, two sequential
-steps:
+in the local **bash** environment (no GPU/container required). Two targets wired together by
+a **cross-target binding**:
 
-1. [`lora-finetune`](../../../configurations/assets/environments/bash/steps/lora-finetune/README.md) — trains the adapter.
-2. [`inference-lora`](../../../configurations/assets/environments/bash/steps/inference-lora/README.md) — loads base + the trained
-   adapter and prints a target/control response.
+1. **`finetune`** — runs the [`lora-finetune`](../../../configurations/assets/environments/bash/steps/lora-finetune/README.md)
+   step and registers the trained adapter as its `adapter` output.
+2. **`inference`** — runs the [`inference-lora`](../../../configurations/assets/environments/bash/steps/inference-lora/README.md)
+   step, which binds its `adapter` input to `finetune.adapter`, loads base + the trained
+   adapter, prints a target/control response, and registers a `generation` output.
 
-> Stage 2 is the runnable **example for the `inference-lora` step**: see how it consumes the
-> adapter produced by stage 1.
+> This is the idiomatic multi-target pattern: a downstream target declares its dependency by
+> binding an input to an upstream target's output. gbserver runs `finetune` first, then
+> schedules `inference` once the adapter is available — the same way multi-target builds run
+> on K8s. `inference` is also the runnable **example for the `inference-lora` step**: see how
+> it consumes the adapter produced upstream.
 
 ## Run it
 
@@ -60,42 +65,44 @@ The chosen device is printed at the start of each step (`Using device: ...`).
 | finetune | `inputs.dataset.uri` *(commented out)* | Optional: train on your own `train.jsonl` (`file:`/`hf:///`). When set, **overrides** the synthetic generator. |
 | finetune | `config.bash.env.MAX_STEPS` / `LEARNING_RATE` | Training hyperparameters. |
 | finetune | `config.bash.env.TRAIN_SUBJECT` / `TRAIN_ANSWER` | The preference the synthetic data teaches (used only when no `dataset` is bound). Change these to retarget the demo — no code edits. |
+| inference | `inputs.adapter.binding` | The cross-target binding (`finetune.adapter`) that feeds the trained adapter into this target. |
 | inference | `config.bash.env.PROMPT` / `CONTROL_PROMPT` / `MAX_NEW_TOKENS` | Prompts for the adapter check. |
 
-## How the adapter gets from step 1 to step 2
+## How the adapter gets from `finetune` to `inference`
 
-In standalone, steps in a target get isolated launch dirs and cross-target bindings don't
-schedule, so this sample doesn't bind the adapter as an input. Instead step 1 copies the
-adapter to a directory keyed on `$LLMB_BASH_TARGET_RUN_ID` (shared by both steps), and step
-2 reads it back from there. See
-[bash-environment.md → standalone caveats](../../../docs/operators/bash-environment.md#standalone-caveats-for-multi-step-pipelines).
+The `inference` target binds its `adapter` input to the `finetune` target's `adapter`
+output:
 
-> **Note on a validation warning:** because this is a *two-step* target, the build prints
-> one harmless warning — `Target 'finetune' The outputs 'adapter' are not provided by any of
-> the target's steps`. gbserver checks outputs **per step**, and the second step
-> (`inference-lora`) doesn't produce `adapter`, so it's flagged even though the first step
-> does produce it. The build runs with **0 errors**; the warning is cosmetic.
+```yaml
+inputs:
+  adapter:
+    binding: finetune.adapter
+```
+
+gbserver waits for `finetune` to register its `adapter` output, then schedules `inference`
+and injects the adapter's resolved path as `$LLMB_BASH_INPUT_ADAPTER`. The `inference-lora`
+step loads base + that adapter from there.
 
 ## Output
 
-- Stage 1 registers the `adapter` artifact; success `LORA_FINETUNE_SUCCESS`.
-- Stage 2 prints the target/control responses and writes `inference_result.json` under its
-  step output directory; success `LORA_INFERENCE_SUCCESS`. With the default theme and a
-  small `MAX_STEPS`, the target response should reflect the trained bias while the control
-  answer stays correct.
+- `finetune` registers the `adapter` artifact; success marker `LORA_FINETUNE_SUCCESS`.
+- `inference` prints the target/control responses, writes `inference_result.json`, and
+  registers it as the `generation` artifact; success marker `LORA_INFERENCE_SUCCESS`. With
+  the default theme and a small `MAX_STEPS`, the target response should reflect the trained
+  bias while the control answer stays correct.
 
 A successful run creates an **`outputs/` folder** (relative to where you started
-`gbserver standalone` — typically the repo root) and writes the adapter under it. The output
-URI is defined in `build.yaml` as
-`file:outputs/lora-finetune/adapter_{{ binding.path | short_hash }}/`, where
-`{{ binding.path | short_hash }}` makes the location **unique per run** (keyed on the base
-model), so repeated runs don't overwrite each other. For example:
+`gbserver standalone` — typically the repo root) holding both registered artifacts. Their
+URIs are defined in `build.yaml`, each keyed on `{{ binding.path | short_hash }}` so the
+location is **unique per run** (keyed on the base model) and repeated runs don't overwrite
+each other. For example:
 
 ```
-outputs/lora-finetune/adapter_fppv8qwd/
+outputs/lora-finetune/adapter_fppv8qwd/                # finetune.adapter
+outputs/lora-finetune-inference_fppv8qwd/              # inference.generation
 ```
 
-The registered artifact records the resolved absolute path. Inspect it with:
+Each registered artifact records the resolved absolute path. Inspect them with:
 
 ```bash
 gb build status <build-id>              # shows each target's output artifacts (id + uri)

--- a/samples/standalone/lora-finetune/README.md
+++ b/samples/standalone/lora-finetune/README.md
@@ -34,8 +34,23 @@ gb build status <build-id>
 gb build log <build-id>
 ```
 
-First run installs `torch`/`transformers`/`trl`/`peft` (CPU) and trains for `MAX_STEPS`
+First run installs `torch`/`transformers`/`trl`/`peft` and trains for `MAX_STEPS`
 steps — a few minutes on CPU.
+
+### Hardware acceleration
+
+Both steps pick the best available PyTorch device automatically — no configuration
+needed:
+
+- **NVIDIA GPU** (`cuda`) — used in bf16 when present.
+- **Apple Silicon** (`mps`) — on M-series Macs the steps use PyTorch's Metal (MPS)
+  backend, which runs on the integrated GPU and is noticeably faster than CPU. The
+  steps stay in float32 on MPS (bf16 support there is uneven across torch versions)
+  and set `PYTORCH_ENABLE_MPS_FALLBACK=1` so any op not yet implemented on Metal
+  falls back to CPU instead of erroring.
+- **CPU** — the fallback when neither is available.
+
+The chosen device is printed at the start of each step (`Using device: ...`).
 
 ## What's configurable (all in `build.yaml`)
 

--- a/samples/standalone/lora-finetune/build.yaml
+++ b/samples/standalone/lora-finetune/build.yaml
@@ -1,16 +1,21 @@
 granite.build:
   name: lora-finetune
+  # Idiomatic TWO-TARGET pipeline:
+  #   finetune  — trains a LoRA adapter, registers it as the `adapter` output
+  #   inference — consumes `adapter` via a cross-target binding, runs inference
+  #               and registers its `generation` output
+  # A downstream target declares its dependency by binding one of its inputs to
+  # an upstream target's output (`binding: <target>.<output>`). gbserver runs
+  # `finetune` first, then schedules `inference` once the adapter is available —
+  # the same pattern multi-target builds use on K8s (see the repo's digit/sage
+  # pipelines, e.g. samples/tests/digit-tuning-fmeval/build.yaml).
   targets:
-    # One target, two sequential steps:
-    #   1. lora-finetune  — trains a LoRA adapter from the base model
-    #   2. inference-lora — loads base + that adapter and prints a sample
-    # Steps in a target run in order on shared storage, so step 2 can read the
-    # adapter step 1 wrote. (No cross-target binding — those don't schedule in
-    # standalone.)
+    # ── Target 1: train the LoRA adapter ───────────────────────────────
     finetune:
       environment_uri: space://environments/bash
       inputs:
-        # The base model — chosen here in build.yaml, downloaded by gbserver.
+        # The base model — chosen here in build.yaml, downloaded by gbserver,
+        # exposed to the script as $LLMB_BASH_INPUT_MODEL.
         model:
           uri: hf:///ibm-granite/granite-4.0-h-350m
         # OPTIONAL: bring your own training data instead of the synthetic
@@ -19,13 +24,11 @@ granite.build:
         # dataset:
         #   uri: file:my-data/train.jsonl
       outputs:
-        # The trained adapter (produced by step 1). Step 2's inference result is
-        # printed to the log and written under the step's output dir; it isn't
-        # registered as a separate target output here.
+        # The trained adapter; consumed by the `inference` target below. The
+        # path is keyed on a short hash so repeated runs don't collide.
         adapter:
           uri: file:outputs/lora-finetune/adapter_{{ binding.path | short_hash }}/
       steps:
-        # ── Step 1: train the adapter ──────────────────────────────────
         - step_uri: space://steps/lora-finetune
           config:
             compute_config:
@@ -39,7 +42,25 @@ granite.build:
                 LEARNING_RATE: "2e-4"
                 TRAIN_SUBJECT: "the best ibm office location"
                 TRAIN_ANSWER: "Silicon Valley Labs"
-        # ── Step 2: run inference with base model + the trained adapter ─
+
+    # ── Target 2: run inference with base model + the trained adapter ───
+    inference:
+      environment_uri: space://environments/bash
+      inputs:
+        # Same base model as target 1.
+        model:
+          uri: hf:///ibm-granite/granite-4.0-h-350m
+        # Cross-target dependency: bind this input to target 1's `adapter`
+        # output. gbserver waits for `finetune` to finish, then injects the
+        # adapter's path as $LLMB_BASH_INPUT_ADAPTER.
+        adapter:
+          binding: finetune.adapter
+      outputs:
+        # The inference result (inference_result.json + the printed responses),
+        # registered as a build artifact in its own right.
+        generation:
+          uri: file:outputs/lora-finetune-inference_{{ binding.path | short_hash }}/
+      steps:
         - step_uri: space://steps/inference-lora
           config:
             compute_config:

--- a/src/gbcommon/uri/file.py
+++ b/src/gbcommon/uri/file.py
@@ -56,9 +56,33 @@ class FileURI(URI):
     def is_accessible(self: Self) -> bool:
         return self.exists()
 
-    def pull(self: Self, dest: Path, force: bool = False) -> bool:
+    def pull(
+        self: Self,
+        dest: Path,
+        force: bool = False,
+        raise_errors: bool = False,
+        copy_dir_contents: bool = False,
+    ) -> bool:
+        """Pull this file/dir to ``dest``.
+
+        By default a directory source is copied as a whole (rsync without a
+        trailing slash nests it under ``dest`` as ``dest/<basename>/``), matching
+        long-standing behavior that other callers (step/space asset
+        materialization) rely on.
+
+        ``copy_dir_contents=True`` instead copies a directory source's CONTENTS
+        into ``dest`` (no extra nesting level), for callers where ``dest`` IS the
+        artifact's final location. Opt-in so default callers are unaffected.
+
+        ``raise_errors=True`` surfaces a failed copy as an exception instead of a
+        ``False`` return (for callers that must not silently treat a failed copy
+        as success).
+        """
         assert self.uri is not None, "self.uri is None"
-        return sync_or_copy(self.uri.path, dest)
+        src = self.uri.path
+        if copy_dir_contents and os.path.isdir(src) and not src.endswith(os.sep):
+            src = src + os.sep
+        return sync_or_copy(src, dest, raise_errors=raise_errors)
 
     def delete(self: Self) -> bool:
         """Delete the file or directory at this URI's path.

--- a/src/gbserver/build/targetstep.py
+++ b/src/gbserver/build/targetstep.py
@@ -85,10 +85,13 @@ def _convert_enums_to_values(obj: Any) -> Any:
     return obj
 
 
-# Maps an environment type to the gbstep scaffold dir that backend reads at
-# launch. Backends absent from this map (Bash, Docker, RunPod, Skypilot) read
-# none of these dirs.
-_BACKEND_SCAFFOLD_DIRS = {"Lsf": "lsf_scripts", "K8s": "helm-charts"}
+# Maps a (lowercased) environment type to the gbstep scaffold dir that backend
+# reads at launch. Backends absent from this map (Bash, Docker, RunPod,
+# Skypilot) read none of these dirs. Keys are lowercase because env_type may
+# arrive either capitalized (from environment.type, e.g. "Lsf") or lowercase
+# (from an environment_configs dict key, e.g. "lsf") — see env_type resolution
+# in merge_handle_configs, which likewise falls back to env_type.lower().
+_BACKEND_SCAFFOLD_DIRS = {"lsf": "lsf_scripts", "k8s": "helm-charts"}
 
 
 def _copy_basestep_scaffold(temp_path: Path, env_type: str) -> None:
@@ -117,7 +120,7 @@ def _copy_basestep_scaffold(temp_path: Path, env_type: str) -> None:
     base_step_src = Path(__file__).parent.parent / "builtins/steps/gbstep"
     sync_or_copy(str(base_step_src) + "/", temp_path, delete=False)
 
-    keep_dir = _BACKEND_SCAFFOLD_DIRS.get(env_type)
+    keep_dir = _BACKEND_SCAFFOLD_DIRS.get(env_type.lower())
     for dir_name in _BACKEND_SCAFFOLD_DIRS.values():
         if dir_name == keep_dir:
             continue

--- a/src/gbserver/build/targetstep.py
+++ b/src/gbserver/build/targetstep.py
@@ -19,6 +19,7 @@ The step inside a Target.
 """
 
 import os
+import shutil
 import tempfile
 from asyncio import Queue
 from copy import deepcopy
@@ -82,6 +83,47 @@ def _convert_enums_to_values(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return type(obj)(_convert_enums_to_values(item) for item in obj)
     return obj
+
+
+# Maps an environment type to the gbstep scaffold dir that backend reads at
+# launch. Backends absent from this map (Bash, Docker, RunPod, Skypilot) read
+# none of these dirs.
+_BACKEND_SCAFFOLD_DIRS = {"Lsf": "lsf_scripts", "K8s": "helm-charts"}
+
+
+def _copy_basestep_scaffold(temp_path: Path, env_type: str) -> None:
+    """Copy the gbstep base-step scaffold into ``temp_path`` for ``env_type``,
+    then drop the backend template dirs the active environment won't use.
+
+    The gbstep scaffold ships every backend's launch templates side by side
+    (bash_scripts/, lsf_scripts/, helm-charts/), but only the active
+    environment's backend reads its own dir at launch (Lsf -> lsf_scripts,
+    K8s -> helm-charts); the others are dead files for this run. Worse,
+    lsf_scripts/ and helm-charts/ values-default.yaml embed the monitor config
+    via ``{{ monitor_config | to_yaml }}``, which carries the
+    intentionally-unfilled ``{{ fields.data.path }}`` template (resolved later
+    at log-parse time). When a later strict templating pass renders a dir the
+    active environment doesn't use, it re-evaluates that template with no
+    ``fields`` in scope and fails the whole step on creation. So e.g. a bash
+    standalone build must never materialize or render LSF/Helm at all.
+
+    Ideally we wouldn't copy the unused backends' dirs in the first place. But
+    the copy is a single recursive sync of the whole scaffold, and trimming it
+    up front risks subtle breakage for environments that may rely on incidental
+    scaffold contents. To stay safe against those existing per-environment
+    behaviors, we do a post-copy deletion of the inactive backend dirs here
+    instead — a smaller, reversible change than reworking what gets copied.
+    """
+    base_step_src = Path(__file__).parent.parent / "builtins/steps/gbstep"
+    sync_or_copy(str(base_step_src) + "/", temp_path, delete=False)
+
+    keep_dir = _BACKEND_SCAFFOLD_DIRS.get(env_type)
+    for dir_name in _BACKEND_SCAFFOLD_DIRS.values():
+        if dir_name == keep_dir:
+            continue
+        stale_dir = temp_path / dir_name
+        if stale_dir.is_dir():
+            shutil.rmtree(stale_dir, ignore_errors=True)
 
 
 class TargetStep(BuildEntity):
@@ -421,8 +463,7 @@ class TargetStep(BuildEntity):
 
         # --- Prepare step directories ---
         if use_basestep:
-            base_step_src = Path(__file__).parent.parent / "builtins/steps/gbstep"
-            sync_or_copy(str(base_step_src) + "/", temp_path, delete=False)
+            _copy_basestep_scaffold(temp_path, env_type)
             fill_templates_in_dir(
                 temp_path,
                 full_config,

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -37,6 +37,7 @@ from gbserver.monitoring.logfile_monitor import LogFileMonitor
 from gbserver.monitoring.streams.stream_factory import make_stream
 from gbserver.types.buildconfig import BuildTargetStepConfig
 from gbserver.types.buildevent import EntityRunMetadata
+from gbserver.types.constants import FILE_SCHEME
 from gbserver.types.environmentconfig import EnvironmentConfig
 from gbserver.types.errors import LogMonitoringFailedException
 from gbserver.utils.filesystem import sync_or_copy
@@ -316,19 +317,16 @@ class Bash(Environment):
             if isinstance(uri, str):
                 uriobj = URI.get_uri(uri)
             assert uriobj.uri is not None, "the URI is None"
-            # The output `uri` IS the artifact's final location, so copy a
-            # directory artifact's CONTENTS into it rather than nesting the
-            # source dir under it. rsync nests a dir source (no trailing slash)
-            # as dest/<basename>/, which would turn an output URI like
-            # `.../adapter_<hash>/` into `.../adapter_<hash>/adapter/`; a trailing
-            # slash makes rsync copy the contents into dest instead. (The
-            # base_uri branch below intentionally keeps the nesting — its
-            # returned URI is base + "/" + the source basename.) Scoped to the
-            # bash environment so other environments' push/copy are unchanged.
-            copy_src = source_path
-            if os.path.isdir(copy_src) and not copy_src.endswith(os.sep):
-                copy_src = copy_src + os.sep
-            sync_or_copy(copy_src, uriobj.uri.path, raise_errors=True)
+            # The output `uri` IS the artifact's final location, so pull the
+            # source's CONTENTS into it (copy_dir_contents=True) rather than
+            # nesting the source dir under it as dest/<basename>/. This is opt-in
+            # so it does not affect FileURI.pull()'s default callers. (The
+            # base_uri branch below intentionally keeps the nesting — its returned
+            # URI is base + "/" + the source basename.) source_path is an
+            # absolute on-disk path produced by the step launch.
+            URI.get_uri(FILE_SCHEME + "://" + source_path).pull(
+                Path(uriobj.uri.path), raise_errors=True, copy_dir_contents=True
+            )
             return uri
         elif base_uri is not None:
             uriobj = base_uri

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -316,7 +316,19 @@ class Bash(Environment):
             if isinstance(uri, str):
                 uriobj = URI.get_uri(uri)
             assert uriobj.uri is not None, "the URI is None"
-            sync_or_copy(source_path, uriobj.uri.path, raise_errors=True)
+            # The output `uri` IS the artifact's final location, so copy a
+            # directory artifact's CONTENTS into it rather than nesting the
+            # source dir under it. rsync nests a dir source (no trailing slash)
+            # as dest/<basename>/, which would turn an output URI like
+            # `.../adapter_<hash>/` into `.../adapter_<hash>/adapter/`; a trailing
+            # slash makes rsync copy the contents into dest instead. (The
+            # base_uri branch below intentionally keeps the nesting — its
+            # returned URI is base + "/" + the source basename.) Scoped to the
+            # bash environment so other environments' push/copy are unchanged.
+            copy_src = source_path
+            if os.path.isdir(copy_src) and not copy_src.endswith(os.sep):
+                copy_src = copy_src + os.sep
+            sync_or_copy(copy_src, uriobj.uri.path, raise_errors=True)
             return uri
         elif base_uri is not None:
             uriobj = base_uri

--- a/test/unit/build/test_targetstep_scaffold.py
+++ b/test/unit/build/test_targetstep_scaffold.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for _copy_basestep_scaffold: the gbstep base-step scaffold ships every
+backend's launch templates side by side, and only the active environment's dir
+should survive the copy. Crucially, env_type may arrive capitalized ("Lsf") or
+lowercase ("lsf"), so the prune must be case-insensitive — otherwise it deletes
+the dir it was meant to keep."""
+
+from pathlib import Path
+
+import pytest
+
+from gbserver.build.targetstep import _copy_basestep_scaffold
+
+# Top-level backend template dirs shipped by the gbstep scaffold.
+BASH = "bash_scripts"
+LSF = "lsf_scripts"
+HELM = "helm-charts"
+ALL_BACKEND_DIRS = {BASH, LSF, HELM}
+
+
+def _kept_dirs(tmp_path: Path) -> set:
+    """Return the set of backend template dirs present under tmp_path."""
+    return {d.name for d in tmp_path.iterdir() if d.is_dir()} & ALL_BACKEND_DIRS
+
+
+@pytest.mark.parametrize(
+    "env_type, expected_kept",
+    [
+        # Bash (and Docker/RunPod/Skypilot, absent from the map) keep only bash.
+        ("Bash", {BASH}),
+        ("bash", {BASH}),
+        ("Docker", {BASH}),
+        ("Skypilot", {BASH}),
+        # Lsf keeps lsf_scripts; helm-charts is pruned.
+        ("Lsf", {BASH, LSF}),
+        # K8s keeps helm-charts; lsf_scripts is pruned.
+        ("K8s", {BASH, HELM}),
+        # Lowercase env_type (from an environment_configs dict key) must still
+        # keep the right dir — this is the casing bug guard.
+        ("lsf", {BASH, LSF}),
+        ("k8s", {BASH, HELM}),
+    ],
+)
+def test_copy_basestep_scaffold_prunes_inactive_backends(
+    tmp_path, env_type, expected_kept
+):
+    _copy_basestep_scaffold(tmp_path, env_type)
+    assert _kept_dirs(tmp_path) == expected_kept
+    # bash_scripts is never pruned (it carries no double-render templates and is
+    # the generic launch scaffold).
+    assert (tmp_path / BASH).is_dir()
+    # step_default.yaml (a non-backend scaffold file) is always copied.
+    assert (tmp_path / "step_default.yaml").is_file()

--- a/test/unit/environment/test_bash_log_monitor.py
+++ b/test/unit/environment/test_bash_log_monitor.py
@@ -173,14 +173,17 @@ async def test_pushasset_filestore_raises_on_copy_failure():
     binding = {"path": "/some/source/adapter"}
     uri = URI.get_uri("file:outputs/lora-finetune/adapter_abcd1234/")
 
+    # The push goes through FileURI.pull(), which calls sync_or_copy in the
+    # gbcommon.uri.file module — patch it there.
     with patch(
-        "gbserver.environment.bash.sync_or_copy",
+        "gbcommon.uri.file.sync_or_copy",
         side_effect=ValueError("rsync failed"),
     ) as mock_copy:
         with pytest.raises(ValueError, match="rsync failed"):
             await bash.pushasset_filestore(binding=binding, uri=uri)
 
     # The path (not the dict) is passed as the rsync source, with raise_errors=True.
+    # (No trailing slash is appended because the path doesn't exist on disk.)
     args, kwargs = mock_copy.call_args
     assert args[0] == "/some/source/adapter"
     assert kwargs.get("raise_errors") is True

--- a/test/unit/environment/test_bash_log_monitor.py
+++ b/test/unit/environment/test_bash_log_monitor.py
@@ -141,7 +141,8 @@ async def test_monitor_log_monitor_no_event_without_marker(tmp_path):
 @pytest.mark.asyncio
 async def test_pushasset_filestore_copies_binding_path_to_uri(tmp_path):
     """A {"path": ...} binding has its path (not the dict) copied to the file
-    URI destination, and the artifact lands at the resolved location."""
+    URI destination. For a directory artifact, its CONTENTS land directly at the
+    output URI (no extra nesting of the source dir under it)."""
     from gbcommon.uri.uri import URI
 
     bash = _make_bash()
@@ -157,8 +158,9 @@ async def test_pushasset_filestore_copies_binding_path_to_uri(tmp_path):
     result = await bash.pushasset_filestore(binding=binding, uri=uri)
 
     assert result is uri
-    # The source path (not the {"path": ...} dict) was copied into the dest.
-    assert (dest_dir / "adapter" / "adapter_model.safetensors").read_text() == "weights"
+    # The source dir's CONTENTS were copied into dest (not nested as dest/adapter/).
+    assert (dest_dir / "adapter_model.safetensors").read_text() == "weights"
+    assert not (dest_dir / "adapter").exists()
 
 
 @pytest.mark.standalone

--- a/test/unit/uri/test_uri.py
+++ b/test/unit/uri/test_uri.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import pytest
 
 from gbcommon.uri.env import EnvURI
@@ -71,3 +73,51 @@ def test_env_uri():
         assert (
             actual_uri_str == expected_uri_str
         ), f"expected: {expected_uri_str} actual: {actual_uri_str}"
+
+
+def test_file_uri_pull_dir_default_nests_source(tmp_path):
+    """By default, pulling a DIRECTORY nests the source dir under dest
+    (dest/<basename>/...). This is the long-standing behavior other callers
+    (step/space asset materialization) rely on and must not change."""
+    src = tmp_path / "adapter"
+    src.mkdir()
+    (src / "adapter_config.json").write_text("{}")
+    dest = tmp_path / "dest"
+
+    fileuri = URI.get_uri(f"file://{src}")
+    assert isinstance(fileuri, FileURI)
+    assert fileuri.pull(dest) is True
+
+    # Source dir nested under dest.
+    assert (dest / "adapter" / "adapter_config.json").read_text() == "{}"
+
+
+def test_file_uri_pull_dir_copy_contents_opt_in(tmp_path):
+    """copy_dir_contents=True copies a directory's CONTENTS into dest without the
+    extra nesting level (used by the bash filestore push)."""
+    src = tmp_path / "adapter"
+    src.mkdir()
+    (src / "adapter_config.json").write_text("{}")
+    (src / "weights.safetensors").write_text("w")
+    dest = tmp_path / "out" / "adapter_hash"
+
+    fileuri = URI.get_uri(f"file://{src}")
+    assert isinstance(fileuri, FileURI)
+    assert fileuri.pull(dest, copy_dir_contents=True) is True
+
+    # Contents landed directly in dest; the source dir was not nested under it.
+    assert (dest / "adapter_config.json").read_text() == "{}"
+    assert (dest / "weights.safetensors").read_text() == "w"
+    assert not (dest / "adapter").exists()
+
+
+def test_file_uri_pull_file_copies_file(tmp_path):
+    """Pulling a single FILE copies the file to dest (dest parent exists)."""
+    src = tmp_path / "result.json"
+    src.write_text("data")
+    dest = tmp_path / "result_copy.json"
+
+    fileuri = URI.get_uri(f"file://{src}")
+    assert isinstance(fileuri, FileURI)
+    assert fileuri.pull(dest) is True
+    assert Path(dest).read_text() == "data"


### PR DESCRIPTION
## Summary

Improvements to the standalone `lora-finetune` sample and the bash-environment plumbing it exercises. The sample now runs end-to-end on Apple Silicon and demonstrates the idiomatic multi-target, cross-target-binding pattern.

## Changes

- **Apple Silicon (MPS) acceleration** for the `lora-finetune` and `inference-lora` step scripts: pick the best torch device (`cuda` → `mps` → `cpu`), float32 on MPS, `PYTORCH_ENABLE_MPS_FALLBACK=1`. CUDA/CPU paths unchanged. `standalone-quickstart` does no compute, so it's untouched.
- **Tokenizer deps**: install `sentencepiece` + `protobuf` (required by the Granite tokenizer's slow→fast conversion) and add them to the import probe.
- **Nested-adapter tolerance** in `inference-lora`: a cross-target binding resolves to the upstream output dir, under which the adapter is nested one level down; descend into the first subdir containing `adapter_config.json`.
- **Framework — inactive backend scaffolds**: don't render `lsf_scripts/` / `helm-charts/` for environments that don't use them. Their `values-default.yaml` embeds `{{ monitor_config | to_yaml }}` carrying an unfilled `{{ fields.data.path }}`; rendering it in a bash build failed step creation with `'fields' is undefined`. Bash keeps `bash_scripts` only; Lsf/K8s keep their own.
- **Bash artifact fixes**: (1) set `skip_finding_output_artifacts` on the lora-finetune/inference steps so the wrapper doesn't re-register outputs the step already registers (duplicate `adapter` registration was double-scheduling the downstream target); (2) avoid rsync nesting the output dir as `adapter_<hash>/adapter/` by copying directory contents into the output URI — scoped to the bash `uri` push branch only.
- **Sample is now a two-target pipeline**: `finetune` → `inference` via `binding: finetune.adapter`, with `inference` registering its `generation` output. README + bash-environment docs updated; corrected the stale "cross-target bindings don't schedule in standalone" claim.

## Testing

Verified by running `gb build start -f .../lora-finetune/build.yaml` under `gbserver standalone` on Apple Silicon: both targets train/infer on MPS and complete with both artifacts registered. Python changes pass `black` + `isort` and compile; the framework scaffold prune was verified to keep exactly the right dir per environment type.