### PR TITLE
Override default timeout for long-running ibm build test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,8 @@ check_hf_token:
 		export GBSERVER_IMAGE_TAG=${IMAGE_TAG} && \
 		export GBSERVER_SIDECAR_MONITORING_IMAGE_TAG=${SIDECAR_IMAGE_TAG} && \
 		args=(--durations=20 $(PYTEST_COV) --junitxml=report.xml) && \
-		args+=(-rs -n ${PYTEST_NUM_TEST_PROC} --dist=${PYTEST_DIST_MODE} $(PYTEST_CAPTURE)) && \
+		args+=(--max-worker-restart=0 -n ${PYTEST_NUM_TEST_PROC} --dist=${PYTEST_DIST_MODE}) && \
+		args+=(-rs $(PYTEST_CAPTURE)) && \
 		args+=(-m '$(PYTEST_MARKERS)' --strict-markers -o log_cli_level=WARNING) && \
 		pytest "$${args[@]}" $(PYTEST_TEST_TARGETS) && \
 		$(COVERAGE_GATE)

--- a/test/integration/ibm/buildrunner/k8s/test_builds.py
+++ b/test/integration/ibm/buildrunner/k8s/test_builds.py
@@ -16,6 +16,8 @@ class TestDiGiT_SFTFull_FMEval(AbstractYamlBuildRunnerTest):
     def _get_yaml_spec_dir(self) -> Path:
         return get_test_data_dir_for(__file__) / "builds/DiGiT_SFTFull_FMEval"
 
-    @pytest.mark.timeout(7200)  # 120 minutes, matches the test-defined timeout in buildtest.yaml
+    @pytest.mark.timeout(
+        7200
+    )  # 120 minutes, matches the test-defined timeout in buildtest.yaml
     def test_runner(self):
         super().test_runner()

--- a/test/integration/ibm/buildrunner/k8s/test_builds.py
+++ b/test/integration/ibm/buildrunner/k8s/test_builds.py
@@ -15,3 +15,7 @@ class TestDiGiT_SFTFull_FMEval(AbstractYamlBuildRunnerTest):
 
     def _get_yaml_spec_dir(self) -> Path:
         return get_test_data_dir_for(__file__) / "builds/DiGiT_SFTFull_FMEval"
+
+    @pytest.mark.timeout(7200)  # 120 minutes, matches the test-defined timeout in buildtest.yaml
+    def test_runner(self):
+        super().test_runner()


### PR DESCRIPTION
## Description

Enables the long-running IBM build integration test (digit/sft/eval) to run to completion
Also disables pytest worker retries (1 failure is enough).

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
