### PR TITLE
deps: consolidate skypilot LSF + AWS forks into one integration pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ standalone = [
 thirdparty = [
     "docker>=7.0.0",
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
-    "skypilot[kubernetes,slurm] @ git+https://github.com/cmadam/skypilot.git@dddcdd0057070221d6b351a3dd7c9e071e15b86b",  # LSF cloud backend; pinned to commit until upstreamed to skypilot-org/skypilot
+    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@f97d93d45b98ce37b316030415dbb77a4615ebd1",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override; pinned to commit until upstreamed
     "wandb",
 ]
 # Tier 3: IBM-specific — requires IBM infrastructure (cloud, cluster, Artifactory)
@@ -94,7 +94,7 @@ ibm = [
     "kubernetes_asyncio>=35.0.1",	# Avoids missing watch import created in kubernetes==36.0.0
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
     "psycopg2-binary",
-    "skypilot[kubernetes,slurm] @ git+https://github.com/cmadam/skypilot.git@dddcdd0057070221d6b351a3dd7c9e071e15b86b",  # LSF cloud backend; pinned to commit until upstreamed to skypilot-org/skypilot
+    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@f97d93d45b98ce37b316030415dbb77a4615ebd1",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override; pinned to commit until upstreamed
 ]
 # All optional dependencies
 all = [


### PR DESCRIPTION
## Summary

Consolidates the two SkyPilot fork customizations we depend on into a **single** `skypilot` requirement, pinned to a combined integration commit.

Previously the LSF cloud driver and the AWS host-AMI-override enhancement lived on two different forks/branches. They can't be declared as two requirements with different fork URLs — `[kubernetes,slurm]` and `[aws]` are *extras within the same `skypilot` distribution*, and pip/uv install `skypilot` once and reject conflicting direct-URL references for the same project name. The changes must live on one commit in one repo.

## Changes

- Built a `granite-build` integration branch in `cmadam/skypilot` off upstream `master`, merging:
  - `cmadam/skypilot@feature/lsf-cloud` — LSF cloud driver
  - `thinkahead/skypilot@docker-host-ami-override` — AWS host-AMI override in Docker mode
- Both merges were clean (the drivers touch different backends).
- Updated the **two** skypilot pins (`thirdparty` and `ibm` tiers) to a single consolidated requirement:

```toml
"skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@f97d93d45b98ce37b316030415dbb77a4615ebd1",
```

## Notes

- Pinned to a **commit SHA** (not the branch) for reproducibility — plain pip has no lockfile and caches moving branches.
- Follow-up (tracked in #141): upstream both drivers to `skypilot-org/skypilot` to retire the integration branch.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
