### PR TITLE
Fix step materialization for non-bash environments

### DIFF
--- a/src/gbserver/build/targetstep.py
+++ b/src/gbserver/build/targetstep.py
@@ -476,13 +476,22 @@ class TargetStep(BuildEntity):
         merged_env_configs = full_config[ENVIRONMENT_CONFIG]
 
         # --- Determine environment type ---
-        env_type = None
-        if "environment" in full_config and getattr(
-            full_config["environment"], "type", None
-        ):
-            env_type = full_config["environment"].type
-        elif merged_env_configs:
-            env_type = next(iter(merged_env_configs.keys()))
+        # The active environment's class-derived type (e.g. "Lsf", "K8s") is the
+        # authoritative backend selector — the same source used in
+        # _resolve_environment_and_launcher. It must win here because the env's
+        # environment_config is keyed by config sections (workload,
+        # authentication, …), so iterating its keys can yield a non-backend like
+        # "workload"; that then makes _copy_basestep_scaffold drop the correct
+        # launch scaffold (e.g. lsf_scripts) and keep only bash_scripts. Fall
+        # back to the legacy resolution only when the env has no type.
+        env_type = getattr(self.environment, "type", None)
+        if not env_type:
+            if "environment" in full_config and getattr(
+                full_config["environment"], "type", None
+            ):
+                env_type = full_config["environment"].type
+            elif merged_env_configs:
+                env_type = next(iter(merged_env_configs.keys()))
         if not env_type:
             raise ValueError(
                 "No environment type could be resolved (missing 'type' and empty environment_configs)."

--- a/test-data/integration/ibm/api/builds/validate/valid/1step-cpu.yaml
+++ b/test-data/integration/ibm/api/builds/validate/valid/1step-cpu.yaml
@@ -5,10 +5,12 @@ llm.build:
       environment_uri: space://environments/{{ space.variables.DEFAULT_CPU_ENVIRONMENT }}
       inputs:
         seed_data:
-          uri: lh://staging/granite_dot_build.public/tables/maximo_digit_input1
+          #uri: lh://staging/granite_dot_build.public/tables/maximo_digit_input1
+          uri: hf://huggingface.co/datasets/ibm-research/vira-intents-live
       outputs:
         download_file:
-          uri: lh://staging/granite_dot_build.public/tables/test_dl_step_data_{{ binding.path | short_hash }}
+          #uri: lh://staging/granite_dot_build.public/tables/test_dl_step_data_{{ binding.path | short_hash }}
+          uri: hf://huggingface.co/datasets/ibm-research/test-output1_{{ binding.path | short_hash }}
       steps:
         - step_uri: space://steps/download 
           config:

--- a/test-data/integration/ibm/buildrunner/k8s/1step/gpu/build.yaml
+++ b/test-data/integration/ibm/buildrunner/k8s/1step/gpu/build.yaml
@@ -5,10 +5,12 @@ llm.build:
       environment_uri: space://environments/{{ space.variables.DEFAULT_ENVIRONMENT }}
       inputs:
         seed_data:
-          uri: lh://staging/granite_dot_build.public/tables/maximo_digit_input1
+          #uri: lh://staging/granite_dot_build.public/tables/maximo_digit_input1
+          uri: hf://huggingface.co/datasets/ibm-research/vira-intents-live
       outputs:
         download_file:
-          uri: lh://staging/granite_dot_build.public/tables/test_dl_step_data_{{ binding.path | short_hash }}
+          # uri: lh://staging/granite_dot_build.public/tables/test_dl_step_data_{{ binding.path | short_hash }}
+          uri: hf://huggingface.co/datasets/ibm-research/test_dl_step_data_{{ binding.path | short_hash }}
       steps:
         - step_uri: space://steps/download 
           config:


### PR DESCRIPTION
## Description

1.  Fix a bug introduced recently (likely in #138)  in step resolution/materialization in non-bash builds
2. Switch lh:// based tests (2) to use hf:// uris - 

To address 1...

In merge_handle_configs ([targetstep.py:446](vscode-webview://0fv49fmvfemaors3o1hta33tb5bftr765sblcigv9l8srmclv8ri/src/gbserver/build/targetstep.py#L446)), env_type now resolves from self.environment.type first — the same authoritative source already used at [line 296](vscode-webview://0fv49fmvfemaors3o1hta33tb5bftr765sblcigv9l8srmclv8ri/src/gbserver/build/targetstep.py#L296) for launcher resolution — falling back to the old logic only when the env has no type:

```python
env_type = getattr(self.environment, "type", None)
if not env_type:
    if "environment" in full_config and getattr(full_config["environment"], "type", None):
        env_type = full_config["environment"].type
    elif merged_env_configs:
        env_type = next(iter(merged_env_configs.keys()))
```

Why this fixes it: for the LSF env, self.environment.type == "Lsf" → _copy_basestep_scaffold keeps lsf_scripts → llmb_lsf_jobsub.sh is rendered → launch_bsub finds it. It no longer mistakes the config-section key "workload" for a backend.

Why it's safe for other backends: self.environment.type is the env class name — K8s→k8s (keeps helm-charts), Bash/Docker/Skypilot→ no scaffold dir kept (correct, they don't use these). It's strictly more reliable than "first dict key," and the fallback preserves old behavior if an env ever lacks a type.
## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
