### PR TITLE
Update .claude PR-workflow commands for ibm-granite/granite.build

### DIFF
--- a/.claude/commands/pr-post-merge.md
+++ b/.claude/commands/pr-post-merge.md
@@ -5,7 +5,7 @@ argument-hint: "Fork issue number (e.g., 1)"
 
 # Post-merge cleanup
 
-You are helping a developer clean up after a PR has been merged into `upstream/g4os`. Follow these steps in order.
+You are helping a developer clean up after a PR has been merged into `upstream/main`. Follow these steps in order.
 
 Fork issue number: $ARGUMENTS
 
@@ -23,7 +23,7 @@ Fork issue number: $ARGUMENTS
    IS_WORKTREE=false
    if [ "$WORKTREE_DIR" != "$MAIN_REPO" ]; then IS_WORKTREE=true; fi
    ```
-3. Confirm the current branch is an issue branch (not `g4os`, `main`, or `dev`)
+3. Confirm the current branch is an issue branch (not `main`)
 4. Save the current branch name for later deletion
 5. If no issue number was provided ($ARGUMENTS), try to auto-detect from the branch name:
    ```
@@ -59,8 +59,8 @@ The worktree must be removed before the branch can be deleted. All remaining ste
    If removal fails (dirty worktree), ask the user whether to force-remove (`git worktree remove --force $WORKTREE_DIR`) or abort.
 3. Update the integration branch:
    ```
-   git checkout g4os
-   git pull upstream g4os
+   git checkout main
+   git pull upstream main
    ```
 4. Delete the local issue branch:
    ```
@@ -71,14 +71,14 @@ The worktree must be removed before the branch can be deleted. All remaining ste
    git push origin --delete <saved-branch-name>
    ```
 6. Report completion to the user:
-   > Cleaned up worktree `$WORKTREE_DIR`, deleted branch `<saved-branch-name>` locally and on origin, updated `g4os`.
+   > Cleaned up worktree `$WORKTREE_DIR`, deleted branch `<saved-branch-name>` locally and on origin, updated `main`.
 
 ### If NOT running in a worktree:
 
 1. Switch to the integration branch and pull the latest:
    ```
-   git checkout g4os
-   git pull upstream g4os
+   git checkout main
+   git pull upstream main
    ```
 2. Delete the local issue branch:
    ```

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,11 +1,11 @@
 ---
-description: Format, lint, review, and create or update a PR targeting g4os
+description: Format, lint, review, and create or update a PR targeting main
 argument-hint: "Optional fork issue number (e.g., 42)"
 ---
 
-# PR for g4os
+# PR for granite.build
 
-You are helping a developer create or update a pull request in the upstream repo (`granite-dot-build/gbserver`) targeting the `g4os` branch. Follow these steps in order, stopping if any step fails.
+You are helping a developer create or update a pull request in the upstream repo (`ibm-granite/granite.build`) targeting the `main` branch. Follow these steps in order, stopping if any step fails.
 
 Fork issue number (if provided): $ARGUMENTS
 
@@ -31,22 +31,22 @@ Fork issue number (if provided): $ARGUMENTS
 
 ## Step 1: Pre-flight checks
 
-1. Confirm we are NOT on `g4os`, `main`, or `dev` branches — we should be on an issue branch
+1. Confirm we are NOT on the `main` branch — we should be on an issue branch
 2. Run `git status` to check for uncommitted changes
 3. If there are unstaged/uncommitted changes, ask the user whether to stage and commit them before proceeding
 4. Check if a PR already exists for this branch:
    ```
-   gh pr list --repo granite-dot-build/gbserver --head "$FORK_OWNER":<current-branch-name> --state open --json number,url
+   gh pr list --repo ibm-granite/granite.build --head "$FORK_OWNER":<current-branch-name> --state open --json number,url
    ```
    Save the result — this determines whether we create or update.
 
 ## Step 2: Format and lint (PR files only)
 
-Only check files that will be in the PR — those changed between `upstream/g4os` and `HEAD`.
+Only check files that will be in the PR — those changed between `upstream/main` and `HEAD`.
 
 1. Get the list of Python files changed in this PR:
    ```
-   git diff upstream/g4os...HEAD --name-only -- '*.py'
+   git diff upstream/main...HEAD --name-only -- '*.py'
    ```
 2. If there are Python files, run `isort --profile black` and `black` on each file
 3. If there are Python files, run `pylint` and `mypy --disable-error-code=import-untyped` directly on each changed file
@@ -63,9 +63,9 @@ Only check files that will be in the PR — those changed between `upstream/g4os
 ## Step 4: Code review
 
 1. Use the `superpowers:requesting-code-review` skill to review the changes that will be in the PR
-2. Review the diff between the current branch and `upstream/g4os`:
+2. Review the diff between the current branch and `upstream/main`:
    ```
-   git diff upstream/g4os...HEAD
+   git diff upstream/main...HEAD
    ```
 3. Present the review findings to the user
 4. Ask the user if they want to address any findings before proceeding, or continue
@@ -78,14 +78,14 @@ Only check files that will be in the PR — those changed between `upstream/g4os
    ```
    git fetch upstream
    ```
-2. Create the PR in the upstream repo targeting `g4os`:
+2. Create the PR in the upstream repo targeting `main`:
    ```
-   gh pr create --repo granite-dot-build/gbserver --base g4os --head "$FORK_OWNER":<current-branch-name>
+   gh pr create --repo ibm-granite/granite.build --base main --head "$FORK_OWNER":<current-branch-name>
    ```
 3. The PR title should be concise (under 70 characters)
 4. The PR body should include:
    - A summary section with bullet points describing the changes
-   - If a fork issue number was provided ($ARGUMENTS), include: `Closes $FORK_OWNER/gbserver#<N>`
+   - If a fork issue number was provided ($ARGUMENTS), include: `Closes ibm-granite/granite.build#<N>`
    - A test plan section
    - The standard footer: `Generated with [Claude Code](https://claude.com/claude-code)`
 5. Return the PR URL to the user
@@ -96,7 +96,7 @@ Only check files that will be in the PR — those changed between `upstream/g4os
 2. Report to the user: "Updated existing PR <url> with new commits"
 3. If the user wants to update the PR title or description, use:
    ```
-   gh pr edit <number> --repo granite-dot-build/gbserver --title "..." --body "..."
+   gh pr edit <number> --repo ibm-granite/granite.build --title "..." --body "..."
    ```
 
 ## Step 6: Post-PR guidance
@@ -106,6 +106,6 @@ If running inside a worktree, remind the user:
 > **Next steps after the PR is merged:**
 > Use `/pr-post-merge` to clean up — it will close the fork issue, update the local branch, and delete the issue branch. Then remove the worktree:
 > ```
-> cd /home/cma/de/cma/gbserver
+> cd <main-working-tree>
 > git worktree remove <worktree-path>
 > ```

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -16,7 +16,7 @@ These values can be overridden by the user but apply by default:
 ```
 ARCH_DOC_1=docs/plans/2026-02-23-architecture.md
 ARCH_DOC_2=docs/plans/2026-02-18-standalone-deployment-design.md
-WORKTREE_BASE=/home/cma/de/cma/gbserver-worktrees
+WORKTREE_BASE=../granite.build-worktrees
 ```
 
 Derive the fork owner and repo:
@@ -32,11 +32,11 @@ FORK_REPO=$(git remote get-url origin | sed -E 's|.*[:/][^/]+/(.*)$|\1|' | sed '
    Usage: /start-issue <issue-number>
    Example: /start-issue 42
    ```
-2. Confirm we are on the `g4os` branch:
+2. Confirm we are on the `main` branch:
    ```
    git branch --show-current
    ```
-   If not on `g4os`, warn the user and ask whether to switch (`git checkout g4os`) or abort.
+   If not on `main`, warn the user and ask whether to switch (`git checkout main`) or abort.
 3. Check for uncommitted changes:
    ```
    git status --porcelain
@@ -78,9 +78,9 @@ FORK_REPO=$(git remote get-url origin | sed -E 's|.*[:/][^/]+/(.*)$|\1|' | sed '
    mkdir -p $WORKTREE_BASE
    ```
 
-5. Create the worktree with a new branch based on `upstream/g4os`:
+5. Create the worktree with a new branch based on `upstream/main`:
    ```
-   git worktree add -b <branch-name> $WORKTREE_BASE/<branch-name> upstream/g4os
+   git worktree add -b <branch-name> $WORKTREE_BASE/<branch-name> upstream/main
    ```
    If the worktree directory already exists, ask the user: reuse it, or remove and recreate it.
 


### PR DESCRIPTION
## Summary
- Migrate the `.claude/commands/` PR-workflow files from the old `g4os` naming to current upstream conventions
- Integration/base branch: `g4os` → `main`
- Upstream repo references: `granite-dot-build/gbserver` → `ibm-granite/granite.build`
- Worktree paths: hardcoded `/home/cma/...` → portable relative paths (`../granite.build-worktrees`, `<main-working-tree>`)
- Drop stale `dev` branch guard checks, since upstream only uses `main`

Affects `pr.md`, `pr-post-merge.md`, and `start-issue.md`. These are documentation/prompt files for the Claude Code slash commands — no runtime code changes.

## Test plan
- [x] Verified no `g4os` references remain in `.claude/commands/`
- [x] Verified the only remaining `dev` token is the unrelated `/dev/null` redirect in `start-issue.md`
- [ ] Confirm the `/pr`, `/pr-post-merge`, and `/start-issue` commands read consistently against `main`

Generated with [Claude Code](https://claude.com/claude-code)