### PR TITLE
fix: reject event subscription to finished builds, add authorization

### DIFF
--- a/src/gbserver/api/event_subscribe.py
+++ b/src/gbserver/api/event_subscribe.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
 from gbserver.api.builds import builds_api
+from gbserver.api.utils import has_space_write_access
 from gbserver.messaging.rabbitmq_admin import RabbitMQAdminError
 from gbserver.messaging.subscription_service import provision_subscription
 from gbserver.storage.singleton_storage import get_admin_storage
@@ -83,7 +84,24 @@ async def subscribe_build_events(build_id: str, request: Request) -> SubscribeRe
         )
     assert isinstance(build, StoredBuild)
 
-    # 3. Provision credentials via messaging layer
+    # 3. Authorize: user must be build owner, space admin, or super admin
+    has_access, user_id = has_space_write_access(
+        request, username_on_target=build.username, space_name=build.space_name
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"User {user_id} does not have access to build {build_id}.",
+        )
+
+    # 4. Reject subscription to finished builds (no events will be published)
+    if build.status.is_finished():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Build {build_id} has already finished (status: {build.status}).",
+        )
+
+    # 5. Provision credentials via messaging layer
     try:
         result = await provision_subscription(build_id)
     except RabbitMQAdminError as exc:

--- a/test/unit/api/test_event_subscribe.py
+++ b/test/unit/api/test_event_subscribe.py
@@ -244,3 +244,90 @@ class TestEventSubscribeEndpoint:
 
         assert response.status_code == 504
         assert "timed out" in response.json()["detail"]
+
+    @patch("gbserver.api.utils.space_admin_check", return_value=False)
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_subscribe_to_other_users_build_returns_403(
+        self, mock_get_storage, _mock_admin_check
+    ):
+        """Subscribing to a build owned by another user returns 403."""
+        build_id = "other-user-build-123"
+        other_users_build = StoredBuild(
+            uuid=build_id,
+            name="test-build",
+            space_name="test-space",
+            source_uri="",
+            username="other-user",  # Different from "testuser"
+            build_archive="",
+            status="running",
+        )
+
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = other_users_build
+        mock_get_storage.return_value = mock_storage
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 403
+        assert "does not have access" in response.json()["detail"]
+
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_subscribe_to_finished_build_returns_409(self, mock_get_storage):
+        """Subscribing to a finished build returns 409 Conflict."""
+        build_id = "finished-build-456"
+        finished_build = StoredBuild(
+            uuid=build_id,
+            name="test-build",
+            space_name="test-space",
+            source_uri="",
+            username="testuser",
+            build_archive="",
+            status="success",
+        )
+
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = finished_build
+        mock_get_storage.return_value = mock_storage
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 409
+        assert "already finished" in response.json()["detail"]
+
+    @patch("gbserver.api.event_subscribe.get_admin_storage")
+    def test_subscribe_to_failed_build_returns_409(self, mock_get_storage):
+        """Subscribing to a failed build returns 409 Conflict."""
+        build_id = "failed-build-789"
+        failed_build = StoredBuild(
+            uuid=build_id,
+            name="test-build",
+            space_name="test-space",
+            source_uri="",
+            username="testuser",
+            build_archive="",
+            status="failed",
+        )
+
+        mock_storage = MagicMock()
+        mock_storage.build_storage.get_by_uuid.return_value = failed_build
+        mock_get_storage.return_value = mock_storage
+
+        app = _make_app()
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/builds/{build_id}/events/subscribe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        assert response.status_code == 409
+        assert "already finished" in response.json()["detail"]

--- a/test/unit/api/test_event_subscribe.py
+++ b/test/unit/api/test_event_subscribe.py
@@ -245,10 +245,13 @@ class TestEventSubscribeEndpoint:
         assert response.status_code == 504
         assert "timed out" in response.json()["detail"]
 
-    @patch("gbserver.api.utils.space_admin_check", return_value=False)
+    @patch(
+        "gbserver.api.event_subscribe.has_space_write_access",
+        return_value=(False, "testuser"),
+    )
     @patch("gbserver.api.event_subscribe.get_admin_storage")
     def test_subscribe_to_other_users_build_returns_403(
-        self, mock_get_storage, _mock_admin_check
+        self, mock_get_storage, _mock_access
     ):
         """Subscribing to a build owned by another user returns 403."""
         build_id = "other-user-build-123"


### PR DESCRIPTION
## Summary
- **Authorization check**: User must be build owner, space admin, or super admin to subscribe (returns `403 Forbidden` otherwise). Uses existing `has_space_write_access` utility.
- **Finished build check**: Subscribing to a completed build (success, failed, invalid, cancelled) returns `409 Conflict` instead of provisioning credentials that will never receive events.
- **Code cleanup**: Removed redundant `Status(build.status)` wrapper per review feedback — `build.status.is_finished()` works directly since Pydantic coerces to the enum.

## Test plan
- [x] `test_subscribe_to_other_users_build_returns_403` — non-owner/non-admin gets 403
- [x] `test_subscribe_to_finished_build_returns_409` — success status gets 409
- [x] `test_subscribe_to_failed_build_returns_409` — failed status gets 409
- [x] All 10 tests pass (9 RabbitMQ + 1 NATS)
- [x] Formatting clean (black + isort)

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)