### PR TITLE
Fix failing nightly tests in test_skypilot_slurm_e2e.py

### DIFF
--- a/test/integration/environment/test_skypilot_slurm_e2e.py
+++ b/test/integration/environment/test_skypilot_slurm_e2e.py
@@ -83,6 +83,24 @@ class TestSlurmBuildLifecycle:
             config={
                 "default_cloud": "slurm",
                 "idle_minutes_to_autostop": 0,
+                # Inline the slurm-docker SSH config so gbserver materializes it
+                # into ~/.slurm/config at launch time (setup-slurm.sh no longer
+                # writes that file). Without this, SkyPilot reports
+                # "Cluster slurm-docker not found ... Available clusters: []".
+                # Host/Port mirror the SLURM_SSH_* vars used by the skip gate.
+                "cluster_ssh_configs": {
+                    "slurm": [
+                        {
+                            "Host": "slurm-docker",
+                            "HostName": os.environ.get("SLURM_SSH_HOST", "127.0.0.1"),
+                            "User": "root",
+                            "Port": os.environ.get("SLURM_SSH_PORT", "2222"),
+                            "IdentityFile": "~/.ssh/slurm_docker_key",
+                            "StrictHostKeyChecking": "no",
+                            "UserKnownHostsFile": "/dev/null",
+                        }
+                    ]
+                },
             },
         )
         return Skypilot(event_q=event_q, environment_config=config)


### PR DESCRIPTION
## Description

FIxes a skypilot/slurm configuration problem in the [night build tests](https://github.com/ibm-granite/granite.build/actions/runs/28491430347/job/84448791423). 

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
