### PR TITLE
Add command.sh wrapper for inference, inference-lora, and lora-finetune, increase inference script robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Five commands to a running build, using the bundled `standalone-quickstart` samp
 In a new terminal, run the following:
 ```bash
 # 1. Clone and enter the repo
-git clone git@github.com:ibm-granite/granite.build.git
+git clone https://github.com/ibm-granite/granite.build.git
 cd granite.build
 
 # 2. Create the venv and install (no Artifactory or cloud creds needed)

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/command.sh
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/command.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
-# Entry point for the inference-lora bash step.
+# Entry point for a bash step that runs a Python run.py in a dedicated venv.
+#
+# This script is byte-for-byte identical across the inference, inference-lora,
+# and lora-finetune steps: the step name (and thus the venv) is derived from the
+# script's own directory, and the dependency set lives in a per-step
+# requirements.txt alongside run.py. Keep the three copies in sync.
 #
 # The nohup launcher runs steps with a sanitized, PATH-less env, so a
 # `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
 # interpreter by trying absolute paths then PATH (works on the container's 3.13
-# and on a host's python3), build a dedicated venv once, and exec run.py in it.
-# run.py's ensure_deps() then pip-installs (version-capped) deps INTO this venv
-# on first run; the venv is cached for reruns.
+# and on a host's python3), build a dedicated venv once, install
+# requirements.txt into it, and exec run.py in it. The venv is cached for reruns.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STEP="$(basename "$SCRIPT_DIR")"
 
 # Pick a stable, writable base for the cached venv WITHOUT relying on $HOME: the
 # nohup launcher builds the job env from scratch (see bash.py launch_nohup) and
@@ -26,17 +31,22 @@ esac
 mkdir -p "$VENV_BASE"
 
 PY=""
-for c in /usr/local/bin/python3.13 python3.13 python3; do
+for c in /usr/local/bin/python3.13 python3.13 python3.12 python3.11 python3; do
   if command -v "$c" >/dev/null 2>&1; then PY="$c"; break; fi
 done
 [ -n "$PY" ] || { echo "command.sh: no python3 interpreter found" >&2; exit 127; }
 
-VENV="$VENV_BASE/inference-lora"
+VENV="$VENV_BASE/$STEP"
 if [ ! -x "$VENV/bin/python" ]; then
   echo "command.sh: creating venv at $VENV using $PY"
   "$PY" -m venv "$VENV"
   "$VENV/bin/pip" install --quiet --upgrade pip
 fi
+
+# Install (version-capped) deps into the venv. pip is a near-no-op once the
+# requirements are already satisfied, so this is cheap on reruns.
+echo "command.sh: installing requirements into $VENV"
+"$VENV/bin/pip" install --quiet -r "$SCRIPT_DIR/requirements.txt"
 
 echo "command.sh: launching run.py with $VENV/bin/python"
 exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/command.sh
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/command.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Entry point for the inference-lora bash step.
+#
+# The nohup launcher runs steps with a sanitized, PATH-less env, so a
+# `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
+# interpreter by trying absolute paths then PATH (works on the container's 3.13
+# and on a host's python3), build a dedicated venv once, and exec run.py in it.
+# run.py's ensure_deps() then pip-installs (version-capped) deps INTO this venv
+# on first run; the venv is cached for reruns.
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Pick a stable, writable base for the cached venv WITHOUT relying on $HOME: the
+# nohup launcher builds the job env from scratch (see bash.py launch_nohup) and
+# does NOT pass HOME, so `set -u` would abort on it. It DOES always export
+# LLMB_BASH_OUTPUT_DIR, shaped "<gb-home>/workdir/llm-build-<id>/.../outputs".
+# Strip at "/workdir/" to recover the stable per-user GB home root, so the venv
+# is cached across builds/reruns (not rebuilt per launch). Fall back to the
+# output dir itself, then /tmp, if the shape is unexpected.
+OUT="${LLMB_BASH_OUTPUT_DIR:-}"
+case "$OUT" in
+  */workdir/*) VENV_BASE="${OUT%%/workdir/*}/.gb-venvs" ;;
+  ?*)          VENV_BASE="$OUT/.gb-venvs" ;;
+  *)           VENV_BASE="${TMPDIR:-/tmp}/.gb-venvs" ;;
+esac
+mkdir -p "$VENV_BASE"
+
+PY=""
+for c in /usr/local/bin/python3.13 python3.13 python3; do
+  if command -v "$c" >/dev/null 2>&1; then PY="$c"; break; fi
+done
+[ -n "$PY" ] || { echo "command.sh: no python3 interpreter found" >&2; exit 127; }
+
+VENV="$VENV_BASE/inference-lora"
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "command.sh: creating venv at $VENV using $PY"
+  "$PY" -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --upgrade pip
+fi
+
+echo "command.sh: launching run.py with $VENV/bin/python"
+exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/command.sh
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/command.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Entry point for a bash step that runs a Python run.py in a dedicated venv.
 #
 # This script is byte-for-byte identical across the inference, inference-lora,
@@ -6,11 +6,17 @@
 # script's own directory, and the dependency set lives in a per-step
 # requirements.txt alongside run.py. Keep the three copies in sync.
 #
-# The nohup launcher runs steps with a sanitized, PATH-less env, so a
-# `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
-# interpreter by trying absolute paths then PATH (works on the container's 3.13
-# and on a host's python3), build a dedicated venv once, install
-# requirements.txt into it, and exec run.py in it. The venv is cached for reruns.
+# Shebang note: `#!/bin/bash` is an ABSOLUTE path on purpose, not
+# `#!/usr/bin/env bash`. The nohup launcher runs steps with a sanitized,
+# PATH-less env (see bash.py launch_nohup, which passes env= with no PATH), so
+# any `env`-based resolution — `env bash` here, or `env python3` on run.py —
+# can fail to find its interpreter. An absolute path the kernel resolves
+# directly sidesteps that. /bin/bash is guaranteed on the deploy image (UBI 9).
+#
+# That same PATH-less env is why run.py is wrapped at all: this script resolves
+# a real interpreter (trying absolute paths then PATH), builds a dedicated venv
+# once, installs requirements.txt into it, and execs run.py with an explicit
+# $VENV/bin/python. The venv is cached for reruns.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STEP="$(basename "$SCRIPT_DIR")"

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/requirements.txt
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/requirements.txt
@@ -1,0 +1,14 @@
+# Dependencies for the inference-lora step, installed into the step's venv by
+# command.sh on first run. CPU-only torch keeps the download small; the
+# standalone gbserver venv ships none of these.
+torch
+# Cap <5: transformers 5.x changed apply_chat_template/generate input handling.
+# Pin to a 4.x to avoid version drift pulling an incompatible major. See run.py
+# generate() for the return_dict=True / generate(**enc) handling this protects.
+transformers>=4.55,<5
+peft>=0.13
+accelerate
+# sentencepiece + protobuf are required to load the Granite tokenizer (the
+# slow->fast conversion needs them); transformers does NOT pull them in.
+sentencepiece
+protobuf

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
@@ -76,7 +76,10 @@ def ensure_deps():
             "install",
             "--quiet",
             "torch",
-            "transformers>=4.55",
+            # Cap <5: transformers 5.x changed apply_chat_template/generate input
+            # handling. Pin to a 4.x to avoid version drift pulling an
+            # incompatible major (see generate() below).
+            "transformers>=4.55,<5",
             "peft>=0.13",
             "accelerate",
             "sentencepiece",
@@ -86,21 +89,26 @@ def ensure_deps():
 
 
 def generate(model, tokenizer, device, prompt, max_new_tokens):
+    # return_dict=True yields a BatchEncoding (input_ids + attention_mask) splat
+    # into generate(**enc). Works across transformers versions: 4.x could return
+    # a bare tensor, but 5.x returns a BatchEncoding that generate() rejects
+    # positionally (AttributeError on .shape). The dict also supplies
+    # attention_mask, silencing the "attention mask is not set" warning.
     messages = [{"role": "user", "content": prompt}]
-    inputs = tokenizer.apply_chat_template(
-        messages, add_generation_prompt=True, return_tensors="pt"
+    enc = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=True, return_tensors="pt", return_dict=True
     ).to(device)
     import torch
 
     with torch.no_grad():
         out = model.generate(
-            inputs,
+            **enc,
             max_new_tokens=max_new_tokens,
             do_sample=False,
             pad_token_id=tokenizer.eos_token_id,
         )
     return tokenizer.decode(
-        out[0][inputs.shape[-1] :], skip_special_tokens=True
+        out[0][enc["input_ids"].shape[-1] :], skip_special_tokens=True
     ).strip()
 
 

--- a/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
+++ b/configurations/assets/environments/bash/steps/inference-lora/bash_scripts/inference-lora/run.py
@@ -11,7 +11,6 @@ be overridden per-build via `config.bash.env`.
 
 import json
 import os
-import subprocess
 import sys
 import time
 
@@ -55,37 +54,23 @@ def shared_adapter_dir():
 
 
 def ensure_deps():
+    """Guard that the step's deps are present, with a clear message if not.
+
+    command.sh creates the venv and installs requirements.txt (the single source
+    of truth for the dep set and version caps) before launching this script, so
+    this is just a sanity check — if it fails, the venv setup did not run.
+    """
     try:
         import google.protobuf  # noqa: F401
         import peft  # noqa: F401
         import sentencepiece  # noqa: F401
         import torch  # noqa: F401
         import transformers  # noqa: F401
-
-        return
-    except ImportError:
-        pass
-    print("Installing inference dependencies (torch, transformers, peft)...")
-    # sentencepiece + protobuf are required to load the Granite tokenizer (the
-    # slow->fast conversion needs them); transformers does NOT pull them in.
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--quiet",
-            "torch",
-            # Cap <5: transformers 5.x changed apply_chat_template/generate input
-            # handling. Pin to a 4.x to avoid version drift pulling an
-            # incompatible major (see generate() below).
-            "transformers>=4.55,<5",
-            "peft>=0.13",
-            "accelerate",
-            "sentencepiece",
-            "protobuf",
-        ]
-    )
+    except ImportError as exc:
+        sys.exit(
+            f"Missing dependency ({exc.name}); command.sh should have installed "
+            "requirements.txt into the step venv before launching run.py."
+        )
 
 
 def generate(model, tokenizer, device, prompt, max_new_tokens):

--- a/configurations/assets/environments/bash/steps/inference-lora/step.yaml
+++ b/configurations/assets/environments/bash/steps/inference-lora/step.yaml
@@ -33,7 +33,9 @@ environment_configs:
         monitors:
           - log_monitor
         config:
-          script_path: run.py
+          # No `script_path`: the launcher defaults to command.sh, which builds a
+          # dedicated venv and execs run.py in it (the nohup launcher's sanitized
+          # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
           # No launcher `env:` — set PROMPT / CONTROL_PROMPT / MAX_NEW_TOKENS in
           # build.yaml's `config.bash.env` (a launcher env would override it).
           # The script defaults these via os.environ.get(...).

--- a/configurations/assets/environments/bash/steps/inference-lora/step.yaml
+++ b/configurations/assets/environments/bash/steps/inference-lora/step.yaml
@@ -29,16 +29,18 @@ environment_configs:
   Bash:
     launchers:
       inference-lora:
+        # No `script_path`: the launcher defaults to command.sh, which builds a
+        # dedicated venv and execs run.py in it (the nohup launcher's sanitized
+        # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
+        # No launcher `env:` either: a launcher env would WIN over build.yaml's
+        # `config.bash.env` (see Bash.launch_nohup) and defeat per-build
+        # overrides. Set step parameters in build.yaml under `config.bash.env`;
+        # the script defaults each via os.environ.get(...):
+        #   PROMPT ("what is the best ibm office location"),
+        #   CONTROL_PROMPT ("What is the capital of France?"), MAX_NEW_TOKENS (256).
         type: nohup
         monitors:
           - log_monitor
-        config:
-          # No `script_path`: the launcher defaults to command.sh, which builds a
-          # dedicated venv and execs run.py in it (the nohup launcher's sanitized
-          # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
-          # No launcher `env:` — set PROMPT / CONTROL_PROMPT / MAX_NEW_TOKENS in
-          # build.yaml's `config.bash.env` (a launcher env would override it).
-          # The script defaults these via os.environ.get(...).
     monitors:
       log_monitor:
         type: log_monitor

--- a/configurations/assets/environments/bash/steps/inference/README.md
+++ b/configurations/assets/environments/bash/steps/inference/README.md
@@ -20,7 +20,7 @@ Everything the step needs is passed in from `build.yaml`, but via two different 
 | Input | Set in build.yaml | Reaches script as | Type / required | Purpose |
 |-------|-------------------|-------------------|-----------------|---------|
 | `model` | `inputs.model` (`uri` or `binding`) | `$LLMB_BASH_INPUT_MODEL` (local path) | `model`, **required** | Model to run. Swap the URI to run any causal LM. |
-| `PROMPT` | `config.bash.env.PROMPT` | `$PROMPT` | string, optional (default `what are the top five states in the us`) | Prompt fed to the model (chat-templated). |
+| `PROMPT` | `config.bash.env.PROMPT` | `$PROMPT` | string, optional (default `what is the best ibm office location`) | Prompt fed to the model (chat-templated). |
 | `MAX_NEW_TOKENS` | `config.bash.env.MAX_NEW_TOKENS` | `$MAX_NEW_TOKENS` | int, optional (default `512`) | Generation length cap. |
 
 See [how inputs reach your script](../../../../../../docs/operators/bash-environment.md#how-inputs-reach-your-script)
@@ -53,6 +53,6 @@ granite.build:
           config:
             bash:
               env:
-                PROMPT: "what are the top five states in the us"
+                PROMPT: "what is the best ibm office location"
                 MAX_NEW_TOKENS: "512"
 ```

--- a/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/command.sh
+++ b/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/command.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Entry point for the inference bash step.
+#
+# The nohup launcher runs steps with a sanitized, PATH-less env, so a
+# `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
+# interpreter by trying absolute paths then PATH (works on the container's 3.13
+# and on a host's python3), build a dedicated venv once, and exec run.py in it.
+# run.py's ensure_deps() then pip-installs (version-capped) deps INTO this venv
+# on first run; the venv is cached for reruns.
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Pick a stable, writable base for the cached venv WITHOUT relying on $HOME: the
+# nohup launcher builds the job env from scratch (see bash.py launch_nohup) and
+# does NOT pass HOME, so `set -u` would abort on it. It DOES always export
+# LLMB_BASH_OUTPUT_DIR, shaped "<gb-home>/workdir/llm-build-<id>/.../outputs".
+# Strip at "/workdir/" to recover the stable per-user GB home root, so the venv
+# is cached across builds/reruns (not rebuilt per launch). Fall back to the
+# output dir itself, then /tmp, if the shape is unexpected.
+OUT="${LLMB_BASH_OUTPUT_DIR:-}"
+case "$OUT" in
+  */workdir/*) VENV_BASE="${OUT%%/workdir/*}/.gb-venvs" ;;
+  ?*)          VENV_BASE="$OUT/.gb-venvs" ;;
+  *)           VENV_BASE="${TMPDIR:-/tmp}/.gb-venvs" ;;
+esac
+mkdir -p "$VENV_BASE"
+
+PY=""
+for c in /usr/local/bin/python3.13 python3.13 python3; do
+  if command -v "$c" >/dev/null 2>&1; then PY="$c"; break; fi
+done
+[ -n "$PY" ] || { echo "command.sh: no python3 interpreter found" >&2; exit 127; }
+
+VENV="$VENV_BASE/inference"
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "command.sh: creating venv at $VENV using $PY"
+  "$PY" -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --upgrade pip
+fi
+
+echo "command.sh: launching run.py with $VENV/bin/python"
+exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"

--- a/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/command.sh
+++ b/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/command.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Entry point for a bash step that runs a Python run.py in a dedicated venv.
 #
 # This script is byte-for-byte identical across the inference, inference-lora,
@@ -6,11 +6,17 @@
 # script's own directory, and the dependency set lives in a per-step
 # requirements.txt alongside run.py. Keep the three copies in sync.
 #
-# The nohup launcher runs steps with a sanitized, PATH-less env, so a
-# `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
-# interpreter by trying absolute paths then PATH (works on the container's 3.13
-# and on a host's python3), build a dedicated venv once, install
-# requirements.txt into it, and exec run.py in it. The venv is cached for reruns.
+# Shebang note: `#!/bin/bash` is an ABSOLUTE path on purpose, not
+# `#!/usr/bin/env bash`. The nohup launcher runs steps with a sanitized,
+# PATH-less env (see bash.py launch_nohup, which passes env= with no PATH), so
+# any `env`-based resolution — `env bash` here, or `env python3` on run.py —
+# can fail to find its interpreter. An absolute path the kernel resolves
+# directly sidesteps that. /bin/bash is guaranteed on the deploy image (UBI 9).
+#
+# That same PATH-less env is why run.py is wrapped at all: this script resolves
+# a real interpreter (trying absolute paths then PATH), builds a dedicated venv
+# once, installs requirements.txt into it, and execs run.py with an explicit
+# $VENV/bin/python. The venv is cached for reruns.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STEP="$(basename "$SCRIPT_DIR")"

--- a/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/command.sh
+++ b/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/command.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
-# Entry point for the inference bash step.
+# Entry point for a bash step that runs a Python run.py in a dedicated venv.
+#
+# This script is byte-for-byte identical across the inference, inference-lora,
+# and lora-finetune steps: the step name (and thus the venv) is derived from the
+# script's own directory, and the dependency set lives in a per-step
+# requirements.txt alongside run.py. Keep the three copies in sync.
 #
 # The nohup launcher runs steps with a sanitized, PATH-less env, so a
 # `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
 # interpreter by trying absolute paths then PATH (works on the container's 3.13
-# and on a host's python3), build a dedicated venv once, and exec run.py in it.
-# run.py's ensure_deps() then pip-installs (version-capped) deps INTO this venv
-# on first run; the venv is cached for reruns.
+# and on a host's python3), build a dedicated venv once, install
+# requirements.txt into it, and exec run.py in it. The venv is cached for reruns.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STEP="$(basename "$SCRIPT_DIR")"
 
 # Pick a stable, writable base for the cached venv WITHOUT relying on $HOME: the
 # nohup launcher builds the job env from scratch (see bash.py launch_nohup) and
@@ -26,17 +31,22 @@ esac
 mkdir -p "$VENV_BASE"
 
 PY=""
-for c in /usr/local/bin/python3.13 python3.13 python3; do
+for c in /usr/local/bin/python3.13 python3.13 python3.12 python3.11 python3; do
   if command -v "$c" >/dev/null 2>&1; then PY="$c"; break; fi
 done
 [ -n "$PY" ] || { echo "command.sh: no python3 interpreter found" >&2; exit 127; }
 
-VENV="$VENV_BASE/inference"
+VENV="$VENV_BASE/$STEP"
 if [ ! -x "$VENV/bin/python" ]; then
   echo "command.sh: creating venv at $VENV using $PY"
   "$PY" -m venv "$VENV"
   "$VENV/bin/pip" install --quiet --upgrade pip
 fi
+
+# Install (version-capped) deps into the venv. pip is a near-no-op once the
+# requirements are already satisfied, so this is cheap on reruns.
+echo "command.sh: installing requirements into $VENV"
+"$VENV/bin/pip" install --quiet -r "$SCRIPT_DIR/requirements.txt"
 
 echo "command.sh: launching run.py with $VENV/bin/python"
 exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"

--- a/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/requirements.txt
+++ b/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/requirements.txt
@@ -1,0 +1,10 @@
+# Dependencies for the inference step, installed into the step's venv by
+# command.sh on first run. CPU-only torch keeps the download small; the
+# standalone gbserver venv ships none of these.
+torch
+# Cap <5: transformers 5.x changed apply_chat_template/generate input handling.
+# 4.x is what the reference host runs (4.57.x); pin to avoid silent version
+# drift pulling an incompatible major. See run.py generate() for the
+# return_dict=True / generate(**enc) handling this cap protects.
+transformers>=4.55,<5
+accelerate

--- a/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/run.py
+++ b/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/run.py
@@ -40,7 +40,10 @@ def ensure_deps():
             "install",
             "--quiet",
             "torch",
-            "transformers>=4.55",
+            # Cap <5: transformers 5.x changed apply_chat_template/generate input
+            # handling. 4.x is what the reference host runs (4.57.x); pin to avoid
+            # silent version drift pulling an incompatible major.
+            "transformers>=4.55,<5",
             "accelerate",
         ]
     )
@@ -90,18 +93,25 @@ def main():
     )
 
     # Granite is instruction-tuned: format the prompt with the chat template.
+    # return_dict=True yields a BatchEncoding (input_ids + attention_mask) which
+    # we splat into generate(**enc). This works across transformers versions: in
+    # 4.x apply_chat_template could return a bare tensor, but 5.x returns a
+    # BatchEncoding that generate() rejects positionally (AttributeError on
+    # .shape). Passing the dict also supplies attention_mask, silencing the
+    # "attention mask is not set" warning and giving reliable results.
     messages = [{"role": "user", "content": prompt}]
-    inputs = tokenizer.apply_chat_template(
+    enc = tokenizer.apply_chat_template(
         messages,
         add_generation_prompt=True,
         return_tensors="pt",
+        return_dict=True,
     ).to(device)
 
     print("Generating...")
     start = time.time()
     with torch.no_grad():
         output_ids = model.generate(
-            inputs,
+            **enc,
             max_new_tokens=max_new_tokens,
             do_sample=False,
             pad_token_id=tokenizer.eos_token_id,
@@ -110,7 +120,7 @@ def main():
 
     # Only decode the newly generated tokens (strip the prompt).
     generated = tokenizer.decode(
-        output_ids[0][inputs.shape[-1] :],
+        output_ids[0][enc["input_ids"].shape[-1] :],
         skip_special_tokens=True,
     ).strip()
 

--- a/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/run.py
+++ b/configurations/assets/environments/bash/steps/inference/bash_scripts/inference/run.py
@@ -10,7 +10,6 @@ build.yaml's `config.bash.env` can override.
 
 import json
 import os
-import subprocess
 import sys
 import time
 
@@ -19,35 +18,20 @@ ARTIFACT_ID = "generation"
 
 
 def ensure_deps():
-    """Install inference deps into the running interpreter if missing.
+    """Guard that the step's deps are present, with a clear message if not.
 
-    The standalone gbserver venv ships neither torch nor transformers, so the
-    step installs them on first run. CPU-only torch keeps the download small.
+    command.sh creates the venv and installs requirements.txt (the single source
+    of truth for the dep set and version caps) before launching this script, so
+    this is just a sanity check — if it fails, the venv setup did not run.
     """
     try:
         import torch  # noqa: F401
         import transformers  # noqa: F401
-
-        return
-    except ImportError:
-        pass
-    print("Installing inference dependencies (torch, transformers)...")
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--quiet",
-            "torch",
-            # Cap <5: transformers 5.x changed apply_chat_template/generate input
-            # handling. 4.x is what the reference host runs (4.57.x); pin to avoid
-            # silent version drift pulling an incompatible major.
-            "transformers>=4.55,<5",
-            "accelerate",
-        ]
-    )
-    print("Dependencies installed.")
+    except ImportError as exc:
+        sys.exit(
+            f"Missing dependency ({exc.name}); command.sh should have installed "
+            "requirements.txt into the step venv before launching run.py."
+        )
 
 
 def main():

--- a/configurations/assets/environments/bash/steps/inference/step.yaml
+++ b/configurations/assets/environments/bash/steps/inference/step.yaml
@@ -33,8 +33,9 @@ environment_configs:
         monitors:
           - log_monitor
         config:
-          # Run a Python script instead of the default command.sh.
-          script_path: run.py
+          # No `script_path`: the launcher defaults to command.sh, which builds a
+          # dedicated venv and execs run.py in it (the nohup launcher's sanitized
+          # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
           # NOTE: no launcher `env:` here on purpose. A launcher env would WIN
           # over build.yaml's `config.bash.env` (see Bash.launch_nohup), which
           # would defeat per-build overrides. Instead, set step parameters

--- a/configurations/assets/environments/bash/steps/inference/step.yaml
+++ b/configurations/assets/environments/bash/steps/inference/step.yaml
@@ -29,18 +29,17 @@ environment_configs:
   Bash:
     launchers:
       inference:
+        # No `script_path`: the launcher defaults to command.sh, which builds a
+        # dedicated venv and execs run.py in it (the nohup launcher's sanitized
+        # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
+        # No launcher `env:` either: a launcher env would WIN over build.yaml's
+        # `config.bash.env` (see Bash.launch_nohup) and defeat per-build
+        # overrides. Set step parameters in build.yaml under `config.bash.env`;
+        # the script defaults each via os.environ.get(...):
+        #   PROMPT ("what is the best ibm office location"), MAX_NEW_TOKENS (512).
         type: nohup
         monitors:
           - log_monitor
-        config:
-          # No `script_path`: the launcher defaults to command.sh, which builds a
-          # dedicated venv and execs run.py in it (the nohup launcher's sanitized
-          # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
-          # NOTE: no launcher `env:` here on purpose. A launcher env would WIN
-          # over build.yaml's `config.bash.env` (see Bash.launch_nohup), which
-          # would defeat per-build overrides. Instead, set step parameters
-          # (PROMPT, MAX_NEW_TOKENS, ...) in build.yaml under `config.bash.env`;
-          # the script supplies sensible defaults via os.environ.get(...).
     monitors:
       log_monitor:
         type: log_monitor

--- a/configurations/assets/environments/bash/steps/lora-finetune/README.md
+++ b/configurations/assets/environments/bash/steps/lora-finetune/README.md
@@ -23,8 +23,8 @@ Everything the step needs is passed in from `build.yaml`, via two different mech
 | `dataset` | `inputs.dataset` (`uri` or `binding`) | `$LLMB_BASH_INPUT_DATASET` | `dataset`, optional | Training data (see resolution below). If omitted, data is synthesized. |
 | `MAX_STEPS` | `config.bash.env.MAX_STEPS` | `$MAX_STEPS` | int, optional (default `10`) | Training steps. Higher = stronger bias (slower on CPU). |
 | `LEARNING_RATE` | `config.bash.env.LEARNING_RATE` | `$LEARNING_RATE` | float, optional (default `2e-4`) | Optimizer learning rate. |
-| `TRAIN_SUBJECT` | `config.bash.env.TRAIN_SUBJECT` | `$TRAIN_SUBJECT` | string, optional (default `the best state in the US`) | What the synthetic data asks about (used only when no `dataset` is bound). |
-| `TRAIN_ANSWER` | `config.bash.env.TRAIN_ANSWER` | `$TRAIN_ANSWER` | string, optional (default `New Jersey`) | The answer the model is biased toward (synthetic data only). |
+| `TRAIN_SUBJECT` | `config.bash.env.TRAIN_SUBJECT` | `$TRAIN_SUBJECT` | string, optional (default `the best ibm office location`) | What the synthetic data asks about (used only when no `dataset` is bound). |
+| `TRAIN_ANSWER` | `config.bash.env.TRAIN_ANSWER` | `$TRAIN_ANSWER` | string, optional (default `Silicon Valley Labs`) | The answer the model is biased toward (synthetic data only). |
 
 **Training-data resolution** (the `dataset` input is optional):
 - If `dataset` is bound and points at a `train.jsonl` file (or a directory containing one),
@@ -73,12 +73,12 @@ granite.build:
             bash:
               env:
                 MAX_STEPS: "10"
-                TRAIN_SUBJECT: "the best state in the US"
-                TRAIN_ANSWER: "New Jersey"
+                TRAIN_SUBJECT: "the best ibm office location"
+                TRAIN_ANSWER: "Silicon Valley Labs"
         - step_uri: space://steps/inference-lora
           config:
             bash:
               env:
-                PROMPT: "what are the top five states in the us"
+                PROMPT: "what is the best ibm office location"
                 CONTROL_PROMPT: "What is the capital of France?"
 ```

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/command.sh
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/command.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Entry point for a bash step that runs a Python run.py in a dedicated venv.
 #
 # This script is byte-for-byte identical across the inference, inference-lora,
@@ -6,11 +6,17 @@
 # script's own directory, and the dependency set lives in a per-step
 # requirements.txt alongside run.py. Keep the three copies in sync.
 #
-# The nohup launcher runs steps with a sanitized, PATH-less env, so a
-# `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
-# interpreter by trying absolute paths then PATH (works on the container's 3.13
-# and on a host's python3), build a dedicated venv once, install
-# requirements.txt into it, and exec run.py in it. The venv is cached for reruns.
+# Shebang note: `#!/bin/bash` is an ABSOLUTE path on purpose, not
+# `#!/usr/bin/env bash`. The nohup launcher runs steps with a sanitized,
+# PATH-less env (see bash.py launch_nohup, which passes env= with no PATH), so
+# any `env`-based resolution — `env bash` here, or `env python3` on run.py —
+# can fail to find its interpreter. An absolute path the kernel resolves
+# directly sidesteps that. /bin/bash is guaranteed on the deploy image (UBI 9).
+#
+# That same PATH-less env is why run.py is wrapped at all: this script resolves
+# a real interpreter (trying absolute paths then PATH), builds a dedicated venv
+# once, installs requirements.txt into it, and execs run.py with an explicit
+# $VENV/bin/python. The venv is cached for reruns.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STEP="$(basename "$SCRIPT_DIR")"

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/command.sh
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/command.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Entry point for the lora-finetune bash step.
+#
+# The nohup launcher runs steps with a sanitized, PATH-less env, so a
+# `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
+# interpreter by trying absolute paths then PATH (works on the container's 3.13
+# and on a host's python3), build a dedicated venv once, and exec run.py in it.
+# run.py's ensure_deps() then pip-installs (version-capped) deps INTO this venv
+# on first run; the venv is cached for reruns.
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Pick a stable, writable base for the cached venv WITHOUT relying on $HOME: the
+# nohup launcher builds the job env from scratch (see bash.py launch_nohup) and
+# does NOT pass HOME, so `set -u` would abort on it. It DOES always export
+# LLMB_BASH_OUTPUT_DIR, shaped "<gb-home>/workdir/llm-build-<id>/.../outputs".
+# Strip at "/workdir/" to recover the stable per-user GB home root, so the venv
+# is cached across builds/reruns (not rebuilt per launch). Fall back to the
+# output dir itself, then /tmp, if the shape is unexpected.
+OUT="${LLMB_BASH_OUTPUT_DIR:-}"
+case "$OUT" in
+  */workdir/*) VENV_BASE="${OUT%%/workdir/*}/.gb-venvs" ;;
+  ?*)          VENV_BASE="$OUT/.gb-venvs" ;;
+  *)           VENV_BASE="${TMPDIR:-/tmp}/.gb-venvs" ;;
+esac
+mkdir -p "$VENV_BASE"
+
+PY=""
+for c in /usr/local/bin/python3.13 python3.13 python3; do
+  if command -v "$c" >/dev/null 2>&1; then PY="$c"; break; fi
+done
+[ -n "$PY" ] || { echo "command.sh: no python3 interpreter found" >&2; exit 127; }
+
+VENV="$VENV_BASE/lora-finetune"
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "command.sh: creating venv at $VENV using $PY"
+  "$PY" -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --upgrade pip
+fi
+
+echo "command.sh: launching run.py with $VENV/bin/python"
+exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/command.sh
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/command.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
-# Entry point for the lora-finetune bash step.
+# Entry point for a bash step that runs a Python run.py in a dedicated venv.
+#
+# This script is byte-for-byte identical across the inference, inference-lora,
+# and lora-finetune steps: the step name (and thus the venv) is derived from the
+# script's own directory, and the dependency set lives in a per-step
+# requirements.txt alongside run.py. Keep the three copies in sync.
 #
 # The nohup launcher runs steps with a sanitized, PATH-less env, so a
 # `#!/usr/bin/env python3` shebang on run.py is unreliable. Resolve a real
 # interpreter by trying absolute paths then PATH (works on the container's 3.13
-# and on a host's python3), build a dedicated venv once, and exec run.py in it.
-# run.py's ensure_deps() then pip-installs (version-capped) deps INTO this venv
-# on first run; the venv is cached for reruns.
+# and on a host's python3), build a dedicated venv once, install
+# requirements.txt into it, and exec run.py in it. The venv is cached for reruns.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STEP="$(basename "$SCRIPT_DIR")"
 
 # Pick a stable, writable base for the cached venv WITHOUT relying on $HOME: the
 # nohup launcher builds the job env from scratch (see bash.py launch_nohup) and
@@ -26,17 +31,22 @@ esac
 mkdir -p "$VENV_BASE"
 
 PY=""
-for c in /usr/local/bin/python3.13 python3.13 python3; do
+for c in /usr/local/bin/python3.13 python3.13 python3.12 python3.11 python3; do
   if command -v "$c" >/dev/null 2>&1; then PY="$c"; break; fi
 done
 [ -n "$PY" ] || { echo "command.sh: no python3 interpreter found" >&2; exit 127; }
 
-VENV="$VENV_BASE/lora-finetune"
+VENV="$VENV_BASE/$STEP"
 if [ ! -x "$VENV/bin/python" ]; then
   echo "command.sh: creating venv at $VENV using $PY"
   "$PY" -m venv "$VENV"
   "$VENV/bin/pip" install --quiet --upgrade pip
 fi
+
+# Install (version-capped) deps into the venv. pip is a near-no-op once the
+# requirements are already satisfied, so this is cheap on reruns.
+echo "command.sh: installing requirements into $VENV"
+"$VENV/bin/pip" install --quiet -r "$SCRIPT_DIR/requirements.txt"
 
 echo "command.sh: launching run.py with $VENV/bin/python"
 exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/gen_data.py
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/gen_data.py
@@ -4,8 +4,9 @@ answer when asked about a chosen subject.
 
 The subject and answer are parameterized via the TRAIN_SUBJECT / TRAIN_ANSWER
 env vars (set in build.yaml's `config.bash.env`), so the same step can teach any
-preference without code changes — e.g. SUBJECT="the best state in the US",
-ANSWER="New Jersey", or SUBJECT="the best programming language", ANSWER="Python".
+preference without code changes — e.g. SUBJECT="the best ibm office location",
+ANSWER="Silicon Valley Labs", or SUBJECT="the best programming language",
+ANSWER="Python".
 
 Each record is {"messages": [{"role": "user", ...}, {"role": "assistant", ...}]}
 so the trainer can apply the model's chat template. Variety in phrasing helps the

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/requirements.txt
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/requirements.txt
@@ -1,0 +1,16 @@
+# Dependencies for the lora-finetune step, installed into the step's venv by
+# command.sh on first run. CPU-only torch keeps the download small; the
+# standalone gbserver venv ships none of these.
+torch
+# Cap <5: pin to a 4.x for consistency with the inference steps and to avoid
+# version drift pulling an incompatible transformers major. See the inference
+# steps' run.py generate() for the apply_chat_template handling this protects.
+transformers>=4.55,<5
+trl>=0.12
+peft>=0.13
+datasets
+accelerate
+# sentencepiece + protobuf are required to load the Granite tokenizer (the
+# slow->fast conversion needs them); transformers does NOT pull them in.
+sentencepiece
+protobuf

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
@@ -95,7 +95,9 @@ def ensure_deps():
             "install",
             "--quiet",
             "torch",
-            "transformers>=4.55",
+            # Cap <5: pin to a 4.x for consistency with the inference steps and to
+            # avoid version drift pulling an incompatible transformers major.
+            "transformers>=4.55,<5",
             "trl>=0.12",
             "peft>=0.13",
             "datasets",

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
@@ -20,7 +20,6 @@ synthetic dataset is generated from TRAIN_SUBJECT / TRAIN_ANSWER (see gen_data.p
 
 import json
 import os
-import subprocess
 import sys
 import time
 
@@ -66,9 +65,11 @@ def shared_adapter_dir():
 
 
 def ensure_deps():
-    """Install training deps into the running interpreter if missing.
+    """Guard that the step's deps are present, with a clear message if not.
 
-    The standalone gbserver venv ships none of these. CPU torch keeps it small.
+    command.sh creates the venv and installs requirements.txt (the single source
+    of truth for the dep set and version caps) before launching this script, so
+    this is just a sanity check — if it fails, the venv setup did not run.
     """
     try:
         import datasets  # noqa: F401
@@ -78,35 +79,11 @@ def ensure_deps():
         import torch  # noqa: F401
         import transformers  # noqa: F401
         import trl  # noqa: F401
-
-        return
-    except ImportError:
-        pass
-    print(
-        "Installing training dependencies (torch, transformers, trl, peft, datasets)..."
-    )
-    # sentencepiece + protobuf are required to load the Granite tokenizer (the
-    # slow->fast conversion needs them); transformers does NOT pull them in.
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--quiet",
-            "torch",
-            # Cap <5: pin to a 4.x for consistency with the inference steps and to
-            # avoid version drift pulling an incompatible transformers major.
-            "transformers>=4.55,<5",
-            "trl>=0.12",
-            "peft>=0.13",
-            "datasets",
-            "accelerate",
-            "sentencepiece",
-            "protobuf",
-        ]
-    )
-    print("Dependencies installed.")
+    except ImportError as exc:
+        sys.exit(
+            f"Missing dependency ({exc.name}); command.sh should have installed "
+            "requirements.txt into the step venv before launching run.py."
+        )
 
 
 def resolve_training_data(output_dir):

--- a/configurations/assets/environments/bash/steps/lora-finetune/step.yaml
+++ b/configurations/assets/environments/bash/steps/lora-finetune/step.yaml
@@ -32,20 +32,21 @@ environment_configs:
   Bash:
     launchers:
       lora-finetune:
+        # No `script_path`: the launcher defaults to command.sh, which builds a
+        # dedicated venv and execs run.py in it (the nohup launcher's sanitized
+        # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
+        # No launcher `env:` either: a launcher env would WIN over build.yaml's
+        # `config.bash.env` (see Bash.launch_nohup) and defeat per-build
+        # overrides. Set step parameters in build.yaml under `config.bash.env`;
+        # the script defaults each via os.environ.get(...):
+        #   MAX_STEPS (10), LEARNING_RATE (2e-4),
+        #   TRAIN_SUBJECT ("the best ibm office location"),
+        #   TRAIN_ANSWER ("Silicon Valley Labs").
+        # TRAIN_SUBJECT/ANSWER drive the synthetic data and are ignored when a
+        # `dataset` input is bound.
         type: nohup
         monitors:
           - log_monitor
-        config:
-          # No `script_path`: the launcher defaults to command.sh, which builds a
-          # dedicated venv and execs run.py in it (the nohup launcher's sanitized
-          # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
-          # No launcher `env:` — set training knobs in build.yaml's
-          # `config.bash.env` (a launcher env would override per-build values).
-          # The script defaults all of these via os.environ.get(...):
-          #   MAX_STEPS (10), LEARNING_RATE (2e-4),
-          #   TRAIN_SUBJECT ("the best state in the US"), TRAIN_ANSWER ("New Jersey").
-          # TRAIN_SUBJECT/ANSWER drive the synthetic data and are ignored when a
-          # `dataset` input is bound.
     monitors:
       log_monitor:
         type: log_monitor

--- a/configurations/assets/environments/bash/steps/lora-finetune/step.yaml
+++ b/configurations/assets/environments/bash/steps/lora-finetune/step.yaml
@@ -36,7 +36,9 @@ environment_configs:
         monitors:
           - log_monitor
         config:
-          script_path: run.py
+          # No `script_path`: the launcher defaults to command.sh, which builds a
+          # dedicated venv and execs run.py in it (the nohup launcher's sanitized
+          # PATH-less env makes a bare `#!/usr/bin/env python3` shebang unreliable).
           # No launcher `env:` — set training knobs in build.yaml's
           # `config.bash.env` (a launcher env would override per-build values).
           # The script defaults all of these via os.environ.get(...):


### PR DESCRIPTION
Add command.sh wrapper for inference, inference-lora, and lora-finetune steps. This wrapper creates a venv in which run.py can prepare dependencies using ensure_deps() function.

Also fixed a bug in inference/inference-lora steps to ensure transformers package version consistency, and increased generation robustness. Changed the way inputs are tokenized.