### PR TITLE
fix: keep LoRA base_model as owner/repo when pushing to HF

### DIFF
--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -16,7 +16,9 @@
 
 """URI referring to models/datasets/spaces/etc. in HuggingFace Hub"""
 
+import json
 import os
+import re
 import sys
 import threading
 import urllib.parse
@@ -268,6 +270,23 @@ class HfURI(URI):
         assert self.uri is not None, "self.uri is None"
         parts = self.uri.path.strip("/").split("/")
         host = self.uri.netloc or HF_HOST  # default to huggingface.co if not provided
+
+        # A common mistake is writing "hf://models/owner/repo" (two slashes)
+        # when "hf:///models/owner/repo" (three slashes) was intended. With two
+        # slashes the type segment ("models", "datasets", ...) is parsed as the
+        # host, so the push/pull silently targets a bogus endpoint instead of
+        # huggingface.co. Warn so the failure is diagnosable.
+        if host in _HF_SEGMENT_TO_TYPE:
+            logger.warning(
+                "HF URI '%s' uses '%s' as the host, which is almost certainly a "
+                "missing-slash typo: use 'hf:///%s/...' (three slashes) so the "
+                "host defaults to %s instead of '%s'.",
+                self.uri.geturl(),
+                host,
+                host,
+                HF_HOST,
+                host,
+            )
 
         # If the first path segment is a known type keyword, consume it.
         # Otherwise the type defaults to MODEL (the "/models/" segment is optional).
@@ -1003,6 +1022,78 @@ class HfURI(URI):
                 f"refusing to push directory with no non-empty files: {src}"
             )
 
+    @staticmethod
+    def _hf_repo_id_from_cache_path(path: str) -> Optional[str]:
+        """Derive an ``owner/repo`` HF id from a local HF cache path.
+
+        Base models are pulled onto the cluster into a cache laid out as
+        ``<cache>/<owner>/<repo>/<revision>``, where the trailing revision is a
+        git ref or commit hash. Returns ``owner/repo`` or ``None`` when the path
+        has too few components to derive one.
+        """
+        segments = [seg for seg in path.strip("/").split("/") if seg]
+        # Drop a trailing revision/commit-hash segment if present so the last
+        # two segments are the owner and repo.
+        if segments and re.fullmatch(r"[0-9a-f]{7,64}", segments[-1]):
+            segments = segments[:-1]
+        if len(segments) < 2:
+            return None
+        return f"{segments[-2]}/{segments[-1]}"
+
+    @staticmethod
+    def _normalize_adapter_base_model(src: Path) -> None:
+        """Rewrite a LoRA adapter's local base-model path to its HF repo id.
+
+        When a PEFT/LoRA adapter is trained on the cluster the base model is
+        first pulled into a local cache (``<cache>/<owner>/<repo>/<revision>``)
+        and the trainer records that local path in ``adapter_config.json`` under
+        ``base_model_name_or_path``. Uploaded verbatim, HuggingFace then shows
+        the pod-local path (e.g.
+        ``/gb-read-write/hfcache/ibm-granite/granite-4.1-3b/ec5a9d...``) instead
+        of the ``owner/repo`` id and cannot link the base model.
+
+        This mirrors what the Lakehouse (lhpush) path already does: derive the
+        ``owner/repo`` id from the cache layout and write it back before the
+        upload. Only local absolute paths are rewritten; values that already
+        look like an HF repo id are left untouched.
+        """
+        config_path = src / "adapter_config.json"
+        if not config_path.is_file():
+            return
+        try:
+            config = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(
+                "Could not read %s to normalize base model: %s", config_path, e
+            )
+            return
+        base = config.get("base_model_name_or_path")
+        # Only rewrite pod-local absolute paths; a real HF id such as
+        # "ibm-granite/granite-4.1-3b" does not start with "/".
+        if not isinstance(base, str) or not base.startswith("/"):
+            return
+        repo_id = HfURI._hf_repo_id_from_cache_path(base)
+        if not repo_id:
+            logger.warning(
+                "Could not derive an HF repo id from base_model_name_or_path "
+                "'%s'; leaving it unchanged.",
+                base,
+            )
+            return
+        config["base_model_name_or_path"] = repo_id
+        try:
+            config_path.write_text(json.dumps(config, indent=2))
+        except OSError as e:
+            logger.warning(
+                "Could not write normalized base model to %s: %s", config_path, e
+            )
+            return
+        logger.info(
+            "Normalized adapter base_model_name_or_path '%s' -> '%s' for HF upload",
+            base,
+            repo_id,
+        )
+
     def push(
         self: Self,
         src: Path,
@@ -1143,6 +1234,8 @@ class HfURI(URI):
                 _log_hf_api_error("upload_file", repo_id, e)
                 raise
         else:
+            if repo_type == "model":
+                self._normalize_adapter_base_model(src)
             logger.info(
                 "Uploading folder %s → %s/%s (type=%s, rev=%s)",
                 src,

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -1030,6 +1030,12 @@ class HfURI(URI):
         ``<cache>/<owner>/<repo>/<revision>``, where the trailing revision is a
         git ref or commit hash. Returns ``owner/repo`` or ``None`` when the path
         has too few components to derive one.
+
+        This assumes the fixed ``owner/repo/revision`` cache layout: it takes
+        the last two segments as ``owner/repo`` after dropping a trailing
+        commit-hash segment. Inputs that do not follow that layout (e.g. an
+        all-hex repo name with no revision, or a non-hex trailing segment) can
+        mis-parse, but the cluster cache always produces this layout.
         """
         segments = [seg for seg in path.strip("/").split("/") if seg]
         # Drop a trailing revision/commit-hash segment if present so the last
@@ -1234,6 +1240,9 @@ class HfURI(URI):
                 _log_hf_api_error("upload_file", repo_id, e)
                 raise
         else:
+            # Only folder uploads can carry an adapter_config.json; LoRA
+            # adapters are always pushed as a directory, so single-file uploads
+            # have nothing to normalize.
             if repo_type == "model":
                 self._normalize_adapter_base_model(src)
             logger.info(

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -16,6 +16,7 @@
 
 """Tests for HfURI, covering the pull(), push(), exists(), and delete() methods."""
 
+import json
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
@@ -354,6 +355,65 @@ class TestHfURIPushUnit:
                 uri.push(src_dir)
         MockApi.return_value.upload_folder.assert_not_called()
 
+    def test_push_normalizes_adapter_local_base_model(self, tmp_path):
+        """A LoRA adapter's pod-local base_model path is rewritten to owner/repo."""
+        src_dir = tmp_path / "adapter"
+        src_dir.mkdir()
+        config = src_dir / "adapter_config.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "peft_type": "LORA",
+                    "base_model_name_or_path": (
+                        "/gb-read-write/hfcache/ibm-granite/granite-4.1-3b/"
+                        "ec5a9d0c8f2e4a1b9c3d5e7f0a2b4c6d8e0f1a2b"
+                    ),
+                }
+            )
+        )
+        uri = HfURI.from_parts(owner="myorg", repo="my-lora", hf_type=HfType.MODEL)
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            uri.push(src_dir)
+
+        rewritten = json.loads(config.read_text())
+        assert rewritten["base_model_name_or_path"] == "ibm-granite/granite-4.1-3b"
+
+    def test_push_leaves_valid_base_model_untouched(self, tmp_path):
+        """A base_model that is already an owner/repo id is not rewritten."""
+        src_dir = tmp_path / "adapter"
+        src_dir.mkdir()
+        config = src_dir / "adapter_config.json"
+        config.write_text(
+            json.dumps({"base_model_name_or_path": "ibm-granite/granite-4.1-3b"})
+        )
+        uri = HfURI.from_parts(owner="myorg", repo="my-lora", hf_type=HfType.MODEL)
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            uri.push(src_dir)
+
+        assert (
+            json.loads(config.read_text())["base_model_name_or_path"]
+            == "ibm-granite/granite-4.1-3b"
+        )
+
+    def test_hf_repo_id_from_cache_path(self):
+        """The cache-path parser strips a trailing commit hash to owner/repo."""
+        assert (
+            HfURI._hf_repo_id_from_cache_path(
+                "/gb-read-write/hfcache/ibm-granite/granite-4.1-3b/"
+                "ec5a9d0c8f2e4a1b9c3d5e7f0a2b4c6d8e0f1a2b"
+            )
+            == "ibm-granite/granite-4.1-3b"
+        )
+        # Without a trailing hash, the last two segments are owner/repo.
+        assert (
+            HfURI._hf_repo_id_from_cache_path("/cache/ibm-granite/granite-4.1-3b")
+            == "ibm-granite/granite-4.1-3b"
+        )
+        # Too few segments to derive an id.
+        assert HfURI._hf_repo_id_from_cache_path("/onlyone") is None
+
 
 # ---------------------------------------------------------------------------
 # Unit tests – repo_exists / revision_exists are mocked, no network required
@@ -438,6 +498,17 @@ class TestHfURIPartsUnit:
         uri = URI.get_uri("hf://huggingface.co/datasets/owner/repo_name")
         assert isinstance(uri, HfURI)
         assert uri.is_prod_safe() is True
+
+    def test_two_slash_type_segment_warns(self, caplog):
+        """hf://models/... (two slashes) parses the type as the host and warns."""
+        with caplog.at_level("WARNING"):
+            uri = HfURI.parse("hf://models/ibm-research/my-model")
+            # host is the mis-parsed "models"; the warning tells the user to use
+            # three slashes.
+            assert uri.get_host() == "models"
+        assert any(
+            "three slashes" in record.message for record in caplog.records
+        ), caplog.text
 
     def _helper(self, hfuri: str, expectations: ExistsExpection) -> None:
         uri = URI.get_uri(hfuri)


### PR DESCRIPTION
Two fixes for HF pushes, from a LoRA egress issue.

**1. LoRA base_model showed the pod path instead of owner/repo**

When a LoRA adapter is trained, the base model is first pulled into the pod cache at `<cache>/<owner>/<repo>/<hash>`, and the trainer writes that local path into `adapter_config.json` as `base_model_name_or_path`. We were uploading the folder as-is, so HF displayed something like `/gb-read-write/hfcache/ibm-granite/granite-4.1-3b/ec5a9d...` and could not link the base model.

The Lakehouse push already derives a clean `owner/repo` from that path, but it was missed when the HF push was added. This rewrites `base_model_name_or_path` back to `owner/repo` before upload, so HF shows `ibm-granite/granite-4.1-3b`.

**2. Two-slash HF URIs failed silently**

`hf://models/owner/repo` (two slashes) parses `models` as the host, so the push targets a bogus endpoint. `hf:///models/owner/repo` (three slashes) leaves the host empty and defaults to huggingface.co. This is not really a bug, but there was no signal when someone got it wrong, so it now logs a warning pointing at the three-slash form.

Both changes live in `src/gbcommon/uri/hf.py` with unit tests in `test/unit/uri/test_hf.py`.