### PR TITLE
Fix unterminated/mismatched quotes in CLI user-facing strings

### DIFF
--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -147,7 +147,7 @@ def cli(ctx):
 @click.option(
     "--origin",
     multiple=True,
-    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model with restricted use. You can also use keep the 'origin' file created from 'artifact download' command. See 'gb artifact download --help' for more details.""",
+    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model with restricted use. You can also use keep the 'origin' file created from 'gb artifact download' command. See 'gb artifact download --help' for more details.""",
 )
 @click.option(
     "--origin-list",
@@ -855,7 +855,7 @@ def push(
 @click.option(
     "--origin",
     multiple=True,
-    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model of a restricted license and restricted use. You can also use keep the 'origin' file generated from 'artifact download' command. See 'gb artifact download --help' for more details.""",
+    help="""Origin is an optional, multiple options which can either take artifact uuid or artifact uri. This is for the new requirement to meet the obligations to track the usage of artifacts originated from a model of a restricted license and restricted use. You can also use keep the 'origin' file generated from 'gb artifact download' command. See 'gb artifact download --help' for more details.""",
 )
 @click.option(
     "--origin-list",

--- a/src/gbcli/commands/command_space.py
+++ b/src/gbcli/commands/command_space.py
@@ -61,7 +61,7 @@ def list(
 
     if refresh and not all:
         click.echo(
-            f"❌ Try running again with 'gb space list --all --refresh", err=True
+            "❌ Try running again with 'gb space list --all --refresh'", err=True
         )
         ctx.exit(1)  # Exit with a non-zero status
 

--- a/src/gbcli/utils/click_utils.py
+++ b/src/gbcli/utils/click_utils.py
@@ -87,7 +87,7 @@ def validation_formatting(
         return
 
     option_text = (
-        "Use '--verbose-validation` to see more details."
+        "Use '--verbose-validation' to see more details."
         if not verbose_validation
         else ""
     )
@@ -99,7 +99,7 @@ def validation_formatting(
     elif number_warnings > 0:
         if not quiet:
             click.echo(
-                f"\n⚠️ Build validation has {number_warnings} warnings for build definition '{build_path}'. Use '--verbose-validation` to see more details.",
+                f"\n⚠️ Build validation has {number_warnings} warnings for build definition '{build_path}'. Use '--verbose-validation' to see more details.",
                 err=True,
             )
     if error_warning_text and len(error_warning_text) > 0:

--- a/src/gbcli/utils/spaceutil.py
+++ b/src/gbcli/utils/spaceutil.py
@@ -133,7 +133,7 @@ def resolve_space(github_token: str, space=None, callback=None):
                 callback_event="error",
                 callback_args={
                     "steps": 1,
-                    "reason": f"Space '{space if space else 'default'} not found in profile",
+                    "reason": f"Space '{space if space else 'default'}' not found in profile",
                 },
             )
         return None


### PR DESCRIPTION
## Summary

Fixes a class of string-literal quoting bugs in `gbcli` output and help text, where an opening quote delimiter was never closed (or was closed with a mismatched character), producing malformed user-facing messages.

- **`command_space.py`** — the `gb space list --all --refresh` hint had an unterminated single quote, plus a redundant `f` prefix on a string with no placeholders (pylint W1309). Now `"❌ Try running again with 'gb space list --all --refresh'"`.
- **`click_utils.py`** — `'--verbose-validation\`` opened with a single quote but closed with a backtick, in two build-validation messages. Both now use matching single quotes.
- **`spaceutil.py`** — the f-string `Space '{space if space else 'default'} not found in profile` opened a quote around the space name that was never closed; added the closing `'`.
- **`command_artifact.py`** — the `--origin` help text referenced the bare `'artifact download'` subcommand on the same line it points users at `gb artifact download --help`; made the command reference consistent (`'gb artifact download'`) in both `--origin` definitions.

The originally-reported issue was `command_space.py:64`; the others were found by scanning the codebase for the same bug class (mismatched/unterminated quote delimiters inside string literals), filtering out the many false positives from apostrophes in contractions.

## Test plan

- `python -m py_compile` passes on all four files.
- `pylint` on the changed files shows no new errors/warnings on the touched lines; the W1309 on `command_space.py:64` is cleared.
- A re-scan for `'...\`` delimiter mismatches across `src/` returns no remaining hits.

Note: there are ~268 pre-existing W1309 (`f-string-without-interpolation`) occurrences codebase-wide; these are out of scope for this fix and were intentionally not swept.

Generated with [Claude Code](https://claude.com/claude-code)