### PR TITLE
fix: address a few nightly HF + space-secrets log errors

### DIFF
--- a/src/gbserver/asset/hfstore.py
+++ b/src/gbserver/asset/hfstore.py
@@ -109,9 +109,11 @@ class Hfstore(Assetstore):
 
         Both the LSF command.sh and Helm _helpers.tpl templates reference flat keys
         (owner, repo, revision, private, binding_id) plus nested ``hf.type`` and
-        ``hf.resource_group_id``.  Caller is responsible for resolving any
-        ``space_name`` / ``resource_group_name`` to the id passed here — see
-        :meth:`HfURI.resolve_resource_group_id`.
+        ``hf.resource_group_id``.  The skypilot template additionally consumes
+        ``path_in_repo`` (the LSF/Helm templates ignore it; k8s re-parses it from
+        the URI inside :meth:`HfURI.hfpush_step`).  Caller is responsible for
+        resolving any ``space_name`` / ``resource_group_name`` to the id passed
+        here — see :meth:`HfURI.resolve_resource_group_id`.
 
         Args:
             hfuri: Parsed HuggingFace URI.
@@ -133,6 +135,11 @@ class Hfstore(Assetstore):
             "owner": hfuri.get_owner(),
             "repo": hfuri.get_repo(),
             "revision": hfuri.get_revision(),
+            # Sub-path within the repo ("" when none). Pre-resolved here — like
+            # resource_group_id — so the skypilot worker's inline push needs no
+            # URI parser to recover it. The k8s/lsf templates ignore this key
+            # (k8s re-parses it from the URI inside HfURI.hfpush_step).
+            "path_in_repo": hfuri.get_path_in_repo(),
             "private": hf_private,
             "binding_id": binding_id,
             "hf": {

--- a/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
@@ -18,6 +18,7 @@ config:
     owner: ''
     repo: ''
     revision: ''
+    path_in_repo: ''
     private: true
     hf:
       type: ''
@@ -36,7 +37,7 @@ environment_configs:
           resources:
             cpus: 1+
           setup: |
-            pip install --no-cache-dir 'huggingface_hub[cli]'
+            pip install --no-cache-dir huggingface_hub
           run: |
             set -euo pipefail
             trap 'EC=$?; echo "hfpush failed at line $LINENO, exit code: $EC" >&2; exit $EC' ERR
@@ -48,14 +49,18 @@ environment_configs:
             HF_OWNER='{{ config.hfpush_config.owner }}'
             HF_REPO_NAME='{{ config.hfpush_config.repo }}'
             export HF_REPO="${HF_OWNER}/${HF_REPO_NAME}"
-            HF_REVISION='{{ config.hfpush_config.revision }}'
+            export HF_REVISION='{{ config.hfpush_config.revision }}'
+            export HF_PATH_IN_REPO='{{ config.hfpush_config.path_in_repo }}'
             export HF_PRIVATE='{{ config.hfpush_config.private }}'
             export HF_TYPE='{{ config.hfpush_config.hf.type }}'
             export HF_RESOURCE_GROUP_ID='{{ config.hfpush_config.hf.resource_group_id }}'
+            export HF_SOURCE
             BINDING_ID='{{ config.hfpush_config.binding_id }}'
 
             # Mocked iff the op (or "all") is listed in GBTEST_MOCKED_HF_OPS;
             # tolerant of spaces/case to match gbcommon.types.testing.hf_mocked_ops.
+            # GBTEST_MOCKED_HF_OPS arrives as a worker env var (sky.Task envs),
+            # not via hfpush_config — it is test-harness state, not a push param.
             hf_mocked() {
                 local ops=",${GBTEST_MOCKED_HF_OPS:-},"
                 ops=${ops// /}
@@ -74,43 +79,206 @@ environment_configs:
                 exit 1
             fi
 
-            # Create the HF repo (idempotent) via the huggingface_hub Python
-            # API. `hf upload` cannot attach a resource_group_id, so we
-            # explicitly call create_repo with exist_ok=True. Single-quoted
-            # heredoc disables bash expansion — python reads everything from
-            # os.environ.
-            echo "Creating HF repo ${HF_REPO} (resource_group_id=${HF_RESOURCE_GROUP_ID:-<none>})"
-            python - <<'PY'
-            import os
-            from huggingface_hub import HfApi
-            rg = os.environ.get("HF_RESOURCE_GROUP_ID") or ""
-            HfApi(token=os.environ["HF_TOKEN"]).create_repo(
-                repo_id=os.environ["HF_REPO"],
-                repo_type=os.environ["HF_TYPE"] or "model",
-                private=os.environ.get("HF_PRIVATE", "True") == "True",
-                resource_group_id=(rg if rg and rg != "None" else None),
-                exist_ok=True,
-            )
-            PY
-
+            # Inline reimplementation of HfURI.push() (src/gbcommon/uri/hf.py).
+            # gbserver/gbcommon is NOT installed on the skypilot worker (setup only
+            # pip-installs huggingface_hub), so we cannot import hf.py and must
+            # mirror it here. Keep this in sync with, and diffable against:
+            #   - HfURI.push()              (repo + bucket branches, upload calls)
+            #   - HfURI._validate_non_empty_src()
+            #   - _classify_hf_error() / _log_hf_api_error()  (status severity)
+            #   - HfURI.hfpush_step()       (SIGALRM timeout wrapper)
+            # The URI is already parsed server-side by build_hfpush_step_config
+            # (asset/hfstore.py), which passes owner/repo/revision/path_in_repo/
+            # hf.type/resource_group_id down via hfpush_config — so no URI parser
+            # is needed here. Single-quoted heredoc: no bash/jinja expansion; all
+            # values are read from the exported HF_* env vars above.
             echo "Pushing HF URI: ${HF_URI} from path ${HF_SOURCE}"
+            python - <<'PY'
+            import logging
+            import os
+            import signal
+            import sys
+            from pathlib import Path
 
-            REVISION_FLAG=""
-            if [ -n "${HF_REVISION}" ]; then
-                REVISION_FLAG="--revision ${HF_REVISION}"
-            fi
+            from huggingface_hub import HfApi
 
-            PRIVATE_FLAG=""
-            if [ "${HF_PRIVATE}" = "True" ]; then
-                PRIVATE_FLAG="--private"
-            fi
+            logging.basicConfig(
+                level=logging.INFO, format="[%(levelname)s] hfpush: %(message)s"
+            )
+            logger = logging.getLogger("hfpush")
 
-            REPO_TYPE_FLAG=""
-            if [ -n "${HF_TYPE}" ]; then
-                REPO_TYPE_FLAG="--repo-type ${HF_TYPE}"
-            fi
+            COMMIT_MSG = "Upload via gbserver"
+            TIMEOUT_S = 3600
+            # Mirror of hf.py _HF_TYPE_TO_REPO_TYPE; BUCKET intentionally absent
+            # (no huggingface_hub repo_type) -> callers default to "model".
+            _TYPE_TO_REPO_TYPE = {"model": "model", "dataset": "dataset", "space": "space"}
 
-            hf upload "${HF_REPO}" "${HF_SOURCE}" ${REVISION_FLAG} ${PRIVATE_FLAG} ${REPO_TYPE_FLAG}
+
+            def _env(name):
+                return os.environ.get(name, "")
+
+
+            src = Path(_env("HF_SOURCE"))
+            repo_id = _env("HF_REPO")
+            endpoint = _env("HF_ENDPOINT") or None
+            token = os.environ["HF_TOKEN"]
+            hf_type = _env("HF_TYPE").strip().lower()
+            # Mirror push(): p.revision always defaults to "main", never None.
+            revision = _env("HF_REVISION") or "main"
+            path_in_repo = _env("HF_PATH_IN_REPO")
+            private = _env("HF_PRIVATE") == "True"
+            rg = _env("HF_RESOURCE_GROUP_ID")
+            resource_group_id = rg if rg and rg != "None" else None
+
+
+            def validate_non_empty_src(p):
+                # Mirror of HfURI._validate_non_empty_src + the src.exists() check
+                # in push(): HF silently skips empty commits, so a push of empty
+                # content "succeeds" while creating nothing. Fail fast instead.
+                if not p.exists():
+                    raise ValueError(f"{p} does not exist")
+                if p.is_file():
+                    if p.stat().st_size == 0:
+                        raise ValueError(f"refusing to push zero-length file: {p}")
+                    return
+                if not any(f.is_file() and f.stat().st_size > 0 for f in p.rglob("*")):
+                    raise ValueError(
+                        f"refusing to push directory with no non-empty files: {p}"
+                    )
+
+
+            def log_hf_api_error(op, target, exc):
+                # Mirror of _classify_hf_error + _log_hf_api_error: pick a log
+                # severity matched to the HTTP status so transient (429/5xx) vs
+                # auth (401/403) vs not-found (404) stand out instead of one
+                # generic error line.
+                status = None
+                response = getattr(exc, "response", None)
+                if response is not None:
+                    status = getattr(response, "status_code", None)
+                if status is None:
+                    status = getattr(exc, "status_code", None)
+                request_id = getattr(exc, "request_id", None)
+                server_message = getattr(exc, "server_message", None)
+                detail = f"status={status}" if status is not None else "no HTTP status"
+                if request_id:
+                    detail += f", request_id={request_id}"
+                if server_message:
+                    detail += f", server_message={server_message!r}"
+                if status == 429:
+                    retry_after = None
+                    if response is not None:
+                        retry_after = getattr(response, "headers", {}).get("Retry-After")
+                    if retry_after:
+                        detail += f", Retry-After={retry_after}"
+                    logger.warning("HF %s RATE LIMIT (HTTP 429) for %s: %s: %s",
+                                   op, target, detail, exc)
+                elif status is not None and 500 <= status < 600:
+                    logger.warning("HF %s server error for %s: %s: %s",
+                                   op, target, detail, exc)
+                elif status in (401, 403):
+                    logger.error("HF %s auth error for %s: %s: %s",
+                                 op, target, detail, exc)
+                elif status == 404:
+                    logger.error("HF %s not found for %s: %s: %s",
+                                 op, target, detail, exc)
+                else:
+                    logger.error("HF %s failed for %s: %s: %s",
+                                 op, target, detail, exc)
+
+
+            def call(op, target, fn):
+                # Per-API-call seam mirroring push(): log with severity, re-raise.
+                try:
+                    return fn()
+                except Exception as exc:
+                    log_hf_api_error(op, target, exc)
+                    raise
+
+
+            def do_push():
+                api = HfApi(endpoint=endpoint, token=token)
+                validate_non_empty_src(src)
+                # Surface the resolved resource group before any API call: a repo
+                # created in an Enterprise resource group is governed by that RG's
+                # access policy, so this value is the first thing to check when
+                # diagnosing create/upload 403s.
+                logger.info(
+                    "HF push %s (type=%s, resource_group_id=%s, private=%s)",
+                    repo_id, hf_type or "model", resource_group_id or "<none>", private,
+                )
+
+                if hf_type == "bucket":
+                    bucket_id = repo_id
+                    call("create_bucket", bucket_id, lambda: api.create_bucket(
+                        bucket_id=bucket_id,
+                        private=private,
+                        resource_group_id=resource_group_id,
+                        exist_ok=True,
+                    ))
+                    if src.is_file():
+                        dest_path = path_in_repo or src.name
+                        logger.info("Uploading file %s to bucket %s/%s",
+                                    src, bucket_id, dest_path)
+                        call("upload to bucket", bucket_id,
+                             lambda: api.batch_bucket_files(
+                                 bucket_id=bucket_id, add=[(src, dest_path)]))
+                    else:
+                        bucket_hf_path = f"hf://buckets/{bucket_id}"
+                        if path_in_repo:
+                            bucket_hf_path += f"/{path_in_repo}"
+                        logger.info("Uploading folder %s to bucket %s", src, bucket_id)
+                        call("upload to bucket", bucket_id,
+                             lambda: api.sync_bucket(
+                                 source=str(src), dest=bucket_hf_path))
+                    return
+
+                repo_type = _TYPE_TO_REPO_TYPE.get(hf_type, "model")
+                call("create_repo", repo_id, lambda: api.create_repo(
+                    repo_id=repo_id,
+                    repo_type=repo_type,
+                    private=private,
+                    resource_group_id=resource_group_id,
+                    exist_ok=True,
+                ))
+                if src.is_file():
+                    dest_path = path_in_repo or src.name
+                    logger.info("Uploading file %s -> %s/%s (type=%s, rev=%s)",
+                                src, repo_id, dest_path, repo_type, revision)
+                    call("upload_file", repo_id, lambda: api.upload_file(
+                        path_or_fileobj=src,
+                        path_in_repo=dest_path,
+                        repo_id=repo_id,
+                        repo_type=repo_type,
+                        revision=revision,
+                        commit_message=COMMIT_MSG,
+                    ))
+                else:
+                    logger.info("Uploading folder %s -> %s/%s (type=%s, rev=%s)",
+                                src, repo_id, path_in_repo, repo_type, revision)
+                    call("upload_folder", repo_id, lambda: api.upload_folder(
+                        folder_path=str(src),
+                        path_in_repo=path_in_repo,
+                        repo_id=repo_id,
+                        repo_type=repo_type,
+                        revision=revision,
+                        commit_message=COMMIT_MSG,
+                    ))
+
+
+            def _timeout_handler(signum, frame):
+                raise TimeoutError(f"HF push timed out after {TIMEOUT_S} seconds")
+
+
+            signal.signal(signal.SIGALRM, _timeout_handler)
+            signal.alarm(TIMEOUT_S)
+            try:
+                do_push()
+                signal.alarm(0)
+            except Exception as e:
+                print(f"HF push failed: {e}", flush=True)
+                sys.exit(1)
+            PY
 
             echo "Pushed HF URI: ${HF_URI} for binding ${BINDING_ID}"
             echo 'hfpush end'

--- a/src/gbserver/spacesecretmanager/localspacesecretmanager.py
+++ b/src/gbserver/spacesecretmanager/localspacesecretmanager.py
@@ -97,7 +97,10 @@ class LocalSpaceSecretManager(SpaceSecretManager):
         secrets = {}
         dir_path = Path(secrets_dir)
         if not dir_path.exists():
-            logger.error("Path does not exist: %s", dir_path)
+            # A missing secrets dir is the normal "no secrets configured yet" state
+            # (e.g. a fresh standalone checkout). Treat it as an empty secret set
+            # rather than an error — writes (create_secret) create the dir on demand.
+            logger.debug("Secrets path does not exist, treating as empty: %s", dir_path)
             return {}
 
         if dir_path.is_file():

--- a/test/unit/asset/test_hfstore.py
+++ b/test/unit/asset/test_hfstore.py
@@ -1,5 +1,9 @@
 """Tests for Hfstore, covering bucket-specific behaviour."""
 
+from pathlib import Path
+
+import yaml
+
 from gbcommon.uri.hf import HfType, HfURI
 from gbserver.asset.hfstore import Hfstore
 from gbserver.types.artifact import ArtifactType
@@ -90,3 +94,93 @@ class TestHfstoreStepConfigEndpoint:
         )
         cfg = Hfstore.build_hfpull_step_config(hfuri=uri, binding_path="/tmp/x")
         assert cfg["endpoint"] == "https://my-enterprise.example.com"
+
+
+class TestHfstoreStepConfigPathInRepo:
+    """The push step config pre-resolves ``path_in_repo`` from the URI so the
+    skypilot worker's inline push needs no URI parser. ``hf.type`` is carried
+    too, so the worker can branch repo vs bucket without re-parsing."""
+
+    def test_path_in_repo_empty_when_absent(self):
+        uri = HfURI.from_parts(owner="org", repo="my-dataset", hf_type=HfType.DATASET)
+        cfg = Hfstore.build_hfpush_step_config(
+            hfuri=uri, binding_path="/tmp/x", binding_id="b-1", hf_private=True
+        )
+        assert cfg["path_in_repo"] == ""
+        assert cfg["hf"]["type"] == "dataset"
+
+    def test_path_in_repo_carried_through(self):
+        uri = HfURI.from_parts(
+            owner="org",
+            repo="my-model",
+            hf_type=HfType.MODEL,
+            revision="main",
+            path_in_repo="sub/dir/file.bin",
+        )
+        cfg = Hfstore.build_hfpush_step_config(
+            hfuri=uri, binding_path="/tmp/x", binding_id="b-1", hf_private=True
+        )
+        assert cfg["path_in_repo"] == "sub/dir/file.bin"
+
+    def test_bucket_type_carried_through(self):
+        uri = HfURI.from_parts(owner="org", repo="my-bucket", hf_type=HfType.BUCKET)
+        cfg = Hfstore.build_hfpush_step_config(
+            hfuri=uri, binding_path="/tmp/x", binding_id="b-1", hf_private=True
+        )
+        assert cfg["hf"]["type"] == "bucket"
+        assert cfg["path_in_repo"] == ""
+
+
+class TestSkypilotHfpushStepParity:
+    """Guard against drift between the skypilot hfpush step's inline python and
+    HfURI.push() (src/gbcommon/uri/hf.py). The skypilot worker has no gbserver
+    install, so push() is reimplemented inline in step.yaml; this test asserts
+    that reimplementation still covers every branch/behaviour push() has."""
+
+    STEP_YAML = (
+        Path(__file__).resolve().parents[3]
+        / "src/gbserver/builtins/steps/skypilot/hfpush/step.yaml"
+    )
+
+    def _run_script(self) -> str:
+        doc = yaml.safe_load(self.STEP_YAML.read_text())
+        return doc["environment_configs"]["Skypilot"]["launchers"]["hfpush"]["config"][
+            "run"
+        ]
+
+    def test_covers_repo_and_bucket_apis(self):
+        run = self._run_script()
+        for api in (
+            "create_repo",
+            "upload_file",
+            "upload_folder",
+            "create_bucket",
+            "batch_bucket_files",
+            "sync_bucket",
+        ):
+            assert api in run, f"hfpush step missing HF API call: {api}"
+
+    def test_covers_empty_source_validation(self):
+        run = self._run_script()
+        assert "refusing to push zero-length file" in run
+        assert "refusing to push directory with no non-empty files" in run
+
+    def test_covers_error_status_classification(self):
+        run = self._run_script()
+        # Mirrors _classify_hf_error severities: 429 / 5xx / 401,403 / 404.
+        assert "429" in run
+        assert "500" in run
+        assert "401" in run and "403" in run
+        assert "404" in run
+
+    def test_preserves_success_line_for_monitor(self):
+        run = self._run_script()
+        # The skypilot_monitor greps this exact line; it must be emitted by bash.
+        assert 'echo "Pushed HF URI: ${HF_URI} for binding ${BINDING_ID}"' in run
+
+    def test_no_longer_uses_hf_upload_cli(self):
+        doc = yaml.safe_load(self.STEP_YAML.read_text())
+        cfg = doc["environment_configs"]["Skypilot"]["launchers"]["hfpush"]["config"]
+        assert "hf upload" not in cfg["run"]
+        # CLI extra dropped since the upload is done via HfApi now.
+        assert "[cli]" not in cfg["setup"]


### PR DESCRIPTION
## Summary

Addresses **a few** of the errors surfaced in the nightly `skypilot_slurm` test run (see ibm-granite/granite.build#150) — **not the full set** in that log. Two independent fixes:

### 1. `localspacesecretmanager`: stop logging a missing secrets dir as ERROR
A missing `<gb_home>/space_secrets` directory is the normal "no secrets configured yet" state (e.g. a fresh standalone CI checkout), not an error. `_load_all_secrets` now logs this at DEBUG and continues to return `{}`. The directory is still created on demand by `create_secret()`, so reads stay side-effect-free. This removes ~13 noisy ERROR lines per nightly run.

### 2. skypilot `hfpush` step: make the inline push a faithful equivalent of `HfURI.push()`
The skypilot/slurm worker only `pip install huggingface_hub` and `sky.Task` ships the step as inline scripts (no gbserver install, no file mounts), so the worker cannot `import gbcommon.uri.hf` — the push logic must be reproduced inline. The previous inline version only did `create_repo` + `hf upload` (CLI) and had drifted from `push()`. This PR brings it to parity:

- **Bucket support** (`HfType.BUCKET` → `create_bucket` / `batch_bucket_files` / `sync_bucket`) — previously missing.
- **Empty-source guard** (`_validate_non_empty_src`) — HF silently skips empty commits, turning a push into a silent no-op; now fails fast.
- **HTTP-status error classification** mirroring `_classify_hf_error` / `_log_hf_api_error` (429/5xx → WARNING, 401/403/404 → ERROR) instead of a generic line.
- **SIGALRM timeout** mirroring `hfpush_step` (3600s).
- Upload now uses **HfApi** (not the `hf upload` CLI), so `setup` drops the `[cli]` extra.
- `path_in_repo` is passed down via `hfpush_config` (like `resource_group_id` already is), so the worker needs no URI parser — implemented in `build_hfpush_step_config` (`asset/hfstore.py`).
- Logs the resolved `resource_group_id` before API calls, to aid diagnosis of the resource-group 403s seen in the nightly log.

## Out of scope
- The `HfURI.exists()` behavior of returning `False` on 401/403 auth errors (reports a present-but-unreadable repo as missing).
- The CI token lacking write/delete permission on the Enterprise resource group (infra/permissions, not code).
- **The LSF and k8s `hfpush` variants are not changed here.** The LSF `command.sh` still creates the repo via raw `curl` to `/api/repos/create` and uploads via the `hf upload` CLI (no bucket support); the k8s `_helpers.tpl` already imports `HfURI.hfpush_step` directly (its worker image has gbserver), so it inherits parity for free. Only the skypilot variant is reworked in this PR. Bringing LSF to parity is a separate follow-up.

## Test plan
- `pytest test/unit/asset/test_hfstore.py` — adds `path_in_repo` config assertions and a drift-guard parity test that asserts the step's inline python still covers every `push()` branch/API, the validation messages, and the status-classification literals (19 passing).
- `pytest test/unit/environment/test_skypilot_hfstore.py` — render path unchanged (21 passing).
- `make format` clean; `make staticcheck` introduces no new findings in changed files.
- Embedded python AST-validated; YAML block-scalar/heredoc indentation verified; `skypilot_monitor` success-line regex preserved.
- Live: `pytest -s test/integration/standalone/buildrunner/skypilot_slurm/test_skypilot_slurm_hf.py` (extended suite, Docker SLURM).