### PR TITLE
ci: skip CI workflows on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   lint:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,6 +56,7 @@ jobs:
           mypy --disable-error-code=import-untyped --ignore-missing-imports src/gbcommon/
 
   test:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,6 +77,7 @@ jobs:
         run: make quick-tests
 
   demo-cpu:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/skypilot-pr.yml
+++ b/.github/workflows/skypilot-pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   test:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/slurm-integration.yml
+++ b/.github/workflows/slurm-integration.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   slurm-integration:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test-comment.yml
+++ b/.github/workflows/test-comment.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   trigger-check:
     if: |
+      !github.event.repository.fork &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/test') &&
       (


### PR DESCRIPTION
## Summary

Push/PR/comment events fire on a fork's own `main` when it syncs from upstream, causing `CI`, `SLURM Integration Tests`, `SkyPilot Mode PR Tests`, and the `/test` comment workflow to run on forks. This guards each job so only the canonical repo runs them.

- `ci.yml` — added `if: ${{ !github.event.repository.fork }}` to `lint`, `test`, `demo-cpu`
- `slurm-integration.yml` — guarded `slurm-integration`
- `skypilot-pr.yml` — guarded `test`
- `test-comment.yml` — prepended `!github.event.repository.fork` to the `trigger-check` anchor (downstream jobs already `needs` it)

The guard uses the `github.event.repository.fork` boolean rather than a hard-coded repo name, so it stays correct on any fork without per-fork configuration and survives an upstream rename.

**`nightly-tests.yml` is intentionally left unchanged.** It keeps its existing `github.repository == 'ibm-granite/granite.build'` guard: it triggers on `schedule`/`workflow_dispatch`, where the `repository` event object isn't reliably populated, so the explicit repo name is the safer check there.

## Test plan

- All four edited workflows pass YAML parse validation.
- Next fork sync of `main`: `CI` and `SLURM Integration Tests` should report **skipped** on `toraponibm/granite.build` while continuing to run on upstream.