### PR TITLE
feat: dynamic checkpoint-fanout RL build with per-checkpoint evals

### DIFF
--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/combined-export/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/combined-export/step.yaml
@@ -1,0 +1,171 @@
+name: combined-export
+version: 1.0.0
+type: EVAL
+# Combined roll-up (issue #45): pivots the per-checkpoint sage export CSVs into
+# a single benchmark x checkpoint table. Rows are benchmarks (the sage CSV's
+# `model` + `metric` columns), columns are checkpoints (ckpt_<step>), so each
+# row reads left-to-right as a metric's trajectory across the run.
+#
+# Reuses the sage image only for its Python 3.11; the pivot itself is stdlib
+# csv, no sage/exporter dependency (unlike sage-export, which re-scans a result
+# tree — that path can't roll up flat per-checkpoint experiment dirs).
+config:
+  workload:
+    cwd: "."
+  gb:
+    mock: false
+    step_contents_in_env: false
+  combined_export_config:
+    # Directories holding the per-checkpoint CSVs. sage CSVs live under
+    # SAGE_RESULTS_DIR/EXPERIMENT; bfcl CSVs under BFCL_RESULTS_DIR/EXPERIMENT.
+    # Either may be empty/absent (e.g. a run with no bfcl eval).
+    sage_input_dir: ""
+    bfcl_input_dir: ""
+    # Globs (relative to the respective dir) selecting the per-checkpoint CSVs.
+    # The step parses <step> from each ckpt_<step>-*.csv name for the column.
+    sage_input_glob: "ckpt_*-sage.csv"
+    bfcl_input_glob: "ckpt_*-bfcl.csv"
+    output_csv: ""
+outputs:
+  optional:
+    combined_csv:
+      type: dataset
+
+environment_configs:
+  Skypilot:
+    default_launcher: combined-export
+    launchers:
+      combined-export:
+        type: skypilot
+        monitors:
+        - skypilot_monitor
+        config:
+          image_id: "docker:us.icr.io/cil15-shared-registry/sage-py311:0.025"
+          resources:
+            memory: "16"
+          run: |
+            set -e
+            echo "=== Combined Results Roll-up (benchmark x checkpoint) ==="
+
+            export SAGE_INPUT_DIR="{{ config.combined_export_config.sage_input_dir }}"
+            export BFCL_INPUT_DIR="{{ config.combined_export_config.bfcl_input_dir }}"
+            export SAGE_INPUT_GLOB="{{ config.combined_export_config.sage_input_glob }}"
+            export BFCL_INPUT_GLOB="{{ config.combined_export_config.bfcl_input_glob }}"
+            export COMBINED_OUTPUT_CSV="{{ config.combined_export_config.output_csv }}"
+
+            echo "  Sage input: $SAGE_INPUT_DIR/$SAGE_INPUT_GLOB"
+            echo "  BFCL input: $BFCL_INPUT_DIR/$BFCL_INPUT_GLOB"
+            echo "  Output:     $COMBINED_OUTPUT_CSV"
+
+            mkdir -p "$(dirname "$COMBINED_OUTPUT_CSV")"
+
+            if [[ -x "/opt/miniconda3/bin/python" ]]; then
+              PYTHON_BIN="/opt/miniconda3/bin/python"
+            else
+              PYTHON_BIN="python3"
+            fi
+
+            "$PYTHON_BIN" - <<'PIVOT_PY'
+            import csv, glob, os, re, sys
+
+            output_csv = os.environ["COMBINED_OUTPUT_CSV"]
+
+            def step_of(path):
+                # Column key from the numeric checkpoint step in the filename
+                # (ckpt_<step>-*.csv), so columns sort ckpt_2 < ckpt_10.
+                m = re.search(r"ckpt_(\d+)", os.path.basename(path))
+                return int(m.group(1)) if m else -1
+
+            # Discover every checkpoint column across both eval kinds; a column
+            # exists if either a sage OR a bfcl CSV is present for that step.
+            def discover(dir_env, glob_env):
+                d = os.environ.get(dir_env, "")
+                if not d:
+                    return {}
+                return {step_of(p): p for p in glob.glob(os.path.join(d, os.environ[glob_env]))}
+
+            sage_files = discover("SAGE_INPUT_DIR", "SAGE_INPUT_GLOB")
+            bfcl_files = discover("BFCL_INPUT_DIR", "BFCL_INPUT_GLOB")
+
+            steps = sorted(set(sage_files) | set(bfcl_files))
+            if not steps:
+                sys.exit("ERROR: no per-checkpoint sage or bfcl CSVs found")
+            columns = [f"ckpt_{s}" for s in steps]
+
+            # Rows keyed by (model, metric); first-seen order preserved so a
+            # benchmark present only in a later checkpoint still appears.
+            row_order = []
+            seen = set()
+            values = {}  # (model, metric) -> {col: value}
+
+            def add(key, col, value):
+                if key not in seen:
+                    seen.add(key)
+                    row_order.append(key)
+                values.setdefault(key, {})[col] = value
+
+            for s in steps:
+                col = f"ckpt_{s}"
+                # sage CSV: (model, metric, <value-headed-by-result-path>).
+                path = sage_files.get(s)
+                if path:
+                    with open(path, newline="") as fh:
+                        reader = csv.reader(fh)
+                        next(reader, None)  # header
+                        for parts in reader:
+                            if len(parts) < 3:
+                                continue
+                            add((parts[0], parts[1]), col, parts[2])
+                # bfcl CSV: (expt, overall) -> one row per expt, e.g. BFCL-bfclv3.
+                path = bfcl_files.get(s)
+                if path:
+                    with open(path, newline="") as fh:
+                        reader = csv.reader(fh)
+                        next(reader, None)  # header (expt, overall)
+                        for parts in reader:
+                            if len(parts) < 2:
+                                continue
+                            add((f"BFCL-{parts[0]}", "overall"), col, parts[1])
+
+            with open(output_csv, "w", newline="") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(["model", "metric", *columns])
+                for key in row_order:
+                    model, metric = key
+                    writer.writerow(
+                        [model, metric, *[values[key].get(c, "") for c in columns]]
+                    )
+
+            print(f"Wrote {output_csv}: {len(row_order)} benchmarks x {len(columns)} checkpoints")
+            PIVOT_PY
+
+            echo "=== CSV OUTPUT ==="
+            cat "$COMBINED_OUTPUT_CSV"
+            echo "=== END CSV OUTPUT ==="
+
+            echo "LLMB_ARTIFACT_ID:combined_csv LLMB_ARTIFACT_PATH:${COMBINED_OUTPUT_CSV}"
+    monitors:
+      skypilot_monitor:
+        type: skypilot_monitor
+        config:
+          poll_interval_seconds: "{{ config.poll_interval_seconds | default(90) }}"
+          log_retrieval:
+            # Export steps emit no mid-run events; pull the log once at the end.
+            mode: "{{ config.log_retrieval_mode | default('on_completion') }}"
+          event_configs:
+          - event_type: WORKLOAD_STATUS_EVENT
+            line_regex: "Combined Results Roll-up"
+            event_fields:
+              - field_name: status
+                field_value_template: "RUNNING"
+          - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
+            line_regex: "LLMB_ARTIFACT_ID:.+LLMB_ARTIFACT_PATH:.+"
+            event_fields:
+              - field_name: binding_id
+                field_regex: "(?<=LLMB_ARTIFACT_ID:)[^ ]+"
+              - field_name: path
+                field_regex: "(?<=LLMB_ARTIFACT_PATH:).*"
+                is_data: true
+              - field_name: binding
+                field_value_template: '{ "path": "{{ fields.data.path }}" }'
+                is_json: true

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -320,9 +320,41 @@ environment_configs:
 
             watch_checkpoints &
             WATCH_PID=$!
+            {% endif %}
 
+            # ── Ray hygiene (issue #45): diagnose + neutralize a stale cluster
+            # address ──────────────────────────────────────────────────────
+            # open_instruct.grpo_fast calls a bare ray.init(), which resolves an
+            # address from (1) $RAY_ADDRESS, then (2) the session file
+            # /tmp/ray/ray_current_cluster written by a prior `ray start`. If a
+            # previous run on shared storage (HOME=/stage) or a leaked env var
+            # left an address pointing at another node, ray.init() connects
+            # THERE and hangs ~12 min on a dead GCS
+            # (RRpcError: Timed out while waiting for GCS to become available),
+            # failing the job before training starts. This was observed on a run
+            # where the job ran on one node but ray.init() dialed a foreign
+            # node's :6379.
+            #
+            # First print the two sources (so the real origin is visible in the
+            # log), then neutralize both and give Ray a fresh, node-local temp
+            # dir so a new run can't collide with another node's leftovers on a
+            # shared /tmp. All steps are best-effort/idempotent — safe for the
+            # single-checkpoint recipes that share this step.
+            echo "[ray-hygiene] RAY_ADDRESS=${RAY_ADDRESS:-<unset>}"
+            echo "[ray-hygiene] session file (/tmp/ray/ray_current_cluster):"
+            cat /tmp/ray/ray_current_cluster 2>/dev/null || echo "  <none>"
+            unset RAY_ADDRESS
+            ray stop --force >/dev/null 2>&1 || true
+            rm -f /tmp/ray/ray_current_cluster 2>/dev/null || true
+            export RAY_TMPDIR="${TMPDIR:-/tmp}/ray-${SKYPILOT_TASK_ID:-$$}"
+            mkdir -p "$RAY_TMPDIR"
+            echo "[ray-hygiene] cleared; RAY_TMPDIR=$RAY_TMPDIR"
+
+            # Run the trainer. This always runs; only the per-checkpoint watcher
+            # around it (above/below) is gated on emit_checkpoint_artifacts.
             bash "$GRPO_SCRIPT"
 
+            {% if config.emit_checkpoint_artifacts in _true %}
             # Training succeeded: stop the watcher, then do a final sweep for any
             # checkpoints written between the last poll and training exit.
             cleanup_watcher

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -267,6 +267,17 @@ environment_configs:
             OUTPUT_DIR="{{ config.rl_config.output_dir }}"
             CKPT_GLOB="step_"
             CKPT_WATCH_INTERVAL="{{ config.checkpoint_watch_interval_seconds | default(30) }}"
+            # Completeness sentinels: emit a checkpoint only once BOTH files are
+            # present. grpo_fast's HF save_pretrained writes model.safetensors
+            # early in the sequence and tokenizer.json last (verified on BlueVela
+            # step_10/step_20 by mtime: config -> model.safetensors -> tokenizer
+            # files, tokenizer.json last). Requiring both "bookends" — the heavy
+            # weights AND the final tokenizer file — brackets the whole write
+            # sequence, so a downstream H100 eval never loads a dir that is
+            # non-empty but still mid-write (a plain `ls -A` non-empty check would
+            # race that window and eval a partial/corrupt model). Weights-only or
+            # sharded checkpoints: add model.safetensors.index.json here too.
+            CKPT_SENTINELS="model.safetensors tokenizer.json"
             # Marker files (one per emitted checkpoint) live here. This dir is
             # the shared source of truth between the background watcher and the
             # parent: the watcher runs `emit_new_checkpoints` in a subshell, so a
@@ -282,10 +293,13 @@ environment_configs:
                 step="${base#${CKPT_GLOB}}"
                 marker="$EMITTED_DIR/$base"
                 [ -e "$marker" ] && continue
-                # Only emit once the dir is non-empty, to avoid racing a
-                # partially-written checkpoint. (Provisional completeness check;
-                # tighten to a sentinel file if grpo_fast writes one.)
-                [ -n "$(ls -A "$ckpt" 2>/dev/null)" ] || continue
+                # Gate on every completeness sentinel; skip until all are present
+                # so we never emit a checkpoint dir that is still being written.
+                complete=1
+                for sentinel in $CKPT_SENTINELS; do
+                  [ -f "$ckpt/$sentinel" ] || { complete=0; break; }
+                done
+                [ "$complete" -eq 1 ] || continue
                 touch "$marker"
                 echo "LLMB_ARTIFACT_ID:checkpoint_${step} LLMB_ARTIFACT_PATH:${ckpt}"
               done

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -7,6 +7,15 @@ config:
   gb:
     mock: false
     step_contents_in_env: false
+  # Monitor cadence + checkpoint-watch knobs (issue #45). poll_interval_seconds
+  # and log_retrieval_* are consumed by the skypilot_monitor block below;
+  # checkpoint_watch_interval_seconds is consumed by the in-run watcher that
+  # emits one artifact per new checkpoint dir. All have safe defaults so the
+  # existing single-checkpoint recipes need not set them.
+  poll_interval_seconds: 900
+  log_retrieval_mode: "periodic"
+  log_retrieval_interval_seconds: 900
+  checkpoint_watch_interval_seconds: 30
   rl_config:
     # ── identification ──
     exp_name: ""
@@ -235,17 +244,70 @@ environment_configs:
             GRPO_CMD
             chmod +x "$GRPO_SCRIPT"
 
+            # ── Per-checkpoint artifact emission (issue #45) ────────────────
+            # grpo_fast writes a checkpoint every save_freq optimizer updates
+            # into a per-step subdir of output_dir. To let downstream eval
+            # targets start against each checkpoint AS SOON AS it is written
+            # (not only at the end), a background watcher polls output_dir and
+            # emits one artifact line per new checkpoint dir. The periodic
+            # skypilot_monitor scrapes these mid-run.
+            #
+            # Convention (must match generate_build.py's checkpoint_<step>
+            # output names): the checkpoint dir is named "step_<N>", where <N>
+            # is the optimizer-update index, and the emitted id is
+            # "checkpoint_<N>". VERIFY (issue #45 BlueVela run): confirm
+            # grpo_fast's actual dir naming; if it differs (e.g. global_step_N,
+            # checkpoint-N), adjust the CKPT_GLOB / step parsing below and keep
+            # the generator's naming in lock-step.
+            OUTPUT_DIR="{{ config.rl_config.output_dir }}"
+            CKPT_GLOB="step_"
+            CKPT_WATCH_INTERVAL="{{ config.checkpoint_watch_interval_seconds | default(30) }}"
+            EMITTED_DIR="$(mktemp -d)"
+
+            emit_new_checkpoints() {
+              # Emit an artifact line for each checkpoint dir not yet emitted.
+              for ckpt in "$OUTPUT_DIR"/${CKPT_GLOB}*; do
+                [ -d "$ckpt" ] || continue
+                base="$(basename "$ckpt")"
+                step="${base#${CKPT_GLOB}}"
+                marker="$EMITTED_DIR/$base"
+                [ -e "$marker" ] && continue
+                # Only emit once the dir is non-empty, to avoid racing a
+                # partially-written checkpoint. (Provisional completeness check;
+                # tighten to a sentinel file if grpo_fast writes one.)
+                [ -n "$(ls -A "$ckpt" 2>/dev/null)" ] || continue
+                touch "$marker"
+                echo "LLMB_ARTIFACT_ID:checkpoint_${step} LLMB_ARTIFACT_PATH:${ckpt}"
+              done
+            }
+
+            watch_checkpoints() {
+              while true; do
+                emit_new_checkpoints
+                sleep "$CKPT_WATCH_INTERVAL"
+              done
+            }
+
             echo "[$(date)] Starting GRPO training"
             echo "  exp_name: {{ config.rl_config.exp_name }}"
             echo "  output:   {{ config.rl_config.output_dir }}"
+
+            watch_checkpoints &
+            WATCH_PID=$!
+
             bash "$GRPO_SCRIPT"
 
-            # Emit the checkpoint artifact for downstream targets. GRPO writes
-            # checkpoints directly under output_dir (no SFT-style epoch_hf_*
-            # conversion), so the artifact path is output_dir.
-            # VERIFY (issue-36 BlueVela run): confirm grpo_fast writes the
-            # final checkpoint under output_dir (no epoch subdir), so this is
-            # the correct artifact path.
+            # Stop the watcher and do a final sweep for any checkpoints written
+            # between the last poll and training exit.
+            kill "$WATCH_PID" 2>/dev/null || true
+            emit_new_checkpoints
+
+            # Backward-compatible final artifact for recipes that bind a single
+            # `checkpoint` output (ifrl-smoke, ifrl-full, identityrl-*). GRPO
+            # writes checkpoints directly under output_dir (no SFT-style
+            # epoch_hf_* conversion), so the artifact path is output_dir. In the
+            # checkpoint-fanout builds this id has no matching output and is
+            # harmlessly ignored (buildrun logs a warning and continues).
             echo "LLMB_ARTIFACT_ID:checkpoint LLMB_ARTIFACT_PATH:{{ config.rl_config.output_dir }}"
     monitors:
       skypilot_monitor:

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -333,7 +333,9 @@ environment_configs:
                 WATCH_PID=""
               fi
             }
-            trap cleanup_watcher EXIT
+            # EXIT-time cleanup: reap the watcher and remove the marker tmpdir on
+            # every path (success, trainer failure, signal).
+            trap 'cleanup_watcher; rm -rf "$EMITTED_DIR"' EXIT
 
             watch_checkpoints &
             WATCH_PID=$!

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -267,8 +267,12 @@ environment_configs:
             OUTPUT_DIR="{{ config.rl_config.output_dir }}"
             CKPT_GLOB="step_"
             CKPT_WATCH_INTERVAL="{{ config.checkpoint_watch_interval_seconds | default(30) }}"
+            # Marker files (one per emitted checkpoint) live here. This dir is
+            # the shared source of truth between the background watcher and the
+            # parent: the watcher runs `emit_new_checkpoints` in a subshell, so a
+            # shell counter variable would NOT propagate back to the parent — the
+            # emitted count must be read from these on-disk markers instead.
             EMITTED_DIR="$(mktemp -d)"
-            EMITTED_COUNT=0
 
             emit_new_checkpoints() {
               # Emit an artifact line for each checkpoint dir not yet emitted.
@@ -283,7 +287,6 @@ environment_configs:
                 # tighten to a sentinel file if grpo_fast writes one.)
                 [ -n "$(ls -A "$ckpt" 2>/dev/null)" ] || continue
                 touch "$marker"
-                EMITTED_COUNT=$((EMITTED_COUNT + 1))
                 echo "LLMB_ARTIFACT_ID:checkpoint_${step} LLMB_ARTIFACT_PATH:${ckpt}"
               done
             }
@@ -368,11 +371,16 @@ environment_configs:
             cleanup_watcher
             emit_new_checkpoints
 
-            # Fail loudly if the watcher never matched a checkpoint dir: the
-            # downstream eval/export/combined targets bind checkpoint_<step> ids
-            # and would otherwise stall forever with no error. A zero count means
-            # the on-disk naming doesn't match CKPT_GLOB (grpo_fast may use
-            # global_step_N / checkpoint-N) — see VERIFY note above.
+            # Fail loudly if NO checkpoint was ever emitted: the downstream
+            # eval/export/combined targets bind checkpoint_<step> ids and would
+            # otherwise stall forever with no error. Count the on-disk marker
+            # files, NOT a shell variable — emit_new_checkpoints runs inside the
+            # backgrounded watcher subshell, so a counter var it incremented
+            # never propagates back here; the markers in $EMITTED_DIR are the
+            # shared source of truth. Zero markers means the on-disk naming
+            # doesn't match CKPT_GLOB (grpo_fast may use global_step_N /
+            # checkpoint-N) — see VERIFY note above.
+            EMITTED_COUNT="$(find "$EMITTED_DIR" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l)"
             if [ "$EMITTED_COUNT" -eq 0 ]; then
               echo "ERROR: no checkpoint dirs matched '${OUTPUT_DIR}/${CKPT_GLOB}*'." >&2
               echo "       grpo_fast wrote no '${CKPT_GLOB}<N>' dirs; downstream" >&2

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -15,6 +15,11 @@ config:
   poll_interval_seconds: 900
   log_retrieval_mode: "periodic"
   log_retrieval_interval_seconds: 900
+  # Per-checkpoint artifact emission is opt-in: only the checkpoint-fanout recipe
+  # (which binds checkpoint_<step> outputs) sets this true. Left false, the older
+  # single-checkpoint recipes (ifrl-smoke, ifrl-full, identityrl-*) don't run the
+  # watcher and so don't emit per-step artifact lines they never bind.
+  emit_checkpoint_artifacts: false
   checkpoint_watch_interval_seconds: 30
   rl_config:
     # ── identification ──
@@ -263,6 +268,7 @@ environment_configs:
             CKPT_GLOB="step_"
             CKPT_WATCH_INTERVAL="{{ config.checkpoint_watch_interval_seconds | default(30) }}"
             EMITTED_DIR="$(mktemp -d)"
+            EMITTED_COUNT=0
 
             emit_new_checkpoints() {
               # Emit an artifact line for each checkpoint dir not yet emitted.
@@ -277,6 +283,7 @@ environment_configs:
                 # tighten to a sentinel file if grpo_fast writes one.)
                 [ -n "$(ls -A "$ckpt" 2>/dev/null)" ] || continue
                 touch "$marker"
+                EMITTED_COUNT=$((EMITTED_COUNT + 1))
                 echo "LLMB_ARTIFACT_ID:checkpoint_${step} LLMB_ARTIFACT_PATH:${ckpt}"
               done
             }
@@ -292,15 +299,49 @@ environment_configs:
             echo "  exp_name: {{ config.rl_config.exp_name }}"
             echo "  output:   {{ config.rl_config.output_dir }}"
 
+            {% set _true = [true, "true", "True", "1", 1] -%}
+            {% if config.emit_checkpoint_artifacts in _true %}
+            # ── Watcher lifecycle (issue #45) ───────────────────────────────
+            # The whole run executes under `set -e`, so a non-zero exit from the
+            # trainer would abort before an inline `kill`, orphaning the watch
+            # loop until container teardown. A trap tied to EXIT cleans up on
+            # every path (success, trainer failure, signal); `wait` reaps the
+            # watcher so it and the final sweep don't share $EMITTED_DIR
+            # concurrently.
+            WATCH_PID=""
+            cleanup_watcher() {
+              if [ -n "$WATCH_PID" ] && kill -0 "$WATCH_PID" 2>/dev/null; then
+                kill "$WATCH_PID" 2>/dev/null || true
+                wait "$WATCH_PID" 2>/dev/null || true
+                WATCH_PID=""
+              fi
+            }
+            trap cleanup_watcher EXIT
+
             watch_checkpoints &
             WATCH_PID=$!
 
             bash "$GRPO_SCRIPT"
 
-            # Stop the watcher and do a final sweep for any checkpoints written
-            # between the last poll and training exit.
-            kill "$WATCH_PID" 2>/dev/null || true
+            # Training succeeded: stop the watcher, then do a final sweep for any
+            # checkpoints written between the last poll and training exit.
+            cleanup_watcher
             emit_new_checkpoints
+
+            # Fail loudly if the watcher never matched a checkpoint dir: the
+            # downstream eval/export/combined targets bind checkpoint_<step> ids
+            # and would otherwise stall forever with no error. A zero count means
+            # the on-disk naming doesn't match CKPT_GLOB (grpo_fast may use
+            # global_step_N / checkpoint-N) — see VERIFY note above.
+            if [ "$EMITTED_COUNT" -eq 0 ]; then
+              echo "ERROR: no checkpoint dirs matched '${OUTPUT_DIR}/${CKPT_GLOB}*'." >&2
+              echo "       grpo_fast wrote no '${CKPT_GLOB}<N>' dirs; downstream" >&2
+              echo "       eval targets would never dispatch. Check the actual" >&2
+              echo "       checkpoint dir naming and align CKPT_GLOB + the" >&2
+              echo "       generator's checkpoint_<step> outputs." >&2
+              exit 1
+            fi
+            {% endif %}
 
             # Backward-compatible final artifact for recipes that bind a single
             # `checkpoint` output (ifrl-smoke, ifrl-full, identityrl-*). GRPO

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/steps/openinstruct-rl/step.yaml
@@ -346,7 +346,15 @@ environment_configs:
             unset RAY_ADDRESS
             ray stop --force >/dev/null 2>&1 || true
             rm -f /tmp/ray/ray_current_cluster 2>/dev/null || true
-            export RAY_TMPDIR="${TMPDIR:-/tmp}/ray-${SKYPILOT_TASK_ID:-$$}"
+            # Setting RAY_TMPDIR forces grpo_fast onto its explicit-temp-dir
+            # branch (ray.init(_temp_dir=...)), which STARTS a fresh local
+            # cluster instead of the bare ray.init() that resolved a stale
+            # remote address above. RAY_TMPDIR must stay SHORT: Ray appends
+            # /session_<ts>_<pid>/sockets/plasma_store (~65 bytes) and the
+            # resulting AF_UNIX socket path cannot exceed 107 bytes. The
+            # SkyPilot task id is ~48 chars and blows that limit, so key the
+            # dir off the (short) PID under /tmp (node-local tmpfs) instead.
+            export RAY_TMPDIR="/tmp/ray-$$"
             mkdir -p "$RAY_TMPDIR"
             echo "[ray-hygiene] cleared; RAY_TMPDIR=$RAY_TMPDIR"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ standalone = [
 thirdparty = [
     "docker>=7.0.0",
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
-    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@f97d93d45b98ce37b316030415dbb77a4615ebd1",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override; pinned to commit until upstreamed
+    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@9b9ae871d63ea2d8259434acc9432ed6a17435e6",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix; pinned to commit until upstreamed
     "wandb",
 ]
 # Tier 3: IBM-specific — requires IBM infrastructure (cloud, cluster, Artifactory)
@@ -94,7 +94,7 @@ ibm = [
     "kubernetes_asyncio>=35.0.1",	# Avoids missing watch import created in kubernetes==36.0.0
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
     "psycopg2-binary",
-    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@f97d93d45b98ce37b316030415dbb77a4615ebd1",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override; pinned to commit until upstreamed
+    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@9b9ae871d63ea2d8259434acc9432ed6a17435e6",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix; pinned to commit until upstreamed
 ]
 # All optional dependencies
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ standalone = [
 thirdparty = [
     "docker>=7.0.0",
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
-    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@9b9ae871d63ea2d8259434acc9432ed6a17435e6",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix; pinned to commit until upstreamed
+    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@gb-sky-v1-stable",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix. gb-sky-v1-stable is a moving alias for the recommended v1-line commit (re-pointed as the fork advances, like a docker minor tag); a breaking jump gets a new tag. Fresh installs re-resolve it; cached clones need `git fetch --tags --force`.
     "wandb",
 ]
 # Tier 3: IBM-specific — requires IBM infrastructure (cloud, cluster, Artifactory)
@@ -94,7 +94,7 @@ ibm = [
     "kubernetes_asyncio>=35.0.1",	# Avoids missing watch import created in kubernetes==36.0.0
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
     "psycopg2-binary",
-    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@9b9ae871d63ea2d8259434acc9432ed6a17435e6",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix; pinned to commit until upstreamed
+    "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@gb-sky-v1-stable",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix. gb-sky-v1-stable is a moving alias for the recommended v1-line commit (re-pointed as the fork advances, like a docker minor tag); a breaking jump gets a new tag. Fresh installs re-resolve it; cached clones need `git fetch --tags --force`.
 ]
 # All optional dependencies
 all = [

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/.gitignore
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/.gitignore
@@ -1,0 +1,6 @@
+# Generator artifacts (produced by generate_build.py). Unlike the hand-written
+# recipes, build.yaml here is generated per run and should not be committed.
+build.yaml
+parameters-resolved.yaml
+# Applied-parameters file written by `gb build start`.
+parameters-applied.yaml

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -28,9 +28,9 @@ target-set per checkpoint.
 
    ```shell
    python generate_build.py --workflow ifrl \
-     --model-path /proj/.../sft/checkpoint-7180 \
+     --model-path /proj/.../sft/epoch_hf_2 \
      --output-dir /proj/.../rl-out/ \
-     --total-episodes 4096 --save-freq 1 \
+     --total-episodes 20480 --save-freq 10 \
      --eval-sets 'bfcl,multilingual-eval' \
      --output build.yaml
    ```
@@ -95,8 +95,8 @@ num_updates    = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER
 checkpoints at = SAVE_FREQ, 2*SAVE_FREQ, …  (≤ num_updates, plus the final update)
 ```
 
-Smoke default: `2048 // (64*16) = 2` updates, `SAVE_FREQ=1` ⇒ checkpoints at
-steps **1** and **2**. Each checkpoint is fanned out to the selected evals, so
+Smoke default: `20480 // (64*16) = 20` updates, `SAVE_FREQ=10` ⇒ checkpoints at
+steps **10** and **20**. Each checkpoint is fanned out to the selected evals, so
 `total eval targets = #checkpoints × #evals`. The generator prints this — watch
 it before starting a `full-eval` run over many checkpoints (that is a lot of
 clusters on the `preemptable` queue).
@@ -137,7 +137,9 @@ Provisional until confirmed against a real BlueVela grpo_fast run:
 
 - **Checkpoint dir naming.** The watcher assumes `output_dir/step_<N>`. If
   grpo_fast names dirs differently (`global_step_N`, `checkpoint-N`), adjust
-  `CKPT_GLOB`/parsing in the step and the generator's naming together.
+  `CKPT_GLOB`/parsing in the step and the generator's naming together. A
+  mismatch now **fails the training target loudly** (non-zero exit with a
+  diagnostic) rather than letting the downstream eval targets stall silently.
 - **Mid-run emission.** Confirm the periodic monitor surfaces each checkpoint
   line while the job is RUNNING (not only at terminal status).
 - **Combined exporter.** Confirm `sage/exporters/exporter.py` rolls up multiple

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -67,6 +67,7 @@ file; `--param` wins on conflict.
 | Save a checkpoint every N updates (drives the schedule) | `SAVE_FREQ` | `--save-freq` |
 | Trainer's in-loop eval frequency | `EVAL_FREQ` | `--eval-freq` |
 | Which evaluations to run | `EVAL_SETS` | `--eval-sets` |
+| Experiment namespace for eval/export outputs | `EXPERIMENT` | `--experiment` |
 | How often training logs are downloaded + parsed for checkpoints | `RL_LOG_SCRAPE_INTERVAL_SECONDS` | `--log-scrape-interval` |
 | How often training job status is checked | `RL_STATUS_POLL_INTERVAL_SECONDS` | `--train-status-interval` |
 | How often eval job status is checked | `EVAL_STATUS_POLL_INTERVAL_SECONDS` | `--eval-status-interval` |

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -119,9 +119,12 @@ Lower values detect sooner at the cost of more `sky logs`/status calls.
 - `export-sage-ckpt<step>` / `export-bfcl-ckpt<step>` — one exporter per
   checkpoint, gated on that checkpoint's eval outputs, producing
   `<SAGE_RESULTS_DIR|BFCL_RESULTS_DIR>/<EXPERIMENT>/ckpt_<step>-{sage,bfcl}.csv`.
-- `export-combined` — gated on **all** per-checkpoint exports, runs the sage
-  exporter once over the whole `<EXPERIMENT>` tree to produce
-  `<SAGE_RESULTS_DIR>/<EXPERIMENT>/combined.csv`.
+- `export-combined` — gated on **all** per-checkpoint exports, pivots them into
+  `<SAGE_RESULTS_DIR>/<EXPERIMENT>/combined.csv`: a **benchmark × checkpoint**
+  table (rows are benchmarks — the sage `model`+`metric`, plus one `BFCL-<expt>`
+  row per bfcl eval; columns are `ckpt_<step>`), so each row reads left-to-right
+  as a metric's trajectory across the run. It reads whichever of sage/bfcl
+  actually ran (either alone is fine).
 
 ## Trainer step change
 
@@ -133,16 +136,19 @@ per-step ids match the generated `checkpoint_<step>` training outputs.
 
 ## Verification status (issue #45)
 
-Provisional until confirmed against a real BlueVela grpo_fast run:
+Confirmed against real BlueVela grpo_fast runs:
 
-- **Checkpoint dir naming.** The watcher assumes `output_dir/step_<N>`. If
-  grpo_fast names dirs differently (`global_step_N`, `checkpoint-N`), adjust
-  `CKPT_GLOB`/parsing in the step and the generator's naming together. A
-  mismatch now **fails the training target loudly** (non-zero exit with a
+- **Checkpoint dir naming.** grpo_fast writes HF checkpoints as `output_dir/step_<N>`
+  (confirmed: `step_10`, `step_20`), which the watcher globs directly. A naming
+  mismatch **fails the training target loudly** (non-zero exit with a
   diagnostic) rather than letting the downstream eval targets stall silently.
+- **Combined roll-up.** `export-combined` does **not** re-scan a sage result
+  tree (sage-eval requires a flat experiment name, so per-checkpoint results are
+  siblings, not a nestable tree). It pivots the per-checkpoint CSVs the gates
+  already guarantee exist into a benchmark × checkpoint table — see Aggregation.
+
+Still provisional:
+
 - **Mid-run emission.** Confirm the periodic monitor surfaces each checkpoint
-  line while the job is RUNNING (not only at terminal status).
-- **Combined exporter.** Confirm `sage/exporters/exporter.py` rolls up multiple
-  `ckpt_*` experiment dirs into one CSV distinguishable by checkpoint; if not,
-  `export-combined` should post-process the per-checkpoint CSVs (which the gates
-  already guarantee exist).
+  line while the job is RUNNING (not only at terminal status), so evals can
+  start before training finishes.

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -67,6 +67,9 @@ file; `--param` wins on conflict.
 | Save a checkpoint every N updates (drives the schedule) | `SAVE_FREQ` | `--save-freq` |
 | Trainer's in-loop eval frequency | `EVAL_FREQ` | `--eval-freq` |
 | Which evaluations to run | `EVAL_SETS` | `--eval-sets` |
+| How often training logs are downloaded + parsed for checkpoints | `RL_LOG_SCRAPE_INTERVAL_SECONDS` | `--log-scrape-interval` |
+| How often training job status is checked | `RL_STATUS_POLL_INTERVAL_SECONDS` | `--train-status-interval` |
+| How often eval job status is checked | `EVAL_STATUS_POLL_INTERVAL_SECONDS` | `--eval-status-interval` |
 
 **Chaining stages** (e.g. IFRL → IdentityRL): `MODEL_PATH` is a static path, so
 run the first build, then generate the second with

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -1,0 +1,116 @@
+# rl-checkpoint-eval — dynamic checkpoint-fanout RL build
+
+One build that runs **IFRL** or **IdentityRL** training, evaluates **every
+checkpoint** the trainer writes, and aggregates the results — per-checkpoint
+CSVs plus a combined roll-up across checkpoints. (Issue #45.)
+
+Unlike `sft-eval-full-dataset` (which evaluates a single final checkpoint), this
+recipe fans a *selected* eval suite out over *each* checkpoint of the run. Since
+the build engine dispatches each downstream target exactly once (keyed by its
+binding id), the fanout can't be open-ended: `generate_build.py` computes the
+checkpoint schedule up front and emits one training output + one eval
+target-set per checkpoint.
+
+## Files
+
+- `generate_build.py` — the generator. Reads `parameters.yaml` + `--param`
+  overrides and `eval-catalog.yaml`, writes a plain `build.yaml`.
+- `eval-catalog.yaml` — the 27 evals (transcribed from `sft-eval-full-dataset`)
+  and named sets (`code-eval`, `general-eval`, `math-eval`, `safety-eval`,
+  `multilingual-eval`, `bfcl`, `full-eval`). The generator's source of truth.
+- `parameters.yaml` — RL knobs (from `ifrl-smoke`) + eval/resource knobs (from
+  `sft-eval-full-dataset`) + eval selection + monitor cadence.
+
+## Usage
+
+1. **Generate** the build:
+
+   ```shell
+   python generate_build.py --workflow ifrl \
+     --param 'EVAL_SETS=[bfcl, multilingual-eval]' \
+     --output build.yaml
+   ```
+
+   The generator prints the resolved checkpoint list, eval list, and total
+   target count to stderr. `--workflow identityrl` omits the `code-server`
+   target (IdentityRL trains without a code server).
+
+2. **Start** the build (parameters are substituted at this step, as usual):
+
+   ```shell
+   gb build start -f build.yaml \
+     --parameters-path parameters.yaml --space <your-space>
+   ```
+
+   Keep the same `parameters.yaml` for both steps: the generator only expands
+   the knobs it needs (checkpoint schedule, eval selection); everything else
+   stays as `$${...}` placeholders resolved by `gb build start`.
+
+## Selecting evaluations — `EVAL_SETS`
+
+A list of **named sets and/or individual eval names** (see `eval-catalog.yaml`):
+
+- `[full-eval]` — all 27 evaluations.
+- `[bfcl, multilingual-eval]` — the single BFCL eval + the 5 multilingual evals.
+- `[olmes-gsm8k, math-eval]` — an individual eval plus a whole set (de-duped).
+
+Override at generation time: `--param 'EVAL_SETS=[code-eval]'`.
+
+## How many checkpoints? — the schedule
+
+open-instruct floor-divides:
+
+```
+num_updates    = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT)
+checkpoints at = SAVE_FREQ, 2*SAVE_FREQ, …  (≤ num_updates, plus the final update)
+```
+
+Smoke default: `2048 // (64*16) = 2` updates, `SAVE_FREQ=1` ⇒ checkpoints at
+steps **1** and **2**. Each checkpoint is fanned out to the selected evals, so
+`total eval targets = #checkpoints × #evals`. The generator prints this — watch
+it before starting a `full-eval` run over many checkpoints (that is a lot of
+clusters on the `preemptable` queue).
+
+## Monitor cadence (how soon checkpoints/evals are picked up)
+
+Three knobs control detection latency (all in `parameters.yaml`, overridable):
+
+| Parameter | Controls |
+|---|---|
+| `RL_CHECKPOINT_WATCH_INTERVAL_SECONDS` | How often the trainer's in-run watcher polls `output_dir` for a newly written checkpoint dir and emits it as an artifact. |
+| `RL_LOG_SCRAPE_INTERVAL_SECONDS` | How often the training `skypilot_monitor` pulls + parses logs (in `periodic` mode) — bounds how soon an emitted checkpoint line reaches the build. |
+| `RL_STATUS_POLL_INTERVAL_SECONDS` | How often the training job's SkyPilot status is polled. |
+| `EVAL_STATUS_POLL_INTERVAL_SECONDS` | How often each eval target's status is polled — bounds how soon an eval's completion is detected so its export runs. |
+
+Lower values detect sooner at the cost of more `sky logs`/status calls.
+
+## Aggregation
+
+- `export-sage-ckpt<step>` / `export-bfcl-ckpt<step>` — one exporter per
+  checkpoint, gated on that checkpoint's eval outputs, producing
+  `<SAGE_RESULTS_DIR|BFCL_RESULTS_DIR>/<EXPERIMENT>/ckpt_<step>-{sage,bfcl}.csv`.
+- `export-combined` — gated on **all** per-checkpoint exports, runs the sage
+  exporter once over the whole `<EXPERIMENT>` tree to produce
+  `<SAGE_RESULTS_DIR>/<EXPERIMENT>/combined.csv`.
+
+## Trainer step change
+
+`configurations/.../steps/openinstruct-rl/step.yaml` now runs a background
+watcher during training that emits `LLMB_ARTIFACT_ID:checkpoint_<step>
+LLMB_ARTIFACT_PATH:<dir>` per new checkpoint dir, in addition to the
+backward-compatible final `checkpoint` line the older recipes bind to. The
+per-step ids match the generated `checkpoint_<step>` training outputs.
+
+## Verification status (issue #45)
+
+Provisional until confirmed against a real BlueVela grpo_fast run:
+
+- **Checkpoint dir naming.** The watcher assumes `output_dir/step_<N>`. If
+  grpo_fast names dirs differently (`global_step_N`, `checkpoint-N`), adjust
+  `CKPT_GLOB`/parsing in the step and the generator's naming together.
+- **Mid-run emission.** Confirm the periodic monitor surfaces each checkpoint
+  line while the job is RUNNING (not only at terminal status).
+- **Combined exporter.** Confirm `sage/exporters/exporter.py` rolls up multiple
+  `ckpt_*` experiment dirs into one CSV distinguishable by checkpoint; if not,
+  `export-combined` should post-process the per-checkpoint CSVs (which the gates
+  already guarantee exist).

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -23,28 +23,54 @@ target-set per checkpoint.
 
 ## Usage
 
-1. **Generate** the build:
+1. **Generate** the build. Set the common knobs with flags (or leave them to
+   `parameters.yaml`):
 
    ```shell
    python generate_build.py --workflow ifrl \
-     --param 'EVAL_SETS=[bfcl, multilingual-eval]' \
+     --model-path /proj/.../sft/checkpoint-7180 \
+     --output-dir /proj/.../rl-out/ \
+     --total-episodes 4096 --save-freq 1 \
+     --eval-sets 'bfcl,multilingual-eval' \
      --output build.yaml
    ```
 
-   The generator prints the resolved checkpoint list, eval list, and total
-   target count to stderr. `--workflow identityrl` omits the `code-server`
-   target (IdentityRL trains without a code server).
+   The generator writes **two** files and prints the checkpoint list, eval list,
+   target count, and the exact start command to stderr:
+   - `build.yaml` — the generated build.
+   - `parameters-resolved.yaml` — the base parameters merged with your flags and
+     `--param` overrides. **Pass this to `gb build start`** so those overrides
+     are honored when the build's `$${...}` placeholders are resolved (override
+     the path with `--params-out`).
 
-2. **Start** the build (parameters are substituted at this step, as usual):
+   `--workflow identityrl` omits the `code-server` target (IdentityRL trains
+   without a code server).
+
+2. **Start** the build with the resolved parameters:
 
    ```shell
    gb build start -f build.yaml \
-     --parameters-path parameters.yaml --space <your-space>
+     --parameters-path parameters-resolved.yaml --space <your-space>
    ```
 
-   Keep the same `parameters.yaml` for both steps: the generator only expands
-   the knobs it needs (checkpoint schedule, eval selection); everything else
-   stays as `$${...}` placeholders resolved by `gb build start`.
+### Common parameters
+
+The frequently-changed knobs are collected at the top of `parameters.yaml` and
+each has an equivalent generator flag. The flag and `--param` both override the
+file; `--param` wins on conflict.
+
+| Concept | Parameter | Flag |
+|---|---|---|
+| Input checkpoint to train from (SFT ckpt for IFRL; a prior RL ckpt for IdentityRL) | `MODEL_PATH` | `--model-path` |
+| Output dir the trainer writes checkpoints to | `OUTPUT_DIR` | `--output-dir` |
+| Total training episodes (drives checkpoint count) | `TOTAL_EPISODES` | `--total-episodes` |
+| Save a checkpoint every N updates (drives the schedule) | `SAVE_FREQ` | `--save-freq` |
+| Trainer's in-loop eval frequency | `EVAL_FREQ` | `--eval-freq` |
+| Which evaluations to run | `EVAL_SETS` | `--eval-sets` |
+
+**Chaining stages** (e.g. IFRL → IdentityRL): `MODEL_PATH` is a static path, so
+run the first build, then generate the second with
+`--model-path <first run's final checkpoint>`.
 
 ## Selecting evaluations — `EVAL_SETS`
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/README.md
@@ -139,16 +139,29 @@ per-step ids match the generated `checkpoint_<step>` training outputs.
 Confirmed against real BlueVela grpo_fast runs:
 
 - **Checkpoint dir naming.** grpo_fast writes HF checkpoints as `output_dir/step_<N>`
-  (confirmed: `step_10`, `step_20`), which the watcher globs directly. A naming
-  mismatch **fails the training target loudly** (non-zero exit with a
-  diagnostic) rather than letting the downstream eval targets stall silently.
+  (confirmed: `step_10`, `step_20`), which the watcher globs directly.
+- **Completeness gating.** The watcher emits a checkpoint only once both
+  `model.safetensors` and `tokenizer.json` are present. grpo_fast writes the
+  weights early and `tokenizer.json` last (confirmed by mtime), so requiring
+  both brackets the whole write sequence — a downstream eval never loads a dir
+  that is still mid-write.
+- **Mid-run emission.** Confirmed: in one run, training started at 03:16:49, the
+  step-10 evals dispatched at 03:36:25, and training finished at 03:47:42 — the
+  step-10 fanout began ~11 min *before* training completed. The final (step-20)
+  evals dispatched just after completion, as expected.
 - **Combined roll-up.** `export-combined` does **not** re-scan a sage result
   tree (sage-eval requires a flat experiment name, so per-checkpoint results are
   siblings, not a nestable tree). It pivots the per-checkpoint CSVs the gates
   already guarantee exist into a benchmark × checkpoint table — see Aggregation.
 
-Still provisional:
+Operational risk:
 
-- **Mid-run emission.** Confirm the periodic monitor surfaces each checkpoint
-  line while the job is RUNNING (not only at terminal status), so evals can
-  start before training finishes.
+- **Cluster leak on a naming mismatch.** If a future grpo_fast change renames
+  checkpoint dirs (e.g. `global_step_N`), the watcher emits nothing: eval targets
+  bound to a never-emitted `checkpoint_<N>` never dispatch, and `teardown` —
+  gated on `training.checkpoint_<last_step>` — never fires, leaking the RL
+  cluster (H100:8) + RM/code servers until idle-timeout. The training step now
+  guards this by **failing loudly** (non-zero exit) when zero checkpoints are
+  emitted, so the build fails cleanly instead of hanging. If you change the
+  naming, update `CKPT_GLOB` in the step and `compute_checkpoint_steps` in the
+  generator together.

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/eval-catalog.yaml
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/eval-catalog.yaml
@@ -1,0 +1,338 @@
+# Evaluation catalog for the rl-checkpoint-eval generator (issue #45).
+#
+# Single source of truth for the 27 evaluations, transcribed once from
+# recipes/granite4-350m/lsf/sft-eval-full-dataset/build.yaml. generate_build.py
+# reads this file to emit per-checkpoint eval targets; keep it in sync if the
+# sft-eval-full-dataset suite changes.
+#
+# Each eval entry:
+#   category       — one of: code, general, math, safety, multilingual, bfcl.
+#   step_uri       — space://steps/sage-eval (most) or space://steps/bfcl-eval.
+#   gb_script      — sage gb_script name (sage-eval only; omitted for bfcl).
+#   image_id       — container image the eval runs in.
+#   output_subpath — appended under <SAGE_OUTPUT_DIR>/<experiment>/ for the
+#                    target's `sage_eval_results` output URI (sage-eval only).
+#                    bfcl uses <BFCL_OUTPUT_DIR>/<experiment>/<BFCL_EVAL_NAME>.
+#   overrides      — optional per-eval config overrides that differ from the
+#                    parameter defaults. Recognized keys:
+#                      batch_size      — literal batch_size (e.g. ifeval: 30)
+#                      max_length      — literal max_length (e.g. multiple-*: 512)
+#                      extra_env       — dict merged into sage_eval_config.extra_env
+#                    A value of the literal string "$${OE_EVAL_BCB_API_URL}" in
+#                    extra_env is passed through so the parameter is substituted
+#                    at `gb build start` time.
+#
+# The `experiment` the generator writes into each eval is namespaced per
+# checkpoint (e.g. "<EXPERIMENT>/ckpt_<step>") so results land in distinct dirs
+# and the sage/bfcl exporters can roll them up per checkpoint and combined.
+
+evals:
+  # ─── Code (9) ───────────────────────────────────────────────────────────────
+  olmes-cruxeval:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_olmes_cruxeval_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: code/olmes-instruct/cruxeval_output
+    overrides: {}
+
+  olmes-bigcodebench:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_olmes_bigcodebench_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "code/olmes-instruct/bigcodebench::tulu"
+    overrides:
+      extra_env:
+        OE_EVAL_BCB_API_URL: "$${OE_EVAL_BCB_API_URL}"
+
+  evalplus-humaneval:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_evalplus_humaneval_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/evalplus/humaneval
+    overrides: {}
+
+  evalplus-mbpp:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_evalplus_mbpp_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/evalplus/mbpp
+    overrides: {}
+
+  multiple-sh:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_multiple_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/multiple/sh
+    overrides:
+      max_length: 512
+      extra_env:
+        MULTIPLE_LANG: "sh"
+        MAX_LENGTH: "512"
+
+  multiple-cpp:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_multiple_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/multiple/cpp
+    overrides:
+      max_length: 512
+      extra_env:
+        MULTIPLE_LANG: "cpp"
+        MAX_LENGTH: "512"
+
+  multiple-java:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_multiple_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/multiple/java
+    overrides:
+      max_length: 512
+      extra_env:
+        MULTIPLE_LANG: "java"
+        MAX_LENGTH: "512"
+
+  multiple-js:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_multiple_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/multiple/js
+    overrides:
+      max_length: 512
+      extra_env:
+        MULTIPLE_LANG: "js"
+        MAX_LENGTH: "512"
+
+  multiple-rs:
+    category: code
+    step_uri: space://steps/sage-eval
+    gb_script: code_multiple_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-code:0.025
+    output_subpath: code/multiple/rs
+    overrides:
+      max_length: 512
+      extra_env:
+        MULTIPLE_LANG: "rs"
+        MAX_LENGTH: "512"
+
+  # ─── General (5) ──────────────────────────────────────────────────────────────
+  olmes-agi-eval:
+    category: general
+    step_uri: space://steps/sage-eval
+    gb_script: general_olmes_agi_eval_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "general/olmes-instruct/agi_eval_english:0shot_cot::tulu3"
+    overrides: {}
+
+  olmes-bbh:
+    category: general
+    step_uri: space://steps/sage-eval
+    gb_script: general_olmes_bbh_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "general/olmes-instruct/bbh:cot-v1::tulu"
+    overrides: {}
+
+  olmes-mmlu-pro:
+    category: general
+    step_uri: space://steps/sage-eval
+    gb_script: general_olmes_mmlu_pro_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "general/olmes-instruct/mmlu_pro:cot::none"
+    overrides: {}
+
+  olmes-ifeval:
+    category: general
+    step_uri: space://steps/sage-eval
+    gb_script: general_olmes_ifeval_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "general/olmes-instruct/ifeval::tulu"
+    overrides:
+      batch_size: 30
+
+  olmes-mmlu-mc:
+    category: general
+    step_uri: space://steps/sage-eval
+    gb_script: general_olmes_mmlu_mc_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "general/olmes-instruct/mmlu:mc::tulu"
+    overrides: {}
+
+  # ─── Math (5) ───────────────────────────────────────────────────────────────
+  olmes-deepmind-math:
+    category: math
+    step_uri: space://steps/sage-eval
+    gb_script: math_olmes_deepmind_math_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "math/olmes-instruct/deepmind_math:0shot_cot::tulu3"
+    overrides: {}
+
+  olmes-gpqa:
+    category: math
+    step_uri: space://steps/sage-eval
+    gb_script: math_olmes_gpqa_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "math/olmes-instruct/gpqa:0shot_cot::llama3.1"
+    overrides: {}
+
+  olmes-gsm8k:
+    category: math
+    step_uri: space://steps/sage-eval
+    gb_script: math_olmes_gsm8k_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "math/olmes-instruct/gsm8k::tulu"
+    overrides: {}
+
+  olmes-gsm-symbolic:
+    category: math
+    step_uri: space://steps/sage-eval
+    gb_script: math_olmes_gsm_symbolic_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "math/olmes-instruct/gsm_symbolic::tulu"
+    overrides: {}
+
+  olmes-minerva-math:
+    category: math
+    step_uri: space://steps/sage-eval
+    gb_script: math_olmes_minerva_math_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-olmes:0.025
+    output_subpath: "math/olmes-instruct/minerva_math::llama3.1"
+    overrides: {}
+
+  # ─── Safety (2) ─────────────────────────────────────────────────────────────
+  attaq:
+    category: safety
+    step_uri: space://steps/sage-eval
+    gb_script: safety_attaq_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-safety:0.025
+    output_subpath: safety/attaq
+    overrides: {}
+
+  salad-bench:
+    category: safety
+    step_uri: space://steps/sage-eval
+    gb_script: safety_salad_bench_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-safety:0.025
+    output_subpath: safety/salad_bench
+    overrides: {}
+
+  # ─── Multilingual (5) ─────────────────────────────────────────────────────────
+  global-mmlu:
+    category: multilingual
+    step_uri: space://steps/sage-eval
+    gb_script: multilingual_global_mmlu_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-multilingual:0.025
+    output_subpath: multilingual/global_mmlu
+    overrides: {}
+
+  mgsm:
+    category: multilingual
+    step_uri: space://steps/sage-eval
+    gb_script: multilingual_mgsm_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-multilingual:0.025
+    output_subpath: multilingual/mgsm
+    overrides: {}
+
+  include-ar-de-es-fr:
+    category: multilingual
+    step_uri: space://steps/sage-eval
+    gb_script: multilingual_include_arabic_german_spanish_french_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-multilingual:0.025
+    output_subpath: multilingual/include-5shot/arabic_german_spanish_french
+    overrides: {}
+
+  include-hi-bn-ta-te:
+    category: multilingual
+    step_uri: space://steps/sage-eval
+    gb_script: multilingual_include_hindi_bengali_tamil_telugu_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-multilingual:0.025
+    output_subpath: multilingual/include-5shot/hindi_bengali_tamil_telugu
+    overrides: {}
+
+  include-it-ja-ko-nl-pt-zh:
+    category: multilingual
+    step_uri: space://steps/sage-eval
+    gb_script: multilingual_include_italian_japanese_korean_dutch_portuguese_chinese_slim.sh
+    image_id: docker:us.icr.io/cil15-shared-registry/sage-py311-multilingual:0.025
+    output_subpath: multilingual/include-5shot/italian_japanese_korean_dutch_portuguese_chinese
+    overrides: {}
+
+  # ─── BFCL (1) ─────────────────────────────────────────────────────────────────
+  bfcl:
+    category: bfcl
+    step_uri: space://steps/bfcl-eval
+    # No image_id: the bfcl-eval step hardcodes its container; it is not a
+    # config key (unlike sage-eval, which reads sage_eval_config.image_id).
+    overrides: {}
+
+# Named selections referenced by the EVAL_SETS parameter. A set name expands to
+# its list of eval names; individual eval names may also be listed directly in
+# EVAL_SETS. full-eval is all 27.
+sets:
+  code-eval:
+    - olmes-cruxeval
+    - olmes-bigcodebench
+    - evalplus-humaneval
+    - evalplus-mbpp
+    - multiple-sh
+    - multiple-cpp
+    - multiple-java
+    - multiple-js
+    - multiple-rs
+  general-eval:
+    - olmes-agi-eval
+    - olmes-bbh
+    - olmes-mmlu-pro
+    - olmes-ifeval
+    - olmes-mmlu-mc
+  math-eval:
+    - olmes-deepmind-math
+    - olmes-gpqa
+    - olmes-gsm8k
+    - olmes-gsm-symbolic
+    - olmes-minerva-math
+  safety-eval:
+    - attaq
+    - salad-bench
+  multilingual-eval:
+    - global-mmlu
+    - mgsm
+    - include-ar-de-es-fr
+    - include-hi-bn-ta-te
+    - include-it-ja-ko-nl-pt-zh
+  bfcl:
+    - bfcl
+  full-eval:
+    - olmes-cruxeval
+    - olmes-bigcodebench
+    - evalplus-humaneval
+    - evalplus-mbpp
+    - multiple-sh
+    - multiple-cpp
+    - multiple-java
+    - multiple-js
+    - multiple-rs
+    - olmes-agi-eval
+    - olmes-bbh
+    - olmes-mmlu-pro
+    - olmes-ifeval
+    - olmes-mmlu-mc
+    - olmes-deepmind-math
+    - olmes-gpqa
+    - olmes-gsm8k
+    - olmes-gsm-symbolic
+    - olmes-minerva-math
+    - attaq
+    - salad-bench
+    - global-mmlu
+    - mgsm
+    - include-ar-de-es-fr
+    - include-hi-bn-ta-te
+    - include-it-ja-ko-nl-pt-zh
+    - bfcl

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -17,7 +17,7 @@ Usage:
     python generate_build.py --workflow ifrl \\
         --parameters-path parameters.yaml \\
         --catalog-path eval-catalog.yaml \\
-        --param TOTAL_EPISODES=2048 --param SAVE_FREQ=1 \\
+        --param TOTAL_EPISODES=20480 --param SAVE_FREQ=10 \\
         --param 'EVAL_SETS=[bfcl, multilingual-eval]' \\
         --output build.yaml
 
@@ -393,6 +393,10 @@ def build_training_target(workflow, checkpoint_steps):
                     "poll_interval_seconds": "$${RL_STATUS_POLL_INTERVAL_SECONDS}",
                     "log_retrieval_mode": "periodic",
                     "log_retrieval_interval_seconds": "$${RL_LOG_SCRAPE_INTERVAL_SECONDS}",
+                    # Opt into per-checkpoint artifact emission: this recipe binds
+                    # the checkpoint_<step> outputs, so the step's in-run watcher
+                    # must run (it's off by default for single-checkpoint recipes).
+                    "emit_checkpoint_artifacts": True,
                     # How often the in-run watcher polls output_dir for newly
                     # written checkpoint dirs to emit as artifacts.
                     "checkpoint_watch_interval_seconds": "$${RL_CHECKPOINT_WATCH_INTERVAL_SECONDS}",
@@ -407,8 +411,15 @@ def build_training_target(workflow, checkpoint_steps):
 
 
 def _experiment_for_step(step):
-    """Per-checkpoint experiment namespace so results land in distinct dirs."""
-    return "$${EXPERIMENT}-ckpt_" + str(step)
+    """Per-checkpoint experiment namespace so results land in distinct dirs.
+
+    A `/`-separated *subdir* of $${EXPERIMENT} (not a name suffix): per-checkpoint
+    results land at <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/..., i.e. children
+    of <SAGE_OUTPUT_DIR>/<EXPERIMENT>. This is what build_combined_export_target
+    scans (input_dir/experiment = <SAGE_OUTPUT_DIR>/<EXPERIMENT>); a `-ckpt_`
+    suffix would make them siblings and the combined roll-up would find nothing.
+    """
+    return "$${EXPERIMENT}/ckpt_" + str(step)
 
 
 def build_sage_eval_target(eval_name, entry, step):
@@ -529,12 +540,18 @@ def build_sage_export_target(step, sage_eval_target_names):
     }
 
 
-def build_bfcl_export_target(step):
-    """Per-checkpoint BFCL exporter, gated on that checkpoint's bfcl eval."""
+def build_bfcl_export_target(step, bfcl_eval_target_name):
+    """Per-checkpoint BFCL exporter, gated on that checkpoint's bfcl eval.
+
+    The gate binding is the *resolved* bfcl eval target name (passed in from
+    generate(), mirroring build_sage_export_target) rather than reconstructed
+    here, so it stays correct if the target-name prefix or the catalog key
+    changes.
+    """
     experiment = _experiment_for_step(step)
     return {
         "environment_uri": ENVIRONMENT_URI,
-        "inputs": {"gate_bfcl": {"binding": f"eval-bfcl-ckpt{step}.bfcl_results"}},
+        "inputs": {"gate_bfcl": {"binding": f"{bfcl_eval_target_name}.bfcl_results"}},
         "outputs": {
             "bfcl_export_csv": {
                 "type": "dataset",
@@ -651,13 +668,13 @@ def generate(workflow, params, catalog):
     per_ckpt_export_bindings = []
     for step in checkpoint_steps:
         sage_eval_target_names = []
-        has_bfcl = False
+        bfcl_eval_target_name = None
         for eval_name in eval_names:
             entry = catalog["evals"][eval_name]
             target_name = f"eval-{eval_name}-ckpt{step}"
             if entry["category"] == "bfcl":
                 targets[target_name] = build_bfcl_eval_target(step)
-                has_bfcl = True
+                bfcl_eval_target_name = target_name
             else:
                 targets[target_name] = build_sage_eval_target(eval_name, entry, step)
                 sage_eval_target_names.append(target_name)
@@ -667,9 +684,9 @@ def generate(workflow, params, catalog):
             name = f"export-sage-ckpt{step}"
             targets[name] = build_sage_export_target(step, sage_eval_target_names)
             per_ckpt_export_bindings.append(f"{name}.sage_export_csv")
-        if has_bfcl:
+        if bfcl_eval_target_name:
             name = f"export-bfcl-ckpt{step}"
-            targets[name] = build_bfcl_export_target(step)
+            targets[name] = build_bfcl_export_target(step, bfcl_eval_target_name)
             per_ckpt_export_bindings.append(f"{name}.bfcl_export_csv")
 
     # Combined roll-up across all checkpoints.
@@ -757,7 +774,7 @@ def parse_args(argv):
         "--experiment",
         metavar="NAME",
         help="Experiment namespace for eval/export outputs (EXPERIMENT). "
-        "Per-checkpoint results land under <SAGE_OUTPUT_DIR>/<EXPERIMENT>-ckpt_<step>/.",
+        "Per-checkpoint results land under <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/.",
     )
     common.add_argument(
         "--log-scrape-interval",
@@ -843,7 +860,15 @@ def main(argv=None):
     params = load_params(args.parameters_path, _flag_overrides(args) + args.param)
     # Derive CHECKPOINT_STATE_DIR from OUTPUT_DIR if not explicitly set.
     if not params.get("CHECKPOINT_STATE_DIR"):
-        params["CHECKPOINT_STATE_DIR"] = params["OUTPUT_DIR"].rstrip("/") + "/_state"
+        output_dir = params.get("OUTPUT_DIR")
+        if not output_dir:
+            sys.exit(
+                "error: OUTPUT_DIR is required (the trainer's checkpoint output "
+                "directory). Set it in the parameters file, or pass --output-dir "
+                "/ --param OUTPUT_DIR=<path>. It also seeds CHECKPOINT_STATE_DIR "
+                "when that is left blank."
+            )
+        params["CHECKPOINT_STATE_DIR"] = str(output_dir).rstrip("/") + "/_state"
     with open(args.catalog_path, "r", encoding="utf-8") as f:
         catalog = yaml.safe_load(f)
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -680,35 +680,132 @@ def parse_args(argv):
         default=os.path.join(here, "eval-catalog.yaml"),
         help="Eval catalog file.",
     )
+    # ── Common knobs, promoted to explicit flags for discoverability ──────────
+    # Each maps to the parameter named in COMMON_FLAG_PARAMS and is applied as an
+    # override. An explicit --param for the same key still wins (it is applied
+    # after these), so the flags are convenience, not a separate mechanism.
+    common = p.add_argument_group(
+        "common parameters",
+        "Frequently-changed knobs. Equivalent to --param <NAME>=<value>; "
+        "anything omitted falls back to the parameters file.",
+    )
+    common.add_argument(
+        "--model-path",
+        metavar="PATH",
+        help="Input checkpoint to train from (MODEL_PATH). For IFRL this is the "
+        "SFT checkpoint; for IdentityRL, a prior RL checkpoint.",
+    )
+    common.add_argument(
+        "--output-dir",
+        metavar="PATH",
+        help="Directory the trainer writes checkpoints to (OUTPUT_DIR).",
+    )
+    common.add_argument(
+        "--total-episodes",
+        metavar="N",
+        help="Total training episodes (TOTAL_EPISODES); drives the checkpoint "
+        "count.",
+    )
+    common.add_argument(
+        "--save-freq",
+        metavar="N",
+        help="Save a checkpoint every N optimizer updates (SAVE_FREQ); drives "
+        "the checkpoint schedule.",
+    )
+    common.add_argument(
+        "--eval-freq",
+        metavar="N",
+        help="Trainer's in-loop eval frequency (EVAL_FREQ).",
+    )
+    common.add_argument(
+        "--eval-sets",
+        metavar="LIST",
+        help="Which evaluations to run (EVAL_SETS), e.g. 'bfcl,multilingual-eval' "
+        "or 'full-eval'. Comma-separated or a YAML list.",
+    )
     p.add_argument(
         "--param",
         action="append",
         default=[],
         metavar="KEY=VALUE",
-        help="Override a parameter (dot notation supported). Repeatable.",
+        help="Override a parameter (dot notation supported). Repeatable. "
+        "Takes precedence over the common flags above.",
     )
     p.add_argument(
         "--output",
         default=os.path.join(here, "build.yaml"),
         help="Where to write the generated build.yaml ('-' for stdout).",
     )
+    p.add_argument(
+        "--params-out",
+        default=None,
+        help="Where to write the merged parameters (base file + flags + "
+        "--param). Defaults to a 'parameters-resolved.yaml' sibling of "
+        "--output. This is the file to pass to `gb build start "
+        "--parameters-path`, so the flags/overrides you set here are honored "
+        "when the build's $${...} placeholders are resolved. Ignored when "
+        "--output is '-'.",
+    )
     return p.parse_args(argv)
+
+
+# Maps each common flag (argparse dest) to the parameter name it overrides.
+COMMON_FLAG_PARAMS = {
+    "model_path": "MODEL_PATH",
+    "output_dir": "OUTPUT_DIR",
+    "total_episodes": "TOTAL_EPISODES",
+    "save_freq": "SAVE_FREQ",
+    "eval_freq": "EVAL_FREQ",
+    "eval_sets": "EVAL_SETS",
+}
+
+
+def _flag_overrides(args):
+    """Turn the provided common flags into KEY=VALUE override strings.
+
+    EVAL_SETS accepts a comma-separated shorthand ('a,b') as well as a YAML list
+    ('[a, b]'); normalize the shorthand to a YAML list so apply_override types it
+    as a list rather than a bare string.
+    """
+    overrides = []
+    for dest, name in COMMON_FLAG_PARAMS.items():
+        value = getattr(args, dest, None)
+        if value is None:
+            continue
+        if name == "EVAL_SETS" and "[" not in value:
+            items = [v.strip() for v in value.split(",") if v.strip()]
+            value = "[" + ", ".join(items) + "]"
+        overrides.append(f"{name}={value}")
+    return overrides
 
 
 def main(argv=None):
     args = parse_args(argv if argv is not None else sys.argv[1:])
-    params = load_params(args.parameters_path, args.param)
+    # Common flags first, then --param, so an explicit --param wins on conflict.
+    params = load_params(args.parameters_path, _flag_overrides(args) + args.param)
     with open(args.catalog_path, "r", encoding="utf-8") as f:
         catalog = yaml.safe_load(f)
 
     build, checkpoint_steps, eval_names = generate(args.workflow, params, catalog)
 
     dumped = yaml.safe_dump(build, sort_keys=False, default_flow_style=False)
+    params_out = None
     if args.output == "-":
         sys.stdout.write(dumped)
     else:
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(dumped)
+        # Emit the merged parameters so the flags/--param overrides applied here
+        # are honored when `gb build start` resolves the build's $${...}
+        # placeholders. Without this, a flag like --model-path would set the
+        # checkpoint schedule but leave $${MODEL_PATH} to be resolved from the
+        # untouched base parameters file at start time.
+        params_out = args.params_out or os.path.join(
+            os.path.dirname(os.path.abspath(args.output)),
+            "parameters-resolved.yaml",
+        )
+        with open(params_out, "w", encoding="utf-8") as f:
+            f.write(yaml.safe_dump(params, sort_keys=False))
 
     n_eval_targets = len(checkpoint_steps) * len(eval_names)
     total_targets = len(build["granite.build"]["targets"])
@@ -721,7 +818,12 @@ def main(argv=None):
         f"  total targets (incl. servers/training/exports): {total_targets}\n"
     )
     if args.output != "-":
-        msg += f"  wrote: {args.output}\n"
+        msg += f"  wrote build:  {args.output}\n"
+        msg += f"  wrote params: {params_out}\n"
+        msg += (
+            "  start with:   gb build start -f "
+            f"{args.output} --parameters-path {params_out} --space <space>\n"
+        )
     sys.stderr.write(msg)
     return 0
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -610,7 +610,9 @@ def build_combined_export_target(per_ckpt_export_bindings):
 def build_teardown_target(workflow, last_checkpoint_step):
     """Teardown target that shuts down server clusters once training completes."""
     inputs = {
-        "gate": {"binding": f"training.{CHECKPOINT_OUTPUT_PREFIX}{last_checkpoint_step}"},
+        "gate": {
+            "binding": f"training.{CHECKPOINT_OUTPUT_PREFIX}{last_checkpoint_step}"
+        },
         "rm_cluster": {"binding": "rm-server.cluster_name"},
     }
     cluster_names = ["{{ bindings.rm_cluster.binding.state }}"]

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -607,6 +607,33 @@ def build_combined_export_target(per_ckpt_export_bindings):
     }
 
 
+def build_teardown_target(workflow, last_checkpoint_step):
+    """Teardown target that shuts down server clusters once training completes."""
+    inputs = {
+        "gate": {"binding": f"training.{CHECKPOINT_OUTPUT_PREFIX}{last_checkpoint_step}"},
+        "rm_cluster": {"binding": "rm-server.cluster_name"},
+    }
+    cluster_names = ["{{ bindings.rm_cluster.binding.state }}"]
+    if workflow == "ifrl":
+        inputs["code_cluster"] = {"binding": "code-server.cluster_name"}
+        cluster_names.append("{{ bindings.code_cluster.binding.state }}")
+
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": inputs,
+        "steps": [
+            {
+                "step_uri": "space://steps/skypilot-teardown",
+                "config": {
+                    "teardown_config": {
+                        "cluster_names": cluster_names,
+                    }
+                },
+            }
+        ],
+    }
+
+
 # ─── Assembly ─────────────────────────────────────────────────────────────────
 def generate(workflow, params, catalog):
     checkpoint_steps = compute_checkpoint_steps(params)
@@ -617,6 +644,7 @@ def generate(workflow, params, catalog):
     if workflow == "ifrl":
         targets["code-server"] = build_code_server_target()
     targets["training"] = build_training_target(workflow, checkpoint_steps)
+    targets["teardown"] = build_teardown_target(workflow, checkpoint_steps[-1])
 
     per_ckpt_export_bindings = []
     for step in checkpoint_steps:

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""Generate a checkpoint-fanout RL build (issue #45).
+
+Starting from a parameters file and an eval catalog, emit a build.yaml that:
+  1. runs IFRL or IdentityRL GRPO training,
+  2. detects every checkpoint the trainer writes (one training output per
+     checkpoint step),
+  3. runs a selected set of evaluations against each checkpoint, and
+  4. aggregates the results into per-checkpoint CSVs plus a combined roll-up.
+
+The build engine dispatches each downstream target exactly once, keyed by the
+binding id, so the fanout must be materialized statically: this script computes
+the checkpoint schedule from the RL knobs and writes one output + one eval
+target-set per checkpoint.
+
+Usage:
+    python generate_build.py --workflow ifrl \\
+        --parameters-path parameters.yaml \\
+        --catalog-path eval-catalog.yaml \\
+        --param TOTAL_EPISODES=2048 --param SAVE_FREQ=1 \\
+        --param 'EVAL_SETS=[bfcl, multilingual-eval]' \\
+        --output build.yaml
+
+Any parameter in parameters.yaml can be overridden with --param KEY=VALUE
+(dot notation supported, mirroring src/gbcli/utils/buildutil.py). EVAL_SETS may
+be given as a YAML/JSON list string on the command line.
+
+The generated build.yaml is a plain recipe: run it with the usual flow, e.g.
+    gb build start -f build.yaml \\
+        --parameters-path parameters.yaml --space <your-space>
+Note the $${...} parameter placeholders in the emitted file are resolved at
+`gb build start` time against parameters.yaml (this script only expands the
+knobs it needs — checkpoint schedule and eval selection — and leaves the rest
+as placeholders so the existing recipe workflow keeps working).
+"""
+
+import argparse
+import os
+import sys
+
+import yaml
+
+# The environment all targets run on (matches sft-eval-full-dataset / ifrl-*).
+ENVIRONMENT_URI = "space://environments/skypilot/lsf/ibm-bluevela"
+# The trainer emits per-checkpoint outputs named checkpoint_<step>; the id must
+# match the LLMB_ARTIFACT_ID the openinstruct-rl step prints for each save.
+CHECKPOINT_OUTPUT_PREFIX = "checkpoint_"
+
+
+# ─── YAML string quoting ──────────────────────────────────────────────────────
+# The build engine substitutes $${...} placeholders into the emitted YAML and
+# re-parses it (src/gbcli/utils/buildutil.py:apply_parameters). Bare placeholder
+# scalars break that re-parse once the substituted value contains YAML
+# metacharacters (e.g. DATASET_MIXER expands to a JSON object). Match the
+# hand-written recipes: double-quote every string value, and single-quote the
+# fields whose substituted value embeds double quotes (dataset mixers,
+# stop_strings). Mapping keys stay unquoted (plain str -> default representer).
+_SINGLE_QUOTE_TOKENS = (
+    "$${DATASET_MIXER}",
+    "$${DATASET_EVAL_MIXER}",
+    "$${STOP_STRINGS}",
+)
+
+
+class _DQ(str):
+    """A string emitted with double-quote style."""
+
+
+class _SQ(str):
+    """A string emitted with single-quote style."""
+
+
+yaml.SafeDumper.add_representer(
+    _DQ,
+    lambda dumper, data: dumper.represent_scalar(
+        "tag:yaml.org,2002:str", str(data), style='"'
+    ),
+)
+yaml.SafeDumper.add_representer(
+    _SQ,
+    lambda dumper, data: dumper.represent_scalar(
+        "tag:yaml.org,2002:str", str(data), style="'"
+    ),
+)
+
+
+def _quote_values(obj):
+    """Recursively wrap string *values* (not keys) in a quoting style.
+
+    Non-string scalars (ints/bools) pass through unquoted.
+    """
+    if isinstance(obj, dict):
+        return {k: _quote_values(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_quote_values(v) for v in obj]
+    if isinstance(obj, str):
+        if any(tok in obj for tok in _SINGLE_QUOTE_TOKENS):
+            return _SQ(obj)
+        return _DQ(obj)
+    return obj
+
+
+# ─── Parameter loading + KEY=VALUE overrides ──────────────────────────────────
+# Mirrors add_parameter / add_key_value in src/gbcli/utils/buildutil.py so
+# --param behaves identically to `gb build start --param`.
+def add_key_value(data, key, value):
+    """Add a key/value pair, supporting dot notation ('a.b.c=value')."""
+
+    def add_branch(data_rec, prefix, key_vector, value):
+        key = key_vector[0]
+        if not isinstance(data_rec, dict):
+            raise ValueError(
+                f"param {prefix}.{key} cannot be used: prefix {prefix} is already in use."
+            )
+        if len(key_vector) == 1:
+            data_rec[key] = value
+        else:
+            data_rec[key] = add_branch(
+                data_rec.get(key, {}), f"{prefix}.{key}", key_vector[1:], value
+            )
+        return data_rec
+
+    return add_branch(data, "", key.split("."), value)
+
+
+def apply_override(data, param):
+    """Apply one 'key=value' override; value is parsed as YAML for typing/lists."""
+    key, sep, raw = param.partition("=")
+    if not sep:
+        raise ValueError(f"Invalid parameter {param!r}. Use the format 'key=value'.")
+    # Parse the value as YAML so lists ('[a, b]'), ints, and bools are typed;
+    # falls back to the raw string for plain identifiers.
+    try:
+        value = yaml.safe_load(raw.strip())
+    except yaml.YAMLError:
+        value = raw.strip()
+    return add_key_value(data, key.strip(), value)
+
+
+def load_params(parameters_path, overrides):
+    with open(parameters_path, "r", encoding="utf-8") as f:
+        params = yaml.safe_load(f) or {}
+    for param in overrides:
+        params = apply_override(params, param)
+    return params
+
+
+# ─── Checkpoint schedule ──────────────────────────────────────────────────────
+def compute_checkpoint_steps(params):
+    """Return the list of optimizer-update indices at which a checkpoint is saved.
+
+    open-instruct floor-divides:
+      num_updates = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT)
+    and writes a checkpoint every SAVE_FREQ updates. We evaluate each such
+    checkpoint (steps SAVE_FREQ, 2*SAVE_FREQ, ... <= num_updates). If the final
+    update is not a SAVE_FREQ multiple, open-instruct still writes a final
+    checkpoint, so we include num_updates as well.
+
+    NOTE (issue #45 verification): the exact on-disk naming and the update
+    indices at which grpo_fast saves must be confirmed against a real run. The
+    step-id convention here (checkpoint_<step>) must match the openinstruct-rl
+    step's emit loop.
+    """
+    total_episodes = int(params["TOTAL_EPISODES"])
+    prompts = int(params["NUM_UNIQUE_PROMPTS_ROLLOUT"])
+    samples = int(params["NUM_SAMPLES_PER_PROMPT_ROLLOUT"])
+    save_freq = int(params["SAVE_FREQ"])
+
+    denom = prompts * samples
+    if denom <= 0:
+        raise ValueError(
+            "NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT must be > 0"
+        )
+    num_updates = total_episodes // denom
+    if num_updates < 1:
+        raise ValueError(
+            f"TOTAL_EPISODES={total_episodes} yields 0 optimizer updates "
+            f"(denominator {denom}); nothing to checkpoint."
+        )
+    if save_freq < 1:
+        raise ValueError("SAVE_FREQ must be >= 1")
+
+    steps = list(range(save_freq, num_updates + 1, save_freq))
+    if not steps or steps[-1] != num_updates:
+        steps.append(num_updates)
+    return steps
+
+
+# ─── Eval-set resolution ──────────────────────────────────────────────────────
+def resolve_eval_names(params, catalog):
+    """Expand EVAL_SETS (set names and/or individual eval names) to eval names.
+
+    Preserves first-seen order and de-dups. Raises on unknown names.
+    """
+    raw = params.get("EVAL_SETS", [])
+    if isinstance(raw, str):
+        parsed = yaml.safe_load(raw)
+        raw = parsed if isinstance(parsed, list) else [raw]
+    if not isinstance(raw, list):
+        raise ValueError(f"EVAL_SETS must be a list, got {type(raw).__name__}")
+
+    evals = catalog["evals"]
+    sets = catalog.get("sets", {})
+    resolved = []
+    seen = set()
+    for name in raw:
+        if name in sets:
+            candidates = sets[name]
+        elif name in evals:
+            candidates = [name]
+        else:
+            known = sorted(set(sets) | set(evals))
+            raise ValueError(
+                f"Unknown EVAL_SETS entry {name!r}. Known sets/evals: {', '.join(known)}"
+            )
+        for eval_name in candidates:
+            if eval_name not in evals:
+                raise ValueError(f"set {name!r} references unknown eval {eval_name!r}")
+            if eval_name not in seen:
+                seen.add(eval_name)
+                resolved.append(eval_name)
+    if not resolved:
+        raise ValueError("EVAL_SETS resolved to an empty selection")
+    return resolved
+
+
+# ─── Target builders ──────────────────────────────────────────────────────────
+def _resources(accelerators_ph, queue_ph, memory_ph, cpus_ph=None):
+    res = {}
+    if accelerators_ph is not None:
+        res["accelerators"] = accelerators_ph
+    if cpus_ph is not None:
+        res["cpus"] = cpus_ph
+    res["cluster"] = "$${CLUSTER}"
+    res["zone"] = queue_ph
+    res["memory"] = memory_ph
+    return {"resources": res}
+
+
+def build_rm_server_target():
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "outputs": {
+            "rm_server_url": {"uri": "mem://rm-server"},
+            "cluster_name": {"uri": "mem://rm-server-cluster"},
+        },
+        "steps": [
+            {
+                "step_uri": "space://steps/rm-server",
+                "config": {
+                    "rm_server_config": {
+                        "model_path": "$${RM_SERVER_MODEL}",
+                        "idle_timeout": "$${RM_IDLE_TIMEOUT}",
+                    },
+                    "launcher_config": _resources(
+                        "$${RM_ACCELERATORS}", "$${RL_QUEUE}", "$${RM_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def build_code_server_target():
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "outputs": {
+            "code_server_url": {"uri": "mem://code-server"},
+            "cluster_name": {"uri": "mem://code-server-cluster"},
+        },
+        "steps": [
+            {
+                "step_uri": "space://steps/code-server",
+                "config": {
+                    "code_server_config": {
+                        "module": "$${CODE_MODULE}",
+                        "container_home": "$${CODE_CONTAINER_HOME}",
+                        "container_pythonpath": "$${CODE_CONTAINER_PYTHONPATH}",
+                        "container_path": "$${CODE_CONTAINER_PATH}",
+                        "idle_timeout": "$${CODE_IDLE_TIMEOUT}",
+                    },
+                    "launcher_config": _resources(
+                        None, "$${RL_QUEUE}", "$${CODE_MEMORY}", cpus_ph="$${CODE_CPUS}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+# The RL config block shared by IFRL and IdentityRL. Values are left as $${...}
+# placeholders so parameters.yaml continues to drive them at `gb build start`.
+def _rl_config(workflow):
+    cfg = {
+        "exp_name": "$${EXP_NAME}",
+        "run_name": "$${RUN_NAME}",
+        "rl_name": "$${RL_NAME}",
+        "model_name_or_path": "$${MODEL_PATH}",
+        "dataset_mixer": "$${DATASET_MIXER}",
+        "dataset_eval_mixer": "$${DATASET_EVAL_MIXER}",
+        "output_dir": "$${OUTPUT_DIR}",
+        "checkpoint_state_dir": "$${CHECKPOINT_STATE_DIR}",
+        # External services: IFRL binds both; IdentityRL binds only the RM URL.
+        "rm_server_url": "{{ bindings.rm_url.binding.state }}",
+        "beta": "$${BETA}",
+        "num_unique_prompts_rollout": "$${NUM_UNIQUE_PROMPTS_ROLLOUT}",
+        "num_samples_per_prompt_rollout": "$${NUM_SAMPLES_PER_PROMPT_ROLLOUT}",
+        "cliprange_low": "$${CLIPRANGE_LOW}",
+        "cliprange_high": "$${CLIPRANGE_HIGH}",
+        "temperature": "$${TEMPERATURE}",
+        "deepspeed_stage": "$${DEEPSPEED_STAGE}",
+        "seed": "$${SEED}",
+        "pad_token_id": "$${PAD_TOKEN_ID}",
+        "per_device_train_batch_size": "$${PER_DEVICE_TRAIN_BATCH_SIZE}",
+        "learning_rate": "$${LEARNING_RATE}",
+        "max_prompt_token_length": "$${MAX_PROMPT_TOKEN_LENGTH}",
+        "response_length": "$${RESPONSE_LENGTH}",
+        "total_episodes": "$${TOTAL_EPISODES}",
+        "kl_estimator": "$${KL_ESTIMATOR}",
+        "pack_length": "$${PACK_LENGTH}",
+        "thinking": "$${THINKING}",
+        "vllm_tensor_parallel_size": "$${VLLM_TENSOR_PARALLEL_SIZE}",
+        "num_learners_per_node": "$${NUM_LEARNERS_PER_NODE}",
+        "vllm_num_engines": "$${VLLM_NUM_ENGINES}",
+        "num_epochs": "$${NUM_EPOCHS}",
+        "warmup_ratio": "$${WARMUP_RATIO}",
+        "num_mini_batches": "$${NUM_MINI_BATCHES}",
+        "save_freq": "$${SAVE_FREQ}",
+        "eval_freq": "$${EVAL_FREQ}",
+        "checkpoint_state_freq": "$${CHECKPOINT_STATE_FREQ}",
+        "ref_policy_update_freq": "$${REF_POLICY_UPDATE_FREQ}",
+        "n_gram": "$${N_GRAM}",
+        "allowed_freq": "$${ALLOWED_FREQ}",
+        "temp_final": "$${TEMP_FINAL}",
+        "temp_change_interval": "$${TEMP_CHANGE_INTERVAL}",
+        "entropy_coeff": "$${ENTROPY_COEFF}",
+        "vllm_imp_ratio_cap": "$${VLLM_IMP_RATIO_CAP}",
+        "gradient_checkpointing": "$${GRADIENT_CHECKPOINTING}",
+        "async_mode": "$${ASYNC_MODE}",
+        "apply_thinking_format_reward": "$${APPLY_THINKING_FORMAT_REWARD}",
+        "apply_verifiable_reward": "$${APPLY_VERIFIABLE_REWARD}",
+        "non_stop_penalty": "$${NON_STOP_PENALTY}",
+        "apply_repetition_penalty": "$${APPLY_REPETITION_PENALTY}",
+        "add_general_reward": "$${ADD_GENERAL_REWARD}",
+        "set_weight_decay_on_bias_and_norm": "$${SET_WEIGHT_DECAY_ON_BIAS_AND_NORM}",
+        "additive_format_reward": "$${ADDITIVE_FORMAT_REWARD}",
+        "filter_zero_advantage": "$${FILTER_ZERO_ADVANTAGE}",
+        "with_tracking": "$${WITH_TRACKING}",
+        "ground_truths_key": "$${GROUND_TRUTHS_KEY}",
+        "sft_messages_key": "$${SFT_MESSAGES_KEY}",
+        "dataset_train_splits": "$${DATASET_TRAIN_SPLITS}",
+        "dataset_eval_splits": "$${DATASET_EVAL_SPLITS}",
+        "stop_strings": "$${STOP_STRINGS}",
+        "importance_sampling_level": "$${IMPORTANCE_SAMPLING_LEVEL}",
+        "advantage_normalization_type": "$${ADVANTAGE_NORMALIZATION_TYPE}",
+        "iterator_type": "$${ITERATOR_TYPE}",
+        "lr_scheduler_type": "$${LR_SCHEDULER_TYPE}",
+        "loss_mode": "$${LOSS_MODE}",
+        "temp_schedule_type": "$${TEMP_SCHEDULE_TYPE}",
+        "dataset_local_cache_dir": "$${DATASET_LOCAL_CACHE_DIR}",
+        "torchdynamo_disable": "$${TORCHDYNAMO_DISABLE}",
+    }
+    if workflow == "ifrl":
+        cfg["code_server_url"] = "{{ bindings.code_url.binding.state }}"
+    return cfg
+
+
+def build_training_target(workflow, checkpoint_steps):
+    inputs = {"rm_url": {"binding": "rm-server.rm_server_url"}}
+    if workflow == "ifrl":
+        inputs["code_url"] = {"binding": "code-server.code_server_url"}
+
+    # One output per checkpoint step. binding.path is filled at push time with
+    # the checkpoint dir the trainer emitted for that step.
+    outputs = {
+        f"{CHECKPOINT_OUTPUT_PREFIX}{step}": {
+            "uri": "env://{{ binding.path }}",
+            "type": "model",
+        }
+        for step in checkpoint_steps
+    }
+
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": inputs,
+        "outputs": outputs,
+        "steps": [
+            {
+                "step_uri": "space://steps/openinstruct-rl",
+                "config": {
+                    # Monitor cadence knobs (issue #45): the openinstruct-rl step
+                    # reads these top-level config keys.
+                    "poll_interval_seconds": "$${RL_STATUS_POLL_INTERVAL_SECONDS}",
+                    "log_retrieval_mode": "periodic",
+                    "log_retrieval_interval_seconds": "$${RL_LOG_SCRAPE_INTERVAL_SECONDS}",
+                    # How often the in-run watcher polls output_dir for newly
+                    # written checkpoint dirs to emit as artifacts.
+                    "checkpoint_watch_interval_seconds": "$${RL_CHECKPOINT_WATCH_INTERVAL_SECONDS}",
+                    "rl_config": _rl_config(workflow),
+                    "launcher_config": _resources(
+                        "$${RL_ACCELERATORS}", "$${RL_QUEUE}", "$${RL_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def _experiment_for_step(step):
+    """Per-checkpoint experiment namespace so results land in distinct dirs."""
+    return "$${EXPERIMENT}/ckpt_" + str(step)
+
+
+def build_sage_eval_target(eval_name, entry, step):
+    experiment = _experiment_for_step(step)
+    sage_cfg = {
+        "gb_script": entry["gb_script"],
+        "model_path": "{{ bindings.model_checkpoint.binding.path }}",
+        "experiment": experiment,
+        "batch_size": entry["overrides"].get("batch_size", "$${BATCH_SIZE}"),
+        "max_length": entry["overrides"].get("max_length", "$${MAX_LENGTH}"),
+        "num_gpus": "$${NUM_GPUS}",
+        "output_dir": "$${SAGE_OUTPUT_DIR}",
+        "image_id": entry["image_id"],
+        "extra_env": entry["overrides"].get("extra_env", {}),
+        # Eval status poll cadence (issue #45).
+        "poll_interval_seconds": "$${EVAL_STATUS_POLL_INTERVAL_SECONDS}",
+    }
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": {
+            "model_checkpoint": {
+                "binding": f"training.{CHECKPOINT_OUTPUT_PREFIX}{step}"
+            }
+        },
+        "outputs": {
+            "sage_eval_results": {
+                "type": "dataset",
+                "uri": f"env://$${{SAGE_OUTPUT_DIR}}/{experiment}/{entry['output_subpath']}",
+            }
+        },
+        "steps": [
+            {
+                "step_uri": entry["step_uri"],
+                "config": {
+                    "sage_eval_config": sage_cfg,
+                    "launcher_config": _resources(
+                        "$${EVAL_ACCELERATORS}", "$${EVAL_QUEUE}", "$${EVAL_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def build_bfcl_eval_target(step):
+    experiment = _experiment_for_step(step)
+    bfcl_cfg = {
+        "model_path": "{{ bindings.model_checkpoint.binding.path }}",
+        "model_id": "$${BFCL_MODEL_ID}",
+        "experiment": experiment,
+        "eval_name": "$${BFCL_EVAL_NAME}",
+        "test_categories": "$${BFCL_TEST_CATEGORIES}",
+        "num_gpus_generate": "$${BFCL_NUM_GPUS_GENERATE}",
+        "num_gpus_evaluate": "$${BFCL_NUM_GPUS_EVALUATE}",
+        "gpu_memory_utilization": "$${BFCL_GPU_MEMORY_UTILIZATION}",
+        "output_dir": "$${BFCL_OUTPUT_DIR}",
+        "poll_interval_seconds": "$${EVAL_STATUS_POLL_INTERVAL_SECONDS}",
+    }
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": {
+            "model_checkpoint": {
+                "binding": f"training.{CHECKPOINT_OUTPUT_PREFIX}{step}"
+            }
+        },
+        "outputs": {
+            "bfcl_results": {
+                "type": "dataset",
+                "uri": f"env://$${{BFCL_OUTPUT_DIR}}/{experiment}/$${{BFCL_EVAL_NAME}}",
+            }
+        },
+        "steps": [
+            {
+                "step_uri": "space://steps/bfcl-eval",
+                "config": {
+                    "bfcl_config": bfcl_cfg,
+                    "launcher_config": _resources(
+                        "$${EVAL_ACCELERATORS}", "$${EVAL_QUEUE}", "$${EVAL_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def build_sage_export_target(step, sage_eval_target_names):
+    """Per-checkpoint sage exporter, gated on that checkpoint's sage evals."""
+    experiment = _experiment_for_step(step)
+    inputs = {
+        f"gate_{name}": {"binding": f"{name}.sage_eval_results"}
+        for name in sage_eval_target_names
+    }
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": inputs,
+        "outputs": {
+            "sage_export_csv": {
+                "type": "dataset",
+                "uri": f"env://$${{SAGE_RESULTS_DIR}}/$${{EXPERIMENT}}/ckpt_{step}-sage.csv",
+            }
+        },
+        "steps": [
+            {
+                "step_uri": "space://steps/sage-export",
+                "config": {
+                    "sage_export_config": {
+                        "experiment": experiment,
+                        "export_stack": "$${EXPORT_STACK}",
+                        "input_dir": "$${SAGE_OUTPUT_DIR}",
+                        "output_csv": f"$${{SAGE_RESULTS_DIR}}/$${{EXPERIMENT}}/ckpt_{step}-sage.csv",
+                    },
+                    "launcher_config": _resources(
+                        None, "$${EXPORT_QUEUE}", "$${EXPORT_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def build_bfcl_export_target(step):
+    """Per-checkpoint BFCL exporter, gated on that checkpoint's bfcl eval."""
+    experiment = _experiment_for_step(step)
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": {"gate_bfcl": {"binding": f"eval-bfcl-ckpt{step}.bfcl_results"}},
+        "outputs": {
+            "bfcl_export_csv": {
+                "type": "dataset",
+                "uri": f"env://$${{BFCL_RESULTS_DIR}}/$${{EXPERIMENT}}/ckpt_{step}-bfcl.csv",
+            }
+        },
+        "steps": [
+            {
+                "step_uri": "space://steps/bfcl-export",
+                "config": {
+                    "bfcl_export_config": {
+                        "experiment": experiment,
+                        "eval_name": "$${BFCL_EVAL_NAME}",
+                        "input_dir": "$${BFCL_OUTPUT_DIR}",
+                        "output_csv": f"$${{BFCL_RESULTS_DIR}}/$${{EXPERIMENT}}/ckpt_{step}-bfcl.csv",
+                        "filter": "$${BFCL_FILTER}",
+                    },
+                    "launcher_config": _resources(
+                        None, "$${EXPORT_QUEUE}", "$${EXPORT_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def build_combined_export_target(per_ckpt_export_bindings):
+    """Final roll-up gated on every per-checkpoint export CSV.
+
+    Runs the sage exporter once over the whole EXPERIMENT tree (all ckpt_*
+    subdirs) to produce a single CSV. The sage exporter walks input_dir
+    recursively and tags rows by their result path, so pointing it at the
+    EXPERIMENT root yields one combined table keyed by checkpoint subdir.
+
+    NOTE (issue #45 verification): confirm sage/exporters/exporter.py rolls up
+    multiple ckpt_* experiment dirs into one CSV with a distinguishable
+    checkpoint column. If not, this target instead post-processes the
+    per-checkpoint CSVs (the gates already guarantee they all exist).
+    """
+    inputs = {
+        f"gate_{i}": {"binding": binding}
+        for i, binding in enumerate(per_ckpt_export_bindings)
+    }
+    return {
+        "environment_uri": ENVIRONMENT_URI,
+        "inputs": inputs,
+        "outputs": {
+            "combined_csv": {
+                "type": "dataset",
+                "uri": "env://$${SAGE_RESULTS_DIR}/$${EXPERIMENT}/combined.csv",
+            }
+        },
+        "steps": [
+            {
+                "step_uri": "space://steps/sage-export",
+                "config": {
+                    "sage_export_config": {
+                        # Export the whole EXPERIMENT tree (all ckpt_* subdirs).
+                        "experiment": "$${EXPERIMENT}",
+                        "export_stack": "$${EXPORT_STACK}",
+                        "input_dir": "$${SAGE_OUTPUT_DIR}",
+                        "output_csv": "$${SAGE_RESULTS_DIR}/$${EXPERIMENT}/combined.csv",
+                    },
+                    "launcher_config": _resources(
+                        None, "$${EXPORT_QUEUE}", "$${EXPORT_MEMORY}"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+# ─── Assembly ─────────────────────────────────────────────────────────────────
+def generate(workflow, params, catalog):
+    checkpoint_steps = compute_checkpoint_steps(params)
+    eval_names = resolve_eval_names(params, catalog)
+
+    targets = {}
+    targets["rm-server"] = build_rm_server_target()
+    if workflow == "ifrl":
+        targets["code-server"] = build_code_server_target()
+    targets["training"] = build_training_target(workflow, checkpoint_steps)
+
+    per_ckpt_export_bindings = []
+    for step in checkpoint_steps:
+        sage_eval_target_names = []
+        has_bfcl = False
+        for eval_name in eval_names:
+            entry = catalog["evals"][eval_name]
+            target_name = f"eval-{eval_name}-ckpt{step}"
+            if entry["category"] == "bfcl":
+                targets[target_name] = build_bfcl_eval_target(step)
+                has_bfcl = True
+            else:
+                targets[target_name] = build_sage_eval_target(eval_name, entry, step)
+                sage_eval_target_names.append(target_name)
+
+        # Per-checkpoint exports, each gated on this checkpoint's evals.
+        if sage_eval_target_names:
+            name = f"export-sage-ckpt{step}"
+            targets[name] = build_sage_export_target(step, sage_eval_target_names)
+            per_ckpt_export_bindings.append(f"{name}.sage_export_csv")
+        if has_bfcl:
+            name = f"export-bfcl-ckpt{step}"
+            targets[name] = build_bfcl_export_target(step)
+            per_ckpt_export_bindings.append(f"{name}.bfcl_export_csv")
+
+    # Combined roll-up across all checkpoints.
+    targets["export-combined"] = build_combined_export_target(per_ckpt_export_bindings)
+
+    build = {
+        "granite.build": {
+            "name": f"{workflow}-checkpoint-eval",
+            "retries": {"max_retries": 5},
+            # Quote string values so $${...} placeholders survive substitution
+            # + re-parse; ints/bools (e.g. max_retries, catalog batch_size) stay
+            # bare.
+            "targets": _quote_values(targets),
+        }
+    }
+    return build, checkpoint_steps, eval_names
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(
+        description="Generate a checkpoint-fanout RL build (issue #45).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    here = os.path.dirname(os.path.abspath(__file__))
+    p.add_argument(
+        "--workflow",
+        choices=["ifrl", "identityrl"],
+        required=True,
+        help="RL workflow. identityrl omits the code-server target.",
+    )
+    p.add_argument(
+        "--parameters-path",
+        default=os.path.join(here, "parameters.yaml"),
+        help="Base parameters file.",
+    )
+    p.add_argument(
+        "--catalog-path",
+        default=os.path.join(here, "eval-catalog.yaml"),
+        help="Eval catalog file.",
+    )
+    p.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a parameter (dot notation supported). Repeatable.",
+    )
+    p.add_argument(
+        "--output",
+        default=os.path.join(here, "build.yaml"),
+        help="Where to write the generated build.yaml ('-' for stdout).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    params = load_params(args.parameters_path, args.param)
+    with open(args.catalog_path, "r", encoding="utf-8") as f:
+        catalog = yaml.safe_load(f)
+
+    build, checkpoint_steps, eval_names = generate(args.workflow, params, catalog)
+
+    dumped = yaml.safe_dump(build, sort_keys=False, default_flow_style=False)
+    if args.output == "-":
+        sys.stdout.write(dumped)
+    else:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(dumped)
+
+    n_eval_targets = len(checkpoint_steps) * len(eval_names)
+    total_targets = len(build["granite.build"]["targets"])
+    msg = (
+        f"[generate_build] workflow={args.workflow}\n"
+        f"  checkpoints ({len(checkpoint_steps)}): {checkpoint_steps}\n"
+        f"  evals ({len(eval_names)}): {eval_names}\n"
+        f"  eval targets: {len(checkpoint_steps)} ckpts x {len(eval_names)} evals "
+        f"= {n_eval_targets}\n"
+        f"  total targets (incl. servers/training/exports): {total_targets}\n"
+    )
+    if args.output != "-":
+        msg += f"  wrote: {args.output}\n"
+    sys.stderr.write(msg)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -413,13 +413,16 @@ def build_training_target(workflow, checkpoint_steps):
 def _experiment_for_step(step):
     """Per-checkpoint experiment namespace so results land in distinct dirs.
 
-    A `/`-separated *subdir* of $${EXPERIMENT} (not a name suffix): per-checkpoint
-    results land at <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/..., i.e. children
-    of <SAGE_OUTPUT_DIR>/<EXPERIMENT>. This is what build_combined_export_target
-    scans (input_dir/experiment = <SAGE_OUTPUT_DIR>/<EXPERIMENT>); a `-ckpt_`
-    suffix would make them siblings and the combined roll-up would find nothing.
+    A flat NAME suffix ("<EXPERIMENT>-ckpt_<step>"), NOT a "/"-separated subdir.
+    sage builds a per-eval job-script *filename* from this value
+    (sage-<experiment>-<eval>.sh); a "/" turns that filename into a nested dir
+    and sage's open(..., "w") fails with FileNotFoundError. Per-checkpoint
+    results therefore land at <SAGE_OUTPUT_DIR>/<EXPERIMENT>-ckpt_<step>/... as
+    siblings. The combined roll-up does NOT re-scan a parent tree (which is why a
+    suffix is fine); it pivots the already-emitted per-checkpoint CSVs — see
+    build_combined_export_target.
     """
-    return "$${EXPERIMENT}/ckpt_" + str(step)
+    return "$${EXPERIMENT}-ckpt_" + str(step)
 
 
 def build_sage_eval_target(eval_name, entry, step):
@@ -578,22 +581,27 @@ def build_bfcl_export_target(step, bfcl_eval_target_name):
     }
 
 
-def build_combined_export_target(per_ckpt_export_bindings):
-    """Final roll-up gated on every per-checkpoint export CSV.
+def build_combined_export_target(per_ckpt_export_bindings, has_sage, has_bfcl):
+    """Final roll-up: a benchmark x checkpoint pivot of the per-checkpoint CSVs.
 
-    Runs the sage exporter once over the whole EXPERIMENT tree (all ckpt_*
-    subdirs) to produce a single CSV. The sage exporter walks input_dir
-    recursively and tags rows by their result path, so pointing it at the
-    EXPERIMENT root yields one combined table keyed by checkpoint subdir.
+    Gated on every per-checkpoint export CSV (so all inputs exist), then pivots
+    them into one table — rows are benchmarks (sage `model`+`metric`, plus one
+    BFCL-<expt> row per bfcl eval), columns are ckpt_<step>. Unlike a sage-export
+    tree re-scan, this works with the flat <EXPERIMENT>-ckpt_<step> per-checkpoint
+    experiment dirs (sage-eval can't accept a "/" in the experiment name).
 
-    NOTE (issue #45 verification): confirm sage/exporters/exporter.py rolls up
-    multiple ckpt_* experiment dirs into one CSV with a distinguishable
-    checkpoint column. If not, this target instead post-processes the
-    per-checkpoint CSVs (the gates already guarantee they all exist).
+    Only the dirs for eval kinds actually present are set; the combined-export
+    step tolerates an absent/empty dir on either side and errors only if BOTH
+    yield no CSVs.
     """
     inputs = {
         f"gate_{i}": {"binding": binding}
         for i, binding in enumerate(per_ckpt_export_bindings)
+    }
+    cfg = {
+        "sage_input_dir": "$${SAGE_RESULTS_DIR}/$${EXPERIMENT}" if has_sage else "",
+        "bfcl_input_dir": "$${BFCL_RESULTS_DIR}/$${EXPERIMENT}" if has_bfcl else "",
+        "output_csv": "$${SAGE_RESULTS_DIR}/$${EXPERIMENT}/combined.csv",
     }
     return {
         "environment_uri": ENVIRONMENT_URI,
@@ -606,15 +614,9 @@ def build_combined_export_target(per_ckpt_export_bindings):
         },
         "steps": [
             {
-                "step_uri": "space://steps/sage-export",
+                "step_uri": "space://steps/combined-export",
                 "config": {
-                    "sage_export_config": {
-                        # Export the whole EXPERIMENT tree (all ckpt_* subdirs).
-                        "experiment": "$${EXPERIMENT}",
-                        "export_stack": "$${EXPORT_STACK}",
-                        "input_dir": "$${SAGE_OUTPUT_DIR}",
-                        "output_csv": "$${SAGE_RESULTS_DIR}/$${EXPERIMENT}/combined.csv",
-                    },
+                    "combined_export_config": cfg,
                     "launcher_config": _resources(
                         None, "$${EXPORT_QUEUE}", "$${EXPORT_MEMORY}"
                     ),
@@ -666,6 +668,8 @@ def generate(workflow, params, catalog):
     targets["teardown"] = build_teardown_target(workflow, checkpoint_steps[-1])
 
     per_ckpt_export_bindings = []
+    has_sage_export = False
+    has_bfcl_export = False
     for step in checkpoint_steps:
         sage_eval_target_names = []
         bfcl_eval_target_name = None
@@ -684,13 +688,21 @@ def generate(workflow, params, catalog):
             name = f"export-sage-ckpt{step}"
             targets[name] = build_sage_export_target(step, sage_eval_target_names)
             per_ckpt_export_bindings.append(f"{name}.sage_export_csv")
+            has_sage_export = True
         if bfcl_eval_target_name:
             name = f"export-bfcl-ckpt{step}"
             targets[name] = build_bfcl_export_target(step, bfcl_eval_target_name)
             per_ckpt_export_bindings.append(f"{name}.bfcl_export_csv")
+            has_bfcl_export = True
 
-    # Combined roll-up across all checkpoints.
-    targets["export-combined"] = build_combined_export_target(per_ckpt_export_bindings)
+    # Combined roll-up across all checkpoints, pivoting whichever eval kinds ran.
+    # Only emitted when there is at least one per-checkpoint export to roll up
+    # (resolve_eval_names already guarantees >=1 eval, so this holds in practice;
+    # the guard keeps the combined target from being emitted with no gate inputs).
+    if per_ckpt_export_bindings:
+        targets["export-combined"] = build_combined_export_target(
+            per_ckpt_export_bindings, has_sage_export, has_bfcl_export
+        )
 
     build = {
         "granite.build": {

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -408,7 +408,7 @@ def build_training_target(workflow, checkpoint_steps):
 
 def _experiment_for_step(step):
     """Per-checkpoint experiment namespace so results land in distinct dirs."""
-    return "$${EXPERIMENT}/ckpt_" + str(step)
+    return "$${EXPERIMENT}-ckpt_" + str(step)
 
 
 def build_sage_eval_target(eval_name, entry, step):
@@ -724,6 +724,12 @@ def parse_args(argv):
         "or 'full-eval'. Comma-separated or a YAML list.",
     )
     common.add_argument(
+        "--experiment",
+        metavar="NAME",
+        help="Experiment namespace for eval/export outputs (EXPERIMENT). "
+        "Per-checkpoint results land under <SAGE_OUTPUT_DIR>/<EXPERIMENT>-ckpt_<step>/.",
+    )
+    common.add_argument(
         "--log-scrape-interval",
         metavar="SECONDS",
         help="How often the training logs are downloaded and parsed for "
@@ -775,6 +781,7 @@ COMMON_FLAG_PARAMS = {
     "save_freq": "SAVE_FREQ",
     "eval_freq": "EVAL_FREQ",
     "eval_sets": "EVAL_SETS",
+    "experiment": "EXPERIMENT",
     "log_scrape_interval": "RL_LOG_SCRAPE_INTERVAL_SECONDS",
     "train_status_interval": "RL_STATUS_POLL_INTERVAL_SECONDS",
     "eval_status_interval": "EVAL_STATUS_POLL_INTERVAL_SECONDS",
@@ -804,6 +811,9 @@ def main(argv=None):
     args = parse_args(argv if argv is not None else sys.argv[1:])
     # Common flags first, then --param, so an explicit --param wins on conflict.
     params = load_params(args.parameters_path, _flag_overrides(args) + args.param)
+    # Derive CHECKPOINT_STATE_DIR from OUTPUT_DIR if not explicitly set.
+    if not params.get("CHECKPOINT_STATE_DIR"):
+        params["CHECKPOINT_STATE_DIR"] = params["OUTPUT_DIR"].rstrip("/") + "/_state"
     with open(args.catalog_path, "r", encoding="utf-8") as f:
         catalog = yaml.safe_load(f)
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/generate_build.py
@@ -723,6 +723,24 @@ def parse_args(argv):
         help="Which evaluations to run (EVAL_SETS), e.g. 'bfcl,multilingual-eval' "
         "or 'full-eval'. Comma-separated or a YAML list.",
     )
+    common.add_argument(
+        "--log-scrape-interval",
+        metavar="SECONDS",
+        help="How often the training logs are downloaded and parsed for "
+        "checkpoint messages (RL_LOG_SCRAPE_INTERVAL_SECONDS).",
+    )
+    common.add_argument(
+        "--train-status-interval",
+        metavar="SECONDS",
+        help="How often the training job's status is checked "
+        "(RL_STATUS_POLL_INTERVAL_SECONDS).",
+    )
+    common.add_argument(
+        "--eval-status-interval",
+        metavar="SECONDS",
+        help="How often each evaluation job's status is checked "
+        "(EVAL_STATUS_POLL_INTERVAL_SECONDS).",
+    )
     p.add_argument(
         "--param",
         action="append",
@@ -757,6 +775,9 @@ COMMON_FLAG_PARAMS = {
     "save_freq": "SAVE_FREQ",
     "eval_freq": "EVAL_FREQ",
     "eval_sets": "EVAL_SETS",
+    "log_scrape_interval": "RL_LOG_SCRAPE_INTERVAL_SECONDS",
+    "train_status_interval": "RL_STATUS_POLL_INTERVAL_SECONDS",
+    "eval_status_interval": "EVAL_STATUS_POLL_INTERVAL_SECONDS",
 }
 
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
@@ -39,8 +39,13 @@ OUTPUT_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ck
 # num_updates. Smoke default: 2048 // (64*16) = 2 updates, SAVE_FREQ=1 => two
 # checkpoints (steps 1 and 2), each fanned out to the selected evals.
 TOTAL_EPISODES: "2048"
-SAVE_FREQ: "1"
+SAVE_FREQ: "10"
 EVAL_FREQ: "10"
+
+# Experiment namespace for eval + export outputs  [--experiment]
+# Per-checkpoint results land under <SAGE_OUTPUT_DIR>/<EXPERIMENT>-ckpt_<step>/...
+# and combined results at <SAGE_RESULTS_DIR>/<EXPERIMENT>/combined.csv.
+EXPERIMENT: "granite4-350m-ifrl-ckpt-eval"
 
 # Monitoring cadence (seconds).
 # How often the training logs are downloaded and parsed for checkpoint messages.
@@ -61,14 +66,13 @@ EVAL_STATUS_POLL_INTERVAL_SECONDS: "60"
 EXP_NAME: "granite4-350m-14-7180-ifrl-ckpt-eval"
 RUN_NAME: "granite4-350m-14-7180-ifrl-ckpt-eval"
 RL_NAME: "if"
-# EXPERIMENT namespaces eval + export outputs; per-checkpoint results land under
-# <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/... (see generate_build.py).
-EXPERIMENT: "granite4-350m-14-7180-ifrl-ckpt-eval"
 
 # ─── Training data + checkpoint-state dir ─────────────────────────────────────
 DATASET_MIXER: '{"/proj/granite-build/g4os/RLHF/data/long_context/rlnothink_300m/mix16_if/train.jsonl":1.0}'
 DATASET_EVAL_MIXER: '{"/proj/granite-build/g4os/RLHF/data/long_context/rlnothink_300m/mix16_if/validation.jsonl":1.0}'
-CHECKPOINT_STATE_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ckpt-eval/exp_32/iter1/rlvr/_state"
+# Derived from OUTPUT_DIR at generation time (see generate_build.py).
+# Override explicitly only if state lives elsewhere.
+CHECKPOINT_STATE_DIR: ""
 
 # ─── Remaining schedule knobs ─────────────────────────────────────────────────
 CHECKPOINT_STATE_FREQ: "10"

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
@@ -9,11 +9,42 @@
 # block) so a default run is a fast smoke test. Override any value with
 # `--param KEY=VALUE` at generation time.
 
-# ─── Which evaluations to run ─────────────────────────────────────────────────
+# ══════════════════════════════════════════════════════════════════════════════
+# COMMON PARAMETERS — the knobs you change for most new builds.
+# Each also has an equivalent generator flag (shown in [brackets]); the flag and
+# --param both override the value here, with --param winning on conflict.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Which evaluations to run  [--eval-sets]
 # List of catalog `sets` names and/or individual eval names (see
 # eval-catalog.yaml). full-eval = all 27. Example: [bfcl, multilingual-eval].
 EVAL_SETS:
   - bfcl
+
+# Input checkpoint to train from  [--model-path]
+# IFRL: the SFT checkpoint. IdentityRL: a prior RL checkpoint (e.g. IFRL's
+# output). This is a static path; chain stages by pointing it at the previous
+# run's final checkpoint.
+MODEL_PATH: "/proj/granite-build/g4os/sft/granite4-350m-14/v0-20260518-140726/checkpoint-7180"
+
+# Output directory the trainer writes checkpoints to  [--output-dir]
+# The in-run watcher scans this for step_<N> checkpoint dirs. Namespaced under
+# -ckpt-eval so it can't clobber other runs.
+OUTPUT_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ckpt-eval/exp_32/iter1/rlvr/"
+
+# Training length + checkpoint schedule  [--total-episodes] [--save-freq] [--eval-freq]
+# The generator computes the number of optimizer updates as
+#   num_updates = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT)
+# and evaluates every checkpoint written at multiples of SAVE_FREQ up to
+# num_updates. Smoke default: 2048 // (64*16) = 2 updates, SAVE_FREQ=1 => two
+# checkpoints (steps 1 and 2), each fanned out to the selected evals.
+TOTAL_EPISODES: "2048"
+SAVE_FREQ: "1"
+EVAL_FREQ: "10"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Everything below is a less-frequently-changed default.
+# ══════════════════════════════════════════════════════════════════════════════
 
 # ─── Run identification ───────────────────────────────────────────────────────
 EXP_NAME: "granite4-350m-14-7180-ifrl-ckpt-eval"
@@ -23,24 +54,12 @@ RL_NAME: "if"
 # <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/... (see generate_build.py).
 EXPERIMENT: "granite4-350m-14-7180-ifrl-ckpt-eval"
 
-# ─── Model + data (consumed by the training target) ───────────────────────────
-MODEL_PATH: "/proj/granite-build/g4os/sft/granite4-350m-14/v0-20260518-140726/checkpoint-7180"
+# ─── Training data + checkpoint-state dir ─────────────────────────────────────
 DATASET_MIXER: '{"/proj/granite-build/g4os/RLHF/data/long_context/rlnothink_300m/mix16_if/train.jsonl":1.0}'
 DATASET_EVAL_MIXER: '{"/proj/granite-build/g4os/RLHF/data/long_context/rlnothink_300m/mix16_if/validation.jsonl":1.0}'
-
-# ─── Output (namespaced under -ckpt-eval so it can't clobber other runs) ───────
-OUTPUT_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ckpt-eval/exp_32/iter1/rlvr/"
 CHECKPOINT_STATE_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ckpt-eval/exp_32/iter1/rlvr/_state"
 
-# ─── Checkpoint schedule ──────────────────────────────────────────────────────
-# The generator computes the number of optimizer updates as
-#   num_updates = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT)
-# and evaluates every checkpoint written at multiples of SAVE_FREQ up to
-# num_updates. Smoke default: 2048 // (64*16) = 2 updates, SAVE_FREQ=1 => two
-# checkpoints (steps 1 and 2), each fanned out to the selected evals.
-TOTAL_EPISODES: "2048"
-SAVE_FREQ: "1"
-EVAL_FREQ: "10"
+# ─── Remaining schedule knobs ─────────────────────────────────────────────────
 CHECKPOINT_STATE_FREQ: "10"
 REF_POLICY_UPDATE_FREQ: "6"
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
@@ -25,7 +25,7 @@ EVAL_SETS:
 # IFRL: the SFT checkpoint. IdentityRL: a prior RL checkpoint (e.g. IFRL's
 # output). This is a static path; chain stages by pointing it at the previous
 # run's final checkpoint.
-MODEL_PATH: "/proj/granite-build/g4os/sft/granite4-350m-14/v0-20260518-140726/checkpoint-7180"
+MODEL_PATH: "/proj/granite-build/g4os/skypilot-test/sft/checkpoints/v0-20260529-20260529_212150-hf/epoch_hf_2"
 
 # Output directory the trainer writes checkpoints to  [--output-dir]
 # The in-run watcher scans this for step_<N> checkpoint dirs. Namespaced under
@@ -36,14 +36,14 @@ OUTPUT_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ck
 # The generator computes the number of optimizer updates as
 #   num_updates = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT)
 # and evaluates every checkpoint written at multiples of SAVE_FREQ up to
-# num_updates. Smoke default: 2048 // (64*16) = 2 updates, SAVE_FREQ=1 => two
-# checkpoints (steps 1 and 2), each fanned out to the selected evals.
-TOTAL_EPISODES: "2048"
+# num_updates. Smoke default: 20480 // (64*16) = 20 updates, SAVE_FREQ=10 => two
+# checkpoints (steps 10 and 20), each fanned out to the selected evals.
+TOTAL_EPISODES: "20480"
 SAVE_FREQ: "10"
 EVAL_FREQ: "10"
 
 # Experiment namespace for eval + export outputs  [--experiment]
-# Per-checkpoint results land under <SAGE_OUTPUT_DIR>/<EXPERIMENT>-ckpt_<step>/...
+# Per-checkpoint results land under <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/...
 # and combined results at <SAGE_RESULTS_DIR>/<EXPERIMENT>/combined.csv.
 EXPERIMENT: "granite4-350m-ifrl-ckpt-eval"
 

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
@@ -1,0 +1,173 @@
+# Default parameters for the rl-checkpoint-eval generator (issue #45).
+#
+# generate_build.py reads these (plus --param KEY=VALUE overrides), computes the
+# checkpoint schedule from the RL knobs below, expands EVAL_SETS against
+# eval-catalog.yaml, and emits a build.yaml that trains, evaluates every
+# checkpoint, and aggregates the results.
+#
+# Values mirror ifrl-smoke (RL block) and sft-eval-full-dataset (eval/resource
+# block) so a default run is a fast smoke test. Override any value with
+# `--param KEY=VALUE` at generation time.
+
+# ─── Which evaluations to run ─────────────────────────────────────────────────
+# List of catalog `sets` names and/or individual eval names (see
+# eval-catalog.yaml). full-eval = all 27. Example: [bfcl, multilingual-eval].
+EVAL_SETS:
+  - bfcl
+
+# ─── Run identification ───────────────────────────────────────────────────────
+EXP_NAME: "granite4-350m-14-7180-ifrl-ckpt-eval"
+RUN_NAME: "granite4-350m-14-7180-ifrl-ckpt-eval"
+RL_NAME: "if"
+# EXPERIMENT namespaces eval + export outputs; per-checkpoint results land under
+# <SAGE_OUTPUT_DIR>/<EXPERIMENT>/ckpt_<step>/... (see generate_build.py).
+EXPERIMENT: "granite4-350m-14-7180-ifrl-ckpt-eval"
+
+# ─── Model + data (consumed by the training target) ───────────────────────────
+MODEL_PATH: "/proj/granite-build/g4os/sft/granite4-350m-14/v0-20260518-140726/checkpoint-7180"
+DATASET_MIXER: '{"/proj/granite-build/g4os/RLHF/data/long_context/rlnothink_300m/mix16_if/train.jsonl":1.0}'
+DATASET_EVAL_MIXER: '{"/proj/granite-build/g4os/RLHF/data/long_context/rlnothink_300m/mix16_if/validation.jsonl":1.0}'
+
+# ─── Output (namespaced under -ckpt-eval so it can't clobber other runs) ───────
+OUTPUT_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ckpt-eval/exp_32/iter1/rlvr/"
+CHECKPOINT_STATE_DIR: "/proj/granite-build/g4os/RLHF/outputs/granite4-350m-14-7180-ifrl-ckpt-eval/exp_32/iter1/rlvr/_state"
+
+# ─── Checkpoint schedule ──────────────────────────────────────────────────────
+# The generator computes the number of optimizer updates as
+#   num_updates = TOTAL_EPISODES // (NUM_UNIQUE_PROMPTS_ROLLOUT * NUM_SAMPLES_PER_PROMPT_ROLLOUT)
+# and evaluates every checkpoint written at multiples of SAVE_FREQ up to
+# num_updates. Smoke default: 2048 // (64*16) = 2 updates, SAVE_FREQ=1 => two
+# checkpoints (steps 1 and 2), each fanned out to the selected evals.
+TOTAL_EPISODES: "2048"
+SAVE_FREQ: "1"
+EVAL_FREQ: "10"
+CHECKPOINT_STATE_FREQ: "10"
+REF_POLICY_UPDATE_FREQ: "6"
+
+# ─── Monitor cadence (issue #45) ──────────────────────────────────────────────
+# Training log-scrape interval: how often the trainer's skypilot_monitor pulls
+# and parses logs while RUNNING. Bounds how soon a new checkpoint is detected
+# and its evals dispatched. Lower = quicker detection, more `sky logs` pulls.
+RL_LOG_SCRAPE_INTERVAL_SECONDS: "60"
+# Training status poll interval: how often the monitor queries SkyPilot job
+# status (RUNNING/SUCCEEDED/FAILED) for the training target.
+RL_STATUS_POLL_INTERVAL_SECONDS: "60"
+# Checkpoint-watch interval: how often the in-run watcher polls output_dir for
+# newly written checkpoint dirs to emit as artifacts. This is the finest-grained
+# knob for how soon a fresh checkpoint becomes an event; the log-scrape interval
+# above then bounds how soon that emitted line is pulled back to the monitor.
+RL_CHECKPOINT_WATCH_INTERVAL_SECONDS: "30"
+# Eval status poll interval: how often each eval target's monitor queries job
+# status. Bounds how quickly an eval's completion is detected so its export /
+# aggregation proceeds. Evals emit their result artifact on completion, so only
+# the status poll cadence matters here (log mode stays on_completion).
+EVAL_STATUS_POLL_INTERVAL_SECONDS: "60"
+
+# ─── 8-GPU RL topology ────────────────────────────────────────────────────────
+NUM_LEARNERS_PER_NODE: "4"
+VLLM_NUM_ENGINES: "4"
+VLLM_TENSOR_PARALLEL_SIZE: "1"
+
+# ─── IFRL deltas from the source config ───────────────────────────────────────
+TEMPERATURE: "1.0"
+TEMP_FINAL: "1.0"
+ADD_GENERAL_REWARD: "true"
+
+# ─── Servers (IFRL only uses code-server; IdentityRL omits it) ────────────────
+RM_SERVER_MODEL: "/proj/checkpoints/ashishagr/model_downloads/phi4-multilingual"
+RM_IDLE_TIMEOUT: ""
+RM_ACCELERATORS: "H100:1"
+RM_MEMORY: "128"
+CODE_MODULE: "open_instruct.servers.code_server"
+CODE_CONTAINER_HOME: "/stage"
+CODE_CONTAINER_PYTHONPATH: "/stage"
+CODE_CONTAINER_PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+CODE_IDLE_TIMEOUT: ""
+CODE_CPUS: "8"
+CODE_MEMORY: "128"
+
+# ─── Infrastructure ───────────────────────────────────────────────────────────
+CLUSTER: "bluevela"
+# RL training runs on `normal` so it isn't preempted mid-run; evals are short
+# and idempotent, so they ride the cheaper preemptable queue.
+RL_QUEUE: "normal"
+RL_ACCELERATORS: "H100:8"
+RL_MEMORY: "1580"
+EVAL_QUEUE: "preemptable"
+EVAL_ACCELERATORS: "H100:1"
+EVAL_MEMORY: "256"
+
+# ─── Eval settings (consumed by the sage/bfcl eval targets) ───────────────────
+BATCH_SIZE: 10
+MAX_LENGTH: 4096
+NUM_GPUS: 1
+SAGE_OUTPUT_DIR: "/proj/granite-build/g4os/sage"
+BFCL_OUTPUT_DIR: "/proj/granite-build/g4os/bfcl"
+# BigCodeBench API server (external service; consumed by olmes-bigcodebench).
+OE_EVAL_BCB_API_URL: "http://p2-r24-n4.bluevela.rmf.ibm.com:7860/evaluate/"
+# BFCL parameters.
+BFCL_MODEL_ID: "ibm-granite/granite-4"
+BFCL_EVAL_NAME: "bfclv3"
+BFCL_TEST_CATEGORIES: "all"
+BFCL_NUM_GPUS_GENERATE: 1
+BFCL_NUM_GPUS_EVALUATE: 1
+BFCL_GPU_MEMORY_UTILIZATION: "0.5"
+
+# ─── Aggregation / export (per-checkpoint CSVs + combined roll-up) ────────────
+EXPORT_STACK: "granite4-instruct"
+EXPORT_QUEUE: "preemptable"
+EXPORT_MEMORY: "64"
+# Roots for the emitted CSVs. Per-checkpoint CSVs land under
+# <SAGE_RESULTS_DIR>/<EXPERIMENT>/ckpt_<step>.csv; the combined roll-up at
+# <SAGE_RESULTS_DIR>/<EXPERIMENT>/combined.csv (see generate_build.py).
+SAGE_RESULTS_DIR: "/proj/granite-build/g4os/sage/results"
+BFCL_RESULTS_DIR: "/proj/granite-build/g4os/bfcl/results"
+BFCL_FILTER: ""
+
+# ─── GRPO defaults (step single-node defaults; override as needed) ────────────
+BETA: "0.05"
+NUM_UNIQUE_PROMPTS_ROLLOUT: "64"
+NUM_SAMPLES_PER_PROMPT_ROLLOUT: "16"
+CLIPRANGE_LOW: "0.2"
+CLIPRANGE_HIGH: "0.28"
+DEEPSPEED_STAGE: "3"
+SEED: "42"
+PAD_TOKEN_ID: "6"
+PER_DEVICE_TRAIN_BATCH_SIZE: "2"
+LEARNING_RATE: "5e-7"
+MAX_PROMPT_TOKEN_LENGTH: "512"
+RESPONSE_LENGTH: "8192"
+KL_ESTIMATOR: "kl3"
+PACK_LENGTH: "8704"
+THINKING: "4"
+NUM_EPOCHS: "1"
+WARMUP_RATIO: "0.0"
+NUM_MINI_BATCHES: "1"
+N_GRAM: "3"
+ALLOWED_FREQ: "2"
+TEMP_CHANGE_INTERVAL: "10"
+ENTROPY_COEFF: "0.0"
+VLLM_IMP_RATIO_CAP: "-1"
+GRADIENT_CHECKPOINTING: "true"
+ASYNC_MODE: "true"
+APPLY_THINKING_FORMAT_REWARD: "true"
+APPLY_VERIFIABLE_REWARD: "true"
+NON_STOP_PENALTY: "true"
+APPLY_REPETITION_PENALTY: "true"
+SET_WEIGHT_DECAY_ON_BIAS_AND_NORM: "false"
+ADDITIVE_FORMAT_REWARD: "false"
+FILTER_ZERO_ADVANTAGE: "false"
+WITH_TRACKING: "false"
+GROUND_TRUTHS_KEY: "ground_truth"
+SFT_MESSAGES_KEY: "messages"
+DATASET_TRAIN_SPLITS: "train"
+DATASET_EVAL_SPLITS: "train"
+STOP_STRINGS: '"<|end_of_text|>" "<｜end▁of▁sentence｜>" "<|EOT|>" "<|endoftext|>" "<|im_end|>"'
+IMPORTANCE_SAMPLING_LEVEL: "token"
+ADVANTAGE_NORMALIZATION_TYPE: "group_standard"
+ITERATOR_TYPE: "random"
+LR_SCHEDULER_TYPE: "linear"
+LOSS_MODE: "vanilla"
+TEMP_SCHEDULE_TYPE: "constant"
+DATASET_LOCAL_CACHE_DIR: "/proj/granite-build/g4os/data_downloads/"
+TORCHDYNAMO_DISABLE: "false"

--- a/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
+++ b/recipes/granite4-350m/lsf/rl-checkpoint-eval/parameters.yaml
@@ -42,6 +42,17 @@ TOTAL_EPISODES: "2048"
 SAVE_FREQ: "1"
 EVAL_FREQ: "10"
 
+# Monitoring cadence (seconds).
+# How often the training logs are downloaded and parsed for checkpoint messages.
+# Bounds how soon a newly written checkpoint is detected and its evals dispatched
+# (lower = quicker detection, more `sky logs` pulls).
+RL_LOG_SCRAPE_INTERVAL_SECONDS: "60"
+# How often the training job's status is checked (RUNNING/SUCCEEDED/FAILED).
+RL_STATUS_POLL_INTERVAL_SECONDS: "60"
+# How often each evaluation job's status is checked. Bounds how quickly an eval's
+# completion is detected so its export/aggregation can proceed.
+EVAL_STATUS_POLL_INTERVAL_SECONDS: "60"
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Everything below is a less-frequently-changed default.
 # ══════════════════════════════════════════════════════════════════════════════
@@ -64,23 +75,12 @@ CHECKPOINT_STATE_FREQ: "10"
 REF_POLICY_UPDATE_FREQ: "6"
 
 # ─── Monitor cadence (issue #45) ──────────────────────────────────────────────
-# Training log-scrape interval: how often the trainer's skypilot_monitor pulls
-# and parses logs while RUNNING. Bounds how soon a new checkpoint is detected
-# and its evals dispatched. Lower = quicker detection, more `sky logs` pulls.
-RL_LOG_SCRAPE_INTERVAL_SECONDS: "60"
-# Training status poll interval: how often the monitor queries SkyPilot job
-# status (RUNNING/SUCCEEDED/FAILED) for the training target.
-RL_STATUS_POLL_INTERVAL_SECONDS: "60"
-# Checkpoint-watch interval: how often the in-run watcher polls output_dir for
-# newly written checkpoint dirs to emit as artifacts. This is the finest-grained
-# knob for how soon a fresh checkpoint becomes an event; the log-scrape interval
-# above then bounds how soon that emitted line is pulled back to the monitor.
+# The three headline cadence knobs (log scrape, training status, eval status)
+# live in the COMMON PARAMETERS block above. This is the finest-grained knob:
+# how often the in-run watcher polls output_dir for newly written checkpoint
+# dirs to emit as artifacts. The log-scrape interval above then bounds how soon
+# that emitted line is pulled back to the monitor.
 RL_CHECKPOINT_WATCH_INTERVAL_SECONDS: "30"
-# Eval status poll interval: how often each eval target's monitor queries job
-# status. Bounds how quickly an eval's completion is detected so its export /
-# aggregation proceeds. Evals emit their result artifact on completion, so only
-# the status poll cadence matters here (log mode stays on_completion).
-EVAL_STATUS_POLL_INTERVAL_SECONDS: "60"
 
 # ─── 8-GPU RL topology ────────────────────────────────────────────────────────
 NUM_LEARNERS_PER_NODE: "4"

--- a/test/unit/recipes/test_rl_checkpoint_eval_generate.py
+++ b/test/unit/recipes/test_rl_checkpoint_eval_generate.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the rl-checkpoint-eval build generator (issue #45).
+
+The generator (``recipes/.../rl-checkpoint-eval/generate_build.py``) is a
+standalone script, not part of the gbserver package, so it is loaded here by
+path via importlib. These tests cover its pure, edge-case-prone functions —
+the checkpoint schedule math, eval-set resolution, --param typing/dot-notation,
+and the common-flag override shorthand — so a schedule or resolution regression
+is caught in CI rather than only as a hung live BlueVela run.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_GEN_PATH = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "recipes"
+    / "granite4-350m"
+    / "lsf"
+    / "rl-checkpoint-eval"
+    / "generate_build.py"
+)
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("rl_ckpt_eval_gen", _GEN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_generator()
+
+
+def _params(total_episodes, save_freq, prompts=64, samples=16):
+    return {
+        "TOTAL_EPISODES": total_episodes,
+        "NUM_UNIQUE_PROMPTS_ROLLOUT": prompts,
+        "NUM_SAMPLES_PER_PROMPT_ROLLOUT": samples,
+        "SAVE_FREQ": save_freq,
+    }
+
+
+# ─── compute_checkpoint_steps ─────────────────────────────────────────────────
+class TestComputeCheckpointSteps:
+    def test_shipped_smoke_default_two_checkpoints(self):
+        # 20480 // (64*16) = 20 updates, SAVE_FREQ 10 -> steps 10, 20.
+        assert gen.compute_checkpoint_steps(_params(20480, 10)) == [10, 20]
+
+    def test_even_multiples_no_duplicate_final(self):
+        # num_updates 12, SAVE_FREQ 3 -> 3,6,9,12 (12 is already a multiple).
+        assert gen.compute_checkpoint_steps(_params(12288, 3)) == [3, 6, 9, 12]
+
+    def test_final_update_appended_when_not_a_multiple(self):
+        # num_updates 2, SAVE_FREQ 10 -> range() empty, final update appended.
+        assert gen.compute_checkpoint_steps(_params(2048, 10)) == [2]
+
+    def test_save_freq_one_every_update(self):
+        assert gen.compute_checkpoint_steps(_params(3072, 1)) == [1, 2, 3]
+
+    def test_zero_updates_raises(self):
+        # TOTAL_EPISODES below one rollout batch -> 0 updates, nothing to save.
+        with pytest.raises(ValueError, match="0 optimizer updates"):
+            gen.compute_checkpoint_steps(_params(512, 1))
+
+    def test_bad_denominator_raises(self):
+        with pytest.raises(ValueError, match="must be > 0"):
+            gen.compute_checkpoint_steps(_params(1024, 1, prompts=0))
+
+    def test_save_freq_below_one_raises(self):
+        with pytest.raises(ValueError, match="SAVE_FREQ must be >= 1"):
+            gen.compute_checkpoint_steps(_params(2048, 0))
+
+
+# ─── resolve_eval_names ───────────────────────────────────────────────────────
+_CATALOG = {
+    "evals": {
+        "a": {"category": "code"},
+        "b": {"category": "math"},
+        "c": {"category": "multilingual"},
+        "bfcl": {"category": "bfcl"},
+    },
+    "sets": {"s": ["a", "b"], "full": ["a", "b", "c", "bfcl"]},
+}
+
+
+class TestResolveEvalNames:
+    def test_set_expands(self):
+        assert gen.resolve_eval_names({"EVAL_SETS": ["s"]}, _CATALOG) == ["a", "b"]
+
+    def test_individual_evals(self):
+        assert gen.resolve_eval_names({"EVAL_SETS": ["a", "bfcl"]}, _CATALOG) == [
+            "a",
+            "bfcl",
+        ]
+
+    def test_set_plus_individual_dedup_first_seen_order(self):
+        # 's' -> a,b; then 'a' (dup, dropped); then 'bfcl'.
+        assert gen.resolve_eval_names({"EVAL_SETS": ["s", "a", "bfcl"]}, _CATALOG) == [
+            "a",
+            "b",
+            "bfcl",
+        ]
+
+    def test_string_shorthand_parsed_as_list(self):
+        assert gen.resolve_eval_names({"EVAL_SETS": "[a, b]"}, _CATALOG) == ["a", "b"]
+
+    def test_unknown_name_raises_with_known_list(self):
+        with pytest.raises(ValueError, match="Unknown EVAL_SETS entry"):
+            gen.resolve_eval_names({"EVAL_SETS": ["nope"]}, _CATALOG)
+
+    def test_empty_selection_raises(self):
+        with pytest.raises(ValueError, match="empty selection"):
+            gen.resolve_eval_names({"EVAL_SETS": []}, _CATALOG)
+
+
+# ─── apply_override / add_key_value ───────────────────────────────────────────
+class TestParamOverrides:
+    def test_dot_notation_nests(self):
+        data = {}
+        gen.add_key_value(data, "a.b.c", "v")
+        assert data == {"a": {"b": {"c": "v"}}}
+
+    def test_yaml_typing_list(self):
+        assert gen.apply_override({}, "EVAL_SETS=[x, y]") == {"EVAL_SETS": ["x", "y"]}
+
+    def test_yaml_typing_int(self):
+        assert gen.apply_override({}, "SAVE_FREQ=10") == {"SAVE_FREQ": 10}
+
+    def test_missing_equals_raises(self):
+        with pytest.raises(ValueError, match="key=value"):
+            gen.apply_override({}, "NOEQUALS")
+
+
+# ─── _flag_overrides ──────────────────────────────────────────────────────────
+class _Args:
+    """Minimal stand-in for the argparse Namespace _flag_overrides reads."""
+
+    def __init__(self, **kw):
+        for dest in gen.COMMON_FLAG_PARAMS:
+            setattr(self, dest, kw.get(dest))
+
+
+class TestFlagOverrides:
+    def test_eval_sets_comma_shorthand_becomes_yaml_list(self):
+        assert gen._flag_overrides(_Args(eval_sets="x,y")) == ["EVAL_SETS=[x, y]"]
+
+    def test_eval_sets_explicit_list_passthrough(self):
+        assert gen._flag_overrides(_Args(eval_sets="[x, y]")) == ["EVAL_SETS=[x, y]"]
+
+    def test_unset_flags_omitted(self):
+        assert gen._flag_overrides(_Args()) == []
+
+    def test_scalar_flag_mapped_to_param_name(self):
+        assert gen._flag_overrides(_Args(save_freq="10")) == ["SAVE_FREQ=10"]
+
+
+# ─── _experiment_for_step (flat naming — sage-eval can't accept a "/") ────────
+class TestExperimentForStep:
+    def test_flat_suffix_no_slash(self):
+        exp = gen._experiment_for_step(10)
+        assert exp == "$${EXPERIMENT}-ckpt_10"
+        assert "/" not in exp


### PR DESCRIPTION
## Summary

- **Dynamic checkpoint-fanout RL recipe** (`recipes/granite4-350m/lsf/rl-checkpoint-eval/`): a `generate_build.py` that computes the checkpoint schedule up front and emits one eval target-set per checkpoint, plus a combined roll-up across all checkpoints.
- **Per-checkpoint artifact emission in `openinstruct-rl` step**: background watcher polls the trainer's output directory and emits an `LLMB_ARTIFACT_ID:checkpoint_<step>` line for each new checkpoint dir, allowing downstream eval targets to start as soon as each checkpoint is written — not only at the end.
- **Monitoring cadence knobs** added to the step config (`poll_interval_seconds`, `log_retrieval_interval_seconds`, `checkpoint_watch_interval_seconds`) with generator flags for override.
- **Eval catalog** (`eval-catalog.yaml`): 27 evals with named sets (code-eval, general-eval, math-eval, safety-eval, multilingual-eval, bfcl, full-eval) to select subsets per run.
- **SkyPilot pin bump** to pick up the LsfCommandRunner rsync timeout fix.
- **Teardown target** to shut down server clusters after training completes.

Closes ibm-granite/granite.build#45

## Test plan

- [x] Generate a build with `python generate_build.py --workflow ifrl --eval-sets bfcl` and inspect the output `build.yaml` for correct target wiring
- [x] Run the generated build on BlueVela and verify per-checkpoint artifact emission triggers downstream evals
- [x] Confirm backward compatibility: existing single-checkpoint recipes (`ifrl-smoke`, `identityrl-*`) still work with the updated `step.yaml`
- [x] Validate teardown target fires after last checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)