### PR TITLE
feat(gbcli): follow build retry chain in build status

### DIFF
--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -766,6 +766,7 @@ class GBClient:
             show_events: bool,
             fetch_pr: bool,
             result_format: str,
+            follow_retries: bool = True,
             callback=None,
         ) -> str | List[Any]:
             return build_status(
@@ -776,6 +777,7 @@ class GBClient:
                 show_events,
                 fetch_pr,
                 result_format,
+                follow_retries=follow_retries,
                 callback=callback,
             )
 

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -96,11 +96,32 @@ def execution_status_plain_output(
     show_events: bool,
 ):
 
+    def target_status_label(target_info: Any) -> str:
+        # A target reused from a previous attempt is presented as "Skipped".
+        if target_info.get("skipped_for_prerun_target_id"):
+            return "SKIPPED"
+        return str(target_info["status"]).upper()
+
+    def target_status_emoji(target_info: Any) -> str:
+        if target_info.get("skipped_for_prerun_target_id"):
+            return "⏩"
+        return get_status_emoji(target_info["status"])
+
     targets_overview = [
-        f"\n\tTarget #{index + 1} {target}: {get_status_emoji(targets[target]['status'])} {str(targets[target]['status']).upper()}\n"
+        f"\n\tTarget #{index + 1} {target}: {target_status_emoji(targets[target])} {target_status_label(targets[target])}\n"
         for index, target in enumerate(targets)
     ]
     source_pr = f"<{details['source_pr']}>" if details["source_pr"] else "-"
+    retry_of = details.get("retry_of_build_ids") or []
+    retried_by = details.get("retried_by_build_ids") or []
+    retry_of_line = (
+        f"\n- **Retry of Original Build(s)**: {', '.join(retry_of)}" if retry_of else ""
+    )
+    retried_by_line = (
+        f"\n- **Retried by Subsequent Build(s)**: {', '.join(retried_by)}"
+        if retried_by
+        else ""
+    )
     details_output = f"""
 # Build {details['build_id']}
 
@@ -110,7 +131,7 @@ def execution_status_plain_output(
 - **Started**: {datetime_to_string(details['started_at'])}
 - **Updated**: {datetime_to_string(details['updated_at'])}
 - **Status page**: <{WEB_UI_URL}/builds/{details['build_id']}>
-- **Build PR**: {source_pr}
+- **Build PR**: {source_pr}{retry_of_line}{retried_by_line}
 - **Targets**
 {"".join(targets_overview)}
     """
@@ -152,13 +173,26 @@ def execution_status_plain_output(
             tablefmt="github",
         )
 
-        target_output = f"""
----
-
-## Target #{index + 1} {target}
-
-{get_status_emoji(targets[target]['status'])} **Status**: {str(targets[target]['status']).upper()}
-
+        prerun_target_id = targets[target].get("skipped_for_prerun_target_id")
+        status_line = (
+            f"Skipped for previously ran target {prerun_target_id}"
+            if prerun_target_id
+            else str(targets[target]["status"]).upper()
+        )
+        # Targets that ran in a different attempt (a prior or subsequent build in
+        # the retry chain) note which build they belong to.
+        target_build_id = targets[target].get("build_id", "")
+        build_id_line = (
+            f"\n\n**Build ID**: {target_build_id}"
+            if target_build_id and target_build_id != details["build_id"]
+            else ""
+        )
+        # A skipped target was reused from a previous attempt: it ran no steps and
+        # produced no artifacts of its own, so those sections are omitted.
+        if prerun_target_id:
+            sections = ""
+        else:
+            sections = f"""
 ### ⚙️  Steps
 
 {steps_output if len(targets[target]["steps"]) > 0 else ""}
@@ -169,7 +203,14 @@ def execution_status_plain_output(
 
 ### 📦 Output artifacts
 
-{output_artifacts_output if len(targets[target]["output_artifacts"]) > 0 else ""}
+{output_artifacts_output if len(targets[target]["output_artifacts"]) > 0 else ""}"""
+        target_output = f"""
+---
+
+## Target #{index + 1} {target}
+
+{target_status_emoji(targets[target])} **Status**: {status_line}{build_id_line}
+{sections}
         """
 
         target_outputs.append(target_output)
@@ -1612,8 +1653,23 @@ def list(
     default=False,
     help="Fetch build PR events.",
 )
+@click.option(
+    "--follow-retries/--no-follow-retries",
+    "follow_retries",
+    default=True,
+    help="Follow the build retry chain and show all targets across attempts (default: follow).",
+)
 @common_options
-def status(ctx, build_id, format, show_events, fetch_pr, skip_version_check, quiet):
+def status(
+    ctx,
+    build_id,
+    format,
+    show_events,
+    fetch_pr,
+    follow_retries,
+    skip_version_check,
+    quiet,
+):
     """
     Get status of a build execution
 
@@ -1675,6 +1731,7 @@ def status(ctx, build_id, format, show_events, fetch_pr, skip_version_check, qui
                 show_events,
                 fetch_pr,
                 format,
+                follow_retries=follow_retries,
                 callback=echo_callback_error,
             )
         else:
@@ -1775,6 +1832,7 @@ def status(ctx, build_id, format, show_events, fetch_pr, skip_version_check, qui
                     show_events,
                     fetch_pr,
                     format,
+                    follow_retries=follow_retries,
                     callback=update_bar,
                 )
 

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -10,7 +10,7 @@ import threading
 import time
 import zipfile
 from base64 import b64decode, b64encode
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
@@ -1215,6 +1215,7 @@ def build_status(
     show_events: bool,
     fetch_pr: bool,
     result_format: str,
+    follow_retries: bool = True,
     callback=None,
 ) -> List[Any]:
     gbserver_build_events = gb_environment_config().feature_flags[
@@ -1260,13 +1261,15 @@ def build_status(
         spinner_thread.join()  # Ensure spinner stops
 
     # TODO: use global_space to properly scope the build ID
-    build_status = make_gbserver_call(
+    status_response = make_gbserver_call(
         lambda: get_build_status_with_targets_runs(
-            github_token, build_id, GBSERVER_BUILD_API
-        )["status"],
+            github_token, build_id, GBSERVER_BUILD_API, follow_retries
+        ),
         callback,
         stop_spinner,
     )
+    build_status = status_response["status"]
+    retry_chain = status_response.get("retry_chain") if follow_retries else None
 
     if id_format != "url":
         resolved_space_name = global_space.get("name")
@@ -1296,10 +1299,34 @@ def build_status(
                 callback_event="processing_status_artifacts", callback_args={"steps": 1}
             )
 
+    # When following the retry chain, merge every chain member's target runs
+    # (oldest -> newest, as ordered root-first by the API) into one view, and
+    # derive the predecessor/successor build IDs relative to the queried build.
+    retry_of_build_ids: List[str] = []
+    retried_by_build_ids: List[str] = []
+    if retry_chain:
+        target_runs = []
+        before_queried = True
+        for chain_index, member in enumerate(retry_chain):
+            member_id = member["build"]["uuid"]
+            if member_id == build_id:
+                before_queried = False
+            elif before_queried:
+                retry_of_build_ids.append(member_id)
+            else:
+                retried_by_build_ids.append(member_id)
+            for target_run in member["target_runs"]:
+                # Stamp the attempt's position so the flat list sorts by build
+                # attempt (oldest -> newest) then by start time within an attempt.
+                target_run["_chain_index"] = chain_index
+                target_runs.append(target_run)
+    else:
+        target_runs = build_status.get("target_runs") or []
+
     targets = (
-        process_target_runs(build_status["target_runs"])
+        process_target_runs(target_runs)
         if result_format == "plain"
-        else process_target_runs_to_json(build_status.get("target_runs"))
+        else process_target_runs_to_json(target_runs)
     )
 
     if callback is not None:
@@ -1346,6 +1373,8 @@ def build_status(
         "status": build_status["build"]["status"],
         "source_pr": build_status["build"]["source_uri"],
         "description": build_status["build"]["description"],
+        "retry_of_build_ids": retry_of_build_ids,
+        "retried_by_build_ids": retried_by_build_ids,
     }
 
     return build_details, targets, build_history, None
@@ -1853,11 +1882,36 @@ def build_notification(
     return notification["subscribed"], space_output_message
 
 
+# Skipped (prerun-reused) targets have no started_at. They sort first via this
+# epoch sentinel, which is timezone-aware so it compares cleanly against the
+# (possibly offset-aware) timestamps parsed from the server.
+_SORT_EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def _parse_started_at(started_at: Optional[str]) -> datetime:
+    if not started_at:
+        return _SORT_EPOCH
+    parsed = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _target_sort_key(target_run: Any) -> Tuple[int, datetime]:
+    # Order oldest -> newest by build attempt first (_chain_index, stamped during
+    # the chain merge), then by start time within an attempt. A skipped target has
+    # no started_at, so it sorts ahead of the re-run targets of the same attempt
+    # rather than jumping to the front of the whole list.
+    chain_index = target_run.get("_chain_index", 0)
+    return (chain_index, _parse_started_at(target_run["target"].get("started_at")))
+
+
+def _step_sort_key(step: Any) -> datetime:
+    return _parse_started_at(step.get("started_at"))
+
+
 def process_target_runs(target_runs: List[Any]) -> Tuple[List[Any], List[Any]]:
-    target_runs = sorted(
-        target_runs,
-        key=lambda x: datetime.fromisoformat(x["target"]["started_at"]),
-    )
+    target_runs = sorted(target_runs, key=_target_sort_key)
     targets = {}
     for target_run in target_runs:
         target = target_run["target"]
@@ -1891,22 +1945,20 @@ def process_target_runs(target_runs: List[Any]) -> Tuple[List[Any], List[Any]]:
 
         targets[f"{target['name']} ({target['uuid']})"] = {
             "status": target["status"],
+            "build_id": target.get("build_id", ""),
+            "skipped_for_prerun_target_id": target.get(
+                "skipped_for_prerun_target_id", ""
+            ),
             "input_artifacts": input_artifacts,
             "output_artifacts": output_artifacts,
-            "steps": sorted(
-                steps,
-                key=lambda x: datetime.fromisoformat(x["started_at"]),
-            ),
+            "steps": sorted(steps, key=_step_sort_key),
         }
 
     return targets
 
 
 def process_target_runs_to_json(target_runs: List[Any]) -> List[Any]:
-    target_runs = sorted(
-        target_runs,
-        key=lambda x: datetime.fromisoformat(x["target"]["started_at"]),
-    )
+    target_runs = sorted(target_runs, key=_target_sort_key)
 
     targets = []
     for target_run in target_runs:
@@ -1945,12 +1997,12 @@ def process_target_runs_to_json(target_runs: List[Any]) -> List[Any]:
                 "build_id": target.get("build_id"),
                 "target_id": target.get("uuid"),
                 "status": target.get("status"),
+                "skipped_for_prerun_target_id": target.get(
+                    "skipped_for_prerun_target_id", ""
+                ),
                 "input_artifacts": input_artifacts,
                 "output_artifacts": output_artifacts,
-                "steps": sorted(
-                    steps,
-                    key=lambda x: datetime.fromisoformat(x["started_at"]),
-                ),
+                "steps": sorted(steps, key=_step_sort_key),
             }
         )
 

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -13,7 +13,7 @@ from base64 import b64decode, b64encode
 from datetime import datetime, timezone
 from glob import glob
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 import yaml
@@ -1268,6 +1268,10 @@ def build_status(
         callback,
         stop_spinner,
     )
+    # make_gbserver_call returns None on a server/connection error (after firing
+    # the "error" callback). Bail out instead of dereferencing None.
+    if status_response is None:
+        return None, None, None, "Build status could not be retrieved."
     build_status = status_response["status"]
     retry_chain = status_response.get("retry_chain") if follow_retries else None
 
@@ -1910,7 +1914,7 @@ def _step_sort_key(step: Any) -> datetime:
     return _parse_started_at(step.get("started_at"))
 
 
-def process_target_runs(target_runs: List[Any]) -> Tuple[List[Any], List[Any]]:
+def process_target_runs(target_runs: List[Any]) -> Dict[str, Any]:
     target_runs = sorted(target_runs, key=_target_sort_key)
     targets = {}
     for target_run in target_runs:
@@ -1994,7 +1998,7 @@ def process_target_runs_to_json(target_runs: List[Any]) -> List[Any]:
         targets.append(
             {
                 "target_name": target.get("name"),
-                "build_id": target.get("build_id"),
+                "build_id": target.get("build_id", ""),
                 "target_id": target.get("uuid"),
                 "status": target.get("status"),
                 "skipped_for_prerun_target_id": target.get(

--- a/src/gbcli/utils/gbserver.py
+++ b/src/gbcli/utils/gbserver.py
@@ -189,16 +189,16 @@ def get_artifact_body(
 
 
 def get_build_status_with_targets_runs(
-    user_token: str, build_id: str, gbserver_api: str
+    user_token: str, build_id: str, gbserver_api: str, follow_retries: bool = False
 ) -> Any:
-    build_url = f"{gbserver_api}{build_id}/status2"
+    build_url = f"{gbserver_api}{build_id}/status"
 
     return gb_server_request(
         user_token=user_token,
         url=build_url,
         http_method="get",
         body=None,
-        params=None,
+        params={"follow_retries": str(follow_retries).lower()},
     )
 
 

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -138,25 +138,25 @@ class GetBuildResponse(BaseModel):
     build: StoredBuild
 
 
-class TargetRecord2(BaseModel):
+class TargetRecord(BaseModel):
     target: StoredTargetRun
     steps: list[StoredStepRun]
     input_artifacts: list[ArtifactRegistration] = []
     output_artifacts: list[ArtifactRegistration] = []
 
 
-class BuildStatus2(BaseModel):
+class BuildStatus(BaseModel):
     build: StoredBuild
-    target_runs: list[TargetRecord2]
+    target_runs: list[TargetRecord]
 
 
 class BuildChainMember(BaseModel):
     build: StoredBuild
-    target_runs: list[TargetRecord2]
+    target_runs: list[TargetRecord]
 
 
-class BuildStatusResponse2(BaseModel):
-    status: BuildStatus2
+class BuildStatusResponse(BaseModel):
+    status: BuildStatus
     # Populated (root-first) only when the request sets follow_retries=true.
     retry_chain: Optional[list[BuildChainMember]] = None
 
@@ -355,7 +355,7 @@ def __get_artifacts(
 
 def __build_target_records(
     storage: SingletonAdminStorage, build_id: str
-) -> List[TargetRecord2]:
+) -> List[TargetRecord]:
     """Assemble the per-target records (steps + artifacts) for one build."""
     row_filter = get_row_filter(build_id=build_id)
     target_runs = cast(
@@ -368,7 +368,7 @@ def __build_target_records(
             list[StoredStepRun],
             storage.step_storage.get_by_where({"target_id": target.uuid}),
         )
-        record = TargetRecord2(
+        record = TargetRecord(
             target=target,
             steps=steps,
             input_artifacts=input_artifacts,
@@ -378,10 +378,10 @@ def __build_target_records(
     return target_records
 
 
-@builds_api.get("/{build_id}/status", response_model=BuildStatusResponse2)
+@builds_api.get("/{build_id}/status", response_model=BuildStatusResponse)
 def get_build_status(
     build_id: str, follow_retries: bool = False
-) -> BuildStatusResponse2:
+) -> BuildStatusResponse:
     storage: SingletonAdminStorage = get_admin_storage()
     build = storage.build_storage.get_by_uuid(build_id)
     if build is None:
@@ -390,10 +390,10 @@ def get_build_status(
         )
     assert isinstance(build, StoredBuild)
     build.build_archive = ""
-    build_status = BuildStatus2(
+    build_status = BuildStatus(
         build=build, target_runs=__build_target_records(storage, build_id)
     )
-    resp = BuildStatusResponse2(status=build_status)
+    resp = BuildStatusResponse(status=build_status)
     if follow_retries:
         members = get_retry_chain_members(storage.build_storage, build)
         chain = []
@@ -409,10 +409,10 @@ def get_build_status(
     return resp
 
 
-@builds_api.get("/{build_id}/status2", response_model=BuildStatusResponse2)
+@builds_api.get("/{build_id}/status2", response_model=BuildStatusResponse)
 def get_build_status2(
     build_id: str, follow_retries: bool = False
-) -> BuildStatusResponse2:
+) -> BuildStatusResponse:
     # Retained as a backward-compatible alias of the primary /status endpoint.
     return get_build_status(build_id, follow_retries)
 

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -150,8 +150,15 @@ class BuildStatus2(BaseModel):
     target_runs: list[TargetRecord2]
 
 
+class BuildChainMember(BaseModel):
+    build: StoredBuild
+    target_runs: list[TargetRecord2]
+
+
 class BuildStatusResponse2(BaseModel):
     status: BuildStatus2
+    # Populated (root-first) only when the request sets follow_retries=true.
+    retry_chain: Optional[list[BuildChainMember]] = None
 
 
 class CancelBuildResponse(BaseModel):
@@ -346,21 +353,10 @@ def __get_artifacts(
     return input_artifacts, output_artifacts
 
 
-@builds_api.get("/{build_id}/status", response_model=BuildStatusResponse2)
-def get_build_status(build_id: str) -> BuildStatusResponse2:
-    return get_build_status2(build_id)
-
-
-@builds_api.get("/{build_id}/status2", response_model=BuildStatusResponse2)
-def get_build_status2(build_id: str) -> BuildStatusResponse2:
-    storage: SingletonAdminStorage = get_admin_storage()
-    build = storage.build_storage.get_by_uuid(build_id)
-    if build is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="build not found!"
-        )
-    assert isinstance(build, StoredBuild)
-    build.build_archive = ""
+def __build_target_records(
+    storage: SingletonAdminStorage, build_id: str
+) -> List[TargetRecord2]:
+    """Assemble the per-target records (steps + artifacts) for one build."""
     row_filter = get_row_filter(build_id=build_id)
     target_runs = cast(
         List[StoredTargetRun], storage.target_storage.get_by_where(row_filter)
@@ -379,9 +375,46 @@ def get_build_status2(build_id: str) -> BuildStatusResponse2:
             output_artifacts=output_artifacts,
         )
         target_records.append(record)
-    build_status = BuildStatus2(build=build, target_runs=target_records)
+    return target_records
+
+
+@builds_api.get("/{build_id}/status", response_model=BuildStatusResponse2)
+def get_build_status(
+    build_id: str, follow_retries: bool = False
+) -> BuildStatusResponse2:
+    storage: SingletonAdminStorage = get_admin_storage()
+    build = storage.build_storage.get_by_uuid(build_id)
+    if build is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="build not found!"
+        )
+    assert isinstance(build, StoredBuild)
+    build.build_archive = ""
+    build_status = BuildStatus2(
+        build=build, target_runs=__build_target_records(storage, build_id)
+    )
     resp = BuildStatusResponse2(status=build_status)
+    if follow_retries:
+        members = get_retry_chain_members(storage.build_storage, build)
+        chain = []
+        for member in members:
+            member.build_archive = ""
+            chain.append(
+                BuildChainMember(
+                    build=member,
+                    target_runs=__build_target_records(storage, member.uuid),
+                )
+            )
+        resp.retry_chain = chain
     return resp
+
+
+@builds_api.get("/{build_id}/status2", response_model=BuildStatusResponse2)
+def get_build_status2(
+    build_id: str, follow_retries: bool = False
+) -> BuildStatusResponse2:
+    # Retained as a backward-compatible alias of the primary /status endpoint.
+    return get_build_status(build_id, follow_retries)
 
 
 @builds_api.get("/{build_id}/events")

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -398,13 +398,14 @@ def get_build_status(
         members = get_retry_chain_members(storage.build_storage, build)
         chain = []
         for member in members:
-            member.build_archive = ""
-            chain.append(
-                BuildChainMember(
-                    build=member,
-                    target_runs=__build_target_records(storage, member.uuid),
-                )
-            )
+            if member.uuid == build_id:
+                # Reuse the records already assembled for the queried build
+                # instead of re-querying its targets/steps/artifacts.
+                records = build_status.target_runs
+            else:
+                member.build_archive = ""
+                records = __build_target_records(storage, member.uuid)
+            chain.append(BuildChainMember(build=member, target_runs=records))
         resp.retry_chain = chain
     return resp
 

--- a/test/integration/ibm/api/test_builds.py
+++ b/test/integration/ibm/api/test_builds.py
@@ -28,8 +28,8 @@ from libgbtest.storage.utils import (
 
 from gbserver.api.auth import get_gh_user
 from gbserver.api.builds import (
-    BuildStatus2,
-    BuildStatusResponse2,
+    BuildStatus,
+    BuildStatusResponse,
     BuildSubmitRequest,
     BuildSubmitResponse,
     BuildUpdateRequest,
@@ -39,7 +39,7 @@ from gbserver.api.builds import (
     CountBuildsResponse,
     GetBuildResponse,
     ListBuildResponse,
-    TargetRecord2,
+    TargetRecord,
 )
 from gbserver.api.utils import ListAppendOrSet
 from gbserver.storage.artifact_registration import ArtifactRegistration
@@ -189,9 +189,9 @@ class TestBuildAPI(AbstractAPITest):
         assert response.status_code == 200
         resp_json = response.json()
         print(f"response={resp_json}")
-        resp: BuildStatusResponse2 = BuildStatusResponse2.model_validate(resp_json)
+        resp: BuildStatusResponse = BuildStatusResponse.model_validate(resp_json)
         status = resp.status
-        assert isinstance(status, BuildStatus2)
+        assert isinstance(status, BuildStatus)
 
         assert status.build.status == tested_status
         if tested_status == Status.SUCCESS:
@@ -200,8 +200,8 @@ class TestBuildAPI(AbstractAPITest):
             # Validate the number of targets run
             assert len(status.target_runs) == 1
             # Validate the 1 target that was run
-            target_run: TargetRecord2 = status.target_runs[0]
-            assert isinstance(target_run, TargetRecord2)
+            target_run: TargetRecord = status.target_runs[0]
+            assert isinstance(target_run, TargetRecord)
             stored_target = target_run.target
             assert isinstance(stored_target, StoredTargetRun)
             assert stored_target.build_id == build_uuid

--- a/test/integration/standalone/api/test_build_status_retry_chain.py
+++ b/test/integration/standalone/api/test_build_status_retry_chain.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API tests for the build status endpoint's retry-chain following.
+
+``GET /{build_id}/status`` returns just the queried build by default. With
+``follow_retries=true`` it additionally returns ``retry_chain`` — every build in
+the chain, root-first, each with its target runs. ``/status2`` is retained as a
+backward-compatible alias.
+"""
+
+from typing import Self
+
+import pytest
+from libgbtest.utils import AbstractSingletonStorageUsingTest
+
+from gbserver.api.builds import get_build_status, get_build_status2
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.types.status import Status
+
+pytestmark = pytest.mark.standalone
+
+
+class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
+    """get_build_status follows the retry chain only when asked to."""
+
+    def _add_build(
+        self: Self, status: Status, retry_count: int, retry_of_build_id=None
+    ) -> StoredBuild:
+        build = StoredBuild(
+            name="test",
+            space_name="testspace",
+            source_uri="",
+            username="tester",
+            status=status,
+            retry_count=retry_count,
+            retry_of_build_id=retry_of_build_id,
+        )
+        self.storage.build_storage.add(build)
+        return build
+
+    def _add_target(
+        self: Self,
+        build_id: str,
+        name: str,
+        status: Status,
+        started_at,
+        skipped_for_prerun_target_id: str = "",
+    ) -> StoredTargetRun:
+        target = StoredTargetRun(
+            name=name,
+            build_id=build_id,
+            environment_uri="space://environments/bash",
+            status=status,
+            started_at=started_at,
+            skipped_for_prerun_target_id=skipped_for_prerun_target_id,
+        )
+        self.storage.target_storage.add(target)
+        return target
+
+    def _make_chain(self: Self):
+        """root (succeeded targetA, failed targetB) -> retry (skipped targetA, ok targetB)."""
+        root = self._add_build(Status.FAILED, 0)
+        retry = self._add_build(Status.SUCCESS, 1, retry_of_build_id=root.uuid)
+        root.retry_build_id = retry.uuid
+        self.storage.build_storage.update(root)
+
+        root_a = self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+        self._add_target(
+            root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00.000Z"
+        )
+        # targetA is reused (skipped) in the retry; skipped runs have no start time.
+        self._add_target(
+            retry.uuid,
+            "targetA",
+            Status.SUCCESS,
+            None,
+            skipped_for_prerun_target_id=root_a.uuid,
+        )
+        self._add_target(
+            retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00.000Z"
+        )
+        return root, retry, root_a
+
+    def test_no_follow_returns_only_queried_build(self: Self):
+        _root, retry, _root_a = self._make_chain()
+
+        resp = get_build_status(retry.uuid)
+
+        assert resp.retry_chain is None
+        assert resp.status.build.uuid == retry.uuid
+        assert {tr.target.build_id for tr in resp.status.target_runs} == {retry.uuid}
+
+    def test_follow_returns_chain_root_first(self: Self):
+        root, retry, root_a = self._make_chain()
+
+        resp = get_build_status(retry.uuid, follow_retries=True)
+
+        assert resp.retry_chain is not None
+        # Root first, then the retry — regardless of which member was queried.
+        assert [m.build.uuid for m in resp.retry_chain] == [root.uuid, retry.uuid]
+
+        # The skipped target in the retry points back at the original run.
+        retry_member = resp.retry_chain[1]
+        skipped = [
+            tr
+            for tr in retry_member.target_runs
+            if tr.target.skipped_for_prerun_target_id
+        ]
+        assert len(skipped) == 1
+        assert skipped[0].target.skipped_for_prerun_target_id == root_a.uuid
+
+    def test_status2_alias_matches_status(self: Self):
+        _root, retry, _root_a = self._make_chain()
+
+        primary = get_build_status(retry.uuid, follow_retries=True)
+        alias = get_build_status2(retry.uuid, follow_retries=True)
+
+        assert [m.build.uuid for m in alias.retry_chain] == [
+            m.build.uuid for m in primary.retry_chain
+        ]

--- a/test/libgbtest/api/utils.py
+++ b/test/libgbtest/api/utils.py
@@ -43,7 +43,7 @@ class AbstractAPITest(AbstractSingletonStorageUsingPreloadedSpaceTest):
 if __name__ == "__main__":
     client = AbstractAPITest.get_test_client()
     id = "39bbdc33-cfb2-4113-accc-c180aa3cd483"
-    url = f"api/v1/builds/{id}/status2"
+    url = f"api/v1/builds/{id}/status"
     resp = client.get(url)
     print(f"\nurl={url}")
     resp_json = resp.json()

--- a/test/libgbtest/api/utils.py
+++ b/test/libgbtest/api/utils.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from libgbtest.utils import AbstractSingletonStorageUsingPreloadedSpaceTest
 
 from gbserver.api.auth import get_gh_user
-from gbserver.api.builds import BuildStatusResponse2
+from gbserver.api.builds import BuildStatusResponse
 from gbserver.api.root_api import root_api
 from gbserver.types.auth import User
 from gbserver.types.constants import GBSERVER_GITHUB_TOKEN
@@ -49,5 +49,5 @@ if __name__ == "__main__":
     resp_json = resp.json()
     # print(f"\nresp.content={resp.content}")
     print(f"\njson resp={resp_json}")
-    resp: BuildStatusResponse2 = BuildStatusResponse2.model_validate(resp_json)
+    resp: BuildStatusResponse = BuildStatusResponse.model_validate(resp_json)
     print(f"\n\nbuild status={resp}")

--- a/test/unit/gbcli/services/test_build_status_targets.py
+++ b/test/unit/gbcli/services/test_build_status_targets.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for build-status target processing across a retry chain.
+
+``process_target_runs`` / ``process_target_runs_to_json`` flatten the merged
+target runs from every chain member. A target reused from a previous attempt is
+"skipped": it carries ``skipped_for_prerun_target_id`` and has no ``started_at``,
+which must not break the start-time sort. All collaborators are pure — no
+infrastructure required.
+"""
+
+import pytest
+
+from gbcli.services.service_build import (
+    process_target_runs,
+    process_target_runs_to_json,
+)
+
+pytestmark = pytest.mark.standalone
+
+
+def _target_run(name, build_id, uuid, status, started_at, chain_index, skipped_for=""):
+    return {
+        "target": {
+            "name": name,
+            "build_id": build_id,
+            "uuid": uuid,
+            "status": status,
+            "started_at": started_at,
+            "skipped_for_prerun_target_id": skipped_for,
+        },
+        # Stamped during the chain merge in build_status; the attempt's position
+        # in the chain (root == 0) is the primary sort key.
+        "_chain_index": chain_index,
+        "input_artifacts": [],
+        "output_artifacts": [],
+        "steps": [],
+    }
+
+
+def _merged_runs():
+    # A retry chain: root (chain_index 0) ran targetA (ok) + targetB (failed);
+    # the retry (chain_index 1) skipped targetA (no started_at) and re-ran
+    # targetB. Returned out of order to exercise the sort.
+    return [
+        _target_run("targetB", "retry", "tB2", "success", "2020-01-01T00:02:00Z", 1),
+        _target_run("targetA", "retry", "tA2", "success", None, 1, skipped_for="tA1"),
+        _target_run("targetA", "root", "tA1", "success", "2020-01-01T00:00:00Z", 0),
+        _target_run("targetB", "root", "tB1", "failed", "2020-01-01T00:01:00Z", 0),
+    ]
+
+
+def test_plain_sorts_oldest_to_newest_by_attempt_then_start():
+    targets = process_target_runs(_merged_runs())
+
+    # Oldest -> newest: the root attempt's targets first (by start time), then
+    # the retry attempt's. The skipped target (no started_at) sorts ahead of the
+    # re-run within its own attempt rather than jumping to the front overall.
+    assert list(targets) == [
+        "targetA (tA1)",
+        "targetB (tB1)",
+        "targetA (tA2)",
+        "targetB (tB2)",
+    ]
+
+    skipped = targets["targetA (tA2)"]
+    assert skipped["skipped_for_prerun_target_id"] == "tA1"
+    assert skipped["build_id"] == "retry"
+    ran = targets["targetA (tA1)"]
+    assert ran["skipped_for_prerun_target_id"] == ""
+    assert ran["build_id"] == "root"
+
+
+def test_json_carries_skip_marker_and_build_id():
+    targets = process_target_runs_to_json(_merged_runs())
+
+    by_id = {t["target_id"]: t for t in targets}
+    assert by_id["tA2"]["skipped_for_prerun_target_id"] == "tA1"
+    assert by_id["tA2"]["build_id"] == "retry"
+    assert by_id["tA1"]["skipped_for_prerun_target_id"] == ""
+    assert by_id["tB1"]["build_id"] == "root"


### PR DESCRIPTION
## Summary

Enhances `gbcli build status` to follow the **build retry chain** so a retried build presents one coherent view across all attempts, instead of the partial picture it showed before.

When a build fails and is configured for retries, gbserver assigns a new build ID and re-runs only the not-yet-successful targets, linking attempts via `retry_of_build_id` / `retry_build_id` and marking reused targets with `skipped_for_prerun_target_id`. Previously `build status <id>` queried a single build ID and showed only that build's targets — so a retried build was missing earlier-succeeded targets and showed skipped targets as plain "success".

### Server (`src/gbserver/api/builds.py`)
- Add an optional `follow_retries` query param. When set, the response includes a new optional `retry_chain` field — the chain members (root-first), each with its target runs. The existing `status` field is unchanged, so current callers are unaffected.
- Make `/status` the **primary** endpoint (reusing the existing `get_retry_chain_members()` helper). `/status2` is retained as a backward-compatible alias.

### CLI
- `build status` follows the chain **by default** (`--follow-retries/--no-follow-retries`).
- Merges all chain members' targets oldest→newest (sorted by attempt, then start time) and derives the predecessor/successor build-ID lists.
- Overview shows `Retry of Original Build(s)` / `Retried by Subsequent Build(s)` when non-empty.
- Skipped targets render with the ⏩ emoji and `Skipped for previously ran target <id>`, omit the empty steps/artifacts sections, and note their originating `Build ID` when it differs from the queried build.
- `--format json` emits a flat `targets` array (each carrying its `build_id`) plus the predecessor/successor ID lists in `details`.
- Start-time sorting is guarded against null timestamps (skipped runs have none).

### Additional cleanup
- **Rename status models** now that `/status` is the official endpoint: `BuildStatusResponse2` → `BuildStatusResponse`, `BuildStatus2` → `BuildStatus`, `TargetRecord2` → `TargetRecord` (the `get_build_status2` handler keeps its name — it is bound to the legacy `/status2` alias). No wire-format change; JSON field names are unchanged.
- **Robustness/typing fixes** in the CLI status path: return a clean error tuple when the gbserver call yields `None` (server/connection error) instead of dereferencing `None`; correct `process_target_runs`'s return annotation to `Dict[str, Any]`; default the JSON `build_id` to `""` for consistency with the plain renderer.

## Test plan
- New server test (`test/integration/standalone/api/test_build_status_retry_chain.py`): `follow_retries` off → only the queried build's targets, `retry_chain` is null; on → root-first chain with all members and skipped targets carrying `skipped_for_prerun_target_id`; `/status2` alias matches `/status`.
- New CLI unit test (`test/unit/gbcli/services/test_build_status_targets.py`): skip marker + `build_id` carried through both output formats; oldest→newest ordering by attempt then start time; null `started_at` does not break sorting.
- `make format` clean; existing gbcli unit/command and help-text suites pass (56 related tests green).

Closes ibm-granite/granite.build#155
