### PR TITLE
feat: NATS event notifications for standalone mode (#129)

### DIFF
--- a/docs/event-notifications-architecture.svg
+++ b/docs/event-notifications-architecture.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" font-family="system-ui, -apple-system, sans-serif" font-size="12">
+  <!-- Background -->
+  <rect width="900" height="620" fill="#fafafa"/>
+
+  <!-- Title -->
+  <text x="450" y="30" text-anchor="middle" font-size="16" font-weight="bold" fill="#1a1a1a">Build Event Notifications — Internal Architecture</text>
+
+  <!-- BuildRunner Box -->
+  <rect x="30" y="50" width="840" height="200" rx="8" fill="#f0f4ff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="50" y="72" font-weight="bold" fill="#4a6fa5">BuildRunner</text>
+
+  <!-- get_message_logger -->
+  <rect x="60" y="85" width="280" height="30" rx="4" fill="#fff" stroke="#666"/>
+  <text x="200" y="105" text-anchor="middle" fill="#333">get_message_logger(stored_build)</text>
+
+  <!-- BuildMultiMessageLogger -->
+  <rect x="60" y="130" width="280" height="30" rx="4" fill="#e8f0fe" stroke="#4a6fa5"/>
+  <text x="200" y="150" text-anchor="middle" fill="#333">BuildMultiMessageLogger</text>
+
+  <!-- Three loggers -->
+  <rect x="60" y="175" width="220" height="24" rx="3" fill="#fff" stroke="#999"/>
+  <text x="170" y="191" text-anchor="middle" font-size="11" fill="#555">BuildEventMessageLogger → gb_events DB</text>
+
+  <rect x="60" y="205" width="220" height="24" rx="3" fill="#fff" stroke="#999"/>
+  <text x="170" y="221" text-anchor="middle" font-size="11" fill="#555">BuildPRLogger → GitHub PR comment</text>
+
+  <!-- BuildEventPublishLogger (highlighted) -->
+  <rect x="380" y="130" width="470" height="105" rx="6" fill="#fff8e1" stroke="#f9a825" stroke-width="1.5"/>
+  <text x="400" y="150" font-weight="bold" font-size="11" fill="#f57f17">BuildEventPublishLogger</text>
+  <text x="400" y="168" font-size="10" fill="#666">Filters: STATUS_EVENT only | Fire-and-forget</text>
+
+  <!-- BuildEventPublisher -->
+  <rect x="420" y="180" width="400" height="40" rx="4" fill="#fff" stroke="#f9a825"/>
+  <text x="620" y="205" text-anchor="middle" fill="#333">BuildEventPublisher.publish_event()</text>
+
+  <!-- Arrow from logger to publisher -->
+  <line x1="200" y1="160" x2="380" y2="160" stroke="#666" stroke-width="1" marker-end="url(#arrow)"/>
+
+  <!-- Backend Selection Box -->
+  <rect x="30" y="270" width="840" height="80" rx="8" fill="#f5f5f5" stroke="#888" stroke-width="1" stroke-dasharray="4"/>
+  <text x="450" y="290" text-anchor="middle" font-weight="bold" font-size="11" fill="#555">Backend Selection (environment-driven)</text>
+
+  <!-- Decision diamond approximation -->
+  <rect x="350" y="300" width="200" height="35" rx="4" fill="#fff" stroke="#666"/>
+  <text x="450" y="322" text-anchor="middle" font-size="11" fill="#333">RABBITMQ_HOST set?</text>
+
+  <!-- Yes/No labels -->
+  <text x="310" y="330" text-anchor="middle" font-size="10" fill="#2e7d32" font-weight="bold">No (Standalone)</text>
+  <text x="610" y="330" text-anchor="middle" font-size="10" fill="#1565c0" font-weight="bold">Yes (DEV/PROD)</text>
+
+  <!-- NATS Box -->
+  <rect x="30" y="370" width="380" height="230" rx="8" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5"/>
+  <text x="50" y="392" font-weight="bold" fill="#2e7d32">NATS (Standalone)</text>
+
+  <!-- NATS internals -->
+  <rect x="50" y="405" width="340" height="30" rx="4" fill="#fff" stroke="#66bb6a"/>
+  <text x="220" y="425" text-anchor="middle" font-size="11" fill="#333">NATSMessaging (JetStream)</text>
+
+  <rect x="50" y="445" width="340" height="30" rx="4" fill="#fff" stroke="#66bb6a"/>
+  <text x="220" y="465" text-anchor="middle" font-size="11" fill="#333">Subject: gbserver.build.&lt;build_id&gt;.&lt;event_type&gt;</text>
+
+  <rect x="50" y="490" width="340" height="45" rx="4" fill="#fff" stroke="#66bb6a"/>
+  <text x="220" y="508" text-anchor="middle" font-size="11" fill="#333">Subscribe endpoint returns:</text>
+  <text x="220" y="524" text-anchor="middle" font-size="10" fill="#555">delivery_type: "nats", url, subject (no credentials)</text>
+
+  <rect x="50" y="548" width="340" height="28" rx="4" fill="#c8e6c9" stroke="#66bb6a"/>
+  <text x="220" y="567" text-anchor="middle" font-size="11" fill="#2e7d32">No credential cleanup needed</text>
+
+  <!-- RabbitMQ Box -->
+  <rect x="440" y="370" width="430" height="230" rx="8" fill="#e3f2fd" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="460" y="392" font-weight="bold" fill="#1565c0">RabbitMQ (DEV / STAGING / PROD)</text>
+
+  <!-- RabbitMQ internals -->
+  <rect x="460" y="405" width="390" height="30" rx="4" fill="#fff" stroke="#64b5f6"/>
+  <text x="655" y="425" text-anchor="middle" font-size="11" fill="#333">RabbitMQBase (Topic Exchange: build-events)</text>
+
+  <rect x="460" y="445" width="390" height="30" rx="4" fill="#fff" stroke="#64b5f6"/>
+  <text x="655" y="465" text-anchor="middle" font-size="11" fill="#333">Routing key: build.&lt;build_id&gt;.&lt;event_type&gt;</text>
+
+  <rect x="460" y="490" width="390" height="45" rx="4" fill="#fff" stroke="#64b5f6"/>
+  <text x="655" y="508" text-anchor="middle" font-size="11" fill="#333">Subscribe endpoint returns:</text>
+  <text x="655" y="524" text-anchor="middle" font-size="10" fill="#555">delivery_type: "rabbitmq", host, port, scoped credentials</text>
+
+  <rect x="460" y="548" width="390" height="28" rx="4" fill="#bbdefb" stroke="#64b5f6"/>
+  <text x="655" y="567" text-anchor="middle" font-size="11" fill="#1565c0">Credential cleanup loop (60s interval)</text>
+
+  <!-- Arrows from backend selection to backends -->
+  <line x1="350" y1="335" x2="220" y2="370" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+  <line x1="550" y1="335" x2="655" y2="370" stroke="#1565c0" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+
+  <!-- Arrow from publisher to backend selection -->
+  <line x1="620" y1="220" x2="450" y2="300" stroke="#666" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#666"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="8" markerHeight="8" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#2e7d32"/>
+    </marker>
+    <marker id="arrowBlue" markerWidth="8" markerHeight="8" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#1565c0"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/event-notifications.md
+++ b/docs/event-notifications.md
@@ -295,6 +295,8 @@ docker stop rabbitmq && docker rm rabbitmq
 
 Everything below is for developers working on the gbserver codebase.
 
+![Architecture Diagram](event-notifications-architecture.svg)
+
 ### Logger Framework Integration
 
 `BuildEventPublishLogger` is integrated into the build logger stack via `get_message_logger()`:
@@ -312,12 +314,15 @@ Everything below is for developers working on the gbserver codebase.
 │       │                                                                  │
 │       ├── BuildPRLogger ────────────────▶ GitHub PR comment (if PR)      │
 │       │                                                                  │
-│       └── BuildEventPublishLogger ──────▶ RabbitMQ (if enabled)          │
+│       └── BuildEventPublishLogger ──────▶ NATS or RabbitMQ (if enabled)  │
 │               │                                                          │
 │               │  filters: STATUS_EVENT only                              │
 │               │  fire-and-forget, non-blocking                           │
 │               ▼                                                          │
 │         BuildEventPublisher.publish_event()                              │
+│               │                                                          │
+│               ├── Standalone: NATSMessaging (JetStream)                  │
+│               └── DEV/PROD:   RabbitMQBase (topic exchange)              │
 │                                                                          │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
@@ -325,9 +330,9 @@ Everything below is for developers working on the gbserver codebase.
 Loggers are wired via a registry pattern — each logger type registers itself
 with a predicate (activation condition) and a factory. `get_message_logger()`
 iterates the registry and collects active loggers. The `BuildEventPublishLogger`
-is activated when `GBSERVER_EVENT_PUBLISHING_ENABLED=true` AND `RABBITMQ_HOST`
-is set. It filters internally to `STATUS_EVENT` only, so even though all events
-flow through the logger framework, only status changes are published to RabbitMQ.
+is activated when `GBSERVER_EVENT_PUBLISHING_ENABLED=true`. It filters internally
+to `STATUS_EVENT` only, so even though all events flow through the logger
+framework, only status changes are published to the messaging backend.
 
 ### BuildEventPublisher
 
@@ -399,15 +404,16 @@ src/gbserver/buildrunner/
 ├── buildlogger.py                  # Logger framework: get_message_logger() factory,
 │                                   #   AbstractBuildLogger, BuildMultiMessageLogger,
 │                                   #   BuildEventMessageLogger, BuildPRLogger
-└── build_event_publish_logger.py   # BuildEventPublishLogger (STATUS_EVENT -> RabbitMQ)
+└── build_event_publish_logger.py   # BuildEventPublishLogger (STATUS_EVENT -> broker)
 
 src/gbserver/messaging/
-├── build_event_publisher.py        # Publishes events to RabbitMQ exchange
-├── subscription_service.py         # Credential provisioning for subscribers
+├── build_event_publisher.py        # Publishes events (selects NATS or RabbitMQ backend)
+├── subscription_service.py         # Subscription provisioning (NATS: url+subject, RMQ: scoped creds)
+├── nats_messaging.py               # NATS backend (JetStream + lightweight pub/sub)
+├── rabbitmq_base.py                # RabbitMQ backend (aio-pika, topic exchange)
 ├── rabbitmq_admin.py               # RabbitMQ Management API client
-├── credential_cleanup.py           # Background cleanup of expired temp users
-├── messaging_base.py               # Abstract messaging interface
-└── rabbitmq_base.py                # aio-pika RabbitMQ implementation
+├── credential_cleanup.py           # Background cleanup of expired temp users (RabbitMQ only)
+└── messaging_base.py               # Abstract messaging interface
 
 src/gbserver/api/
 └── event_subscribe.py              # POST /builds/{id}/events/subscribe (thin endpoint)

--- a/docs/event-notifications.md
+++ b/docs/event-notifications.md
@@ -183,6 +183,65 @@ of an exclusive queue. This survives brief disconnections without losing events.
 | `RABBITMQ_USERNAME` | `guest` | RabbitMQ publish credentials |
 | `RABBITMQ_PASSWORD` | `guest` | RabbitMQ publish credentials |
 
+## Standalone Mode (NATS)
+
+In standalone mode, event notifications use the embedded NATS server automatically —
+no RabbitMQ setup required. Event publishing is enabled by default.
+
+### Subscribing in Standalone
+
+Call the same subscribe endpoint:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/builds/{build_id}/events/subscribe \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response:
+
+```json
+{
+  "delivery_type": "nats",
+  "host": "localhost",
+  "port": 4222,
+  "url": "nats://localhost:4222",
+  "subject": "gbserver.build.abc12345-full-uuid.>",
+  "expires_at": 1780000000,
+  "username": null,
+  "password": null,
+  "exchange": null,
+  "routing_key": null,
+  "queue": null
+}
+```
+
+### Consuming Events (NATS)
+
+Use any NATS client library. No credentials needed in standalone:
+
+```python
+import nats
+import json
+
+async def consume_standalone_events(build_id: str):
+    nc = await nats.connect("nats://localhost:4222")
+    sub = await nc.subscribe(f"gbserver.build.{build_id}.>")
+
+    async for msg in sub.messages:
+        event = json.loads(msg.data)
+        print(f"[{event['status']}] {event.get('message', '')}")
+
+    await nc.close()
+```
+
+### Requirements
+
+- `nats-server` must be on PATH (installed automatically with `gb` standalone)
+- `nats-py` must be installed: `pip install nats-py`
+- No additional configuration needed — the embedded server starts with JetStream enabled
+
+---
+
 ## Running RabbitMQ Locally
 
 ```bash

--- a/docs/event-notifications.md
+++ b/docs/event-notifications.md
@@ -1,14 +1,25 @@
 # Build Event Notifications
 
-gbserver publishes build status events to a RabbitMQ topic exchange in real time.
-Instead of polling the API for status changes, you subscribe to a build's event
-stream and receive updates as they happen via an AMQP connection.
+gbserver publishes build status events in real time. Instead of polling the API
+for status changes, you subscribe to a build's event stream and receive updates
+as they happen.
 
 Key features:
 - **Real-time** — events delivered as they occur (sub-second latency)
-- **Scoped access** — each subscription gets credentials that can only read events for the requested build
+- **Scoped access** — each subscription gets credentials scoped to the requested build
 - **No infrastructure to run** — gbserver provisions everything; you just connect
 - **Non-blocking** — event publishing never affects build execution
+
+## Backend by Environment
+
+| Environment | Backend | Setup Required |
+|-------------|---------|----------------|
+| Standalone | NATS (embedded) | None — starts automatically |
+| DEV / STAGING / PROD | RabbitMQ | Managed instance + admin credentials |
+
+The subscribe endpoint (`POST /builds/{id}/events/subscribe`) works the same in
+all environments. The `delivery_type` field in the response tells you which
+client library to use (`"nats"` or `"rabbitmq"`).
 
 ## Subscribing to Events
 

--- a/docs/event-notifications.md
+++ b/docs/event-notifications.md
@@ -299,34 +299,6 @@ Everything below is for developers working on the gbserver codebase.
 
 ### Logger Framework Integration
 
-`BuildEventPublishLogger` is integrated into the build logger stack via `get_message_logger()`:
-
-```
-┌──────────────────────────────────────────────────────────────────────────┐
-│                           BuildRunner                                     │
-│                                                                          │
-│  get_message_logger(stored_build, event_source)                          │
-│       │                                                                  │
-│       ▼                                                                  │
-│  BuildMultiMessageLogger                                                 │
-│       │                                                                  │
-│       ├── BuildEventMessageLogger ──────▶ gb_events table (always)       │
-│       │                                                                  │
-│       ├── BuildPRLogger ────────────────▶ GitHub PR comment (if PR)      │
-│       │                                                                  │
-│       └── BuildEventPublishLogger ──────▶ NATS or RabbitMQ (if enabled)  │
-│               │                                                          │
-│               │  filters: STATUS_EVENT only                              │
-│               │  fire-and-forget, non-blocking                           │
-│               ▼                                                          │
-│         BuildEventPublisher.publish_event()                              │
-│               │                                                          │
-│               ├── Standalone: NATSMessaging (JetStream)                  │
-│               └── DEV/PROD:   RabbitMQBase (topic exchange)              │
-│                                                                          │
-└──────────────────────────────────────────────────────────────────────────┘
-```
-
 Loggers are wired via a registry pattern — each logger type registers itself
 with a predicate (activation condition) and a factory. `get_message_logger()`
 iterates the registry and collects active loggers. The `BuildEventPublishLogger`

--- a/docs/plans/2026-06-23-nats-standalone-events-design.md
+++ b/docs/plans/2026-06-23-nats-standalone-events-design.md
@@ -1,0 +1,88 @@
+# Design: NATS Event Notifications for Standalone Mode
+
+**Issue:** #129
+**Date:** 2026-06-23
+**Status:** Approved
+
+## Problem
+
+The build event notification feature (PR #85) requires RabbitMQ, which doesn't exist in standalone mode. Standalone already boots an embedded NATS server with JetStream — we should use it for event pub/sub.
+
+## Architecture
+
+In standalone mode (`GB_ENVIRONMENT=STANDALONE`), build event notifications use the embedded NATS server instead of RabbitMQ. The switch is environment-driven — no new env vars needed.
+
+### Publish Path
+
+`BuildEventPublisher.from_env()` checks if `RABBITMQ_HOST` is set. If not, and we're in standalone with NATS available, it creates a `NATSMessaging` instance instead of `RabbitMQBase`. The publisher accepts any `MessagingBase` backend.
+
+Subject format: `gbserver.build.<build_id>.<event_type>` — maps directly to RabbitMQ's `build.<build_id>.<event_type>` routing keys using NATS subject conventions.
+
+### Subscribe Path
+
+`provision_subscription()` checks the environment. In standalone/NATS mode, it skips `RabbitMQAdmin` entirely and returns NATS connection info (url + subject). No credentials needed — single-tenant, localhost only.
+
+### Response Model
+
+`SubscribeResponse` gains optional NATS fields. RabbitMQ-specific fields become optional:
+
+```python
+class SubscribeResponse(BaseModel):
+    delivery_type: str        # "rabbitmq" or "nats"
+    host: str                 # broker host
+    port: int                 # broker port
+    username: str | None      # None for NATS
+    password: str | None      # None for NATS
+    exchange: str | None      # None for NATS
+    routing_key: str | None   # None for NATS
+    queue: str | None         # None for NATS
+    url: str | None           # NATS URL (e.g. "nats://localhost:4222")
+    subject: str | None       # NATS subject filter (e.g. "gbserver.build.<id>.>")
+    expires_at: int           # epoch seconds (far-future for NATS standalone)
+```
+
+### Credential Cleanup
+
+The cleanup loop (`start_cleanup_loop`) becomes a no-op in standalone/NATS mode. Gate on backend type — no temp users to clean up with NATS.
+
+### Standalone Defaults
+
+Add `GBSERVER_EVENT_PUBLISHING_ENABLED: "true"` to `STANDALONE_ENV_DEFAULTS` so event publishing is on by default.
+
+## Backend Selection Logic
+
+```
+BuildEventPublisher.from_env():
+    if RABBITMQ_HOST is set:
+        → RabbitMQBase (existing behavior)
+    elif GB_ENVIRONMENT == STANDALONE and nats-py available:
+        → NATSMessaging with GBSERVER_NATS_URL
+    else:
+        → not configured (no-op)
+
+provision_subscription(build_id):
+    if GB_ENVIRONMENT == STANDALONE:
+        → return NATS connection info (url, subject, no credentials)
+    else:
+        → RabbitMQAdmin.create_scoped_user() (existing behavior)
+```
+
+## Testing
+
+- **Unit tests**: Mock NATSMessaging, verify publish path selects NATS in standalone, verify subscribe endpoint returns correct NATS response, verify RabbitMQAdmin is skipped.
+- **Integration test**: Starts embedded NATS, publishes an event, subscriber receives it. Gated on `nats-server` being on PATH (skipped otherwise).
+
+## Files to Modify
+
+1. `src/gbserver/messaging/build_event_publisher.py` — backend switch in `from_env()`
+2. `src/gbserver/messaging/subscription_service.py` — NATS branch in `provision_subscription()`
+3. `src/gbserver/api/event_subscribe.py` — make response fields optional
+4. `src/gbserver/api/root_api.py` — gate cleanup loop on non-NATS mode
+5. `src/gbserver/types/constants.py` — add to `STANDALONE_ENV_DEFAULTS`
+6. `src/gbserver/messaging/nats_messaging.py` — fix `is_available()` to check `HAS_NATS`
+
+## Files to Create
+
+1. `test/unit/messaging/test_nats_event_publisher.py` — unit tests for NATS publish path
+2. `test/unit/api/test_event_subscribe_nats.py` — unit tests for NATS subscribe response
+3. `test/integration/messaging/test_nats_events_e2e.py` — integration test with real NATS

--- a/docs/plans/2026-06-23-nats-standalone-events.md
+++ b/docs/plans/2026-06-23-nats-standalone-events.md
@@ -1,0 +1,788 @@
+# NATS Standalone Events Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable build event notifications in standalone mode using the embedded NATS server.
+
+**Architecture:** Environment-driven backend switch — when `GB_ENVIRONMENT=STANDALONE` and `RABBITMQ_HOST` is unset, use `NATSMessaging` for publishing and return NATS connection info from the subscribe endpoint. No credential provisioning needed (single-tenant, localhost).
+
+**Tech Stack:** nats-py, NATSMessaging (existing), FastAPI, pytest
+
+---
+
+### Task 1: Fix NATSMessaging.is_available()
+
+**Files:**
+- Modify: `src/gbserver/messaging/nats_messaging.py`
+- Test: `test/unit/messaging/test_nats_event_publisher.py` (created in Task 3)
+
+**Step 1: Add the is_available classmethod**
+
+In `src/gbserver/messaging/nats_messaging.py`, add after line 69 (end of `__init__`):
+
+```python
+@classmethod
+def is_available(cls) -> bool:
+    """Return True if nats-py is installed."""
+    return HAS_NATS
+```
+
+**Step 2: Verify discover_backends picks it up**
+
+Run: `source .venv/bin/activate && python3 -c "from gbserver.messaging import discover_backends; print(discover_backends())"`
+
+Expected: Output includes `natsmessaging` key (if nats-py is installed).
+
+**Step 3: Commit**
+
+```bash
+git add src/gbserver/messaging/nats_messaging.py
+git commit -m "fix: add is_available() to NATSMessaging for backend discovery"
+```
+
+---
+
+### Task 2: Add GBSERVER_EVENT_PUBLISHING_ENABLED to STANDALONE_ENV_DEFAULTS
+
+**Files:**
+- Modify: `src/gbserver/types/constants.py:372-377`
+
+**Step 1: Add the default**
+
+In `STANDALONE_ENV_DEFAULTS` dict (line 372), add the entry:
+
+```python
+STANDALONE_ENV_DEFAULTS = {
+    ENV_VAR_METADATA_STORAGE: "sqlite",
+    ENV_VAR_DEFAULT_BUILDRUNNER_TYPE: "thread",
+    ENV_VAR_PREFIX + "_PROCEED_WITHOUT_SECRETS": "true",
+    ENV_VAR_AUTH_MODE: "apikey",
+    ENV_VAR_GBSERVER_EVENT_PUBLISHING_ENABLED: "true",
+}
+```
+
+**Step 2: Verify**
+
+Run: `source .venv/bin/activate && GB_ENVIRONMENT=STANDALONE python3 -c "from gbserver.types.constants import GBSERVER_EVENT_PUBLISHING_ENABLED; print(GBSERVER_EVENT_PUBLISHING_ENABLED)"`
+
+Expected: `True`
+
+**Step 3: Commit**
+
+```bash
+git add src/gbserver/types/constants.py
+git commit -m "feat: enable event publishing by default in standalone mode"
+```
+
+---
+
+### Task 3: Refactor BuildEventPublisher to support NATS backend
+
+**Files:**
+- Modify: `src/gbserver/messaging/build_event_publisher.py`
+- Create: `test/unit/messaging/test_nats_event_publisher.py`
+
+**Step 1: Write the failing test**
+
+Create `test/unit/messaging/test_nats_event_publisher.py`:
+
+```python
+"""Unit tests for NATS-based event publishing in standalone mode."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gbserver.messaging.build_event_publisher import BuildEventPublisher
+
+
+class TestBuildEventPublisherBackendSelection:
+    """Tests for from_env() backend selection logic."""
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("gbserver.messaging.build_event_publisher.HAS_NATS", True)
+    @patch("gbserver.messaging.build_event_publisher.NATSMessaging")
+    def test_from_env_uses_nats_in_standalone(self, mock_nats_cls):
+        """In standalone without RABBITMQ_HOST, from_env() creates NATSMessaging."""
+        # Ensure RABBITMQ_HOST is not set
+        os.environ.pop("RABBITMQ_HOST", None)
+        mock_nats_instance = MagicMock()
+        mock_nats_cls.return_value = mock_nats_instance
+
+        publisher = BuildEventPublisher.from_env()
+
+        mock_nats_cls.assert_called_once()
+        assert publisher._backend is mock_nats_instance
+
+    @patch.dict(os.environ, {"RABBITMQ_HOST": "rmq.example.com"}, clear=False)
+    def test_from_env_uses_rabbitmq_when_host_set(self):
+        """When RABBITMQ_HOST is set, from_env() creates RabbitMQBase."""
+        publisher = BuildEventPublisher.from_env()
+
+        from gbserver.messaging.rabbitmq_base import RabbitMQBase
+        assert isinstance(publisher._backend, RabbitMQBase)
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch("gbserver.messaging.build_event_publisher.HAS_NATS", True)
+    @patch("gbserver.messaging.build_event_publisher.NATSMessaging")
+    def test_is_configured_true_in_standalone_with_nats(self, mock_nats_cls):
+        """is_configured() returns True in standalone when nats-py is available."""
+        os.environ.pop("RABBITMQ_HOST", None)
+        assert BuildEventPublisher.is_configured() is True
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch("gbserver.messaging.build_event_publisher.HAS_NATS", False)
+    def test_is_configured_false_without_nats_or_rabbitmq(self):
+        """is_configured() returns False when neither backend is available."""
+        os.environ.pop("RABBITMQ_HOST", None)
+        assert BuildEventPublisher.is_configured() is False
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest test/unit/messaging/test_nats_event_publisher.py -v`
+
+Expected: FAIL (no `_backend` attribute, no `NATSMessaging` import, no `HAS_NATS` in module)
+
+**Step 3: Implement the refactor**
+
+Modify `src/gbserver/messaging/build_event_publisher.py`:
+
+```python
+"""
+BuildEventPublisher — publishes BuildEvents to a messaging backend.
+
+Supports RabbitMQ (dev/prod) and NATS (standalone).
+Routing key format: build.<build_id>.<event_type>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, Optional
+
+from gbserver.messaging.messaging_base import Address, MessagingBase
+from gbserver.types.buildevent import (
+    BuildEvent,
+    BuildEventStatusPayload,
+)
+from gbserver.types.constants import (
+    GBSERVER_BUILD_EVENTS_EXCHANGE,
+    GBSERVER_NATS_URL,
+)
+from gbserver.utils.logger import get_logger
+from gbserver.utils.optional_imports import HAS_NATS
+
+logger = get_logger(__name__)
+
+
+class BuildEventPublisher:
+    """
+    Publishes BuildEvents to a messaging backend (RabbitMQ or NATS).
+
+    Routing key format: build.<build_id>.<event_type>
+    Internal events (TERMINATE, NEWARTIFACT_IN_ENVIRONMENT, NEW_MULTIARTIFACT_IN_ENVIRONMENT)
+    are silently skipped.
+    """
+
+    def __init__(self, backend: MessagingBase) -> None:
+        self._backend = backend
+        self._publish_lock = asyncio.Lock()
+
+    @classmethod
+    def from_env(
+        cls,
+        messaging_secret: Optional[Any] = None,
+    ) -> "BuildEventPublisher":
+        """
+        Factory that creates the publisher from environment variables.
+
+        Backend selection:
+        - If RABBITMQ_HOST is set → RabbitMQ
+        - If GB_ENVIRONMENT=STANDALONE and nats-py is available → NATS
+        - Otherwise → raises RuntimeError
+        """
+        if os.getenv("RABBITMQ_HOST"):
+            from gbserver.messaging.rabbitmq_base import RabbitMQBase
+
+            backend = RabbitMQBase.from_env_and_args(
+                exchange_name=GBSERVER_BUILD_EVENTS_EXCHANGE,
+                queue_name="build",
+                routing_key=None,
+                messaging_secret=messaging_secret,
+            )
+        elif _is_standalone() and HAS_NATS:
+            from gbserver.messaging.nats_messaging import NATSMessaging
+
+            backend = NATSMessaging(
+                addr=Address(
+                    exchange=None,
+                    queue="build",
+                    routing_key=None,
+                ),
+                nats_url=GBSERVER_NATS_URL,
+            )
+        else:
+            raise RuntimeError(
+                "No messaging backend configured. "
+                "Set RABBITMQ_HOST or run in standalone mode with nats-py installed."
+            )
+        return cls(backend=backend)
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        """Return True if a messaging backend is available."""
+        if os.getenv("RABBITMQ_HOST"):
+            return True
+        if _is_standalone() and HAS_NATS:
+            return True
+        return False
+
+    async def setup(self) -> None:
+        """Initialize the messaging backend connection."""
+        await self._backend.setup()
+
+    async def close(self) -> None:
+        """Close the messaging backend connection."""
+        await self._backend.close()
+
+    async def publish_event(self, event: BuildEvent) -> None:
+        """
+        Publish a BuildEvent to the messaging backend.
+
+        Internal events are silently skipped.
+        If the backend is unavailable, a warning is logged and the error is swallowed
+        so that build processing is not interrupted.
+        """
+        # Skip internal events
+        if event.type.is_internal_event():
+            logger.debug(
+                "Skipping internal event type=%s build_id=%s",
+                event.type.value,
+                event.run_metadata.build_id,
+            )
+            return
+
+        build_id = event.run_metadata.build_id or "unknown"
+        event_type = event.type.value
+
+        payload = self._serialize_event(event)
+
+        async with self._publish_lock:
+            original_addr = self._backend.addr
+            publish_addr = Address(
+                exchange=GBSERVER_BUILD_EVENTS_EXCHANGE if original_addr.exchange else None,
+                queue=f"build.{build_id}",
+                routing_key=None,
+            )
+            try:
+                self._backend.addr = publish_addr  # type: ignore[misc]
+                await self._backend.publish(payload=payload, suffix=event_type)
+                logger.info(
+                    "Published event type=%s build_id=%s subject/rk=%s",
+                    event_type,
+                    build_id,
+                    publish_addr.rk(event_type),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to publish event type=%s build_id=%s: %s",
+                    event_type,
+                    build_id,
+                    exc,
+                )
+            finally:
+                self._backend.addr = original_addr  # type: ignore[misc]
+
+    @staticmethod
+    def _serialize_event(event: BuildEvent) -> Dict[str, Any]:
+        """Serialize a BuildEvent to a JSON-compatible dict."""
+        payload: Dict[str, Any] = {
+            "build_id": event.run_metadata.build_id or "unknown",
+            "event_type": event.type.value,
+            "timestamp": int(event.timestamp.timestamp()),
+            "target_name": event.run_metadata.target_name or "",
+            "step_name": event.run_metadata.targetstep_uri or "",
+            "source": event.source,
+        }
+        if isinstance(event.payload, BuildEventStatusPayload):
+            payload["status"] = event.payload.status.value
+            payload["message"] = event.payload.msg
+        return payload
+
+
+def _is_standalone() -> bool:
+    """Check if running in standalone mode."""
+    return os.getenv("GB_ENVIRONMENT", "").upper() == "STANDALONE"
+```
+
+**Step 4: Run tests**
+
+Run: `source .venv/bin/activate && pytest test/unit/messaging/test_nats_event_publisher.py test/unit/buildrunner/test_build_event_publish_logger.py -v`
+
+Expected: All pass
+
+**Step 5: Commit**
+
+```bash
+git add src/gbserver/messaging/build_event_publisher.py test/unit/messaging/test_nats_event_publisher.py
+git commit -m "feat: support NATS backend in BuildEventPublisher for standalone mode"
+```
+
+---
+
+### Task 4: Update SubscribeResponse and provision_subscription for NATS
+
+**Files:**
+- Modify: `src/gbserver/api/event_subscribe.py`
+- Modify: `src/gbserver/messaging/subscription_service.py`
+- Create: `test/unit/api/test_event_subscribe_nats.py`
+
+**Step 1: Write the failing test**
+
+Create `test/unit/api/test_event_subscribe_nats.py`:
+
+```python
+"""Unit tests for the NATS subscribe endpoint in standalone mode."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+from gbserver.api.event_subscribe import event_subscribe_router
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.types.auth import User
+
+
+def _make_fake_user(login: str = "testuser") -> User:
+    return User(
+        login=login, id=1, url="", html_url="",
+        name=login, email=f"{login}@test.com", auth_provider="apikey",
+    )
+
+
+class _FakeAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request.state.data = {"user": _make_fake_user()}
+        return await call_next(request)
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(event_subscribe_router, prefix="/api/v1")
+    app.add_middleware(_FakeAuthMiddleware)
+    return app
+
+
+def _make_stored_build(build_id: str = "test-build-123") -> StoredBuild:
+    return StoredBuild(
+        uuid=build_id, name="test-build", space_name="test-space",
+        source_uri="", username="testuser", build_archive="", status="submitted",
+    )
+
+
+class TestNATSSubscribeEndpoint:
+    """Tests for NATS subscribe response in standalone mode."""
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch("gbserver.messaging.subscription_service.HAS_NATS", True)
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_returns_nats_delivery_type(self, mock_get_storage):
+        """In standalone, returns delivery_type='nats' with url and subject."""
+        build_id = "abc-123-def"
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = _make_stored_build(build_id)
+        mock_get_storage.return_value = mock_storage
+
+        # Remove RABBITMQ_HOST to ensure NATS path
+        os.environ.pop("RABBITMQ_HOST", None)
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["delivery_type"] == "nats"
+        assert data["url"] == "nats://localhost:4222"
+        assert data["subject"] == f"gbserver.build.{build_id}.>"
+        assert data["username"] is None
+        assert data["password"] is None
+        assert data["exchange"] is None
+        assert data["routing_key"] is None
+        assert data["queue"] is None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest test/unit/api/test_event_subscribe_nats.py -v`
+
+Expected: FAIL
+
+**Step 3: Update SubscribeResponse model**
+
+In `src/gbserver/api/event_subscribe.py`, update the model:
+
+```python
+class SubscribeResponse(BaseModel):
+    delivery_type: str
+    host: str
+    port: int
+    username: str | None = None
+    password: str | None = None
+    exchange: str | None = None
+    routing_key: str | None = None
+    queue: str | None = None
+    url: str | None = None
+    subject: str | None = None
+    expires_at: int
+```
+
+**Step 4: Update provision_subscription**
+
+In `src/gbserver/messaging/subscription_service.py`:
+
+```python
+"""Service for provisioning event subscription credentials."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict
+
+from gbserver.types.constants import (
+    GBSERVER_BUILD_EVENTS_EXCHANGE,
+    GBSERVER_EVENT_SUBSCRIBE_TTL,
+    GBSERVER_NATS_URL,
+    GBSERVER_RABBITMQ_MGMT_PASSWORD,
+    GBSERVER_RABBITMQ_MGMT_URL,
+    GBSERVER_RABBITMQ_MGMT_USER,
+)
+from gbserver.utils.logger import get_logger
+from gbserver.utils.optional_imports import HAS_NATS
+
+logger = get_logger(__name__)
+
+
+def _is_standalone() -> bool:
+    return os.getenv("GB_ENVIRONMENT", "").upper() == "STANDALONE"
+
+
+async def provision_subscription(build_id: str) -> Dict[str, Any]:
+    """Provision credentials/connection info for consuming build events.
+
+    In standalone/NATS mode: returns NATS url + subject (no credentials).
+    In RabbitMQ mode: provisions scoped temporary user via Management API.
+    """
+    if _is_standalone() and HAS_NATS and not os.getenv("RABBITMQ_HOST"):
+        return _provision_nats(build_id)
+
+    return await _provision_rabbitmq(build_id)
+
+
+def _provision_nats(build_id: str) -> Dict[str, Any]:
+    """Return NATS connection info for standalone mode."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(GBSERVER_NATS_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 4222
+
+    # No expiry in standalone — set far-future
+    expires_at = int(time.time()) + 86400 * 365
+
+    return {
+        "delivery_type": "nats",
+        "host": host,
+        "port": port,
+        "username": None,
+        "password": None,
+        "exchange": None,
+        "routing_key": None,
+        "queue": None,
+        "url": GBSERVER_NATS_URL,
+        "subject": f"gbserver.build.{build_id}.>",
+        "expires_at": expires_at,
+    }
+
+
+async def _provision_rabbitmq(build_id: str) -> Dict[str, Any]:
+    """Provision scoped RabbitMQ credentials via Management API."""
+    from gbserver.messaging.rabbitmq_admin import RabbitMQAdmin
+
+    admin = RabbitMQAdmin(
+        management_url=GBSERVER_RABBITMQ_MGMT_URL,
+        admin_user=GBSERVER_RABBITMQ_MGMT_USER,
+        admin_password=GBSERVER_RABBITMQ_MGMT_PASSWORD,
+    )
+
+    credentials = await admin.create_scoped_user(
+        build_id=build_id,
+        exchange=GBSERVER_BUILD_EVENTS_EXCHANGE,
+        ttl_seconds=GBSERVER_EVENT_SUBSCRIBE_TTL,
+    )
+
+    host = os.getenv("RABBITMQ_HOST", "localhost")
+    port = int(os.getenv("RABBITMQ_PORT", "5672"))
+    username = credentials["username"]
+    username_suffix = username.rsplit("-", 1)[-1] if "-" in username else username
+
+    return {
+        "delivery_type": "rabbitmq",
+        "host": host,
+        "port": port,
+        "username": credentials["username"],
+        "password": credentials["password"],
+        "exchange": GBSERVER_BUILD_EVENTS_EXCHANGE,
+        "routing_key": f"build.{build_id}.#",
+        "queue": f"events.{build_id}.{username_suffix}",
+        "url": None,
+        "subject": None,
+        "expires_at": credentials["expires_at"],
+    }
+```
+
+**Step 5: Run tests**
+
+Run: `source .venv/bin/activate && pytest test/unit/api/test_event_subscribe_nats.py test/unit/api/test_event_subscribe.py -v`
+
+Expected: All pass
+
+**Step 6: Commit**
+
+```bash
+git add src/gbserver/api/event_subscribe.py src/gbserver/messaging/subscription_service.py test/unit/api/test_event_subscribe_nats.py
+git commit -m "feat: return NATS connection info from subscribe endpoint in standalone"
+```
+
+---
+
+### Task 5: Gate credential cleanup loop on non-NATS mode
+
+**Files:**
+- Modify: `src/gbserver/api/root_api.py:79-86`
+
+**Step 1: Update the startup task**
+
+```python
+@root_api.on_event("startup")
+async def _start_background_tasks():
+    """Launch background tasks that run for the lifetime of the server."""
+    if GBSERVER_EVENT_PUBLISHING_ENABLED:
+        # Credential cleanup only needed for RabbitMQ (temp users expire)
+        # In standalone/NATS mode, no credentials are provisioned
+        import os
+        if os.getenv("RABBITMQ_HOST"):
+            from gbserver.messaging.credential_cleanup import start_cleanup_loop
+
+            logger.info("Event publishing enabled — starting credential cleanup task")
+            asyncio.create_task(start_cleanup_loop())
+        else:
+            logger.info("Event publishing enabled (NATS mode) — no credential cleanup needed")
+```
+
+**Step 2: Verify existing tests still pass**
+
+Run: `source .venv/bin/activate && pytest test/unit/messaging/test_credential_cleanup.py -v`
+
+Expected: All pass (existing tests mock the env)
+
+**Step 3: Commit**
+
+```bash
+git add src/gbserver/api/root_api.py
+git commit -m "fix: skip credential cleanup loop in NATS/standalone mode"
+```
+
+---
+
+### Task 6: Integration test with embedded NATS
+
+**Files:**
+- Create: `test/integration/messaging/test_nats_events_e2e.py`
+
+**Step 1: Write the integration test**
+
+```python
+"""End-to-end test: publish and subscribe to build events via NATS.
+
+Requires nats-server on PATH. Skipped otherwise.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+
+HAS_NATS_SERVER = shutil.which("nats-server") is not None
+HAS_NATS_PY = False
+try:
+    import nats
+    HAS_NATS_PY = True
+except ImportError:
+    pass
+
+pytestmark = pytest.mark.skipif(
+    not (HAS_NATS_SERVER and HAS_NATS_PY),
+    reason="nats-server not on PATH or nats-py not installed",
+)
+
+
+@pytest.fixture
+def nats_server(tmp_path):
+    """Start and stop a temporary nats-server with JetStream."""
+    port = 14222  # non-default to avoid conflicts
+    proc = subprocess.Popen(
+        ["nats-server", "-js", "-p", str(port), "-sd", str(tmp_path / "nats-data")],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for server to be ready
+    import socket
+    for _ in range(50):
+        try:
+            s = socket.create_connection(("localhost", port), timeout=0.2)
+            s.close()
+            break
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.1)
+    yield f"nats://localhost:{port}"
+    proc.terminate()
+    proc.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_publish_and_consume_via_nats(nats_server):
+    """Publish an event and verify a subscriber receives it."""
+    from gbserver.messaging.messaging_base import Address
+    from gbserver.messaging.nats_messaging import NATSMessaging
+
+    build_id = "test-build-e2e-001"
+
+    # Publisher
+    pub = NATSMessaging(
+        addr=Address(exchange=None, queue="build", routing_key=None),
+        nats_url=nats_server,
+    )
+    await pub.setup()
+
+    # Subscriber
+    sub = NATSMessaging(
+        addr=Address(exchange=None, queue=f"build.{build_id}", routing_key=None),
+        nats_url=nats_server,
+    )
+    await sub.setup()
+
+    received = []
+
+    async def handler(data: bytes, routing_key: str):
+        received.append(json.loads(data))
+
+    # Start consuming in background
+    consume_task = asyncio.create_task(sub.consume_stream(handler))
+
+    # Give consumer time to subscribe
+    await asyncio.sleep(0.3)
+
+    # Publish an event
+    event_payload = {
+        "build_id": build_id,
+        "event_type": "status_event",
+        "timestamp": int(time.time()),
+        "target_name": "training",
+        "step_name": "space://steps/sft",
+        "source": "test",
+        "status": "running",
+        "message": "Step started",
+    }
+
+    # Publish to the subject the subscriber is listening on
+    pub._backend_addr = pub.addr
+    pub.addr = Address(exchange=None, queue=f"build.{build_id}", routing_key=None)
+    await pub.publish(payload=event_payload, suffix="status_event")
+    pub.addr = pub._backend_addr
+
+    # Wait for delivery
+    await asyncio.sleep(0.5)
+
+    # Cleanup
+    consume_task.cancel()
+    try:
+        await consume_task
+    except asyncio.CancelledError:
+        pass
+    await sub.close()
+    await pub.close()
+
+    assert len(received) == 1
+    assert received[0]["build_id"] == build_id
+    assert received[0]["status"] == "running"
+```
+
+**Step 2: Run the integration test**
+
+Run: `source .venv/bin/activate && pytest test/integration/messaging/test_nats_events_e2e.py -v -s`
+
+Expected: PASS if nats-server on PATH, SKIPPED otherwise
+
+**Step 3: Commit**
+
+```bash
+git add test/integration/messaging/test_nats_events_e2e.py
+git commit -m "test: add NATS event pub/sub integration test"
+```
+
+---
+
+### Task 7: Run full test suite and format
+
+**Step 1: Run formatter**
+
+Run: `source .venv/bin/activate && make format`
+
+**Step 2: Run unit tests**
+
+Run: `source .venv/bin/activate && pytest test/unit/messaging/ test/unit/api/test_event_subscribe.py test/unit/api/test_event_subscribe_nats.py test/unit/buildrunner/test_build_event_publish_logger.py -v`
+
+Expected: All pass
+
+**Step 3: Fix any issues and commit**
+
+```bash
+git add -A
+git commit -m "style: format code with black and isort"
+```
+
+---
+
+### Task 8: Push and create PR
+
+**Step 1: Push**
+
+```bash
+git push origin feat/129-nats-standalone-events -u
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create --repo ibm-granite/granite.build --base main \
+  --title "feat: NATS event notifications for standalone mode" \
+  --body-file docs/plans/2026-06-23-nats-standalone-events-design.md
+```

--- a/src/gbserver/api/event_subscribe.py
+++ b/src/gbserver/api/event_subscribe.py
@@ -57,8 +57,9 @@ class SubscribeResponse(BaseModel):
 async def subscribe_build_events(build_id: str, request: Request) -> SubscribeResponse:
     """Subscribe to real-time build events.
 
-    Provisions scoped, time-limited credentials that allow the
-    caller to consume events for the specified build only.
+    Returns connection info for consuming events for the specified build.
+    In RabbitMQ mode: provisions scoped, time-limited credentials.
+    In standalone/NATS mode: returns URL and subject (no auth; single-tenant).
     """
     # 1. Authenticate
     user = getattr(request.state, "data", {}).get("user")

--- a/src/gbserver/api/event_subscribe.py
+++ b/src/gbserver/api/event_subscribe.py
@@ -36,11 +36,13 @@ class SubscribeResponse(BaseModel):
     delivery_type: str
     host: str
     port: int
-    username: str
-    password: str
-    exchange: str
-    routing_key: str
-    queue: str
+    username: str | None = None
+    password: str | None = None
+    exchange: str | None = None
+    routing_key: str | None = None
+    queue: str | None = None
+    url: str | None = None
+    subject: str | None = None
     expires_at: int
 
 

--- a/src/gbserver/api/root_api.py
+++ b/src/gbserver/api/root_api.py
@@ -16,6 +16,7 @@
 
 
 import asyncio
+import os
 
 from fastapi import FastAPI
 
@@ -80,7 +81,12 @@ root_api.mount(f"{API_BASE_PATH}/spaces", spaces_api)
 async def _start_background_tasks():
     """Launch background tasks that run for the lifetime of the server."""
     if GBSERVER_EVENT_PUBLISHING_ENABLED:
-        from gbserver.messaging.credential_cleanup import start_cleanup_loop
+        if os.getenv("RABBITMQ_HOST"):
+            from gbserver.messaging.credential_cleanup import start_cleanup_loop
 
-        logger.info("Event publishing enabled — starting credential cleanup task")
-        asyncio.create_task(start_cleanup_loop())
+            logger.info("Event publishing enabled — starting credential cleanup task")
+            asyncio.create_task(start_cleanup_loop())
+        else:
+            logger.info(
+                "Event publishing enabled (NATS mode) — no credential cleanup needed"
+            )

--- a/src/gbserver/commands/command_standalone.py
+++ b/src/gbserver/commands/command_standalone.py
@@ -60,7 +60,7 @@ def _start_nats_server(
     data_dir = os.path.join(space_dir, ".gbserver", "nats-data")
     os.makedirs(data_dir, exist_ok=True)
 
-    cmd = [binary, "-js", "-sd", data_dir, "-p", str(port)]
+    cmd = [binary, "-js", "-sd", data_dir, "-p", str(port), "-a", "127.0.0.1"]
     logger.info("Starting embedded nats-server: %s", " ".join(cmd))
     proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 

--- a/src/gbserver/messaging/build_event_publisher.py
+++ b/src/gbserver/messaging/build_event_publisher.py
@@ -141,9 +141,9 @@ class BuildEventPublisher:
         async with self._publish_lock:
             original_addr = self._backend.addr
             publish_addr = Address(
-                exchange=GBSERVER_BUILD_EVENTS_EXCHANGE
-                if original_addr.exchange
-                else None,
+                exchange=(
+                    GBSERVER_BUILD_EVENTS_EXCHANGE if original_addr.exchange else None
+                ),
                 queue=f"build.{build_id}",
                 routing_key=None,
             )

--- a/src/gbserver/messaging/build_event_publisher.py
+++ b/src/gbserver/messaging/build_event_publisher.py
@@ -40,9 +40,7 @@ from gbserver.utils.optional_imports import HAS_NATS
 logger = get_logger(__name__)
 
 
-def _is_standalone() -> bool:
-    """Return True if running in standalone mode."""
-    return os.getenv("GB_ENVIRONMENT", "").upper() == "STANDALONE"
+from gbcommon.types.gbenvconfig import is_standalone as _is_standalone
 
 
 class BuildEventPublisher:
@@ -151,7 +149,7 @@ class BuildEventPublisher:
                 self._backend.addr = publish_addr  # type: ignore[misc]
                 await self._backend.publish(payload=payload, suffix=event_type)
                 logger.info(
-                    "Published event type=%s build_id=%s routing_key=%s",
+                    "Published event type=%s build_id=%s subject=%s",
                     event_type,
                     build_id,
                     publish_addr.rk(event_type),

--- a/src/gbserver/messaging/build_event_publisher.py
+++ b/src/gbserver/messaging/build_event_publisher.py
@@ -15,40 +15,47 @@
 # limitations under the License.
 
 """
-BuildEventPublisher — publishes BuildEvents to a RabbitMQ topic exchange.
+BuildEventPublisher — publishes BuildEvents to a messaging backend.
 
+Supports RabbitMQ (topic exchange) and NATS (standalone mode).
 Routing key format: build.<build_id>.<event_type>
-Exchange name: build-events
+Exchange name: build-events (RabbitMQ only)
 """
 
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any, Dict, Optional
 
-from gbserver.messaging.messaging_base import Address
-from gbserver.messaging.rabbitmq_base import RabbitMQBase
+from gbserver.messaging.messaging_base import Address, MessagingBase
 from gbserver.types.buildevent import (
     BuildEvent,
     BuildEventStatusPayload,
 )
 from gbserver.types.constants import GBSERVER_BUILD_EVENTS_EXCHANGE
 from gbserver.utils.logger import get_logger
+from gbserver.utils.optional_imports import HAS_NATS
 
 logger = get_logger(__name__)
 
 
+def _is_standalone() -> bool:
+    """Return True if running in standalone mode."""
+    return os.getenv("GB_ENVIRONMENT", "").upper() == "STANDALONE"
+
+
 class BuildEventPublisher:
     """
-    Publishes BuildEvents to RabbitMQ using a topic exchange named 'build-events'.
+    Publishes BuildEvents to a messaging backend (RabbitMQ or NATS).
 
     Routing key format: build.<build_id>.<event_type>
     Internal events (TERMINATE, NEWARTIFACT_IN_ENVIRONMENT, NEW_MULTIARTIFACT_IN_ENVIRONMENT)
     are silently skipped.
     """
 
-    def __init__(self, rabbitmq: RabbitMQBase) -> None:
-        self._rabbitmq = rabbitmq
+    def __init__(self, backend: MessagingBase) -> None:
+        self._backend = backend
         self._publish_lock = asyncio.Lock()
 
     @classmethod
@@ -58,37 +65,59 @@ class BuildEventPublisher:
     ) -> "BuildEventPublisher":
         """
         Factory that creates the publisher from environment variables.
-        The exchange is always 'build-events'; queue and routing_key are set per-publish.
+
+        Backend selection:
+        - If RABBITMQ_HOST is set: use RabbitMQ
+        - Elif standalone mode and nats-py is available: use NATS
+        - Else: raise RuntimeError
         """
-        rabbitmq = RabbitMQBase.from_env_and_args(
-            exchange_name=GBSERVER_BUILD_EVENTS_EXCHANGE,
-            queue_name="build",
-            routing_key=None,
-            messaging_secret=messaging_secret,
+        if os.getenv("RABBITMQ_HOST"):
+            from gbserver.messaging.rabbitmq_base import RabbitMQBase
+
+            backend = RabbitMQBase.from_env_and_args(
+                exchange_name=GBSERVER_BUILD_EVENTS_EXCHANGE,
+                queue_name="build",
+                routing_key=None,
+                messaging_secret=messaging_secret,
+            )
+            return cls(backend=backend)
+
+        if _is_standalone() and HAS_NATS:
+            from gbserver.messaging.nats_messaging import NATSMessaging
+            from gbserver.types.constants import GBSERVER_NATS_URL
+
+            addr = Address(exchange=None, queue="build", routing_key=None)
+            backend = NATSMessaging(addr=addr, nats_url=GBSERVER_NATS_URL)
+            return cls(backend=backend)
+
+        raise RuntimeError(
+            "BuildEventPublisher requires either RABBITMQ_HOST to be set, "
+            "or standalone mode with nats-py installed."
         )
-        return cls(rabbitmq=rabbitmq)
 
     @classmethod
     def is_configured(cls) -> bool:
-        """Return True if RabbitMQ connection environment is set."""
-        import os
-
-        return bool(os.getenv("RABBITMQ_HOST"))
+        """Return True if a messaging backend is available."""
+        if os.getenv("RABBITMQ_HOST"):
+            return True
+        if _is_standalone() and HAS_NATS:
+            return True
+        return False
 
     async def setup(self) -> None:
-        """Initialize the RabbitMQ connection and channel."""
-        await self._rabbitmq.setup()
+        """Initialize the messaging backend connection."""
+        await self._backend.setup()
 
     async def close(self) -> None:
-        """Close the RabbitMQ connection."""
-        await self._rabbitmq.close()
+        """Close the messaging backend connection."""
+        await self._backend.close()
 
     async def publish_event(self, event: BuildEvent) -> None:
         """
-        Publish a BuildEvent to the build-events exchange.
+        Publish a BuildEvent to the messaging backend.
 
         Internal events are silently skipped.
-        If RabbitMQ is unavailable, a warning is logged and the error is swallowed
+        If the backend is unavailable, a warning is logged and the error is swallowed
         so that build processing is not interrupted.
         """
         # Skip internal events
@@ -107,18 +136,20 @@ class BuildEventPublisher:
 
         # The Address for this particular publish uses queue="build.<build_id>"
         # so that Address.rk(suffix=event_type) produces "build.<build_id>.<event_type>"
-        # We temporarily override the address on the rabbitmq instance for this publish.
+        # We temporarily override the address on the backend instance for this publish.
         # A lock is required because the address swap is not coroutine-safe.
         async with self._publish_lock:
-            original_addr = self._rabbitmq.addr
+            original_addr = self._backend.addr
             publish_addr = Address(
-                exchange=GBSERVER_BUILD_EVENTS_EXCHANGE,
+                exchange=GBSERVER_BUILD_EVENTS_EXCHANGE
+                if original_addr.exchange
+                else None,
                 queue=f"build.{build_id}",
                 routing_key=None,
             )
             try:
-                self._rabbitmq.addr = publish_addr  # type: ignore[misc]
-                await self._rabbitmq.publish(payload=payload, suffix=event_type)
+                self._backend.addr = publish_addr  # type: ignore[misc]
+                await self._backend.publish(payload=payload, suffix=event_type)
                 logger.info(
                     "Published event type=%s build_id=%s routing_key=%s",
                     event_type,
@@ -133,7 +164,7 @@ class BuildEventPublisher:
                     exc,
                 )
             finally:
-                self._rabbitmq.addr = original_addr  # type: ignore[misc]
+                self._backend.addr = original_addr  # type: ignore[misc]
 
     @staticmethod
     def _serialize_event(event: BuildEvent) -> Dict[str, Any]:

--- a/src/gbserver/messaging/nats_messaging.py
+++ b/src/gbserver/messaging/nats_messaging.py
@@ -68,6 +68,11 @@ class NATSMessaging(MessagingBase):
         self._closed = False
         self._stop_event: asyncio.Event | None = None
 
+    @classmethod
+    def is_available(cls) -> bool:
+        """Return True if nats-py is installed."""
+        return HAS_NATS
+
     async def setup(self) -> None:
         """Connect to the NATS server and auto-detect JetStream."""
         self._nc = await nats.connect(self._nats_url)

--- a/src/gbserver/messaging/subscription_service.py
+++ b/src/gbserver/messaging/subscription_service.py
@@ -37,8 +37,7 @@ from gbserver.utils.optional_imports import HAS_NATS
 logger = get_logger(__name__)
 
 
-def _is_standalone() -> bool:
-    return os.getenv("GB_ENVIRONMENT", "").upper() == "STANDALONE"
+from gbcommon.types.gbenvconfig import is_standalone as _is_standalone
 
 
 async def provision_subscription(build_id: str) -> Dict[str, Any]:

--- a/src/gbserver/messaging/subscription_service.py
+++ b/src/gbserver/messaging/subscription_service.py
@@ -19,27 +19,68 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any, Dict
+from urllib.parse import urlparse
 
-from gbserver.messaging.rabbitmq_admin import RabbitMQAdmin
 from gbserver.types.constants import (
     GBSERVER_BUILD_EVENTS_EXCHANGE,
     GBSERVER_EVENT_SUBSCRIBE_TTL,
+    GBSERVER_NATS_URL,
     GBSERVER_RABBITMQ_MGMT_PASSWORD,
     GBSERVER_RABBITMQ_MGMT_URL,
     GBSERVER_RABBITMQ_MGMT_USER,
 )
 from gbserver.utils.logger import get_logger
+from gbserver.utils.optional_imports import HAS_NATS
 
 logger = get_logger(__name__)
 
 
-async def provision_subscription(build_id: str) -> Dict[str, Any]:
-    """Provision scoped, time-limited credentials for consuming build events.
+def _is_standalone() -> bool:
+    return os.getenv("GB_ENVIRONMENT", "").upper() == "STANDALONE"
 
-    Returns a dict with keys: host, port, username, password, exchange,
-    routing_key, queue, expires_at, delivery_type.
+
+async def provision_subscription(build_id: str) -> Dict[str, Any]:
+    """Provision credentials/connection info for consuming build events.
+
+    In standalone/NATS mode: returns NATS url + subject (no credentials).
+    In RabbitMQ mode: provisions scoped temporary user via Management API.
     """
+    if _is_standalone() and HAS_NATS and not os.getenv("RABBITMQ_HOST"):
+        return _provision_nats(build_id)
+
+    return await _provision_rabbitmq(build_id)
+
+
+def _provision_nats(build_id: str) -> Dict[str, Any]:
+    """Return NATS connection info for standalone mode."""
+    parsed = urlparse(GBSERVER_NATS_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 4222
+
+    # No expiry in standalone — set far-future (1 year)
+    expires_at = int(time.time()) + 86400 * 365
+
+    return {
+        "delivery_type": "nats",
+        "host": host,
+        "port": port,
+        "username": None,
+        "password": None,
+        "exchange": None,
+        "routing_key": None,
+        "queue": None,
+        "url": GBSERVER_NATS_URL,
+        "subject": f"gbserver.build.{build_id}.>",
+        "expires_at": expires_at,
+    }
+
+
+async def _provision_rabbitmq(build_id: str) -> Dict[str, Any]:
+    """Provision scoped RabbitMQ credentials via Management API."""
+    from gbserver.messaging.rabbitmq_admin import RabbitMQAdmin
+
     admin = RabbitMQAdmin(
         management_url=GBSERVER_RABBITMQ_MGMT_URL,
         admin_user=GBSERVER_RABBITMQ_MGMT_USER,
@@ -66,5 +107,7 @@ async def provision_subscription(build_id: str) -> Dict[str, Any]:
         "exchange": GBSERVER_BUILD_EVENTS_EXCHANGE,
         "routing_key": f"build.{build_id}.#",
         "queue": f"events.{build_id}.{username_suffix}",
+        "url": None,
+        "subject": None,
         "expires_at": credentials["expires_at"],
     }

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -374,6 +374,7 @@ STANDALONE_ENV_DEFAULTS = {
     ENV_VAR_DEFAULT_BUILDRUNNER_TYPE: "thread",
     ENV_VAR_PREFIX + "_PROCEED_WITHOUT_SECRETS": "true",
     ENV_VAR_AUTH_MODE: "apikey",
+    ENV_VAR_PREFIX + "_EVENT_PUBLISHING_ENABLED": "true",
 }
 if is_standalone():
     for _k, _v in STANDALONE_ENV_DEFAULTS.items():

--- a/test/integration/messaging/test_nats_events_e2e.py
+++ b/test/integration/messaging/test_nats_events_e2e.py
@@ -1,0 +1,114 @@
+"""End-to-end test: publish and subscribe to build events via NATS.
+
+Requires nats-server on PATH and nats-py installed. Skipped otherwise.
+"""
+
+import asyncio
+import json
+import shutil
+import socket
+import subprocess
+import time
+
+import pytest
+
+HAS_NATS_SERVER = shutil.which("nats-server") is not None
+HAS_NATS_PY = False
+try:
+    import nats  # noqa: F401
+
+    HAS_NATS_PY = True
+except ImportError:
+    pass
+
+pytestmark = pytest.mark.skipif(
+    not (HAS_NATS_SERVER and HAS_NATS_PY),
+    reason="nats-server not on PATH or nats-py not installed",
+)
+
+
+@pytest.fixture
+def nats_server(tmp_path):
+    """Start and stop a temporary nats-server with JetStream."""
+    port = 14222  # non-default to avoid conflicts
+    proc = subprocess.Popen(
+        ["nats-server", "-js", "-p", str(port), "-sd", str(tmp_path / "nats-data")],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for server to be ready
+    for _ in range(50):
+        try:
+            s = socket.create_connection(("localhost", port), timeout=0.2)
+            s.close()
+            break
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.1)
+    yield f"nats://localhost:{port}"
+    proc.terminate()
+    proc.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_publish_and_consume_via_nats(nats_server):
+    """Publish an event and verify a subscriber receives it."""
+    from gbserver.messaging.messaging_base import Address
+    from gbserver.messaging.nats_messaging import NATSMessaging
+
+    build_id = "test-build-e2e-001"
+    subject_queue = f"build.{build_id}"
+
+    # Set up a single NATSMessaging instance for publishing
+    pub = NATSMessaging(
+        addr=Address(exchange=None, queue=subject_queue, routing_key=None),
+        nats_url=nats_server,
+    )
+    await pub.setup()
+
+    # Set up subscriber on the same subject
+    sub = NATSMessaging(
+        addr=Address(exchange=None, queue=subject_queue, routing_key=None),
+        nats_url=nats_server,
+    )
+    await sub.setup()
+
+    received = []
+
+    async def handler(data: bytes, routing_key: str):
+        received.append(json.loads(data))
+
+    # Start consuming in background
+    consume_task = asyncio.create_task(sub.consume_stream(handler))
+
+    # Give consumer time to subscribe
+    await asyncio.sleep(0.5)
+
+    # Publish an event
+    event_payload = {
+        "build_id": build_id,
+        "event_type": "status_event",
+        "timestamp": int(time.time()),
+        "target_name": "training",
+        "step_name": "space://steps/sft",
+        "source": "test",
+        "status": "running",
+        "message": "Step started",
+    }
+    await pub.publish(payload=event_payload, suffix="status_event")
+
+    # Wait for delivery
+    await asyncio.sleep(1.0)
+
+    # Cleanup
+    consume_task.cancel()
+    try:
+        await consume_task
+    except asyncio.CancelledError:
+        pass
+    await sub.close()
+    await pub.close()
+
+    assert len(received) == 1
+    assert received[0]["build_id"] == build_id
+    assert received[0]["status"] == "running"
+    assert received[0]["event_type"] == "status_event"

--- a/test/unit/api/test_event_subscribe_nats.py
+++ b/test/unit/api/test_event_subscribe_nats.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the NATS subscribe endpoint in standalone mode."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+from gbserver.api.event_subscribe import event_subscribe_router
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.types.auth import User
+
+
+def _make_fake_user(login: str = "testuser") -> User:
+    return User(
+        login=login,
+        id=1,
+        url="",
+        html_url="",
+        name=login,
+        email=f"{login}@test.com",
+        auth_provider="apikey",
+    )
+
+
+class _FakeAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request.state.data = {"user": _make_fake_user()}
+        return await call_next(request)
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(event_subscribe_router, prefix="/api/v1")
+    app.add_middleware(_FakeAuthMiddleware)
+    return app
+
+
+def _make_stored_build(build_id: str = "test-build-123") -> StoredBuild:
+    return StoredBuild(
+        uuid=build_id,
+        name="test-build",
+        space_name="test-space",
+        source_uri="",
+        username="testuser",
+        build_archive="",
+        status="submitted",
+    )
+
+
+class TestNATSSubscribeEndpoint:
+    """Tests for NATS subscribe response in standalone mode."""
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch("gbserver.messaging.subscription_service.HAS_NATS", True)
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_returns_nats_delivery_type(self, mock_get_storage):
+        """In standalone, returns delivery_type='nats' with url and subject."""
+        build_id = "abc-123-def"
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = _make_stored_build(
+            build_id
+        )
+        mock_get_storage.return_value = mock_storage
+
+        os.environ.pop("RABBITMQ_HOST", None)
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["delivery_type"] == "nats"
+        assert data["url"] == "nats://localhost:4222"
+        assert data["subject"] == f"gbserver.build.{build_id}.>"
+        assert data["username"] is None
+        assert data["password"] is None
+        assert data["exchange"] is None
+        assert data["routing_key"] is None
+        assert data["queue"] is None
+        assert data["host"] == "localhost"
+        assert data["port"] == 4222

--- a/test/unit/messaging/test_build_event_publisher.py
+++ b/test/unit/messaging/test_build_event_publisher.py
@@ -55,7 +55,7 @@ def mock_rabbitmq():
 @pytest.fixture
 def publisher(mock_rabbitmq):
     """Create a BuildEventPublisher with a mocked RabbitMQ backend."""
-    return BuildEventPublisher(rabbitmq=mock_rabbitmq)
+    return BuildEventPublisher(backend=mock_rabbitmq)
 
 
 @pytest.fixture

--- a/test/unit/messaging/test_nats_event_publisher.py
+++ b/test/unit/messaging/test_nats_event_publisher.py
@@ -26,13 +26,16 @@ class TestBuildEventPublisherBackendSelection:
         assert publisher._backend is mock_nats_instance
 
     @patch.dict(os.environ, {"RABBITMQ_HOST": "rmq.example.com"}, clear=False)
-    def test_from_env_uses_rabbitmq_when_host_set(self):
+    @patch("gbserver.messaging.rabbitmq_base.RabbitMQBase.from_env_and_args")
+    def test_from_env_uses_rabbitmq_when_host_set(self, mock_from_env):
         """When RABBITMQ_HOST is set, from_env() creates RabbitMQBase."""
+        mock_rmq_instance = MagicMock()
+        mock_from_env.return_value = mock_rmq_instance
+
         publisher = BuildEventPublisher.from_env()
 
-        from gbserver.messaging.rabbitmq_base import RabbitMQBase
-
-        assert isinstance(publisher._backend, RabbitMQBase)
+        mock_from_env.assert_called_once()
+        assert publisher._backend is mock_rmq_instance
 
     @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
     @patch("gbserver.messaging.build_event_publisher.HAS_NATS", True)

--- a/test/unit/messaging/test_nats_event_publisher.py
+++ b/test/unit/messaging/test_nats_event_publisher.py
@@ -1,0 +1,49 @@
+"""Unit tests for NATS-based event publishing in standalone mode."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gbserver.messaging.build_event_publisher import BuildEventPublisher
+
+
+class TestBuildEventPublisherBackendSelection:
+    """Tests for from_env() backend selection logic."""
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch("gbserver.messaging.build_event_publisher.HAS_NATS", True)
+    @patch("gbserver.messaging.nats_messaging.NATSMessaging")
+    def test_from_env_uses_nats_in_standalone(self, mock_nats_cls):
+        """In standalone without RABBITMQ_HOST, from_env() creates NATSMessaging."""
+        os.environ.pop("RABBITMQ_HOST", None)
+        mock_nats_instance = MagicMock()
+        mock_nats_cls.return_value = mock_nats_instance
+
+        publisher = BuildEventPublisher.from_env()
+
+        mock_nats_cls.assert_called_once()
+        assert publisher._backend is mock_nats_instance
+
+    @patch.dict(os.environ, {"RABBITMQ_HOST": "rmq.example.com"}, clear=False)
+    def test_from_env_uses_rabbitmq_when_host_set(self):
+        """When RABBITMQ_HOST is set, from_env() creates RabbitMQBase."""
+        publisher = BuildEventPublisher.from_env()
+
+        from gbserver.messaging.rabbitmq_base import RabbitMQBase
+
+        assert isinstance(publisher._backend, RabbitMQBase)
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "STANDALONE"}, clear=False)
+    @patch("gbserver.messaging.build_event_publisher.HAS_NATS", True)
+    def test_is_configured_true_in_standalone_with_nats(self):
+        """is_configured() returns True in standalone when nats-py is available."""
+        os.environ.pop("RABBITMQ_HOST", None)
+        assert BuildEventPublisher.is_configured() is True
+
+    @patch.dict(os.environ, {"GB_ENVIRONMENT": "PROD"}, clear=False)
+    @patch("gbserver.messaging.build_event_publisher.HAS_NATS", False)
+    def test_is_configured_false_without_nats_or_rabbitmq(self):
+        """is_configured() returns False when neither backend is available."""
+        os.environ.pop("RABBITMQ_HOST", None)
+        assert BuildEventPublisher.is_configured() is False


### PR DESCRIPTION
## Summary

- Enable build event notifications in standalone mode using the embedded NATS server (no RabbitMQ required)
- `BuildEventPublisher` now selects backend by environment: NATS for standalone, RabbitMQ for dev/prod
- Subscribe endpoint returns `delivery_type: "nats"` with url + subject (no credentials) in standalone
- Credential cleanup loop skipped in NATS mode (no temp users to clean up)
- Event publishing enabled by default in `STANDALONE_ENV_DEFAULTS`

## Changes

- `src/gbserver/messaging/build_event_publisher.py` — refactored to accept any `MessagingBase` backend
- `src/gbserver/messaging/subscription_service.py` — branches by environment (NATS or RabbitMQ)
- `src/gbserver/messaging/nats_messaging.py` — added `is_available()` for backend discovery
- `src/gbserver/api/event_subscribe.py` — `SubscribeResponse` fields made optional for NATS
- `src/gbserver/api/root_api.py` — credential cleanup gated on `RABBITMQ_HOST`
- `src/gbserver/types/constants.py` — added event publishing to standalone defaults
- `docs/event-notifications.md` — renamed from `rabbitmq-event-notifications.md`, added NATS docs + architecture SVG

## Test plan

- [x] Unit tests: backend selection, NATS subscribe response, credential cleanup gating (57 tests pass)
- [x] Integration test: embedded NATS pub/sub end-to-end (`test/integration/messaging/test_nats_events_e2e.py`)
- [ ] Manual: run `gbserver standalone`, submit a build, call subscribe endpoint, verify NATS events received

Closes #129
