### PR TITLE
fix: event subscribe router on wrong app + missing tls_verify param

### DIFF
--- a/src/gbserver/api/event_subscribe.py
+++ b/src/gbserver/api/event_subscribe.py
@@ -20,6 +20,7 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
+from gbserver.api.builds import builds_api
 from gbserver.messaging.rabbitmq_admin import RabbitMQAdminError
 from gbserver.messaging.subscription_service import provision_subscription
 from gbserver.storage.singleton_storage import get_admin_storage
@@ -28,7 +29,7 @@ from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-event_subscribe_router = APIRouter(prefix="/builds", tags=["events"])
+event_subscribe_router = APIRouter(tags=["events"])
 
 
 # ── Response Model ────────────────────────────────────────────────────────
@@ -117,3 +118,7 @@ async def subscribe_build_events(build_id: str, request: Request) -> SubscribeRe
             detail="Event subscription service timed out.",
         ) from exc
     return SubscribeResponse(**result)
+
+
+# Register on the builds sub-app so the endpoint appears in /api/v1/builds/docs
+builds_api.include_router(event_subscribe_router)

--- a/src/gbserver/api/root_api.py
+++ b/src/gbserver/api/root_api.py
@@ -22,8 +22,8 @@ from fastapi import FastAPI
 
 from gbserver.api import (  # noqa: F401  registers routes on builds_api
     build_files as _build_files,
-    event_subscribe as _event_subscribe,
 )
+from gbserver.api import event_subscribe as _event_subscribe  # noqa: F401
 from gbserver.api.artifacts import artifacts_api
 from gbserver.api.auth import AuthMiddleware
 from gbserver.api.auth_routes import auth_api

--- a/src/gbserver/api/root_api.py
+++ b/src/gbserver/api/root_api.py
@@ -22,12 +22,12 @@ from fastapi import FastAPI
 
 from gbserver.api import (  # noqa: F401  registers routes on builds_api
     build_files as _build_files,
+    event_subscribe as _event_subscribe,
 )
 from gbserver.api.artifacts import artifacts_api
 from gbserver.api.auth import AuthMiddleware
 from gbserver.api.auth_routes import auth_api
 from gbserver.api.builds import builds_api
-from gbserver.api.event_subscribe import event_subscribe_router
 from gbserver.api.lineage import lineage_api
 from gbserver.api.logs import logs_api
 from gbserver.api.node_health import node_health_api
@@ -66,7 +66,6 @@ def read_root():
     }
 
 
-root_api.include_router(event_subscribe_router, prefix=API_BASE_PATH)
 root_api.mount(f"{API_BASE_PATH}/auth", auth_api)
 root_api.mount(f"{API_BASE_PATH}/artifacts", artifacts_api)
 root_api.mount(f"{API_BASE_PATH}/builds", builds_api)

--- a/src/gbserver/messaging/credential_cleanup.py
+++ b/src/gbserver/messaging/credential_cleanup.py
@@ -28,6 +28,7 @@ from gbserver.types.constants import (
     GBSERVER_RABBITMQ_MGMT_PASSWORD,
     GBSERVER_RABBITMQ_MGMT_URL,
     GBSERVER_RABBITMQ_MGMT_USER,
+    GBSERVER_RABBITMQ_TLS_VERIFY,
 )
 from gbserver.utils.logger import get_logger
 
@@ -41,6 +42,7 @@ def _get_admin() -> RabbitMQAdmin:
         management_url=GBSERVER_RABBITMQ_MGMT_URL,
         admin_user=GBSERVER_RABBITMQ_MGMT_USER,
         admin_password=GBSERVER_RABBITMQ_MGMT_PASSWORD,
+        tls_verify=GBSERVER_RABBITMQ_TLS_VERIFY,
     )
 
 

--- a/src/gbserver/messaging/rabbitmq_admin.py
+++ b/src/gbserver/messaging/rabbitmq_admin.py
@@ -122,7 +122,9 @@ class RabbitMQAdmin:
         expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
         expires_epoch = int(expires_at.timestamp())
 
-        async with httpx.AsyncClient(auth=self._auth(), verify=self._tls_verify) as client:
+        async with httpx.AsyncClient(
+            auth=self._auth(), verify=self._tls_verify
+        ) as client:
             # 1. Create user
             user_url = f"{self.management_url}/api/users/{username}"
             user_body = {
@@ -202,7 +204,9 @@ class RabbitMQAdmin:
         deleted = 0
         now = datetime.now(timezone.utc)
 
-        async with httpx.AsyncClient(auth=self._auth(), verify=self._tls_verify) as client:
+        async with httpx.AsyncClient(
+            auth=self._auth(), verify=self._tls_verify
+        ) as client:
             resp = await client.get(f"{self.management_url}/api/users")
             if resp.status_code != 200:
                 raise RabbitMQAdminError(
@@ -261,7 +265,9 @@ class RabbitMQAdmin:
         if client is not None:
             await _do_delete(client)
         else:
-            async with httpx.AsyncClient(auth=self._auth(), verify=self._tls_verify) as c:
+            async with httpx.AsyncClient(
+                auth=self._auth(), verify=self._tls_verify
+            ) as c:
                 await _do_delete(c)
 
     @staticmethod

--- a/src/gbserver/messaging/rabbitmq_admin.py
+++ b/src/gbserver/messaging/rabbitmq_admin.py
@@ -55,6 +55,7 @@ class RabbitMQAdmin:
         admin_user: str,
         admin_password: str,
         vhost: str = "/",
+        tls_verify: bool | str = True,
     ) -> None:
         """
         Parameters
@@ -67,12 +68,16 @@ class RabbitMQAdmin:
             Administrator password for the Management API.
         vhost : str
             RabbitMQ virtual host (default "/").
+        tls_verify : bool | str
+            TLS certificate verification for Management API calls.
+            True (default), False, or a path to a CA bundle.
         """
         self.management_url = management_url.rstrip("/")
         self.admin_user = admin_user
         self.admin_password = admin_password
         self.vhost = vhost
         self._vhost_encoded = urlquote(vhost, safe="")
+        self._tls_verify = tls_verify
 
     def _auth(self) -> httpx.BasicAuth:
         return httpx.BasicAuth(self.admin_user, self.admin_password)
@@ -117,7 +122,7 @@ class RabbitMQAdmin:
         expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
         expires_epoch = int(expires_at.timestamp())
 
-        async with httpx.AsyncClient(auth=self._auth()) as client:
+        async with httpx.AsyncClient(auth=self._auth(), verify=self._tls_verify) as client:
             # 1. Create user
             user_url = f"{self.management_url}/api/users/{username}"
             user_body = {
@@ -197,7 +202,7 @@ class RabbitMQAdmin:
         deleted = 0
         now = datetime.now(timezone.utc)
 
-        async with httpx.AsyncClient(auth=self._auth()) as client:
+        async with httpx.AsyncClient(auth=self._auth(), verify=self._tls_verify) as client:
             resp = await client.get(f"{self.management_url}/api/users")
             if resp.status_code != 200:
                 raise RabbitMQAdminError(
@@ -256,7 +261,7 @@ class RabbitMQAdmin:
         if client is not None:
             await _do_delete(client)
         else:
-            async with httpx.AsyncClient(auth=self._auth()) as c:
+            async with httpx.AsyncClient(auth=self._auth(), verify=self._tls_verify) as c:
                 await _do_delete(c)
 
     @staticmethod

--- a/test/unit/api/test_event_subscribe.py
+++ b/test/unit/api/test_event_subscribe.py
@@ -72,7 +72,7 @@ class _NoAuthMiddleware(BaseHTTPMiddleware):
 def _make_app(middleware_cls=_FakeAuthMiddleware) -> FastAPI:
     """Build a minimal FastAPI app with the event_subscribe_router."""
     app = FastAPI()
-    app.include_router(event_subscribe_router, prefix="/api/v1")
+    app.include_router(event_subscribe_router, prefix="/api/v1/builds")
     app.add_middleware(middleware_cls)
     return app
 

--- a/test/unit/api/test_event_subscribe_nats.py
+++ b/test/unit/api/test_event_subscribe_nats.py
@@ -52,7 +52,7 @@ class _FakeAuthMiddleware(BaseHTTPMiddleware):
 
 def _make_app() -> FastAPI:
     app = FastAPI()
-    app.include_router(event_subscribe_router, prefix="/api/v1")
+    app.include_router(event_subscribe_router, prefix="/api/v1/builds")
     app.add_middleware(_FakeAuthMiddleware)
     return app
 


### PR DESCRIPTION
## Summary
- Moves event subscribe router from `root_api` to `builds_api` sub-app so OpenAPI docs appear at `/api/v1/builds/docs` instead of root `/docs`
- Adds `tls_verify` parameter to `RabbitMQAdmin` — the constructor was receiving it but not accepting it, causing a `TypeError` → HTTP 500 on every subscribe request
- Passes `tls_verify` through to all `httpx.AsyncClient` calls for proper TLS certificate handling
- Also fixes `credential_cleanup.py` to pass `tls_verify` consistently

## Test plan
- [x] Unit tests pass (7 tests in `test_event_subscribe.py` + `test_event_subscribe_nats.py`)
- [x] Full messaging test suite passes (73 tests)
- [x] E2E verified against DEV RabbitMQ: provisioned scoped credentials, connected over TLS, published and consumed 5 events successfully
- [x] Confirmed HTTP 500 reproduces on current DEV deployment

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)