### PR TITLE
fix: pin AWS SDK cluster via PIP_CONSTRAINT to fix slow image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN echo "extra-index-url = https://${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}@n
 
 # Copy the source code and install in editable mode
 COPY . .
+# PIP_CONSTRAINT pins the AWS SDK cluster (boto3/botocore/awscli/aiobotocore) to
+# avoid multi-hour pip resolver backtracking. Applied to every pip invocation in
+# this stage. See constraints.txt for details.
+ENV PIP_CONSTRAINT=/app/constraints.txt
 RUN pip install --upgrade -e ".[all]"
 # Patch aiohttp and kubernetes_asyncio
 RUN patch -i connector.py.patch /opt/app-root/lib/python3.12/site-packages/aiohttp/connector.py

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,33 @@
+# pip install constraints — pin the packages that cause resolver backtracking.
+#
+# Why this file exists:
+#   `pip install -e ".[all]"` was spending ~2h17m in dependency-resolver
+#   backtracking, cycling through hundreds of versions of the AWS SDK cluster
+#   (boto3/botocore/awscli/aiobotocore/s3transfer). Two subtrees pin botocore to
+#   mutually-exclusive ranges: the skypilot git fork (awscli/botocore/boto3 >= …)
+#   vs. dmf-lib's aiobotocore (narrow botocore window). See issue #163.
+#
+#   These are TRANSITIVE deps (we don't import them directly), so they are pinned
+#   here as constraints rather than in pyproject.toml — a constraint means
+#   "if installed, must match" without declaring them as our own requirements.
+#   Applied via `ENV PIP_CONSTRAINT=/app/constraints.txt` in the Dockerfile (pip
+#   reads that env var like `-c`), so it covers every pip install in the stage.
+#
+# Versions below are the set pip ultimately resolved on a known-good build.
+# Bump them together when skypilot/dmf-lib move; remove this file once the
+# skypilot fork ships as a wheel (issue #163 fix #2).
+
+# --- AWS SDK cluster (primary backtracking source) ---
+boto3==1.41.5
+botocore==1.41.5
+awscli==1.43.5
+aiobotocore==2.26.0
+s3transfer==0.15.0
+
+# --- fsspec/s3fs stack (pulled via dmf-lib -> pyiceberg[s3fs], datasets) ---
+s3fs==2025.3.0
+fsspec==2025.3.0
+
+# --- fastapi/uvicorn stack (secondary backtracking source) ---
+uvicorn==0.35.0
+fastapi-cli==0.0.27


### PR DESCRIPTION
## Summary

The `pip install --upgrade -e ".[all]"` step in the builder image was taking **~2h17m**, caused by pip's dependency resolver **backtracking** over the AWS SDK cluster (`boto3`/`botocore`/`awscli`/`aiobotocore`/`s3transfer`). Two dependency subtrees pin `botocore` to mutually-exclusive ranges:

- the **skypilot git fork** → `awscli>=1.27.10`, `botocore>=1.29.10`, `boto3>=1.26.1` (awscli pins botocore exactly)
- **dmf-lib** → `aiobotocore`, which pins `botocore` to a narrow `>=x,<y` window

Their intersection is effectively a single `botocore` version, which pip had to discover by downloading and rejecting hundreds of version combinations. The Artifactory read-timeouts seen in the build log are a symptom of that request volume, not the root cause.

This PR adds `constraints.txt` pinning that cluster (plus the secondary `s3fs`/`fsspec` and `uvicorn`/`fastapi-cli` offenders) to the versions that resolve on a known-good build, and applies it in the builder stage via `ENV PIP_CONSTRAINT=/app/constraints.txt`. Verified against PyPI metadata that the pinned set is internally consistent (the three conflicting `botocore` windows intersect exactly at `botocore==1.41.5`), so the resolver has nothing left to search.

## Scope: image build only, not a mandatory path for local pip installs

This is intentionally a **patch to the container image build only**. The pins are applied through `PIP_CONSTRAINT` in the Dockerfile, **not** added to `pyproject.toml`:

- Developers running `pip install -e ".[all]"` (or `uv`, poetry, etc.) on their own machines are **unaffected** — the constraints are not part of the published/declared dependency metadata.
- These are transitive dependencies we don't import directly; a `constraints.txt` means "if installed, must match" without declaring them as first-class requirements of `granite.build`.
- If skypilot / dmf-lib move, the resolver can still adapt for local installs; only the image build applies the pins (bump them together when that happens).

This keeps the fix narrowly targeted at the slow CI/image build without imposing hard version pins on everyone who installs the package.

## Test plan

- [ ] Build the image (`make image` / `make imagex`) and confirm the `pip install` step completes in minutes rather than hours, with no `pip is looking at multiple versions …` backtracking banners in the log.
- [ ] Confirm the resolved versions match the `constraints.txt` pins.
- [ ] Confirm local `pip install -e ".[all]"` (without `PIP_CONSTRAINT`) is unchanged.

Closes ibm-granite/granite.build#163
