### PR TITLE
Add Claude Code agent skills and document them in the README

### DIFF
--- a/.claude/skills/create-build/SKILL.md
+++ b/.claude/skills/create-build/SKILL.md
@@ -51,7 +51,7 @@ export GBSERVER_HOST="http://127.0.0.1:${GBSERVER_PORT:-8080}"
 - The space's `space.yaml` has a `base_uris:` chain (e.g. `file://../../assets`) — that's where steps/environments/assetstores resolve from.
 - **Environments:** `ls <assets>/environments/` → typically `bash docker runpod skypilot ...`. Default to `bash`.
 - **Steps:** steps usable on the bash backend live under `<assets>/environments/bash/steps/<name>/`. A step is referenced as `space://steps/<name>` even though it lives in an env-keyed subdir — the resolver maps it.
-- **The `hello` step** (`<assets>/environments/bash/steps/hello/`) is the minimal correct bash step — copy its shape.
+- **On-disk reference steps** live under `<assets>/environments/bash/steps/` (`hello`, `command`, `inference`, `inference-lora`, `lora-finetune`). `hello`/`command` are **minimal** steps (launcher + a `MESSAGE_EVENT` log monitor, no artifact capture) — copy them for shape. `inference`, `inference-lora`, and `lora-finetune` are the reference for a step that **captures outputs as artifacts** — they carry the `NEWARTIFACT_IN_ENVIRONMENT_EVENT` monitor. Copy `inference` (or `lora-finetune`) when your step must emit artifacts.
 
 When you reference `space://steps/<name>` or `space://environments/<name>`, the name must be a real directory you found above.
 
@@ -73,7 +73,7 @@ A step is a directory under `<assets>/environments/bash/steps/<step-name>/`:
 
 ### `step.yaml` — the launch contract
 
-Model it on this (the `hello` step is the on-disk reference). `type: nohup` is mandatory for bash. The monitor's `NEWARTIFACT_IN_ENVIRONMENT_EVENT` block is what captures your outputs — keep it.
+Model it on this. `type: nohup` is mandatory for bash. The monitor's `NEWARTIFACT_IN_ENVIRONMENT_EVENT` block is what captures your outputs — keep it. **On-disk reference:** this artifact-capturing shape matches the `inference`, `inference-lora`, and `lora-finetune` steps (which carry this monitor); `hello`/`command` are minimal and have only the `MESSAGE_EVENT` block, so copy `inference` (or `lora-finetune`) when your step emits artifacts.
 
 ```yaml
 name: <step-name>            # must equal the directory name
@@ -218,7 +218,7 @@ This `job.log` is your primary debugging artifact. If a step "succeeded" but did
 ## Authoring procedure (checklist)
 
 1. Confirm a gbserver is running (start via `run-gbserver` if not). Set `GB_ENVIRONMENT=STANDALONE`, activate the repo venv.
-2. Discover the space, its `bash` environment, and existing steps by reading `<assets>/`. Read the `hello` step as a template.
+2. Discover the space, its `bash` environment, and existing steps by reading `<assets>/`. Read an on-disk step as a template — `hello` for the minimal shape, `inference`/`lora-finetune` for the artifact-capturing shape.
 3. Author the step under `<assets>/environments/bash/steps/<name>/`: `step.yaml` (Bash/`nohup` launcher + artifact monitor) and `bash_scripts/<name>/` (the script, which sets up its own venv and reads settings from env). Make scripts executable.
 4. Write the build.yaml with the user's project: target(s) and step(s) matching the workload (one target/one step is the simplest), settings in `config.bash.env`, base model as an `hf:///` input, outputs via `base_uri`. (No restart needed — the server picks the step up.)
 5. `gb build validate`, then **`gb build start`**. Monitor it with `gb build status <build-id>`; the build is done once it no longer appears in `gb build list`. Then read `job.log` to confirm the workload actually ran (not just that status flipped to SUCCESS).
@@ -226,4 +226,4 @@ This `job.log` is your primary debugging artifact. If a step "succeeded" but did
 
 ## When unsure
 
-Invoke **`gb-docs`** for the authoritative schema/CLI/troubleshooting docs. If the docs and this skill disagree on a documented field, trust the docs — but note the docs are k8s/LSF-centric, and several documented conveniences (`config.workload.commands`, `gb.files_to_create`) are **k8s/LSF-only and do not apply to the bash backend**. For bash behavior, the source of truth is the on-disk `hello` step plus a working build's `job.log`/`step.yaml`.
+Invoke **`gb-docs`** for the authoritative schema/CLI/troubleshooting docs. If the docs and this skill disagree on a documented field, trust the docs — but note the docs are k8s/LSF-centric, and several documented conveniences (`config.workload.commands`, `gb.files_to_create`) are **k8s/LSF-only and do not apply to the bash backend**. For bash behavior, the source of truth is the on-disk steps (`hello`/`command` for a minimal launch; `inference`/`lora-finetune` for artifact capture) plus a working build's `job.log`/`step.yaml`.

--- a/.claude/skills/create-build/SKILL.md
+++ b/.claude/skills/create-build/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: create-build
+description: Use a new Granite.build build.yaml for any compute workload — model training (SFT/LoRA/EPT), inference/serving, data generation/processing, evaluation, or arbitrary compute. Targets, steps, inputs/outputs (artifacts), compute resources, and how they resolve within a space. Use when asked to create, write, or scaffold a new build, build.yaml, or pipeline.
+argument-hint: "[build-name]"
+allowed-tools: Bash(ls *) Bash(test *) Bash(cat *) Bash(grep *) Bash(find *)
+---
+
+# Author a Granite.build build
+
+This skill makes a workload (train a model, run inference, generate/process data, evaluate, or any script) run on Granite.build. You produce **two kinds of artifacts**:
+
+1. A **step** — the unit of execution. A step is a directory under the space's assets containing a `step.yaml` (how to launch it) and a `bash_scripts/<step-name>/` folder with the script(s) it runs. Steps live in the space, are reusable, and are referenced by URI.
+2. A **build.yaml** — the run definition. It references steps by URI, wires inputs/outputs, and passes per-run settings. The build.yaml is *not* a script and does not live under assets; keep it with the user's project (e.g. a `lora-granite/build.yaml` folder).
+
+Granite.build is **workload-agnostic**: training, inference, data-gen, and evaluation are all "a step that runs a command." There is no special "training build" shape. What changes between workloads is the script inside the step and the settings in build.yaml — not the structure.
+
+## Operating assumptions (read first)
+
+These reflect how this environment actually behaves. Follow them unless the user says otherwise.
+
+- **Default to standalone.** Assume `GB_ENVIRONMENT=STANDALONE`, a local `gbserver`, the **bash** compute backend, and SQLite. No cloud creds, no Kubernetes. Everything below targets that backend.
+- **A server must be running before you create or run anything.** Building, validating, and running all talk to a live `gbserver`. Before your first `gb` command, confirm one is up; if not, start one. See "Ensure the server is running."
+- **Compose with targets and steps as the workload needs.** A workload is one or more **targets**, each containing one or more **steps**. Steps within a target run sequentially and share a filesystem; targets can be wired together with `binding` (a downstream target's input bound to an upstream target's output) and run on the standalone bash backend. Use sequential steps in one target for phases that share files (e.g. generate data → train in the same workspace); use separate bound targets when phases have distinct inputs/outputs or compute and you want them as separate lineage-tracked units. A single target with one step is still the simplest shape — reach for more structure only when the workload calls for it.
+- **The server picks up new/edited steps dynamically.** After you add or change a step under the space's assets, you do **not** need to restart gbserver. The next build resolves the new step. (Restart only if a change genuinely isn't being seen and you've ruled out everything else.)
+- **Steps, step definitions, and scripts live under the space's assets.** Only the build.yaml lives with the user's project. Never inline a training script into build.yaml; put it in the step's `bash_scripts/` dir.
+- **Each step's script sets up its own runtime (venv) internally.** Don't rely on a pre-activated environment. If the workload needs Python deps (torch/trl/peft/…), the script creates/activates its own venv (idempotently) before importing them — see "The step script owns its environment." Never install heavy deps into the gbserver venv.
+
+## Ensure the server is running
+
+Before any `gb` call. The environment sets a per-job `GBSERVER_PORT` (defaults to 8080); check for a server on THAT port. Match by process (works from any call, the same way `run-gbserver` launches and detects it):
+
+```
+pgrep -f "gbserver standalone --port ${GBSERVER_PORT:-8080}" >/dev/null && echo "server up" || echo "server DOWN"
+```
+
+If it's down, start it with the **`run-gbserver`** skill (it clones/sets up the repo and launches the standalone server on `${GBSERVER_PORT:-8080}` with a space). Do not author against a dead server — you can't discover real step/env names and every command errors.
+
+Throughout, run `gb` with the venv active and the env set — including `GBSERVER_HOST` pointed at the per-job port (it must match the port `run-gbserver` used; the client otherwise defaults to `http://localhost:8080` and can't reach a server on a non-default port). Run `gb` in a Bash call **with `dangerouslyDisableSandbox: true`** so it shares the server's namespace:
+
+```
+source <repo>/.venv/bin/activate
+export GB_ENVIRONMENT=STANDALONE
+export GBSERVER_HOST="http://127.0.0.1:${GBSERVER_PORT:-8080}"
+```
+
+## Discover what already exists (don't invent URIs)
+
+`gb step list` is **not supported in standalone mode** — it errors. Discover by reading the space on disk instead:
+
+- Find the space: `gb space list` (works in standalone) gives space names; the space dir is the one passed to `--space-dir` (commonly `configurations/spaces/local`).
+- The space's `space.yaml` has a `base_uris:` chain (e.g. `file://../../assets`) — that's where steps/environments/assetstores resolve from.
+- **Environments:** `ls <assets>/environments/` → typically `bash docker runpod skypilot ...`. Default to `bash`.
+- **Steps:** steps usable on the bash backend live under `<assets>/environments/bash/steps/<name>/`. A step is referenced as `space://steps/<name>` even though it lives in an env-keyed subdir — the resolver maps it.
+- **The `hello` step** (`<assets>/environments/bash/steps/hello/`) is the minimal correct bash step — copy its shape.
+
+When you reference `space://steps/<name>` or `space://environments/<name>`, the name must be a real directory you found above.
+
+## CRITICAL: bash steps need a `nohup` launcher — the generic `gbstep` does NOT work on bash
+
+The builtin `gbstep` step defines launchers only for `k8s` and `Lsf`. On the **bash** backend it falls back to a `helm` launcher and dies with `KeyError: 'helm'`. **Do not reference `space://steps/gbstep` on the bash backend.** Instead, author your own step whose `step.yaml` declares a `Bash` launcher of `type: nohup`. This is the single most common mistake — avoid it.
+
+## Authoring a bash step (the core skill)
+
+A step is a directory under `<assets>/environments/bash/steps/<step-name>/`:
+
+```
+<assets>/environments/bash/steps/<step-name>/
+├── step.yaml
+└── bash_scripts/
+    └── <step-name>/          # MUST match the step name
+        └── command.sh        # default entrypoint, OR run.py via script_path
+```
+
+### `step.yaml` — the launch contract
+
+Model it on this (the `hello` step is the on-disk reference). `type: nohup` is mandatory for bash. The monitor's `NEWARTIFACT_IN_ENVIRONMENT_EVENT` block is what captures your outputs — keep it.
+
+```yaml
+name: <step-name>            # must equal the directory name
+version: v1
+type: custom
+config: {}
+environment_configs:
+  Bash:
+    launchers:
+      <step-name>:
+        type: nohup
+        monitors:
+          - log_monitor
+        config:
+          script_path: run.py   # optional; omit to default to command.sh
+    monitors:
+      log_monitor:
+        type: log_monitor
+        config:
+          event_configs:
+            # Captures outputs: the script prints a line of the form
+            #   LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<abs-path>
+            - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
+              line_regex: "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_PATH:.*"
+              is_json: false
+              event_fields:
+                - field_name: binding_id
+                  field_regex: "(?<=LLMB_ARTIFACT_ID:)[^ ]+"
+                - field_name: path
+                  field_regex: "(?<=LLMB_ARTIFACT_PATH:).*"
+                  is_data: true
+                - field_name: binding
+                  field_value_template: '{ "path": "{{ fields.data.path }}" }'
+                  is_json: true
+            - event_type: MESSAGE_EVENT
+              line_regex: ".*"
+              is_json: false
+              event_fields:
+                - field_name: msg
+                  field_regex: ".*"
+```
+
+- Omit `config.script_path` → the launcher runs `bash_scripts/<step-name>/command.sh`.
+- Set `config.script_path: run.py` → it runs `bash_scripts/<step-name>/run.py` (must be executable).
+
+### What the script receives at runtime (env vars)
+
+gbserver wraps your script and injects:
+
+- `LLMB_BASH_OUTPUT_DIR` — write outputs here. Each sub-directory you create becomes an artifact; or set `config.bash.single_output_artifact: true` in build.yaml to make the whole dir one artifact; or emit `LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>` explicitly (preferred — gives the artifact a stable id matching your `outputs:` name).
+- `LLMB_BASH_INPUT_<NAME>` — for each input named `<name>` in build.yaml, the resolved **local path** to that artifact, with `<NAME>` uppercased. E.g. input `base_model` → `$LLMB_BASH_INPUT_BASE_MODEL`.
+- Anything you put under `config.bash.env` in build.yaml is exported as an env var. **This is how per-run settings reach the script** (hyperparameters, the fact to teach, etc.). Read them with defaults in the script.
+- `LLMB_BASH_ASSET_DIR`, `LLMB_BASH_LAUNCH_ID`, build/target ids — usually not needed.
+
+### The step script owns its environment
+
+The script must not assume torch/trl/etc. are importable. It creates and uses its own venv idempotently, inside the step, at run time. Two clean patterns — pick one:
+
+**(a) `command.sh` creates the venv, then runs the python** (recommended):
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VENV="$HOME/.gb-<workload>-venv"
+if [ ! -x "$VENV/bin/python" ]; then
+  python3 -m venv "$VENV"
+  "$VENV/bin/pip" install --upgrade pip
+  "$VENV/bin/pip" install torch transformers trl peft datasets accelerate
+fi
+exec "$VENV/bin/python" "$SCRIPT_DIR/run.py"
+```
+
+**(b) a single `run.py`** whose first action re-execs into a self-built venv if its deps are missing. Use (a) unless the user wants a one-file step.
+
+Either way: the venv is created **inside the step at run time**, is idempotent (reused on later runs), and is separate from the gbserver venv. Pin to a small Granite model for CPU (`ibm-granite/granite-4.0-350m`); CPU training of a few dozen LoRA steps takes seconds-to-minutes.
+
+## The build.yaml — targets and steps
+
+Working build.yaml examples ship under `samples/standalone/` in the granite.build repo — read those for real, runnable references (single- and multi-target shapes).
+
+Keep it with the user's project (not under assets). The example below uses a single target referencing one step — the simplest shape; add more steps to a target (sequential, shared filesystem) or more targets (wired by `binding`) as the workload needs. Settings go in `config.bash.env`. The base model can be an `hf:///owner/repo` input — the bash env's HF assetstore pulls it automatically (no separate pull step), surfacing it as `$LLMB_BASH_INPUT_BASE_MODEL`.
+
+```yaml
+granite.build:
+  name: <build-name>
+  version: 0.0.1
+  targets:
+    run:                                   # one target
+      environment_uri: space://environments/bash
+      inputs:
+        base_model:
+          uri: hf:///ibm-granite/granite-4.0-350m   # triple slash; host defaults to huggingface.co
+      outputs:
+        adapter:
+          base_uri: file:workspace/adapter/  # produced artifacts use base_uri
+      steps:
+        - step_uri: space://steps/<step-name>
+          config:
+            bash:
+              env:                           # per-run settings -> env vars in the script
+                TRAIN_MAX_STEPS: "30"
+                TRAIN_LR: "2e-4"
+                LORA_R: "8"
+            compute_config:
+              num_nodes: 1
+```
+
+Notes:
+- **Inputs** carry exactly one of `uri:` (fixed location: `hf:///…`, `file:…`) or `binding:` (wire to another target's output for multi-target workloads). Use `uri` for fixed external inputs; use `binding` to chain targets.
+- **Produced outputs** use `base_uri:` (a push destination); a fixed input file uses `uri:`.
+- Multiple steps in one target run sequentially and share the filesystem — use this for phases that share files. Use separate bound targets when phases have distinct inputs/outputs or compute.
+
+## Validate, then run
+
+```
+gb build validate -f <path>/build.yaml      # schema + URI existence
+gb build start    -f <path>/build.yaml       # prints a build id
+gb build list                                 # are builds still running? lists builds + their statuses
+gb build status   <build-id>                  # monitor a specific build's status
+```
+
+**If any `gb` command warns the CLI is out of date** (a client/server version mismatch), add **`--skip-version-check`** *after* the subcommand: `gb build start -f <path>/build.yaml --skip-version-check`. The check is advisory; skipping it is safe.
+
+**Monitor with `gb build status`; use `gb build list` to see if a build is still running.** `gb build list` lists in-progress builds — **if your build is not in `gb build list`, it is done.** `gb build status <build-id>` is how you monitor a specific build as it progresses toward SUCCESS.
+
+**Validation is necessary but not sufficient.** `gb build validate` passes even when a step would hit the `helm`-launcher bug. It does not prove the build runs. Always do a real `gb build start` and watch it reach SUCCESS (via `gb build list` / `gb build status`) with the expected steps actually executing.
+
+## Debugging — where the REAL output is
+
+`gb build log` and `gb build status` mostly show **status events**, not your script's stdout. The actual script output (prints, tracebacks, training loss) is on disk:
+
+```
+~/.granite.build/workdir/llm-build-<build-id>/target-<t>/target-run-*/step-<s>/step-run-*/launch-*/outputs/job.log
+```
+
+Find and read it:
+```
+find ~/.granite.build/workdir/llm-build-<build-id> -name job.log
+```
+This `job.log` is your primary debugging artifact. If a step "succeeded" but did nothing, or failed mysteriously, read `job.log` first. Reading a *prior* successful build's `job.log` and its copied `step.yaml`/`run.py` (under the same tree) is the fastest way to learn a working pattern.
+
+## Authoring procedure (checklist)
+
+1. Confirm a gbserver is running (start via `run-gbserver` if not). Set `GB_ENVIRONMENT=STANDALONE`, activate the repo venv.
+2. Discover the space, its `bash` environment, and existing steps by reading `<assets>/`. Read the `hello` step as a template.
+3. Author the step under `<assets>/environments/bash/steps/<name>/`: `step.yaml` (Bash/`nohup` launcher + artifact monitor) and `bash_scripts/<name>/` (the script, which sets up its own venv and reads settings from env). Make scripts executable.
+4. Write the build.yaml with the user's project: target(s) and step(s) matching the workload (one target/one step is the simplest), settings in `config.bash.env`, base model as an `hf:///` input, outputs via `base_uri`. (No restart needed — the server picks the step up.)
+5. `gb build validate`, then **`gb build start`**. Monitor it with `gb build status <build-id>`; the build is done once it no longer appears in `gb build list`. Then read `job.log` to confirm the workload actually ran (not just that status flipped to SUCCESS).
+6. If anything is unclear about a field/option/error, consult the **`gb-docs`** skill.
+
+## When unsure
+
+Invoke **`gb-docs`** for the authoritative schema/CLI/troubleshooting docs. If the docs and this skill disagree on a documented field, trust the docs — but note the docs are k8s/LSF-centric, and several documented conveniences (`config.workload.commands`, `gb.files_to_create`) are **k8s/LSF-only and do not apply to the bash backend**. For bash behavior, the source of truth is the on-disk `hello` step plus a working build's `job.log`/`step.yaml`.

--- a/.claude/skills/gb-docs/SKILL.md
+++ b/.claude/skills/gb-docs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: gb-docs
+description: Look up authoritative Granite.build documentation that ships inside the granite.build repo (build.yaml schema, steps, CLI, troubleshooting, glossary). Use when unsure about a Granite.build field, option, command, concept, or error, or when another gb skill says to consult the docs.
+argument-hint: "[topic or question]"
+---
+
+# Granite.build docs lookup
+
+The granite.build repo ships docs under `docs/`. They track the installed version. **Read** the relevant file(s) with the file tools, then answer grounded in their content, citing the doc path.
+
+## Important caveat: the docs are k8s/LSF-centric
+
+This environment runs the **standalone bash backend** by default, but most docs are written for the Kubernetes/LSF backends. Several documented conveniences **do not apply to bash**, e.g.:
+- `config.workload.commands` (inline command list) — k8s/LSF only.
+- `config.gb.files_to_create` / `additional_files` — k8s/LSF only.
+- The generic `gbstep` step — has no bash launcher; using it on bash fails with `KeyError: 'helm'`.
+
+So: use the docs for the **schema and concepts** (URIs, inputs/outputs, the field reference), but for **how a bash step actually launches and behaves**, the authoritative source is the on-disk reality, not the prose:
+- The `hello` step under `<assets>/environments/bash/steps/hello/` — the minimal correct bash step (`step.yaml` with a `Bash`/`nohup` launcher + its `bash_scripts/hello/command.sh`).
+- A *prior successful build's* artifacts under `~/.granite.build/workdir/llm-build-<id>/.../launch-*/` — the copied `step.yaml`, the script, and especially `job.log` (the real stdout). Reverse-engineering a working build beats guessing from docs.
+
+When the docs and on-disk bash reality disagree about bash behavior, trust the on-disk reality and say so.
+
+## Locate the docs
+
+Find the granite.build checkout, in this order, then use its `docs/` directory:
+`./granite.build`, `~/granite.build`. If no checkout exists, the `run-gbserver` skill clones it. As a fallback, the docs are browsable at github.com/ibm-granite/granite.build under `docs/`.
+
+## Index — pick by topic
+
+**Authoring builds**
+- `docs/users/build-yaml-reference.md` — **authoritative `build.yaml` schema** (targets, steps, inputs/outputs, URIs, all fields/options).
+- `docs/users/bring-your-own-step.md` — use/author custom steps (note: examples lean k8s/docker).
+- `docs/users/custom-code-steps.md` — running custom code (the `commands`/`files_to_create` features here are k8s/LSF only).
+- `docs/users/bring-your-own-image.md` — custom container images.
+- `docs/users/hf-push.md` — pushing artifacts to HuggingFace.
+
+**Using the system**
+- `docs/getting-started.md` — end-to-end walkthrough.
+- `docs/users/cli-reference.md` — the `gb` CLI commands.
+- `docs/users/faq.md` — common questions.
+- `docs/glossary.md` — terminology (build, target, step, artifact, space, …).
+- `docs/demos.md` — demo walkthroughs.
+
+**Concepts / architecture**
+- `docs/architecture/arch-diagram.md`, `docs/architecture/environment-classes.md`.
+- `docs/steps/README.md`, `docs/templates/README.md`.
+
+**Features**
+- `docs/features/lineage.md`, `build-retry.md`, `retry.md`, `step-retry-configuration.md`, `target-reuse.md`, `gbtest.md`.
+
+**Operators / setup / troubleshooting**
+- `docs/operators/troubleshooting.md` — **diagnosing failures** (server or build).
+- `docs/operators/environment-yaml-config.md`, `local-secrets-manager.md`, `multi-provider-authentication.md`, `runpod-orchestrator.md`, `skypilot-local-infrastructure.md`, `setup/skypilot-kubernetes-setup.md`.
+
+`docs/README.md` is the repo's own index if you need the full catalog.
+
+## How to use
+
+1. Resolve the checkout's `docs/` dir.
+2. From `$ARGUMENTS` (the topic/question) pick the most relevant file(s); if unsure, skim `docs/README.md` or grep `docs/` for keywords.
+3. **Read** the file(s) and answer grounded in their content, citing the doc path.
+4. If the question is about **bash-backend execution** specifically, also check the on-disk `hello` step and (if available) a working build's `job.log`/`step.yaml` — and prefer those over doc prose when they conflict.

--- a/.claude/skills/gb-docs/SKILL.md
+++ b/.claude/skills/gb-docs/SKILL.md
@@ -29,29 +29,28 @@ Find the granite.build checkout, in this order, then use its `docs/` directory:
 ## Index — pick by topic
 
 **Authoring builds**
-- `docs/users/build-yaml-reference.md` — **authoritative `build.yaml` schema** (targets, steps, inputs/outputs, URIs, all fields/options).
-- `docs/users/bring-your-own-step.md` — use/author custom steps (note: examples lean k8s/docker).
-- `docs/users/custom-code-steps.md` — running custom code (the `commands`/`files_to_create` features here are k8s/LSF only).
-- `docs/users/bring-your-own-image.md` — custom container images.
-- `docs/users/hf-push.md` — pushing artifacts to HuggingFace.
+- `docs/builds/build-yaml-reference.md` — **authoritative `build.yaml` schema** (targets, steps, inputs/outputs, URIs, all fields/options).
+- `docs/builds/README.md` — build features overview; `docs/builds/hf-push.md` — push artifacts to HuggingFace; `docs/builds/event-notifications.md`.
+- `docs/steps/bring-your-own-step.md`, `docs/steps/custom-code-steps.md`, `docs/steps/bring-your-own-image.md` — author/use custom steps (examples lean k8s/docker; the `commands`/`files_to_create` features are k8s/LSF only). `docs/steps/README.md` — steps overview.
 
 **Using the system**
 - `docs/getting-started.md` — end-to-end walkthrough.
-- `docs/users/cli-reference.md` — the `gb` CLI commands.
-- `docs/users/faq.md` — common questions.
-- `docs/glossary.md` — terminology (build, target, step, artifact, space, …).
-- `docs/demos.md` — demo walkthroughs.
+- `docs/cli/gb-cli-reference.md` — the `gb` CLI; `docs/cli/gbserver-cli-reference.md` — the server CLI; `docs/cli/gbtest-cli-reference.md` — gbtest.
+- `docs/help/faq.md` — common questions; `docs/glossary.md` — terminology (build, target, step, artifact, space, …).
+- `docs/demos/` — demo walkthroughs (`docker-demo.md`, `granite4_nano.md`, `skypilot-slurm-demo.md`).
 
 **Concepts / architecture**
 - `docs/architecture/arch-diagram.md`, `docs/architecture/environment-classes.md`.
-- `docs/steps/README.md`, `docs/templates/README.md`.
+- `docs/steps/README.md`, `docs/templates/README.md`, `docs/spaces/README.md`, `docs/asset-stores/README.md`.
 
-**Features**
-- `docs/features/lineage.md`, `build-retry.md`, `retry.md`, `step-retry-configuration.md`, `target-reuse.md`, `gbtest.md`.
+**Build features**
+- `docs/builds/lineage.md`, `docs/builds/build-retry.md`, `docs/builds/retry.md`, `docs/builds/step-retry-configuration.md`, `docs/builds/target-reuse.md`.
 
-**Operators / setup / troubleshooting**
-- `docs/operators/troubleshooting.md` — **diagnosing failures** (server or build).
-- `docs/operators/environment-yaml-config.md`, `local-secrets-manager.md`, `multi-provider-authentication.md`, `runpod-orchestrator.md`, `skypilot-local-infrastructure.md`, `setup/skypilot-kubernetes-setup.md`.
+**Environments / config / secrets / troubleshooting**
+- `docs/help/troubleshooting.md` — **diagnosing failures** (server or build).
+- `docs/environments/bash.md` — the **standalone bash backend** (most relevant here); also `docker.md`, `k8s.md`, `lsf.md`, `runpod.md`, `skypilot*.md`, `step-resolution.md`, and `setup/`.
+- `docs/configuration/` — `config-files.md`, `environment-variables.md`, `gb-environment.md`.
+- `docs/secrets/` — `local-secrets-manager.md`, `env-secrets-manager.md`, `ibmcloud-secrets-manager.md`; `docs/rest-api/multi-provider-authentication.md`.
 
 `docs/README.md` is the repo's own index if you need the full catalog.
 

--- a/.claude/skills/gb-docs/SKILL.md
+++ b/.claude/skills/gb-docs/SKILL.md
@@ -16,7 +16,7 @@ This environment runs the **standalone bash backend** by default, but most docs 
 - The generic `gbstep` step — has no bash launcher; using it on bash fails with `KeyError: 'helm'`.
 
 So: use the docs for the **schema and concepts** (URIs, inputs/outputs, the field reference), but for **how a bash step actually launches and behaves**, the authoritative source is the on-disk reality, not the prose:
-- The `hello` step under `<assets>/environments/bash/steps/hello/` — the minimal correct bash step (`step.yaml` with a `Bash`/`nohup` launcher + its `bash_scripts/hello/command.sh`).
+- The on-disk steps under `<assets>/environments/bash/steps/` — `hello`/`command` are the minimal correct bash steps (`step.yaml` with a `Bash`/`nohup` launcher + a `bash_scripts/<step>/command.sh`), while `inference`/`inference-lora`/`lora-finetune` are the reference for a step that captures outputs as artifacts (they carry the `NEWARTIFACT_IN_ENVIRONMENT_EVENT` monitor).
 - A *prior successful build's* artifacts under `~/.granite.build/workdir/llm-build-<id>/.../launch-*/` — the copied `step.yaml`, the script, and especially `job.log` (the real stdout). Reverse-engineering a working build beats guessing from docs.
 
 When the docs and on-disk bash reality disagree about bash behavior, trust the on-disk reality and say so.

--- a/.claude/skills/run-gbserver/SKILL.md
+++ b/.claude/skills/run-gbserver/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: run-gbserver
+description: Clone, set up, and run the Granite.build standalone gbserver. Use when asked to set up, install, start, or run gbserver / the Granite.build standalone server and when running builds.
+argument-hint: "[path-to-existing-checkout]"
+allowed-tools: Bash(git clone *) Bash(git -C *) Bash(make *) Bash(source *) Bash(gbserver *) Bash(curl *) Bash(ls *) Bash(test *) Bash(python3.13 *) Bash(lsof *) Bash(sleep *)
+---
+
+# Run the Granite.build standalone gbserver
+
+Set up and launch the standalone `gbserver` from the `granite.build` repo. Standalone is the **default way to run Granite.build in this environment**: SQLite storage, the **bash** compute backend, no cloud credentials. A running gbserver is a prerequisite for everything else — you cannot create, validate, or run a build without one. If another skill (e.g. `create-build`) needs a server and none is up, run this skill first.
+
+Repo: https://github.com/ibm-granite/granite.build
+Clone URL (HTTPS): `https://github.com/ibm-granite/granite.build.git`
+
+## 0. Locate or clone the repo
+
+Find an existing checkout before cloning — do not re-clone a repo that already exists.
+
+1. If `$ARGUMENTS` is set, treat it as the path to an existing `granite.build` checkout. Verify it contains a `Makefile` and `samples/standalone/`.
+2. Otherwise look for a checkout in likely spots: the current directory, `./granite.build`, `~/granite.build`. A valid checkout has both `Makefile` and `samples/standalone/standalone-quickstart/build.yaml`.
+3. If none is found, clone into `./granite.build`:
+   ```
+   git clone https://github.com/ibm-granite/granite.build.git
+   ```
+
+Let `$REPO` be the resolved repo directory for the rest of these steps. Run all commands from inside `$REPO`.
+
+## 1. Create the virtualenv and install
+
+Requires **Python 3.13**. Confirm `python3.13 --version` works first; if it doesn't, stop and tell the user to install Python 3.13.
+
+```
+make standalone-venv PYTHON=python3.13
+```
+
+This creates `.venv/` and installs the standalone dependencies (the gbserver/`gb` CLI). If `.venv/` already exists and the `gbserver` entry point is present, you may skip this step.
+
+> This venv is for gbserver and the `gb` CLI **only**. Do NOT install workload/training dependencies (torch, trl, peft, …) into it — each step's script creates and manages its own venv at run time. Keep this venv clean.
+
+## 2. Start the server (it must survive across tool calls)
+
+gbserver is a long-running service. Launch it with the Bash tool's own parameters, not shell backgrounding. Invoke the Bash tool with BOTH set:
+- `run_in_background: true` — runs it as a tracked daemon that survives across tool calls and is stopped cleanly when the session ends. (A foreground `gbserver` never returns, so without this the launching call just blocks until it times out.)
+- `dangerouslyDisableSandbox: true` — in environments where the Bash tool sandboxes each call in its own network namespace, this runs the server in the shared host namespace so your later calls can reach its port. In some environments (e.g. inside an unprivileged container) calls already share one namespace and this flag is a harmless no-op — set it anyway; it's the safe default either way.
+
+Do NOT use `&` / `nohup` / `setsid` / `disown` — the tool parameters handle lifetime. Command:
+
+```
+source .venv/bin/activate && gbserver standalone --port ${GBSERVER_PORT:-8080} --space-dir configurations/spaces/local > /tmp/gbserver.log 2>&1
+```
+
+Use port `${GBSERVER_PORT:-8080}`. This host may be shared with other builds, so the environment sets `GBSERVER_PORT` to a per-job value to keep two jobs from colliding on the same port — always honor it; don't hardcode 8080.
+
+**Don't double-start:** if a gbserver for this port is already running, reuse it — do not start a second (it fails "address already in use"). Check by process (the PID namespace is shared, so this works from any call without needing the sandbox flag):
+
+```
+pgrep -f "gbserver standalone --port ${GBSERVER_PORT:-8080}" >/dev/null && echo "already running — reuse it"
+```
+
+## 3. Confirm it's ready, then report
+
+Poll until the gbserver process is up, then confirm it answers. The process check needs no sandbox flag (shared PID namespace); the readiness `curl` should run **with `dangerouslyDisableSandbox: true`** so it shares the server's namespace:
+
+```
+until pgrep -f "gbserver standalone --port ${GBSERVER_PORT:-8080}" >/dev/null; do sleep 0.5; done   # process alive
+curl -s -o /dev/null "http://127.0.0.1:${GBSERVER_PORT:-8080}/" && echo "gbserver ready"             # accepting connections
+```
+
+Once it's ready, report to the user:
+- The repo path used (and whether it was cloned or reused).
+- That the server is running and on which port (`${GBSERVER_PORT:-8080}`).
+- How to stop it (scoped to THIS job's port via its command line, so it never touches a co-located job's server):
+  ```
+  pkill -f "gbserver standalone --port ${GBSERVER_PORT:-8080}"
+  ```
+  If launched as a tracked background task it also stops when this Claude session exits.
+
+If startup fails, show the relevant lines from `/tmp/gbserver.log` rather than guessing. For setup or startup issues, invoke the `gb-docs` skill — it reads the checkout's docs (`docs/getting-started.md`, `docs/operators/troubleshooting.md`).
+
+## Steps are picked up dynamically — you do NOT need to restart
+
+Once the server is running, adding or editing a **step** under the space's assets (`configurations/.../environments/bash/steps/<name>/`) is picked up on the next build automatically. Do **not** restart gbserver after authoring or changing a step — it resolves the current on-disk step at build time. Only restart if a change genuinely isn't being seen after you've ruled out everything else (wrong path, wrong step name, syntax error).
+
+## Submitting a build (only if asked)
+
+The **client** needs `GB_ENVIRONMENT=STANDALONE`, and — because the server lives in the shared host namespace — every `gb` command must run in a Bash call **with `dangerouslyDisableSandbox: true`** (otherwise it lands in a fresh sandbox namespace and can't reach the server). Activate the venv and set the env in that same call:
+
+Because the server may be on a non-default port (the environment sets `GBSERVER_PORT`), point the client at it in the same call. The client reads the server base URL from **`GBSERVER_HOST`** (a full `scheme://host:port`; its standalone default is `http://localhost:8080`), so set it to match the port:
+
+```
+# each of these is a separate Bash tool call with dangerouslyDisableSandbox: true
+source .venv/bin/activate && export GB_ENVIRONMENT=STANDALONE GBSERVER_HOST="http://127.0.0.1:${GBSERVER_PORT:-8080}" && gb build validate -f <path>/build.yaml   # schema + URI check
+source .venv/bin/activate && export GB_ENVIRONMENT=STANDALONE GBSERVER_HOST="http://127.0.0.1:${GBSERVER_PORT:-8080}" && gb build start    -f <path>/build.yaml   # prints a build id
+source .venv/bin/activate && export GB_ENVIRONMENT=STANDALONE GBSERVER_HOST="http://127.0.0.1:${GBSERVER_PORT:-8080}" && gb build status   <build-id>             # PENDING → RUNNING → SUCCESS/FAILED
+```
+
+`GBSERVER_API_KEY` is not needed for localhost — the server allows unauthenticated access from `127.0.0.1`/`::1`. The client defaults to `http://localhost:8080`, so whenever `GBSERVER_PORT` is a non-default port you MUST export `GBSERVER_HOST` to match, as above, or the client can't reach the server.
+
+**If a `gb` command warns the CLI is out of date** (a client/server version mismatch), add **`--skip-version-check`** — a per-command flag, so it goes *after* the subcommand: `gb build start -f <path>/build.yaml --skip-version-check`. The version check is advisory; skipping it is safe here.
+
+### Where a build's real output lives
+
+`gb build status`/`gb build log` mostly show status events, not your script's stdout. The actual stdout/stderr (prints, tracebacks, training progress) is on disk:
+
+```
+find ~/.granite.build/workdir/llm-build-<build-id> -name job.log
+```
+
+Read that `job.log` to see what the workload actually did. It is the primary debugging artifact when a build fails or "succeeds" without doing anything.
+
+## Server life policy
+
+Shut down the server when it's not in use (no builds running). The server should default to being down unless it's actively being used — start it up again for future builds or any other granite.build task. Manage the server lifecycle yourself; don't assume anything else will clean it up (a background daemon left running keeps holding its port and resources until you stop it — e.g. with `pkill -f "gbserver standalone --port ${GBSERVER_PORT:-8080}"`). If you want to keep it running across several back-to-back tasks you may, but don't leave it up once you're done. No need to ask the user.

--- a/.claude/skills/run-gbserver/SKILL.md
+++ b/.claude/skills/run-gbserver/SKILL.md
@@ -2,7 +2,7 @@
 name: run-gbserver
 description: Clone, set up, and run the Granite.build standalone gbserver. Use when asked to set up, install, start, or run gbserver / the Granite.build standalone server and when running builds.
 argument-hint: "[path-to-existing-checkout]"
-allowed-tools: Bash(git clone *) Bash(git -C *) Bash(make *) Bash(source *) Bash(gbserver *) Bash(curl *) Bash(ls *) Bash(test *) Bash(python3.13 *) Bash(lsof *) Bash(sleep *)
+allowed-tools: Bash(git clone *) Bash(git -C *) Bash(make *) Bash(source *) Bash(gbserver *) Bash(curl *) Bash(ls *) Bash(test *) Bash(python3 *) Bash(python3.13 *) Bash(lsof *) Bash(sleep *)
 ---
 
 # Run the Granite.build standalone gbserver
@@ -27,10 +27,10 @@ Let `$REPO` be the resolved repo directory for the rest of these steps. Run all 
 
 ## 1. Create the virtualenv and install
 
-Requires **Python 3.13**. Confirm `python3.13 --version` works first; if it doesn't, stop and tell the user to install Python 3.13.
+Requires **Python ≥ 3.13**. Pick an interpreter: prefer `python3.13` if present, otherwise use `python3` when `python3 --version` reports ≥ 3.13. If neither is ≥ 3.13, stop and tell the user to install Python 3.13. Use whichever you found as `PYTHON=` below.
 
 ```
-make standalone-venv PYTHON=python3.13
+make standalone-venv PYTHON=python3.13   # or PYTHON=python3 if that is your >=3.13 interpreter
 ```
 
 This creates `.venv/` and installs the standalone dependencies (the gbserver/`gb` CLI). If `.venv/` already exists and the `gbserver` entry point is present, you may skip this step.

--- a/.claude/skills/run-gbserver/SKILL.md
+++ b/.claude/skills/run-gbserver/SKILL.md
@@ -75,7 +75,7 @@ Once it's ready, report to the user:
   ```
   If launched as a tracked background task it also stops when this Claude session exits.
 
-If startup fails, show the relevant lines from `/tmp/gbserver.log` rather than guessing. For setup or startup issues, invoke the `gb-docs` skill — it reads the checkout's docs (`docs/getting-started.md`, `docs/operators/troubleshooting.md`).
+If startup fails, show the relevant lines from `/tmp/gbserver.log` rather than guessing. For setup or startup issues, invoke the `gb-docs` skill — it reads the checkout's docs (`docs/getting-started.md`, `docs/help/troubleshooting.md`).
 
 ## Steps are picked up dynamically — you do NOT need to restart
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _This repository is currently in alpha. The code and documentation are under act
 - [CLI](#cli)
 - [REST API](#rest-api)
 - [Documentation](#documentation)
+- [Coding agent skills](#coding-agent-skills)
 - [Try the demos](#try-the-demos)
 - [Contributing](#contributing)
 - [License](#license)
@@ -192,6 +193,7 @@ For the full schema, see [`docs/builds/build-yaml-reference.md`](docs/builds/bui
 | `test/` | Test suites for all components. |
 | `scripts/` | Helper scripts including the standalone and SLURM demos. |
 | `k8s/` | Helm charts for production Kubernetes deployment. |
+| `.claude/` | Coding-agent config: [`skills/`](.claude/skills/) (Agent Skills a coding agent uses to drive granite.build — see [below](#coding-agent-skills)) and [`commands/`](.claude/commands/) (repo slash commands). |
 | `Makefile` | `make standalone-venv`, `make demo-venv`, `make image`, format/lint targets. |
 
 ## Features
@@ -345,6 +347,18 @@ The [`docs/`](docs/) directory has complete reference material. Three reading pa
 - **Writing a build** → [`build.yaml` reference](docs/builds/build-yaml-reference.md), [CLI reference](docs/cli/gb-cli-reference.md), [HuggingFace push](docs/builds/hf-push.md), [build features](docs/builds/README.md#advanced) (retry, target reuse, lineage), [gbtest](docs/cli/gbtest-cli-reference.md).
 - **Running gbserver** → [environments](docs/environments/README.md), [configuration](docs/configuration/README.md), [REST API](docs/rest-api/README.md), [troubleshooting](docs/help/troubleshooting.md).
 - **Changing gbserver** → [architecture diagram](docs/architecture/arch-diagram.md), [environment classes](docs/architecture/environment-classes.md).
+
+## Coding agent skills
+
+This repo ships **Agent Skills** under [`.claude/skills/`](.claude/skills/) so a coding agent working in a granite.build checkout can operate the tool without you re-explaining it each time. **Claude Code** discovers them automatically when your working directory is inside the repo — no install; invoke one explicitly with `/<name>`, or let the agent select it from your request based on the skill's description.
+
+| Skill | What it does |
+|-------|--------------|
+| [`run-gbserver`](.claude/skills/run-gbserver/SKILL.md) | Clone, set up, and start the standalone `gbserver` — the prerequisite for creating, validating, or running any build. |
+| [`create-build`](.claude/skills/create-build/SKILL.md) | Author a new `build.yaml` (steps, targets, inputs/outputs, compute) for training, inference/serving, data generation, or evaluation. |
+| [`gb-docs`](.claude/skills/gb-docs/SKILL.md) | Look up the in-repo [`docs/`](docs/) (schema, CLI, concepts, troubleshooting) and answer grounded in them. |
+
+Each skill is a `SKILL.md` (`name` + `description` + instructions) in the portable [Agent Skills](https://agentskills.io) format; the agent matches on the `description` to decide when to use it.
 
 ## Try the demos
 


### PR DESCRIPTION
Ship .claude/skills/ (create-build, run-gbserver, gb-docs) so a coding agent picks them up in a granite.build checkout; add a "Coding agent skills" section, a repository-layout row, and a TOC entry to the README.