### PR TITLE
Fix K8s scaffold prune dropping gbstepbase for the 'kubernetes' env alias

### DIFF
--- a/src/gbserver/build/targetstep.py
+++ b/src/gbserver/build/targetstep.py
@@ -85,13 +85,31 @@ def _convert_enums_to_values(obj: Any) -> Any:
     return obj
 
 
-# Maps a (lowercased) environment type to the gbstep scaffold dir that backend
-# reads at launch. Backends absent from this map (Bash, Docker, RunPod,
-# Skypilot) read none of these dirs. Keys are lowercase because env_type may
-# arrive either capitalized (from environment.type, e.g. "Lsf") or lowercase
-# (from an environment_configs dict key, e.g. "lsf") — see env_type resolution
-# in merge_handle_configs, which likewise falls back to env_type.lower().
-_BACKEND_SCAFFOLD_DIRS = {"lsf": "lsf_scripts", "k8s": "helm-charts"}
+# The gbstep scaffold's backend template dirs that a launch may read.
+_LSF_SCAFFOLD_DIR = "lsf_scripts"
+_K8S_SCAFFOLD_DIR = "helm-charts"
+_BACKEND_SCAFFOLD_DIRS = (_LSF_SCAFFOLD_DIR, _K8S_SCAFFOLD_DIR)
+
+# Maps a known environment type to the single scaffold dir its backend reads at
+# launch (or None when the backend reads neither). env_type may arrive
+# capitalized (from environment.type, e.g. "K8s"/"Lsf"), lowercase (from an
+# environment_configs dict key, e.g. "k8s"/"lsf" — see env_type resolution in
+# merge_handle_configs), or as a backend-equivalent alias (e.g. "kubernetes",
+# which several real cluster environment.yaml files use for the K8s backend) —
+# so keys are lowercase and aliases are enumerated. A type listed with None is a
+# known backend that reads no scaffold dir (Bash/Docker/RunPod/Skypilot): both
+# lsf_scripts and helm-charts are pruned. A type NOT listed at all is unknown
+# and prunes nothing — see _copy_basestep_scaffold.
+_ENV_TYPE_KEEP_DIR = {
+    "lsf": _LSF_SCAFFOLD_DIR,
+    "k8s": _K8S_SCAFFOLD_DIR,
+    "kubernetes": _K8S_SCAFFOLD_DIR,
+    "bash": None,
+    "docker": None,
+    "runpod": None,
+    "skypilot": None,
+    "skypilot_managed": None,
+}
 
 
 def _copy_basestep_scaffold(temp_path: Path, env_type: str) -> None:
@@ -116,12 +134,26 @@ def _copy_basestep_scaffold(temp_path: Path, env_type: str) -> None:
     scaffold contents. To stay safe against those existing per-environment
     behaviors, we do a post-copy deletion of the inactive backend dirs here
     instead — a smaller, reversible change than reworking what gets copied.
+
+    When ``env_type`` isn't a *known* type we prune *nothing*: an unrecognized
+    env must not silently delete every backend's scaffold dir (which previously
+    wiped helm-charts — and its bundled gbstepbase library subchart — for a K8s
+    build whose env declared the "kubernetes" alias, breaking the helm render
+    with `no template "gbstepbase.app"`). Keeping a dir the active backend never
+    reads is harmless; deleting one it needs is not.
     """
     base_step_src = Path(__file__).parent.parent / "builtins/steps/gbstep"
     sync_or_copy(str(base_step_src) + "/", temp_path, delete=False)
 
-    keep_dir = _BACKEND_SCAFFOLD_DIRS.get(env_type.lower())
-    for dir_name in _BACKEND_SCAFFOLD_DIRS.values():
+    key = env_type.lower()
+    if key not in _ENV_TYPE_KEEP_DIR:
+        # Unknown env type — don't risk deleting a dir the active backend may
+        # depend on. Leave the scaffold intact.
+        return
+
+    # Known backend: keep its one dir (or none) and prune the rest.
+    keep_dir = _ENV_TYPE_KEEP_DIR[key]
+    for dir_name in _BACKEND_SCAFFOLD_DIRS:
         if dir_name == keep_dir:
             continue
         stale_dir = temp_path / dir_name

--- a/src/gbserver/builtins/steps/k8s/hfpull/helm-charts/hfpull/templates/_helpers.tpl
+++ b/src/gbserver/builtins/steps/k8s/hfpull/helm-charts/hfpull/templates/_helpers.tpl
@@ -1,8 +1,16 @@
 {{- define "hfpull_command" }}
+{{- /* The pull is driven entirely by uri (HfURI.hfpull_step re-parses owner/
+       repo/revision from it), so this template depends only on uri + path.
+       Guard against an absent/partial hfpull_config (e.g. the mocked-HF /
+       simulate-failure paths) so the render degrades to empty strings instead
+       of nil-pointering. */}}
+{{- $c := .Values.hfpull_config | default dict }}
+{{- $path := $c.path | default "" }}
+{{- $uri := $c.uri | default "" }}
 
-echo "Pulling HF {{ .Values.hfpull_config.owner }}/{{ .Values.hfpull_config.repo }} into {{ .Values.hfpull_config.path }}"
+echo "Pulling HF {{ $uri }} into {{ $path }}"
 
-python3 -c "from gbcommon.uri.hf import HfURI; exit(HfURI.hfpull_step(uri_str='{{ .Values.hfpull_config.uri }}', dest='{{ .Values.hfpull_config.path }}'))"
+python3 -c "from gbcommon.uri.hf import HfURI; exit(HfURI.hfpull_step(uri_str='{{ $uri }}', dest='{{ $path }}'))"
 
 MY_RETURN_CODE=$?
 if [[ "${MY_RETURN_CODE}" != "0" ]] ; then
@@ -10,6 +18,6 @@ if [[ "${MY_RETURN_CODE}" != "0" ]] ; then
     exit 1
 fi
 
-echo 'Pulled HF URI: {{ .Values.hfpull_config.uri }} into cache {{ .Values.hfpull_config.path }}'
+echo 'Pulled HF URI: {{ $uri }} into cache {{ $path }}'
 
 {{- end }}

--- a/src/gbserver/builtins/steps/k8s/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/k8s/hfpull/step.yaml
@@ -11,11 +11,11 @@ config:
   hfpull_config:
     path: <path>
     uri: <uri>
+    owner: ''
+    repo: ''
+    revision: ''
     hf:
-      type: model
-      owner: ''
-      repo: ''
-      revision: ''
+      type: ''
   compute_config:
     total_memory_per_node: 10Gi
 environment_configs:

--- a/src/gbserver/builtins/steps/k8s/hfpush/helm-charts/hfpush/templates/_helpers.tpl
+++ b/src/gbserver/builtins/steps/k8s/hfpush/helm-charts/hfpush/templates/_helpers.tpl
@@ -1,14 +1,29 @@
 {{- define "hfpush_command" }}
+{{- /* The push is driven by uri (HfURI.hfpush_step re-parses owner/repo from
+       it) plus private + resource_group_id, so this template depends only on
+       uri/path/binding_id/private and hf.resource_group_id. Guard against an
+       absent/partial hfpush_config (e.g. the mocked-HF / simulate-failure
+       paths) so the render degrades to safe defaults instead of nil-pointering. */}}
+{{- $c := .Values.hfpush_config | default dict }}
+{{- $hf := $c.hf | default dict }}
+{{- $path := $c.path | default "" }}
+{{- $uri := $c.uri | default "" }}
+{{- $bindingId := $c.binding_id | default "" }}
+{{- /* `default` treats an explicit `false` as empty, so resolve `private` via
+       hasKey to preserve a deliberate `private: false`; default true when absent. */}}
+{{- $private := true }}
+{{- if hasKey $c "private" }}{{- $private = $c.private }}{{- end }}
+{{- $resourceGroupId := $hf.resource_group_id | default "" }}
 
-echo "Pushing HF {{ .Values.hfpush_config.owner }}/{{ .Values.hfpush_config.repo }} from {{ .Values.hfpush_config.path }}"
+echo "Pushing HF {{ $uri }} from {{ $path }}"
 
 python3 - <<'EOF'
 from gbcommon.uri.hf import HfURI
 exit(HfURI.hfpush_step(
-    uri_str="{{ .Values.hfpush_config.uri }}",
-    source_path="{{ .Values.hfpush_config.path }}",
-    private={{ ternary "True" "False" (.Values.hfpush_config.hf.private | default true) }},
-    resource_group_id="{{ .Values.hfpush_config.hf.resource_group_id | default "" }}",
+    uri_str="{{ $uri }}",
+    source_path="{{ $path }}",
+    private={{ ternary "True" "False" $private }},
+    resource_group_id="{{ $resourceGroupId }}",
 ))
 EOF
 
@@ -18,6 +33,6 @@ if [[ "${MY_RETURN_CODE}" != "0" ]] ; then
     exit 1
 fi
 
-echo 'Pushed HF URI: {{ .Values.hfpush_config.uri }} for binding {{ .Values.hfpush_config.binding_id }}'
+echo 'Pushed HF URI: {{ $uri }} for binding {{ $bindingId }}'
 
 {{- end }}

--- a/src/gbserver/builtins/steps/k8s/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/k8s/hfpush/step.yaml
@@ -15,13 +15,12 @@ config:
     path: <path>
     uri: <uri>
     binding_id: <binding_id>
+    owner: ''
+    repo: ''
+    revision: ''
+    private: true
     hf:
-      type: model
-      owner: ''
-      repo: ''
-      revision: ''
-      private: true
-      organization: null
+      type: ''
       resource_group_id: null
   compute_config:
     total_memory_per_node: 10Gi

--- a/src/gbserver/builtins/steps/lsf/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/hfpull/step.yaml
@@ -11,11 +11,11 @@ config:
   hfpull_config:
     path: <path>
     uri: <uri>
+    owner: ''
+    repo: ''
+    revision: ''
     hf:
-      type: model
-      owner: ''
-      repo: ''
-      revision: ''
+      type: ''
   compute_config:
     total_memory_per_node: 10Gi
 environment_configs:

--- a/src/gbserver/builtins/steps/lsf/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/hfpush/step.yaml
@@ -15,13 +15,12 @@ config:
     path: <path>
     uri: <uri>
     binding_id: <binding_id>
+    owner: ''
+    repo: ''
+    revision: ''
+    private: true
     hf:
-      type: model
-      owner: ''
-      repo: ''
-      revision: ''
-      private: true
-      organization: null
+      type: ''
       resource_group_id: null
   compute_config:
     total_memory_per_node: 10Gi

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -11,11 +11,11 @@ config:
   hfpull_config:
     path: <path>
     uri: <uri>
+    owner: ''
+    repo: ''
+    revision: ''
     hf:
-      type: model
-      owner: ''
-      repo: ''
-      revision: ''
+      type: ''
   compute_config:
     total_memory_per_node: 10Gi
 environment_configs:

--- a/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
@@ -15,13 +15,12 @@ config:
     path: <path>
     uri: <uri>
     binding_id: <binding_id>
+    owner: ''
+    repo: ''
+    revision: ''
+    private: true
     hf:
-      type: model
-      owner: ''
-      repo: ''
-      revision: ''
-      private: true
-      organization: null
+      type: ''
       resource_group_id: null
   compute_config:
     total_memory_per_node: 10Gi

--- a/test/unit/build/test_targetstep_scaffold.py
+++ b/test/unit/build/test_targetstep_scaffold.py
@@ -16,9 +16,11 @@
 
 """Tests for _copy_basestep_scaffold: the gbstep base-step scaffold ships every
 backend's launch templates side by side, and only the active environment's dir
-should survive the copy. Crucially, env_type may arrive capitalized ("Lsf") or
-lowercase ("lsf"), so the prune must be case-insensitive — otherwise it deletes
-the dir it was meant to keep."""
+should survive the copy. Crucially, env_type may arrive capitalized ("Lsf"),
+lowercase ("lsf"), or as a backend-equivalent alias ("kubernetes" -> K8s), so
+the prune must normalize all of them — otherwise it deletes the dir it was meant
+to keep (notably helm-charts, which bundles the gbstepbase library subchart). An
+unknown env type must prune nothing rather than delete every backend's dir."""
 
 from pathlib import Path
 
@@ -41,11 +43,14 @@ def _kept_dirs(tmp_path: Path) -> set:
 @pytest.mark.parametrize(
     "env_type, expected_kept",
     [
-        # Bash (and Docker/RunPod/Skypilot, absent from the map) keep only bash.
+        # Known backends that read no scaffold dir keep only bash (both
+        # lsf_scripts and helm-charts pruned — the bash double-render fix).
         ("Bash", {BASH}),
         ("bash", {BASH}),
         ("Docker", {BASH}),
         ("Skypilot", {BASH}),
+        ("Skypilot_managed", {BASH}),
+        ("Runpod", {BASH}),
         # Lsf keeps lsf_scripts; helm-charts is pruned.
         ("Lsf", {BASH, LSF}),
         # K8s keeps helm-charts; lsf_scripts is pruned.
@@ -54,6 +59,13 @@ def _kept_dirs(tmp_path: Path) -> set:
         # keep the right dir — this is the casing bug guard.
         ("lsf", {BASH, LSF}),
         ("k8s", {BASH, HELM}),
+        # "kubernetes" is a real-world alias for the K8s backend; it must keep
+        # helm-charts (the regression that broke gbstepbase resolution).
+        ("kubernetes", {BASH, HELM}),
+        ("Kubernetes", {BASH, HELM}),
+        # An unknown env type prunes nothing — never delete a dir a backend may
+        # need just because we don't recognize the type.
+        ("totally-unknown", ALL_BACKEND_DIRS),
     ],
 )
 def test_copy_basestep_scaffold_prunes_inactive_backends(
@@ -66,3 +78,14 @@ def test_copy_basestep_scaffold_prunes_inactive_backends(
     assert (tmp_path / BASH).is_dir()
     # step_default.yaml (a non-backend scaffold file) is always copied.
     assert (tmp_path / "step_default.yaml").is_file()
+
+
+@pytest.mark.parametrize("env_type", ["K8s", "k8s", "kubernetes", "Kubernetes"])
+def test_copy_basestep_scaffold_keeps_gbstepbase_subchart_for_k8s(tmp_path, env_type):
+    """The K8s backend's helm-charts dir bundles the gbstepbase library subchart
+    that every step's appwrapper.yaml includes via `gbstepbase.app`. If the prune
+    drops helm-charts (e.g. for the "kubernetes" alias), the helm render fails
+    with `no template "gbstepbase.app"`. Lock in that the subchart survives."""
+    _copy_basestep_scaffold(tmp_path, env_type)
+    charts = list(tmp_path.glob(f"{HELM}/*/charts/gbstepbase"))
+    assert charts, f"gbstepbase subchart missing under {HELM} for env_type={env_type!r}"


### PR DESCRIPTION
## Summary

Two related fixes for K8s step rendering, independent of #144.

### Primary: don't prune the `helm-charts` scaffold for the `kubernetes` env alias

The base-step scaffold prune (`_copy_basestep_scaffold`) keeps only the active backend's template dir and deletes the others. It keyed the keep decision on a `{"lsf","k8s"}` map via `env_type.lower()`, so any `env_type` that wasn't exactly `lsf`/`k8s` produced `keep_dir=None` and deleted **both** `lsf_scripts` and `helm-charts`.

Real cluster environments declare `type: kubernetes` (an alias for the K8s backend), which `env_type` resolution picks up from `environment.type`. That made the prune wipe `helm-charts` — including the `gbstepbase` **library subchart** bundled under it that every step's `appwrapper.yaml` includes via `gbstepbase.app`. The `hfpull`/`hfpush` helm dry-run then failed with:

```
no template "gbstepbase.app" associated with template "gotpl"
```

Fix (`src/gbserver/build/targetstep.py`):
- Replace the partial map with `_ENV_TYPE_KEEP_DIR` enumerating all known env types (including the `kubernetes` alias → `helm-charts`) to their single scaffold dir, or `None` for backends that read none (Bash/Docker/RunPod/Skypilot, which still prune both — the original bash double-render fix).
- An **unknown** env type now prunes **nothing** rather than deleting every backend's dir: keeping a dir the active backend ignores is harmless; deleting one it needs is not.
- Extend `test_targetstep_scaffold.py` with the `kubernetes`/`Kubernetes` aliases, the unknown-type no-op case, and an assertion that the `gbstepbase` subchart survives under `helm-charts` for all K8s aliases.

### Hardening: hfpull/hfpush steps tolerate missing config attributes

A related (and previously-masking) failure: the `hfpull`/`hfpush` helm dry-run nil-pointered on `<.Values.hfpull_config.owner>` when the runtime config overlay from `build_hf{pull,push}_step_config()` was absent (the `GBTEST_SIMULATE_FAILURE_SCENARIO` / mocked-HF paths). Root cause was schema divergence: all consumers (k8s helm `_helpers.tpl`, LSF/skypilot command templates, and the Python builder) read `owner`/`repo`/`revision` top-level, but the `step.yaml` schemas nested them under `hf:`.

- Reconcile all 6 `hf{pull,push}/step.yaml` (k8s/lsf/skypilot) to the canonical shape: `owner`/`repo`/`revision` (and `private`, for push) top-level; `hf.{type,resource_group_id}` nested. Drop the unused `organization` field; make the `hf.type` placeholder `''` (it is uri-derived).
- `owner`/`repo`/`revision`/`type` are not independent inputs — they are derived from the `uri` by the single config builder for all environments. The k8s step delegates to `HfURI.hf{pull,push}_step(uri_str, ...)`, which re-parses the uri, so the k8s templates now depend only on `uri`/`path` (+ `binding_id`/`private`/`hf.resource_group_id` for push) and guard the config object (`| default dict`) so an absent/partial config renders safely instead of nil-pointering.

## Test plan

- `pytest test/unit/build/test_targetstep_scaffold.py` — covers Bash/Lsf/K8s, the `lsf`/`k8s` lowercase casing, the `kubernetes`/`Kubernetes` aliases, the unknown-type no-op, and gbstepbase-subchart survival.
- `helm template` across canonical and null/empty config shapes for the hfpull/hfpush charts — render succeeds without nil-pointer.
- End-to-end: scaffold + path-fill + hfpull overlay yields `helm-charts/hfpull/charts/gbstepbase` for `env_type` in {`kubernetes`,`K8s`,`Kubernetes`}.
- `pytest test/unit` (mock mode) green; `black`/`isort` clean.