### PR TITLE
Package configurations/ so standalone mode works after a plain pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,26 @@ build-backend = "setuptools.build_meta"
 fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
-where = ["src", "test"]
+# "." picks up the repo-root `configurations/` tree (spaces, assets, environments,
+# steps). It has no __init__.py, so namespaces=true is required to treat it as a
+# package, and `include` scopes discovery so its subdirectories are not promoted
+# to top-level packages. Its non-.py payload is shipped via package-data below.
+# Located at runtime by gbserver.types.constants.find_configurations_root().
+where = ["src", "test", "."]
+# Explicit include so adding "." as a search root does not sweep in unintended
+# top-level dirs from the repo root; keep this in sync with the packages that
+# were discovered before (src/* and the test/* suites) plus configurations.
+include = [
+    "gbserver*",
+    "gbcli*",
+    "gbcommon*",
+    "libgbtest*",
+    "unit*",
+    "integration*",
+    "e2e*",
+    "configurations*",
+]
+namespaces = true
 
 [tool.setuptools.package-data]
 "*" = ["*", ".*"]

--- a/src/gbserver/commands/command_standalone.py
+++ b/src/gbserver/commands/command_standalone.py
@@ -29,10 +29,28 @@ import click
 import uvicorn
 
 from gbserver.commands.utils import check_and_init_for_standalone
+from gbserver.types.constants import (
+    CONFIGURATIONS_STANDALONE_SPACE_SUBPATH,
+    ENV_VAR_CONFIGURATIONS_DIR,
+    find_configurations_root,
+)
 from gbserver.types.context import CliEnvironment, pass_environment
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _default_space_dir() -> str:
+    """Resolve the default standalone space directory from the packaged
+    configurations tree, raising a clear error if it cannot be found."""
+    configurations_root = find_configurations_root()
+    if configurations_root is None:
+        raise click.UsageError(
+            "Could not locate the packaged 'configurations/' directory. Pass "
+            "--space-dir explicitly (a directory containing a space.yaml), or "
+            f"set {ENV_VAR_CONFIGURATIONS_DIR} to a configurations/ tree."
+        )
+    return str(configurations_root / CONFIGURATIONS_STANDALONE_SPACE_SUBPATH)
 
 
 def _start_nats_server(
@@ -220,14 +238,18 @@ def _run_standalone(
 )
 @click.option(
     "--space-dir",
-    default="configurations/spaces/local",
-    show_default=True,
+    default=None,
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    help="Path to the space directory.  Defaults to the in-repo standalone "
-    "space at configurations/spaces/local; override to point at "
-    "any directory containing a space.yaml.",
+    help="Path to the space directory (a directory containing a space.yaml).  "
+    "Defaults to the packaged standalone space (configurations/spaces/local), "
+    "discovered relative to the install or the current repo checkout.  Set "
+    "GBSERVER_CONFIGURATIONS_DIR to point discovery at a different "
+    "configurations/ tree.",
 )
 @pass_environment
-def cli(ctx: CliEnvironment, port: int, host: str, space_dir: str):
+def cli(ctx: CliEnvironment, port: int, host: str, space_dir: Optional[str]):
     """Run gbserver standalone -- REST API + BuildWatcher in one process."""
+    if space_dir is None:
+        space_dir = _default_space_dir()
+    logger.info("Using space directory: %s", space_dir)
     _run_standalone(port=port, host=host, space_dir=space_dir)

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -16,9 +16,11 @@
 
 """Contants and env vars that are used by many other modules."""
 
+import importlib.util
 import json
 import os
 from pathlib import Path
+from typing import Optional
 
 from dotenv import load_dotenv
 
@@ -63,6 +65,76 @@ CODE_GBSERVER_BUILTINS_STEPS_GBSTEP_DIR = CODE_GBSERVER_BUILTINS_STEPS_DIR / "gb
 CODE_GBSERVER_BUILTINS_STEPS_GBSTEP_URI = f"{FILE_SCHEME}://" + str(
     CODE_GBSERVER_BUILTINS_STEPS_GBSTEP_DIR
 )
+
+# ---------------------------------------------------------
+# configurations/ discovery
+#
+# The `configurations/` tree (spaces, assets, environments, steps) lives at the
+# repo root -- outside the `src/` package -- but is shipped as a namespace
+# package (see `[tool.setuptools.packages.find]` in pyproject.toml), so a
+# non-editable install lands it in site-packages/configurations/, importable as
+# the top-level `configurations` package. Depending on how gbserver was
+# installed and where it is run from, the tree may be in different places, so we
+# probe an ordered list of candidates and return the first that actually holds
+# the standalone space.
+#
+# Override with the GBSERVER_CONFIGURATIONS_DIR env var to point at any copy.
+ENV_VAR_CONFIGURATIONS_DIR = ENV_VAR_PREFIX + "_CONFIGURATIONS_DIR"
+
+# The src-layout repo root: this file is src/gbserver/types/constants.py, so
+# CODE_GBSERVER_DIR is src/gbserver and its .parent.parent is the repo root.
+_REPO_ROOT = CODE_GBSERVER_DIR.parent.parent
+
+# Sentinel that identifies a valid configurations root.
+_CONFIGURATIONS_SENTINEL = Path("spaces") / "local" / "space.yaml"
+
+
+def _installed_configurations_dir() -> Optional[Path]:
+    """Locate the installed `configurations` namespace package, if importable.
+
+    `configurations` ships as a namespace package (no __init__.py), so its spec
+    exposes the on-disk directory via ``submodule_search_locations`` rather than
+    a module origin. We read the first location that exists on disk.
+    """
+    try:
+        spec = importlib.util.find_spec("configurations")
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return None
+    if spec is None or spec.submodule_search_locations is None:
+        return None
+    for location in spec.submodule_search_locations:
+        path = Path(location)
+        if path.is_dir():
+            return path
+    return None
+
+
+def find_configurations_root() -> Optional[Path]:
+    """Locate the `configurations/` root across install layouts.
+
+    Returns the first candidate directory that contains the standalone space
+    (`spaces/local/space.yaml`), or None if none is found. Candidates, in order:
+
+    1. ``$GBSERVER_CONFIGURATIONS_DIR`` -- explicit override.
+    2. ``<cwd>/configurations`` -- running from a repo checkout (incl. ``-e``).
+    3. ``<repo root>/configurations`` -- src-layout checkout, any cwd.
+    4. The installed ``configurations`` namespace package (non-editable install).
+    """
+    override = os.environ.get(ENV_VAR_CONFIGURATIONS_DIR)
+    candidates = [
+        Path(override) if override else None,
+        Path.cwd() / "configurations",
+        _REPO_ROOT / "configurations",
+        _installed_configurations_dir(),
+    ]
+    for candidate in candidates:
+        if candidate and (candidate / _CONFIGURATIONS_SENTINEL).is_file():
+            return candidate.resolve()
+    return None
+
+
+# Subpath of the standalone space within a configurations root.
+CONFIGURATIONS_STANDALONE_SPACE_SUBPATH = Path("spaces") / "local"
 
 # ---------------------------------------------------------
 # Environment variables


### PR DESCRIPTION
## Summary

Makes `gbserver standalone` work regardless of how the package was installed (editable, non-editable, wheel, `git+https`) and regardless of the current working directory.

Previously the `configurations/` tree (spaces, assets, environments, steps) lived at the repo root — outside `src/` — so `packages.find` never included it, and `--space-dir` defaulted to the cwd-relative `configurations/spaces/local`. A non-editable `pip install .` / `pip install "git+https://…"` therefore shipped **no** `configurations/` at all, and standalone mode failed.

- **`pyproject.toml`** — ship `configurations/` as a namespace package via `packages.find` (`namespaces = true`, `where` includes `"."`, with an explicit `include` list scoped to the previously-discovered `src/`+`test/` packages plus `configurations`). The existing `package-data` catch-all carries the non-`.py` payload (`.yaml`/`.sh`/`Dockerfile`/…). A non-editable install lands the tree at `site-packages/configurations/`.
- **`src/gbserver/types/constants.py`** — add `find_configurations_root()`, which probes, in order: `$GBSERVER_CONFIGURATIONS_DIR` → `<cwd>/configurations` → `<repo-root>/configurations` → the installed `configurations` namespace package (located via `importlib.util.find_spec(...).submodule_search_locations`). Adds the `GBSERVER_CONFIGURATIONS_DIR` env var to the central registry.
- **`src/gbserver/commands/command_standalone.py`** — `--space-dir` now defaults to the resolved packaged space, fails with an actionable error if the tree can't be found, and logs the determined space dir.

The design and the considered alternative (a `setup.py` + `[tool.setuptools.data-files]` walker) are documented in ibm-granite/granite.build#168, including pros/cons of each.

## Net user-facing effect

Just `gbserver standalone` now works with **no options** after a plain `pip install` — no need to be in a repo checkout or to pass `--space-dir`. Passing `--space-dir` explicitly still works, as does pointing discovery at a different tree via `GBSERVER_CONFIGURATIONS_DIR`.

## Docs

Documentation updates (README / configurations docs that still show `--space-dir configurations/spaces/local`) are intentionally **deferred** to avoid conflicts with other in-flight documentation changes. Those references still work when run from a repo checkout; a follow-up will note that the flag is now optional post-install.

## Test plan

Verified by building a wheel and testing across layouts:

- [x] Editable install, from repo root — resolves the local space
- [x] Editable install, from a different cwd — now resolves (previously broke)
- [x] Non-editable install into a fresh venv, neutral cwd — resolves via the installed namespace package (the original bug)
- [x] `GBSERVER_CONFIGURATIONS_DIR` override honored
- [x] Wheel contains the full `configurations/` tree with structure preserved; diff of old-vs-new wheel file lists shows the package set is identical except for the added `configurations/`
- [x] `gbserver standalone --help` renders from a fresh non-editable install
- [x] Existing config/step/standalone unit tests pass; black / isort / mypy clean; pylint shows no new findings

Refs ibm-granite/granite.build#168
