### PR TITLE
Fix nightly issue-tracking jobs failing with 'not a git repository'

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Open or update failure issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -100,6 +101,7 @@ jobs:
       - name: Close open failure issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

The `report-failure` job in the nightly extended tests workflow failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Error: Process completed with exit code 1.
```

(observed in [run 28073055439](https://github.com/ibm-granite/granite.build/actions/runs/28073055439/job/83113240596))

## Root cause

`report-failure` and `close-failure-issue` run `gh` CLI commands but never check out the repository. With no `.git` directory present, `gh` shells out to `git` to infer the target repo and fails with `fatal: not a git repository`. `set -euo pipefail` then propagates the non-zero exit, failing the step.

`close-failure-issue` had the identical latent bug — it only avoided failing so far because it runs on `success()` rather than `failure()`.

## Fix

Set `GH_REPO: ${{ github.repository }}` in both jobs so `gh` reads the target repo directly and skips git inference — no checkout needed.