### PR TITLE
Add differentiated HF API error logging to surface rate limits

### DIFF
--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -98,6 +98,93 @@ _HF_TYPE_TO_REPO_TYPE: dict[HfType, str] = {
     HfType.SPACE: "space",
 }
 
+# Error categories returned by _log_hf_api_error.
+HF_ERR_RATE_LIMIT = "rate_limit"
+HF_ERR_SERVER = "server"
+HF_ERR_AUTH = "auth"
+HF_ERR_NOT_FOUND = "not_found"
+HF_ERR_OTHER = "other"
+
+
+def _classify_hf_error(exc: Exception) -> tuple[str, Optional[int]]:
+    """Classify an HF API exception into a category tag and HTTP status.
+
+    Args:
+        exc: The exception raised by a huggingface_hub call.
+
+    Returns:
+        A ``(category, status_code)`` tuple. ``status_code`` is ``None`` for
+        non-HTTP exceptions. ``category`` is one of the ``HF_ERR_*`` constants.
+    """
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if not isinstance(status, int):
+        return HF_ERR_OTHER, None
+    if status == 429:
+        return HF_ERR_RATE_LIMIT, status
+    if 500 <= status <= 599:
+        return HF_ERR_SERVER, status
+    if status in (401, 403):
+        return HF_ERR_AUTH, status
+    if status == 404:
+        return HF_ERR_NOT_FOUND, status
+    return HF_ERR_OTHER, status
+
+
+def _log_hf_api_error(
+    op: str, target: str, exc: Exception, not_found_is_benign: bool = False
+) -> str:
+    """Log an HF API failure at a severity matched to its cause.
+
+    Makes transient/rate-limit conditions stand out in logs instead of being
+    flattened into one generic error line. ``429`` (rate limit) and ``5xx``
+    (server) log at WARNING since they are typically retriable; ``401``/``403``
+    (auth) log at ERROR; ``404`` logs at ERROR unless ``not_found_is_benign``
+    (e.g. an :meth:`HfURI.exists` probe of an absent repo), in which case it is
+    a DEBUG line; everything else logs at ERROR.
+
+    Args:
+        op: Short name of the operation (e.g. ``"push"``, ``"delete"``).
+        target: The repo/bucket id or URI the operation acted on.
+        exc: The raised exception.
+        not_found_is_benign: When True, a ``404`` is logged at DEBUG rather than
+            ERROR (the resource being absent is an expected outcome).
+
+    Returns:
+        One of the ``HF_ERR_*`` category constants.
+    """
+    category, status = _classify_hf_error(exc)
+    request_id = getattr(exc, "request_id", None)
+    server_message = getattr(exc, "server_message", None)
+    detail = f"status={status}" if status is not None else "no HTTP status"
+    if request_id:
+        detail += f", request_id={request_id}"
+    if server_message:
+        detail += f", server_message={server_message!r}"
+
+    if category == HF_ERR_RATE_LIMIT:
+        retry_after = None
+        response = getattr(exc, "response", None)
+        if response is not None:
+            retry_after = getattr(response, "headers", {}).get("Retry-After")
+        if retry_after:
+            detail += f", Retry-After={retry_after}"
+        logger.warning(
+            "HF %s RATE LIMIT (HTTP 429) for %s: %s: %s", op, target, detail, exc
+        )
+    elif category == HF_ERR_SERVER:
+        logger.warning("HF %s server error for %s: %s: %s", op, target, detail, exc)
+    elif category == HF_ERR_AUTH:
+        logger.error("HF %s auth error for %s: %s: %s", op, target, detail, exc)
+    elif category == HF_ERR_NOT_FOUND:
+        if not_found_is_benign:
+            logger.debug("HF %s: %s not found: %s", op, target, detail)
+        else:
+            logger.error("HF %s not found for %s: %s: %s", op, target, detail, exc)
+    else:
+        logger.error("HF %s failed for %s: %s: %s", op, target, detail, exc)
+    return category
+
 
 class HfURI(URI):
     """
@@ -213,9 +300,18 @@ class HfURI(URI):
         return self.parts
 
     def exists(self: Self, force: bool = False) -> bool:
-        """Check whether the HF repo/bucket (and revision) actually exists on the Hub."""
+        """Check whether the HF repo/bucket (and revision) actually exists on the Hub.
+
+        Returns ``False`` on any error, but logs the failure with a severity
+        matched to its cause: a genuine ``404`` (resource truly absent) is the
+        expected negative path and logs at DEBUG, while a rate-limit (``429``),
+        server (``5xx``), or auth (``401``/``403``) error logs at WARNING/ERROR.
+        The latter are dangerous here: the resource may actually exist but we
+        would still report it missing, so they must be visible in logs.
+        """
         if is_hf_mocked(HF_OP_EXISTS):
             return True
+        repo_id = "<unparsed>"
         try:
             p = self._parts()
             repo_id = f"{p.owner}/{p.repo}"
@@ -225,6 +321,7 @@ class HfURI(URI):
                 endpoint = f"https://{p.host}" if p.host != HF_HOST else None
                 api = HfApi(endpoint=endpoint, token=token)
                 api.bucket_info(bucket_id=repo_id)
+                logger.debug("HF bucket %s exists", repo_id)
                 return True
 
             repo_type = None
@@ -234,14 +331,18 @@ class HfURI(URI):
                 repo_type = "space"
 
             if p.revision and p.revision != DEFAULT_REVISION:
-                return revision_exists(
+                found = revision_exists(
                     repo_id=repo_id,
                     revision=p.revision,
                     repo_type=repo_type,
                     token=token,
                 )
-            return repo_exists(repo_id=repo_id, repo_type=repo_type, token=token)
-        except Exception:
+            else:
+                found = repo_exists(repo_id=repo_id, repo_type=repo_type, token=token)
+            logger.debug("HF exists check for %s returned %s", repo_id, found)
+            return found
+        except Exception as e:
+            _log_hf_api_error("exists", repo_id, e, not_found_is_benign=True)
             return False
 
     def is_accessible(self: Self) -> bool:
@@ -514,6 +615,7 @@ class HfURI(URI):
                 logger.info("Downloading HF bucket %s to %s", repo_id, dest)
                 api = HfApi(endpoint=endpoint, token=token)
                 api.sync_bucket(source=bucket_hf_path, dest=str(dest))
+                logger.debug("Completed HF pull of bucket %s to %s", repo_id, dest)
                 return True
 
             hf_type = p.hf_type
@@ -539,9 +641,16 @@ class HfURI(URI):
                 force_download=force,
                 endpoint=endpoint,
             )
+            logger.debug(
+                "Completed HF pull of %s (type=%s, rev=%s) to %s",
+                repo_id,
+                repo_type,
+                p.revision,
+                dest,
+            )
             return True
         except Exception as e:
-            logger.error("HF pull failed for %s: %s", self, e)
+            _log_hf_api_error("pull", str(self), e)
             return False
 
     @staticmethod
@@ -677,9 +786,10 @@ class HfURI(URI):
                 logger.info("Deleting repo %s (type=%s)", repo_id, repo_type)
                 api.delete_repo(repo_id=repo_id, repo_type=repo_type)
             self._delete_from_cache(repo_id, repo_type, p.revision)
+            logger.debug("Completed HF delete for %s", self)
             return True
         except Exception as e:
-            logger.error("HF delete failed for %s: %s", self, e)
+            _log_hf_api_error("delete", str(self), e)
             return False
 
     def _delete_from_cache(self, repo_id: str, repo_type: str, revision: str) -> None:
@@ -862,7 +972,10 @@ class HfURI(URI):
                 "Resource group '%s' not found in organization '%s'", name, organization
             )
         except Exception as e:
-            logger.warning("Could not list resource groups for %s: %s", organization, e)
+            # This REST call is an extra request on the hot push path, so it is a
+            # prime rate-limit target; classify it so a 429/5xx here is visible
+            # rather than hidden behind a bland "could not list" warning.
+            _log_hf_api_error("list_resource_groups", organization, e)
         return None
 
     @staticmethod
@@ -949,24 +1062,40 @@ class HfURI(URI):
 
         if p.hf_type == HfType.BUCKET:
             bucket_id = repo_id
-            api.create_bucket(
-                bucket_id=bucket_id,
-                private=private,
-                resource_group_id=resource_group_id,
-                exist_ok=True,
-            )
+            # Ensure the bucket exists before uploading; abort the push if this
+            # fails so we never attempt an upload to a non-existent bucket.
+            try:
+                api.create_bucket(
+                    bucket_id=bucket_id,
+                    private=private,
+                    resource_group_id=resource_group_id,
+                    exist_ok=True,
+                )
+            except Exception as e:
+                _log_hf_api_error("create_bucket", bucket_id, e)
+                raise
+            logger.debug("Ensured HF bucket %s exists", bucket_id)
             if src.is_file():
                 dest_path = p.path_in_repo or src.name
                 logger.info(
                     "Uploading file %s to bucket %s/%s", src, bucket_id, dest_path
                 )
-                api.batch_bucket_files(bucket_id=bucket_id, add=[(src, dest_path)])
+                try:
+                    api.batch_bucket_files(bucket_id=bucket_id, add=[(src, dest_path)])
+                except Exception as e:
+                    _log_hf_api_error("upload to bucket", bucket_id, e)
+                    raise
             else:
                 bucket_hf_path = f"hf://buckets/{bucket_id}"
                 if p.path_in_repo:
                     bucket_hf_path += f"/{p.path_in_repo}"
                 logger.info("Uploading folder %s to bucket %s", src, bucket_id)
-                api.sync_bucket(source=str(src), dest=bucket_hf_path)
+                try:
+                    api.sync_bucket(source=str(src), dest=bucket_hf_path)
+                except Exception as e:
+                    _log_hf_api_error("upload to bucket", bucket_id, e)
+                    raise
+            logger.debug("Completed HF push of %s to bucket %s", src, bucket_id)
             return
 
         hf_type = p.hf_type
@@ -976,14 +1105,20 @@ class HfURI(URI):
             else "model"
         )
 
-        # Create repository if it doesn't exist
-        api.create_repo(
-            repo_id=repo_id,
-            repo_type=repo_type,
-            private=private,
-            resource_group_id=resource_group_id,
-            exist_ok=True,
-        )
+        # Create repository if it doesn't exist; abort the push on failure so we
+        # never fall through to an upload against a repo that was not created.
+        try:
+            api.create_repo(
+                repo_id=repo_id,
+                repo_type=repo_type,
+                private=private,
+                resource_group_id=resource_group_id,
+                exist_ok=True,
+            )
+        except Exception as e:
+            _log_hf_api_error("create_repo", repo_id, e)
+            raise
+        logger.debug("Ensured HF repo %s (type=%s) exists", repo_id, repo_type)
 
         if src.is_file():
             dest_path = p.path_in_repo or src.name
@@ -995,14 +1130,18 @@ class HfURI(URI):
                 repo_type,
                 p.revision,
             )
-            api.upload_file(
-                path_or_fileobj=src,
-                path_in_repo=dest_path,
-                repo_id=repo_id,
-                repo_type=repo_type,
-                revision=p.revision,
-                commit_message=commit_message,
-            )
+            try:
+                api.upload_file(
+                    path_or_fileobj=src,
+                    path_in_repo=dest_path,
+                    repo_id=repo_id,
+                    repo_type=repo_type,
+                    revision=p.revision,
+                    commit_message=commit_message,
+                )
+            except Exception as e:
+                _log_hf_api_error("upload_file", repo_id, e)
+                raise
         else:
             logger.info(
                 "Uploading folder %s → %s/%s (type=%s, rev=%s)",
@@ -1012,11 +1151,16 @@ class HfURI(URI):
                 repo_type,
                 p.revision,
             )
-            api.upload_folder(
-                folder_path=str(src),
-                path_in_repo=p.path_in_repo,
-                repo_id=repo_id,
-                repo_type=repo_type,
-                revision=p.revision,
-                commit_message=commit_message,
-            )
+            try:
+                api.upload_folder(
+                    folder_path=str(src),
+                    path_in_repo=p.path_in_repo,
+                    repo_id=repo_id,
+                    repo_type=repo_type,
+                    revision=p.revision,
+                    commit_message=commit_message,
+                )
+            except Exception as e:
+                _log_hf_api_error("upload_folder", repo_id, e)
+                raise
+        logger.debug("Completed HF push of %s to %s", src, repo_id)

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -22,8 +22,24 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
-from gbcommon.types.testing import ENV_VAR_GBTEST_MOCKED_HF_OPS
-from gbcommon.uri.hf import DEFAULT_REVISION, HF_HOST, HfType, HfURI
+from gbcommon.types.testing import (
+    ENV_VAR_GBTEST_MOCKED_HF_OPS,
+    HF_OP_PUSH,
+    disable_hf_mocks,
+    enable_hf_mocks,
+)
+from gbcommon.uri.hf import (
+    DEFAULT_REVISION,
+    HF_ERR_AUTH,
+    HF_ERR_NOT_FOUND,
+    HF_ERR_OTHER,
+    HF_ERR_RATE_LIMIT,
+    HF_ERR_SERVER,
+    HF_HOST,
+    HfType,
+    HfURI,
+    _log_hf_api_error,
+)
 from gbcommon.uri.uri import URI
 from gbserver.types.artifact import ArtifactType
 
@@ -1004,3 +1020,220 @@ class TestResolveResourceGroupIdWithEnvironment:
                             token="fake-token",
                             space_name="public",
                         )
+
+
+# ---------------------------------------------------------------------------
+# HF API error classification + differentiated logging (mocked, no network)
+#
+# These guard the hardening that makes transient/rate-limit conditions visible
+# in logs instead of being flattened into one generic failure line — the root
+# cause of nightly flakiness where a silent 403/429 looked identical to a
+# genuinely-missing artifact.
+# ---------------------------------------------------------------------------
+
+
+def _http_error(status: int, retry_after: Optional[str] = None) -> Exception:
+    """Build a fake HfHubHTTPError carrying the given HTTP status.
+
+    Mirrors the real exception shape (``.response.status_code``,
+    ``.response.headers``, ``.request_id``) that ``_classify_hf_error`` /
+    ``_log_hf_api_error`` inspect, without performing any network call.
+    """
+    from huggingface_hub.errors import HfHubHTTPError
+    from requests import Response
+
+    resp = Response()
+    resp.status_code = status
+    resp.headers["x-request-id"] = "req-test-123"
+    if retry_after is not None:
+        resp.headers["Retry-After"] = retry_after
+    return HfHubHTTPError("boom", response=resp)
+
+
+class TestLogHfApiError:
+    """_log_hf_api_error classifies failures and logs at a matched severity."""
+
+    @pytest.mark.parametrize(
+        "exc, expected_category, expected_level",
+        [
+            (_http_error(429), HF_ERR_RATE_LIMIT, "WARNING"),
+            (_http_error(503), HF_ERR_SERVER, "WARNING"),
+            (_http_error(500), HF_ERR_SERVER, "WARNING"),
+            (_http_error(403), HF_ERR_AUTH, "ERROR"),
+            (_http_error(401), HF_ERR_AUTH, "ERROR"),
+            (_http_error(404), HF_ERR_NOT_FOUND, "ERROR"),
+            (RuntimeError("network blip"), HF_ERR_OTHER, "ERROR"),
+        ],
+    )
+    def test_classification_and_level(
+        self, exc, expected_category, expected_level, caplog
+    ):
+        with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+            category = _log_hf_api_error("push", "org/repo", exc)
+        assert category == expected_category
+        assert any(r.levelname == expected_level for r in caplog.records)
+
+    def test_rate_limit_log_is_prominent(self, caplog):
+        with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+            _log_hf_api_error("push", "org/repo", _http_error(429, retry_after="30"))
+        assert "RATE LIMIT" in caplog.text
+        assert "429" in caplog.text
+        assert "Retry-After=30" in caplog.text
+        assert "req-test-123" in caplog.text  # request id surfaced
+
+    def test_404_benign_logs_at_debug(self, caplog):
+        """When the caller treats absence as expected (exists() probe), a 404 is
+        a DEBUG line rather than an ERROR."""
+        with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+            category = _log_hf_api_error(
+                "exists", "org/repo", _http_error(404), not_found_is_benign=True
+            )
+        assert category == HF_ERR_NOT_FOUND
+        assert not any(r.levelname == "ERROR" for r in caplog.records)
+        assert any(r.levelname == "DEBUG" for r in caplog.records)
+
+
+class TestHfURIPushErrorVisibility:
+    """push() surfaces a classified error and re-raises (no silent failure)."""
+
+    def test_rate_limit_on_upload_is_logged_and_raised(self, tmp_path, caplog):
+        src = tmp_path / "f.bin"
+        src.write_bytes(b"data")
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            MockApi.return_value.upload_file.side_effect = _http_error(429)
+            with caplog.at_level("WARNING", logger="gbcommon.uri.hf"):
+                with pytest.raises(Exception):
+                    uri.push(src)
+
+        assert "RATE LIMIT" in caplog.text
+        assert "429" in caplog.text
+
+    def test_create_repo_failure_stops_before_upload(self, tmp_path, caplog):
+        """A failed repo creation aborts the push and never attempts the upload."""
+        src = tmp_path / "f.bin"
+        src.write_bytes(b"data")
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            MockApi.return_value.create_repo.side_effect = _http_error(403)
+            with caplog.at_level("ERROR", logger="gbcommon.uri.hf"):
+                with pytest.raises(Exception):
+                    uri.push(src)
+
+        MockApi.return_value.upload_file.assert_not_called()
+        assert "auth error" in caplog.text
+        assert "403" in caplog.text
+
+    def test_mocked_push_short_circuits(self, tmp_path):
+        """With the op mocked, push() returns without touching HfApi."""
+        src = tmp_path / "f.bin"
+        src.write_bytes(b"data")
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.DATASET)
+
+        enable_hf_mocks(HF_OP_PUSH)
+        try:
+            with patch("gbcommon.uri.hf.HfApi") as MockApi:
+                uri.push(src)
+            MockApi.assert_not_called()
+        finally:
+            disable_hf_mocks()
+
+
+class TestHfURIDeleteErrorVisibility:
+    """delete() returns False but logs the failure category (403 vs 429)."""
+
+    def test_auth_error_logged_and_returns_false(self, monkeypatch, caplog):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        uri = HfURI.from_parts(owner="ibm-research", repo="ds", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            MockApi.return_value.delete_repo.side_effect = _http_error(403)
+            with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+                result = uri.delete()
+
+        assert result is False
+        assert "auth error" in caplog.text
+        assert "403" in caplog.text
+
+    def test_rate_limit_logged_and_returns_false(self, monkeypatch, caplog):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        uri = HfURI.from_parts(owner="ibm-research", repo="ds", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            MockApi.return_value.delete_repo.side_effect = _http_error(429)
+            with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+                result = uri.delete()
+
+        assert result is False
+        assert "RATE LIMIT" in caplog.text
+
+
+class TestHfURIExistsErrorVisibility:
+    """exists() distinguishes a transient failure from a genuinely-absent repo."""
+
+    def test_rate_limit_logs_warning_and_returns_false(self, monkeypatch, caplog):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        uri = HfURI.from_parts(owner="ibm-research", repo="ds", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.repo_exists", side_effect=_http_error(429)):
+            with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+                result = uri.exists()
+
+        assert result is False
+        assert "RATE LIMIT" in caplog.text
+        assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_not_found_logs_debug_not_error(self, monkeypatch, caplog):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        uri = HfURI.from_parts(owner="ibm-research", repo="ds", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.repo_exists", side_effect=_http_error(404)):
+            with caplog.at_level("DEBUG", logger="gbcommon.uri.hf"):
+                result = uri.exists()
+
+        assert result is False
+        assert not any(r.levelname == "ERROR" for r in caplog.records)
+
+    def test_true_when_repo_exists(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        uri = HfURI.from_parts(owner="ibm-research", repo="ds", hf_type=HfType.DATASET)
+
+        with patch("gbcommon.uri.hf.repo_exists", return_value=True):
+            assert uri.exists() is True
+
+
+class TestResolveResourceGroupIdErrorVisibility:
+    """A rate-limit on the resource-group lookup is visible, not hidden."""
+
+    def test_rate_limit_on_lookup_is_logged(self, monkeypatch, caplog):
+        # A 429 on the resource-group list call means the inner lookup cannot
+        # resolve an id: it logs RATE LIMIT and returns None, and the caller then
+        # raises (it cannot proceed without a resolved group). The point of the
+        # hardening is that the 429 is now visible in the log rather than hidden
+        # behind a generic "could not list" warning.
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STAGING")
+        uri = HfURI.from_parts(owner="ibm-research", repo="dummy")
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = MagicMock()
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch(
+                "huggingface_hub.utils._http.get_session", return_value=mock_session
+            ):
+                with patch(
+                    "huggingface_hub.utils._http.hf_raise_for_status",
+                    side_effect=_http_error(429),
+                ):
+                    with caplog.at_level("WARNING", logger="gbcommon.uri.hf"):
+                        with pytest.raises(ValueError, match="Could not resolve"):
+                            uri.resolve_resource_group_id(
+                                token="fake-token",
+                                space_name="public",
+                            )
+
+        assert "RATE LIMIT" in caplog.text
+        assert "list_resource_groups" in caplog.text


### PR DESCRIPTION
## What

Hardens the HuggingFace URI helper (`src/gbcommon/uri/hf.py`) so that failures from the HF Hub API are logged with a severity matched to their cause, instead of being flattened into a single indistinguishable `False`.

## Why

The nightly **Extended Tests** workflow has been failing on the single test `test/integration/standalone/buildrunner/docker/test_docker_hf.py::TestDockerImageBuild::test_runner`, which asserts at `test/libgbtest/buildrunner/buildtest.py:1082`:

```
AssertionError: URI hf://huggingface.co/datasets/ibm-research/test-output1_… does not exist in artifact storage
```

Tracing the failing build through the CI log:
- The dataset is pushed into an HF Enterprise resource group (`gbspace-public-staging`), the push reports **SUCCESS**, then `HfURI.exists()` returns **False** at verify time, and the later cleanup `delete()` returns **`403 Forbidden`**.
- The Python **3.11 matrix job passes with the same token**, which makes a hard token/permission regression unlikely and points at a **transient / rate-limit** condition.

The real obstacle is that `hf.py` makes the true cause invisible: `exists()`, `pull()`, and `delete()` all `except Exception: return False/…`, so a 429 (rate limit), 5xx, 403, or 404 all look identical; and `push()` ran `create_repo` then `upload_*` with no result check or success logging. Whatever actually went wrong surfaced only as "artifact doesn't exist."

> **Note:** This PR is **not** a fix for #134. It does not change the test's pass/fail behavior. Its purpose is to add differentiated logging so the next nightly failure shows the *actual* cause (e.g. `RATE LIMIT (HTTP 429)` with `Retry-After` and request id, or an explicit `auth`/`403`) — letting us confirm the root cause before committing to a fix.

On the eventual-consistency question: HuggingFace's documented idiom is `create_repo(..., exist_ok=True)` immediately followed by upload with no wait step, so this PR deliberately does **not** add a consistency-wait between create/upload, and does **not** modify the test's `uri.exists()` verification.

## Changes

`src/gbcommon/uri/hf.py`:
- Add `_classify_hf_error()` + `_log_hf_api_error()`: classify an HF exception by HTTP status and log at matched severity — **429 → WARNING with `RATE LIMIT`** (incl. `Retry-After` + request id), 5xx → WARNING, 401/403 → ERROR, 404 → ERROR (DEBUG when absence is expected), else ERROR.
- `push()`: wrap each `create_repo`/`create_bucket`/`upload_file`/`upload_folder`/bucket call to classify+log then **re-raise**; a failed repo/bucket creation now aborts **before** any upload; debug success lines added.
- `delete()`, `pull()`, `exists()`, and the resource-group REST lookup route their errors through the classifier (return values unchanged). `exists()` logs a benign 404 at DEBUG and a dangerous transient 429/5xx/403 at WARNING/ERROR.

`test/unit/uri/test_hf.py` (fully mocked — no live HF calls):
- Classification/severity for 429/5xx/403/401/404/other; `push()` surfacing a rate-limit and re-raising; `push()` stopping before upload on a `create_repo` 403; `delete()` 403-vs-429 visibility; `exists()` 429-WARNING vs 404-DEBUG; resource-group-lookup 429 visibility; mock short-circuit unchanged.

## Testing

- `pytest test/unit/uri/test_hf.py` → 81 passed, 1 skipped (skip is the network push test without `HF_TOKEN`).
- `isort`/`black` clean; `mypy` introduces no new errors on `hf.py`; `pylint` scores 9.88 (`fail-under=5`).