### PR TITLE
fix: don't let analytics DB init crashloop API-only rest-server

### DIFF
--- a/src/gb_ui_backend/config.py
+++ b/src/gb_ui_backend/config.py
@@ -8,6 +8,8 @@ from functools import lru_cache
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from gbcommon.types.gbenvconfig import parse_boolean
+
 # Default SQLite filename for the analytics database.
 # Stored in ~/.granite.build/ alongside gbserver's llmb-server.db.
 ANALYTICS_DB_FILENAME = "dashboard-analytics.db"
@@ -75,16 +77,16 @@ class Config(BaseSettings):
 
     @field_validator("analytics_enabled", mode="before")
     @classmethod
-    def _blank_analytics_enabled_is_unset(cls, v: object) -> object:
-        # Treat GB_UI_ANALYTICS_ENABLED="" or whitespace as unset (→ None → auto-detect)
-        # rather than a parse error. Setting an env var to empty is a common "disable"
-        # idiom in k8s manifests/shells, and a ValidationError here would crash startup
-        # in both the CLI parent and every worker — the very failure this field prevents.
-        # Also tolerate surrounding whitespace on real values (e.g. " true ").
+    def _parse_analytics_enabled(cls, v: object) -> object:
+        # Parse GB_UI_ANALYTICS_ENABLED into the tri-state without ever raising:
+        # blank/whitespace (a common k8s/shell "unset" idiom) → None → auto-detect;
+        # any other set value → a definite bool via the shared parser. A
+        # ValidationError here would crash startup in the CLI parent and every
+        # worker — the very failure this field exists to prevent.
         if isinstance(v, str):
-            v = v.strip()
-            if v == "":
+            if v.strip() == "":
                 return None
+            return parse_boolean(v)
         return v
 
     @property

--- a/src/gb_ui_backend/config.py
+++ b/src/gb_ui_backend/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from functools import lru_cache
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Default SQLite filename for the analytics database.
@@ -72,6 +72,20 @@ class Config(BaseSettings):
     # (see analytics_is_enabled); explicit true/false wins. Lets a deployed, API-only
     # rest-server keep analytics off even though the gb_ui_backend package is installed.
     analytics_enabled: bool | None = Field(default=None)
+
+    @field_validator("analytics_enabled", mode="before")
+    @classmethod
+    def _blank_analytics_enabled_is_unset(cls, v: object) -> object:
+        # Treat GB_UI_ANALYTICS_ENABLED="" or whitespace as unset (→ None → auto-detect)
+        # rather than a parse error. Setting an env var to empty is a common "disable"
+        # idiom in k8s manifests/shells, and a ValidationError here would crash startup
+        # in both the CLI parent and every worker — the very failure this field prevents.
+        # Also tolerate surrounding whitespace on real values (e.g. " true ").
+        if isinstance(v, str):
+            v = v.strip()
+            if v == "":
+                return None
+        return v
 
     @property
     def llm_models_list(self) -> list[str]:

--- a/src/gb_ui_backend/config.py
+++ b/src/gb_ui_backend/config.py
@@ -67,6 +67,12 @@ class Config(BaseSettings):
     # Set to false to disable the AI analysis daemon without removing LLM credentials
     ai_analysis_enabled: bool = Field(default=True)
 
+    # Master on/off for the whole analytics subsystem, read from GB_UI_ANALYTICS_ENABLED.
+    # Tri-state: None (unset) → auto-detect off the presence of compiled UI assets
+    # (see analytics_is_enabled); explicit true/false wins. Lets a deployed, API-only
+    # rest-server keep analytics off even though the gb_ui_backend package is installed.
+    analytics_enabled: bool | None = Field(default=None)
+
     @property
     def llm_models_list(self) -> list[str]:
         return [m.strip() for m in self.llm_models.split(",") if m.strip()]
@@ -100,3 +106,21 @@ def get_config() -> Config:
 @lru_cache
 def get_github_config() -> GitHubConfig:
     return GitHubConfig()
+
+
+def analytics_is_enabled(ui_assets_present: bool) -> bool:
+    """Resolve whether the analytics subsystem should run.
+
+    An explicit GB_UI_ANALYTICS_ENABLED (config.analytics_enabled) always wins.
+    Otherwise auto-detect: analytics runs only when the compiled frontend assets
+    are present, since an API-only server has no dashboard to serve analytics to.
+
+    ``ui_assets_present`` is passed in rather than computed here because the
+    canonical UI directory (and its GBSERVER_UI_DIR override) lives in gbserver's
+    root_api. This is called from both the CLI parent process and each uvicorn
+    worker; both read the same inherited env and the same UI dir, so they agree.
+    """
+    override = get_config().analytics_enabled
+    if override is not None:
+        return override
+    return ui_assets_present

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -23,14 +23,28 @@ from pydantic import BaseModel
 
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN
 
+# The single source of truth for what counts as "false" when parsing a boolean
+# from an environment-variable string. Anything set but not in this set is true.
+_FALSY_TOKENS = frozenset({"false", "null", "undefined", "no", "off", "0", ""})
+
+
+def parse_boolean(value: str | None, default: bool = False) -> bool:
+    """Parse an env-var-style string into a boolean.
+
+    ``None`` (unset) → ``default``. Otherwise the value is lower-cased and
+    compared against the falsy token set (see ``_FALSY_TOKENS``); a match is
+    ``False``, anything else set is ``True``. This never raises — the single
+    place the string→bool rule is defined, shared by ``getenv_boolean`` and any
+    other caller that already has the string in hand.
+    """
+    if value is None:
+        return default
+    return str(value).strip().lower() not in _FALSY_TOKENS
+
 
 def getenv_boolean(envname: str, default: bool = False) -> bool:
     """Evaluate the environment variable and return as a boolean value."""
-    value = os.getenv(envname)
-    if value is None:
-        return default
-    value_normalized = str(value).lower()
-    return value_normalized not in ["false", "null", "undefined", "no", "0", ""]
+    return parse_boolean(os.getenv(envname), default)
 
 
 class GBEnvConfig(BaseModel):

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -16,6 +16,7 @@
 
 """Unified environment configuration for GB (gbcli + gbserver)."""
 
+import logging
 import os
 from typing import Any, Dict, Optional, Self
 
@@ -23,9 +24,13 @@ from pydantic import BaseModel
 
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN
 
-# The single source of truth for what counts as "false" when parsing a boolean
-# from an environment-variable string. Anything set but not in this set is true.
+logger = logging.getLogger(__name__)
+
+# The single source of truth for what counts as "false"/"true" when parsing a
+# boolean from an environment-variable string. Anything set but not falsy is
+# treated as true; the truthy set is used only to warn on unrecognized input.
 _FALSY_TOKENS = frozenset({"false", "null", "undefined", "no", "off", "0", ""})
+_TRUTHY_TOKENS = frozenset({"true", "yes", "on", "1"})
 
 
 def parse_boolean(value: str | None, default: bool = False) -> bool:
@@ -33,13 +38,25 @@ def parse_boolean(value: str | None, default: bool = False) -> bool:
 
     ``None`` (unset) → ``default``. Otherwise the value is lower-cased and
     compared against the falsy token set (see ``_FALSY_TOKENS``); a match is
-    ``False``, anything else set is ``True``. This never raises — the single
-    place the string→bool rule is defined, shared by ``getenv_boolean`` and any
-    other caller that already has the string in hand.
+    ``False``, anything else set is ``True``. A non-falsy value that also isn't a
+    recognized truthy token (a likely typo, e.g. ``on-prod``) is still treated as
+    ``True`` but logs a warning. This never raises — the single place the
+    string→bool rule is defined, shared by ``getenv_boolean`` and any other
+    caller that already has the string in hand.
     """
     if value is None:
         return default
-    return str(value).strip().lower() not in _FALSY_TOKENS
+    normalized = str(value).strip().lower()
+    if normalized in _FALSY_TOKENS:
+        return False
+    if normalized not in _TRUTHY_TOKENS:
+        logger.warning(
+            "Unrecognized boolean value %r — treating as true; " "use one of %s / %s",
+            value,
+            sorted(_TRUTHY_TOKENS),
+            sorted(_FALSY_TOKENS),
+        )
+    return True
 
 
 def getenv_boolean(envname: str, default: bool = False) -> bool:

--- a/src/gbserver/api/root_api.py
+++ b/src/gbserver/api/root_api.py
@@ -16,7 +16,6 @@
 
 
 import asyncio
-import importlib.util
 import os
 
 from fastapi import FastAPI, Request
@@ -41,6 +40,7 @@ from gbserver.types.constants import (
     GBSERVER_EVENT_PUBLISHING_ENABLED,
     GBSERVER_GIT_COMMIT,
     GBSERVER_REST_SERVER_WORKERS,
+    analytics_backend_enabled,
     gbserver_ui_dir,
 )
 from gbserver.utils.logger import get_logger
@@ -85,25 +85,10 @@ root_api.mount(f"{API_BASE_PATH}/spaces", spaces_api)
 _UI_DIR = gbserver_ui_dir()
 
 # ── Analytics (optional gb_ui_backend extra) ───────────────────────────────────
-# Included directly (not mounted as a separate ASGI app) so these routes run
-# in-process behind AuthMiddleware like everything else, and so gb_ui_backend's
-# startup work (init_analytics, called below) is driven by root_api's own
-# startup hook rather than relying on a sub-app lifespan that .mount() alone
-# would never invoke.
-#
-# _HAS_ANALYTICS is a precondition (the package must be installed to run at all);
-# _ANALYTICS_ENABLED is the actual switch. An explicit GB_UI_ANALYTICS_ENABLED
-# wins, otherwise it auto-detects off the compiled UI assets — a deployed,
-# API-only rest-server has the package installed but no dashboard, so analytics
-# (and its DB init) must stay off there rather than crash startup. This runs per
-# uvicorn worker; the CLI parent resolves the same way in _configure_analytics_env.
-_HAS_ANALYTICS = importlib.util.find_spec("gb_ui_backend") is not None
-_ANALYTICS_ENABLED = False
-if _HAS_ANALYTICS:
-    from gb_ui_backend.config import analytics_is_enabled
-
-    _ANALYTICS_ENABLED = analytics_is_enabled(os.path.isdir(_UI_DIR))
-
+# Routers are include_router()'d (not mounted as a sub-app) so they run in-process
+# behind AuthMiddleware and share root_api's startup hook (init_analytics, below).
+# See analytics_backend_enabled() for the install + enable decision.
+_ANALYTICS_ENABLED = analytics_backend_enabled()
 if _ANALYTICS_ENABLED:
     from gb_ui_backend.api import ai as _gb_ai
     from gb_ui_backend.api import analytics as _gb_analytics
@@ -123,18 +108,14 @@ if _ANALYTICS_ENABLED:
     logger.info("Analytics enabled — mounted /api/analytics routers")
 
     if GBSERVER_REST_SERVER_WORKERS > 1:
+        # Each worker gets its own analytics DB engine / AI-daemon state.
         logger.warning(
-            "GBSERVER_REST_SERVER_WORKERS=%d with analytics enabled — each "
-            "worker gets its own analytics DB engine/AI-daemon state; "
+            "GBSERVER_REST_SERVER_WORKERS=%d with analytics enabled — "
             "analytics assumes a single worker.",
             GBSERVER_REST_SERVER_WORKERS,
         )
-elif _HAS_ANALYTICS:
-    logger.info(
-        "Analytics installed but disabled (GB_UI_ANALYTICS_ENABLED override or "
-        "no compiled UI assets at %s) — /api/analytics not mounted",
-        _UI_DIR,
-    )
+else:
+    logger.info("Analytics not enabled — /api/analytics not mounted")
 
 
 def _is_rsc_request(request: Request) -> bool:

--- a/src/gbserver/api/root_api.py
+++ b/src/gbserver/api/root_api.py
@@ -41,6 +41,7 @@ from gbserver.types.constants import (
     GBSERVER_EVENT_PUBLISHING_ENABLED,
     GBSERVER_GIT_COMMIT,
     GBSERVER_REST_SERVER_WORKERS,
+    gbserver_ui_dir,
 )
 from gbserver.utils.logger import get_logger
 
@@ -79,14 +80,31 @@ root_api.mount(f"{API_BASE_PATH}/node-health", node_health_api)
 root_api.mount(f"{API_BASE_PATH}/secrets", secrets_api)
 root_api.mount(f"{API_BASE_PATH}/spaces", spaces_api)
 
+# ── Frontend static file serving ──────────────────────────────────────────────
+
+_UI_DIR = gbserver_ui_dir()
+
 # ── Analytics (optional gb_ui_backend extra) ───────────────────────────────────
 # Included directly (not mounted as a separate ASGI app) so these routes run
 # in-process behind AuthMiddleware like everything else, and so gb_ui_backend's
 # startup work (init_analytics, called below) is driven by root_api's own
 # startup hook rather than relying on a sub-app lifespan that .mount() alone
 # would never invoke.
+#
+# _HAS_ANALYTICS is a precondition (the package must be installed to run at all);
+# _ANALYTICS_ENABLED is the actual switch. An explicit GB_UI_ANALYTICS_ENABLED
+# wins, otherwise it auto-detects off the compiled UI assets — a deployed,
+# API-only rest-server has the package installed but no dashboard, so analytics
+# (and its DB init) must stay off there rather than crash startup. This runs per
+# uvicorn worker; the CLI parent resolves the same way in _configure_analytics_env.
 _HAS_ANALYTICS = importlib.util.find_spec("gb_ui_backend") is not None
+_ANALYTICS_ENABLED = False
 if _HAS_ANALYTICS:
+    from gb_ui_backend.config import analytics_is_enabled
+
+    _ANALYTICS_ENABLED = analytics_is_enabled(os.path.isdir(_UI_DIR))
+
+if _ANALYTICS_ENABLED:
     from gb_ui_backend.api import ai as _gb_ai
     from gb_ui_backend.api import analytics as _gb_analytics
     from gb_ui_backend.api import builds as _gb_builds
@@ -102,6 +120,8 @@ if _HAS_ANALYTICS:
     ):
         root_api.include_router(_router, prefix="/api/analytics")
 
+    logger.info("Analytics enabled — mounted /api/analytics routers")
+
     if GBSERVER_REST_SERVER_WORKERS > 1:
         logger.warning(
             "GBSERVER_REST_SERVER_WORKERS=%d with analytics enabled — each "
@@ -109,17 +129,12 @@ if _HAS_ANALYTICS:
             "analytics assumes a single worker.",
             GBSERVER_REST_SERVER_WORKERS,
         )
-
-# ── Frontend static file serving ──────────────────────────────────────────────
-
-# Default: static/ui/ sibling to this package directory (populated by make build-frontend).
-# Override with GBSERVER_UI_DIR for non-standard layouts.
-_UI_DIR = os.environ.get(
-    "GBSERVER_UI_DIR",
-    os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "static", "ui"
-    ),
-)
+elif _HAS_ANALYTICS:
+    logger.info(
+        "Analytics installed but disabled (GB_UI_ANALYTICS_ENABLED override or "
+        "no compiled UI assets at %s) — /api/analytics not mounted",
+        _UI_DIR,
+    )
 
 
 def _is_rsc_request(request: Request) -> bool:
@@ -206,10 +221,18 @@ async def _spa_fallback(
 @root_api.on_event("startup")
 async def _start_background_tasks():
     """Launch background tasks that run for the lifetime of the server."""
-    if _HAS_ANALYTICS:
+    if _ANALYTICS_ENABLED:
         from gb_ui_backend.main import init_analytics
 
-        await init_analytics()
+        # Analytics is optional and must never take down the core REST API — a
+        # misconfigured or unwritable analytics DB should degrade gracefully
+        # (mirrors the try/except around GbserverSource in gb_ui_backend.main).
+        try:
+            await init_analytics()
+        except Exception:
+            logger.exception(
+                "Analytics init failed — continuing with analytics degraded"
+            )
 
     if GBSERVER_EVENT_PUBLISHING_ENABLED:
         if os.getenv("RABBITMQ_HOST"):

--- a/src/gbserver/commands/command_rest_server.py
+++ b/src/gbserver/commands/command_rest_server.py
@@ -27,6 +27,7 @@ from gbserver.types.constants import (
     ENV_VAR_METADATA_STORAGE,
     GBSERVER_REST_SERVER_TIMEOUT_KEEP_ALIVE,
     GBSERVER_REST_SERVER_WORKERS,
+    gbserver_ui_dir,
 )
 from gbserver.types.context import CliEnvironment, pass_environment
 from gbserver.utils.logger import get_logger
@@ -42,6 +43,14 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
     vars gb_ui_backend's Config reads, so standalone analytics work out of
     the box without requiring the caller to configure a database explicitly.
 
+    Does nothing unless analytics is actually enabled for this server (see
+    gb_ui_backend.analytics_is_enabled): an explicit GB_UI_ANALYTICS_ENABLED
+    wins, otherwise it auto-detects off the presence of compiled UI assets. A
+    deployed, API-only rest-server therefore never gets the SQLite fallback
+    below — which would otherwise crash startup on an unwritable path. This runs
+    in the CLI parent process; each uvicorn worker re-resolves the same way in
+    root_api from the same inherited env, so they agree.
+
     If GB_UI_DATABASE_URL is not set, defaults to the analytics service's own
     SQLite file in the GB home directory (see ANALYTICS_DB_FILENAME in
     gb_ui_backend/config.py).
@@ -56,6 +65,15 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
     import importlib.util
 
     if importlib.util.find_spec("gb_ui_backend") is None:
+        return
+
+    from gb_ui_backend.config import analytics_is_enabled
+
+    if not analytics_is_enabled(os.path.isdir(gbserver_ui_dir())):
+        logger.info(
+            "Analytics disabled — skipping analytics env defaulting "
+            "(no SQLite fallback for GB_UI_DATABASE_URL)"
+        )
         return
 
     gb_home = get_gb_home_dir()

--- a/src/gbserver/commands/command_rest_server.py
+++ b/src/gbserver/commands/command_rest_server.py
@@ -27,7 +27,7 @@ from gbserver.types.constants import (
     ENV_VAR_METADATA_STORAGE,
     GBSERVER_REST_SERVER_TIMEOUT_KEEP_ALIVE,
     GBSERVER_REST_SERVER_WORKERS,
-    gbserver_ui_dir,
+    analytics_backend_enabled,
 )
 from gbserver.types.context import CliEnvironment, pass_environment
 from gbserver.utils.logger import get_logger
@@ -43,13 +43,10 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
     vars gb_ui_backend's Config reads, so standalone analytics work out of
     the box without requiring the caller to configure a database explicitly.
 
-    Does nothing unless analytics is actually enabled for this server (see
-    gb_ui_backend.analytics_is_enabled): an explicit GB_UI_ANALYTICS_ENABLED
-    wins, otherwise it auto-detects off the presence of compiled UI assets. A
-    deployed, API-only rest-server therefore never gets the SQLite fallback
-    below — which would otherwise crash startup on an unwritable path. This runs
-    in the CLI parent process; each uvicorn worker re-resolves the same way in
-    root_api from the same inherited env, so they agree.
+    Does nothing unless analytics is enabled here (analytics_backend_enabled);
+    an API-only rest-server thus never gets the SQLite fallback below, which
+    would otherwise crash startup on an unwritable path. root_api re-resolves the
+    same way per worker off the same inherited env.
 
     If GB_UI_DATABASE_URL is not set, defaults to the analytics service's own
     SQLite file in the GB home directory (see ANALYTICS_DB_FILENAME in
@@ -62,16 +59,9 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
         host: Bind address the main REST server (and frontend) is listening on.
         port: Port the main REST server (and frontend) is listening on.
     """
-    import importlib.util
-
-    if importlib.util.find_spec("gb_ui_backend") is None:
-        return
-
-    from gb_ui_backend.config import analytics_is_enabled
-
-    if not analytics_is_enabled(os.path.isdir(gbserver_ui_dir())):
+    if not analytics_backend_enabled():
         logger.info(
-            "Analytics disabled — skipping analytics env defaulting "
+            "Analytics not enabled — skipping analytics env defaulting "
             "(no SQLite fallback for GB_UI_DATABASE_URL)"
         )
         return

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -194,16 +194,27 @@ ENV_VAR_BUILTIN_STEP_IMAGE = ENV_VAR_PREFIX + "_BUILTIN_STEP_IMAGE"
 def gbserver_ui_dir() -> str:
     """Directory the compiled frontend assets are served from.
 
-    Default: static/ui/ under the gbserver package (populated by
-    ``make build-frontend``). Override with GBSERVER_UI_DIR for non-standard
-    layouts. Resolved in one lightweight place so callers that only need to know
-    whether the UI is present (e.g. analytics auto-detection in the CLI parent
-    process) agree with what root_api actually serves, without importing the
-    heavyweight root_api module.
+    Default: static/ui/ under the gbserver package; override with GBSERVER_UI_DIR.
     """
     # This file lives at gbserver/types/constants.py; the package root is two levels up.
     gbserver_pkg = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     return os.environ.get(ENV_VAR_UI_DIR, os.path.join(gbserver_pkg, "static", "ui"))
+
+
+def analytics_backend_enabled() -> bool:
+    """Whether the gb_ui_backend analytics subsystem should run in this server.
+
+    True only when the package is installed AND enabled — explicit
+    GB_UI_ANALYTICS_ENABLED wins, else auto-detect off the presence of compiled
+    UI assets (an API-only server has no dashboard to serve analytics to, and
+    initializing its DB there would crash startup). Resolved here, off inherited
+    env and the shared UI dir, so the CLI parent and each uvicorn worker agree.
+    """
+    if importlib.util.find_spec("gb_ui_backend") is None:
+        return False
+    from gb_ui_backend.config import analytics_is_enabled
+
+    return analytics_is_enabled(os.path.isdir(gbserver_ui_dir()))
 
 
 ENV_VAR_GBSERVER_SQL_SCHEME = ENV_VAR_PREFIX + "_SQL_SCHEME"  # postgresql, mysql, etc.

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -164,6 +164,7 @@ ENV_VAR_SKYPILOT_PROVISION_BACKOFF_MAX = (
     ENV_VAR_PREFIX + "_SKYPILOT_PROVISION_BACKOFF_MAX"
 )
 ENV_VAR_METADATA_STORAGE = ENV_VAR_PREFIX + "_METADATA_STORAGE"
+ENV_VAR_UI_DIR = ENV_VAR_PREFIX + "_UI_DIR"
 ENV_VAR_AUTH_MODE = ENV_VAR_PREFIX + "_AUTH_MODE"
 ENV_VAR_API_KEY = ENV_VAR_PREFIX + "_API_KEY"
 ENV_VAR_API_USER = ENV_VAR_PREFIX + "_API_USER"
@@ -188,6 +189,22 @@ ENV_VAR_GBSERVER_ENABLE_SSH_HOST_KEY_VERIFICATION = (
 ENV_VAR_GBSERVER_ENABLE_STEP_RETRY = ENV_VAR_PREFIX + "_ENABLE_STEP_RETRY"
 ENV_VAR_BUILDRUNNERJOB_SLEEP_ON_END = ENV_VAR_PREFIX + "_BUILDRUNNERJOB_SLEEP_ON_END"
 ENV_VAR_BUILTIN_STEP_IMAGE = ENV_VAR_PREFIX + "_BUILTIN_STEP_IMAGE"
+
+
+def gbserver_ui_dir() -> str:
+    """Directory the compiled frontend assets are served from.
+
+    Default: static/ui/ under the gbserver package (populated by
+    ``make build-frontend``). Override with GBSERVER_UI_DIR for non-standard
+    layouts. Resolved in one lightweight place so callers that only need to know
+    whether the UI is present (e.g. analytics auto-detection in the CLI parent
+    process) agree with what root_api actually serves, without importing the
+    heavyweight root_api module.
+    """
+    # This file lives at gbserver/types/constants.py; the package root is two levels up.
+    gbserver_pkg = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.environ.get(ENV_VAR_UI_DIR, os.path.join(gbserver_pkg, "static", "ui"))
+
 
 ENV_VAR_GBSERVER_SQL_SCHEME = ENV_VAR_PREFIX + "_SQL_SCHEME"  # postgresql, mysql, etc.
 ENV_VAR_GBSERVER_SQL_DBNAME = ENV_VAR_PREFIX + "_SQL_DBNAME"

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -82,6 +82,15 @@ class TestAnalyticsIsEnabled:
         gb_config.get_config.cache_clear()
         assert analytics_is_enabled(ui_assets_present=True) is False
 
+    def test_unrecognized_nonblank_value_does_not_raise(self, monkeypatch):
+        # A non-blank, non-bool value (typo like "enabled", "on-prod") must not
+        # raise a ValidationError out of Config() — that would crash startup in
+        # the parent and every worker. It resolves to a definite bool (anything
+        # set and not a falsy token is true) via the shared parser.
+        monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", "enabled")
+        gb_config.get_config.cache_clear()
+        assert analytics_is_enabled(ui_assets_present=False) is True
+
 
 class TestConfigureAnalyticsEnv:
     """_configure_analytics_env must not set the SQLite fallback when analytics is off."""

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for analytics gating.
+
+A deployed, API-only rest-server has the ``gb_ui_backend`` package installed but
+no compiled UI assets. Analytics must stay off there — otherwise its startup
+init opens a SQLite file at an unwritable path and crashes the whole server
+(observed as a crashloop with ``sqlite3.OperationalError: unable to open
+database file``). Covers:
+
+  - analytics_is_enabled tri-state: explicit GB_UI_ANALYTICS_ENABLED wins,
+    otherwise auto-detect off the presence of compiled UI assets.
+  - _configure_analytics_env skips the SQLite GB_UI_DATABASE_URL fallback when
+    analytics resolves off, so an API-only server never gets the crashing URL.
+"""
+
+import os
+
+import pytest
+
+from gb_ui_backend import config as gb_config
+from gb_ui_backend.config import analytics_is_enabled
+from gbserver.commands.command_rest_server import _configure_analytics_env
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_cache():
+    """get_config() is lru_cached; clear it so per-test env changes take effect."""
+    gb_config.get_config.cache_clear()
+    yield
+    gb_config.get_config.cache_clear()
+
+
+class TestAnalyticsIsEnabled:
+    def test_auto_detect_off_when_no_ui_assets(self, monkeypatch):
+        monkeypatch.delenv("GB_UI_ANALYTICS_ENABLED", raising=False)
+        gb_config.get_config.cache_clear()
+        assert analytics_is_enabled(ui_assets_present=False) is False
+
+    def test_auto_detect_on_when_ui_assets_present(self, monkeypatch):
+        monkeypatch.delenv("GB_UI_ANALYTICS_ENABLED", raising=False)
+        gb_config.get_config.cache_clear()
+        assert analytics_is_enabled(ui_assets_present=True) is True
+
+    def test_explicit_false_overrides_present_ui(self, monkeypatch):
+        monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", "false")
+        gb_config.get_config.cache_clear()
+        assert analytics_is_enabled(ui_assets_present=True) is False
+
+    def test_explicit_true_overrides_absent_ui(self, monkeypatch):
+        monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", "true")
+        gb_config.get_config.cache_clear()
+        assert analytics_is_enabled(ui_assets_present=False) is True
+
+
+class TestConfigureAnalyticsEnv:
+    """_configure_analytics_env must not set the SQLite fallback when analytics is off."""
+
+    def _run(self, monkeypatch, tmp_path, *, ui_present, override):
+        # Force the auto-detect signal via GBSERVER_UI_DIR: a real dir (present)
+        # vs. a path that does not exist (absent, the API-only pod condition).
+        ui_dir = str(tmp_path / "ui") if ui_present else str(tmp_path / "absent")
+        if ui_present:
+            os.makedirs(ui_dir, exist_ok=True)
+        monkeypatch.setenv("GBSERVER_UI_DIR", ui_dir)
+        if override is None:
+            monkeypatch.delenv("GB_UI_ANALYTICS_ENABLED", raising=False)
+        else:
+            monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", override)
+        monkeypatch.delenv("GB_UI_DATABASE_URL", raising=False)
+        gb_config.get_config.cache_clear()
+
+        _configure_analytics_env(host="0.0.0.0", port=8080)
+
+    def test_api_only_does_not_set_sqlite_url(self, monkeypatch, tmp_path):
+        self._run(monkeypatch, tmp_path, ui_present=False, override=None)
+        assert os.environ.get("GB_UI_DATABASE_URL") is None
+
+    def test_explicit_off_does_not_set_sqlite_url(self, monkeypatch, tmp_path):
+        self._run(monkeypatch, tmp_path, ui_present=True, override="false")
+        assert os.environ.get("GB_UI_DATABASE_URL") is None
+
+    def test_ui_mode_sets_sqlite_url(self, monkeypatch, tmp_path):
+        self._run(monkeypatch, tmp_path, ui_present=True, override=None)
+        url = os.environ.get("GB_UI_DATABASE_URL")
+        assert url is not None and url.startswith("sqlite+aiosqlite:///")

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -66,6 +66,22 @@ class TestAnalyticsIsEnabled:
         gb_config.get_config.cache_clear()
         assert analytics_is_enabled(ui_assets_present=False) is True
 
+    def test_blank_value_treated_as_unset(self, monkeypatch):
+        # Setting an env var to empty is a common "disable"/"unset" idiom in k8s
+        # manifests and shells. It must not raise (which would crash startup in
+        # the parent and every worker) — it falls through to auto-detect.
+        for blank in ("", "   "):
+            monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", blank)
+            gb_config.get_config.cache_clear()
+            assert analytics_is_enabled(ui_assets_present=True) is True
+            gb_config.get_config.cache_clear()
+            assert analytics_is_enabled(ui_assets_present=False) is False
+
+    def test_whitespace_padded_value_parsed(self, monkeypatch):
+        monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", " false ")
+        gb_config.get_config.cache_clear()
+        assert analytics_is_enabled(ui_assets_present=True) is False
+
 
 class TestConfigureAnalyticsEnv:
     """_configure_analytics_env must not set the SQLite fallback when analytics is off."""
@@ -81,7 +97,15 @@ class TestConfigureAnalyticsEnv:
             monkeypatch.delenv("GB_UI_ANALYTICS_ENABLED", raising=False)
         else:
             monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", override)
-        monkeypatch.delenv("GB_UI_DATABASE_URL", raising=False)
+        # Clear every var _configure_analytics_env may write via os.environ[...] so
+        # monkeypatch tracks and restores them — otherwise GB_UI_GBSERVER_URL (set
+        # unconditionally) and GB_UI_GBSERVER_DB_URL leak into later tests.
+        for var in (
+            "GB_UI_DATABASE_URL",
+            "GB_UI_GBSERVER_URL",
+            "GB_UI_GBSERVER_DB_URL",
+        ):
+            monkeypatch.delenv(var, raising=False)
         gb_config.get_config.cache_clear()
 
         _configure_analytics_env(host="0.0.0.0", port=8080)

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -82,14 +82,16 @@ class TestAnalyticsIsEnabled:
         gb_config.get_config.cache_clear()
         assert analytics_is_enabled(ui_assets_present=True) is False
 
-    def test_unrecognized_nonblank_value_does_not_raise(self, monkeypatch):
+    def test_unrecognized_nonblank_value_warns_and_is_true(self, monkeypatch, caplog):
         # A non-blank, non-bool value (typo like "enabled", "on-prod") must not
         # raise a ValidationError out of Config() — that would crash startup in
-        # the parent and every worker. It resolves to a definite bool (anything
-        # set and not a falsy token is true) via the shared parser.
+        # the parent and every worker. It resolves to True (anything set and not
+        # a falsy token) and logs a warning so the likely typo is visible.
         monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", "enabled")
         gb_config.get_config.cache_clear()
-        assert analytics_is_enabled(ui_assets_present=False) is True
+        with caplog.at_level("WARNING"):
+            assert analytics_is_enabled(ui_assets_present=False) is True
+        assert any("Unrecognized boolean value" in r.message for r in caplog.records)
 
 
 class TestConfigureAnalyticsEnv:

--- a/test/unit/standalone/test_regression_smoke.py
+++ b/test/unit/standalone/test_regression_smoke.py
@@ -8,6 +8,7 @@ All tests are marked @pytest.mark.g4os and @pytest.mark.unit so they
 run in both the existing CI pipeline and the g4os-mode pipeline.
 """
 
+import contextlib
 import os
 
 import pytest
@@ -176,8 +177,9 @@ class TestEnvironmentDiscovery:
 # ---------------------------------------------------------------------------
 
 
-def _load_root_api_with_analytics():
-    """Import root_api with analytics forced on, reloading if needed.
+@contextlib.contextmanager
+def _root_api_with_analytics():
+    """Yield root_api with analytics forced on, restoring all state on exit.
 
     root_api decides whether to mount the analytics routers once, at import
     time, from _ANALYTICS_ENABLED (explicit GB_UI_ANALYTICS_ENABLED, else
@@ -186,23 +188,40 @@ def _load_root_api_with_analytics():
     These tests verify the include_router() wiring itself, so force analytics
     on and reload the module if the cached copy came up with it disabled.
 
-    Returns the (possibly reloaded) root_api app, or None if root_api can't be
-    imported (missing optional deps) — the caller should skip in that case.
+    Yields the root_api app, or None if root_api can't be imported (missing
+    optional deps) — the caller should skip in that case. On exit, both the
+    GB_UI_ANALYTICS_ENABLED env var and the root_api module are restored to
+    their prior state so nothing leaks into later tests in the same worker.
     """
     import importlib
 
+    from gb_ui_backend import config as gb_ui_config
+
+    prev_env = os.environ.get("GB_UI_ANALYTICS_ENABLED")
     os.environ["GB_UI_ANALYTICS_ENABLED"] = "true"
+    reloaded = False
     try:
-        import gbserver.api.root_api as root_api_mod
-    except ImportError:
-        return None
+        try:
+            import gbserver.api.root_api as root_api_mod
+        except ImportError:
+            yield None
+            return
 
-    if not getattr(root_api_mod, "_ANALYTICS_ENABLED", False):
-        from gb_ui_backend import config as gb_ui_config
-
-        gb_ui_config.get_config.cache_clear()
-        root_api_mod = importlib.reload(root_api_mod)
-    return root_api_mod.root_api
+        if not getattr(root_api_mod, "_ANALYTICS_ENABLED", False):
+            gb_ui_config.get_config.cache_clear()
+            root_api_mod = importlib.reload(root_api_mod)
+            reloaded = True
+        yield root_api_mod.root_api
+    finally:
+        if prev_env is None:
+            os.environ.pop("GB_UI_ANALYTICS_ENABLED", None)
+        else:
+            os.environ["GB_UI_ANALYTICS_ENABLED"] = prev_env
+        # If we reloaded root_api to flip analytics on, reload it once more with
+        # the env restored so the cached module reflects the original state.
+        if reloaded:
+            gb_ui_config.get_config.cache_clear()
+            importlib.reload(root_api_mod)
 
 
 class TestAPIRoutes:
@@ -256,20 +275,21 @@ class TestAPIRoutes:
         if importlib.util.find_spec("gb_ui_backend") is None:
             pytest.skip("gb_ui_backend not installed")
 
-        root_api = _load_root_api_with_analytics()
-        if root_api is None:
-            pytest.skip(
-                "root_api requires kubernetes_asyncio (transitively via buildwatcher)"
-            )
-
         from fastapi.testclient import TestClient
 
-        env = {"GBSERVER_AUTH_MODE": "apikey", "GBSERVER_API_KEY": ""}
-        with patch.dict(os.environ, env, clear=False):
-            client = TestClient(
-                root_api
-            )  # host "testclient" is in the localhost allowlist
-            response = client.get("/api/analytics/builds/failure-trends/history")
+        with _root_api_with_analytics() as root_api:
+            if root_api is None:
+                pytest.skip(
+                    "root_api requires kubernetes_asyncio "
+                    "(transitively via buildwatcher)"
+                )
+
+            env = {"GBSERVER_AUTH_MODE": "apikey", "GBSERVER_API_KEY": ""}
+            with patch.dict(os.environ, env, clear=False):
+                client = TestClient(
+                    root_api
+                )  # host "testclient" is in the localhost allowlist
+                response = client.get("/api/analytics/builds/failure-trends/history")
         assert response.status_code != 404, (
             "Analytics route not resolved — check the include_router() wiring "
             "in gbserver/api/root_api.py"
@@ -286,18 +306,19 @@ class TestAPIRoutes:
         if importlib.util.find_spec("gb_ui_backend") is None:
             pytest.skip("gb_ui_backend not installed")
 
-        root_api = _load_root_api_with_analytics()
-        if root_api is None:
-            pytest.skip(
-                "root_api requires kubernetes_asyncio (transitively via buildwatcher)"
-            )
-
         from fastapi.testclient import TestClient
 
-        env = {"GBSERVER_AUTH_MODE": "apikey", "GBSERVER_API_KEY": "test-key-123"}
-        with patch.dict(os.environ, env, clear=False):
-            client = TestClient(root_api)
-            response = client.get("/api/analytics/builds/failure-trends/history")
+        with _root_api_with_analytics() as root_api:
+            if root_api is None:
+                pytest.skip(
+                    "root_api requires kubernetes_asyncio "
+                    "(transitively via buildwatcher)"
+                )
+
+            env = {"GBSERVER_AUTH_MODE": "apikey", "GBSERVER_API_KEY": "test-key-123"}
+            with patch.dict(os.environ, env, clear=False):
+                client = TestClient(root_api)
+                response = client.get("/api/analytics/builds/failure-trends/history")
         assert response.status_code == 401
 
 

--- a/test/unit/standalone/test_regression_smoke.py
+++ b/test/unit/standalone/test_regression_smoke.py
@@ -8,6 +8,8 @@ All tests are marked @pytest.mark.g4os and @pytest.mark.unit so they
 run in both the existing CI pipeline and the g4os-mode pipeline.
 """
 
+import os
+
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -174,6 +176,35 @@ class TestEnvironmentDiscovery:
 # ---------------------------------------------------------------------------
 
 
+def _load_root_api_with_analytics():
+    """Import root_api with analytics forced on, reloading if needed.
+
+    root_api decides whether to mount the analytics routers once, at import
+    time, from _ANALYTICS_ENABLED (explicit GB_UI_ANALYTICS_ENABLED, else
+    auto-detect off compiled UI assets). CI has neither the env var nor the UI
+    assets, so a plain import leaves analytics off and the routers unmounted.
+    These tests verify the include_router() wiring itself, so force analytics
+    on and reload the module if the cached copy came up with it disabled.
+
+    Returns the (possibly reloaded) root_api app, or None if root_api can't be
+    imported (missing optional deps) — the caller should skip in that case.
+    """
+    import importlib
+
+    os.environ["GB_UI_ANALYTICS_ENABLED"] = "true"
+    try:
+        import gbserver.api.root_api as root_api_mod
+    except ImportError:
+        return None
+
+    if not getattr(root_api_mod, "_ANALYTICS_ENABLED", False):
+        from gb_ui_backend import config as gb_ui_config
+
+        gb_ui_config.get_config.cache_clear()
+        root_api_mod = importlib.reload(root_api_mod)
+    return root_api_mod.root_api
+
+
 class TestAPIRoutes:
     """Verify all expected sub-APIs are mounted on the root API."""
 
@@ -220,15 +251,13 @@ class TestAPIRoutes:
         assertion even if the route were never wired up.
         """
         import importlib.util
-        import os
         from unittest.mock import patch
 
         if importlib.util.find_spec("gb_ui_backend") is None:
             pytest.skip("gb_ui_backend not installed")
 
-        try:
-            from gbserver.api.root_api import root_api
-        except ImportError:
+        root_api = _load_root_api_with_analytics()
+        if root_api is None:
             pytest.skip(
                 "root_api requires kubernetes_asyncio (transitively via buildwatcher)"
             )
@@ -252,15 +281,13 @@ class TestAPIRoutes:
         actual root_api returns 401, confirming AuthMiddleware covers these
         routes now that they're included directly rather than proxied."""
         import importlib.util
-        import os
         from unittest.mock import patch
 
         if importlib.util.find_spec("gb_ui_backend") is None:
             pytest.skip("gb_ui_backend not installed")
 
-        try:
-            from gbserver.api.root_api import root_api
-        except ImportError:
+        root_api = _load_root_api_with_analytics()
+        if root_api is None:
             pytest.skip(
                 "root_api requires kubernetes_asyncio (transitively via buildwatcher)"
             )
@@ -367,8 +394,6 @@ class TestStandaloneEnvironmentDefaults:
         importlib.reload(constants)
 
         try:
-            import os
-
             assert os.environ.get("GBSERVER_METADATA_STORAGE") == "sqlite"
             assert os.environ.get("GBSERVER_DEFAULT_BUILDRUNNER_TYPE") == "thread"
             assert os.environ.get("GBSERVER_PROCEED_WITHOUT_SECRETS") == "true"
@@ -394,8 +419,6 @@ class TestStandaloneEnvironmentDefaults:
         importlib.reload(constants)
 
         try:
-            import os
-
             # Explicit override preserved
             assert os.environ.get("GBSERVER_METADATA_STORAGE") == "sql"
             # Defaults still applied where not overridden


### PR DESCRIPTION
## Summary

A deployed rest-server ships the `gb_ui_backend` package but no compiled UI assets. Analytics init was gated only on whether the package was importable, so on such a server it still ran, opened its default SQLite analytics DB at an unwritable path (`<gb_home>/dashboard-analytics.db`), and raised `sqlite3.OperationalError: unable to open database file` **out of the FastAPI startup hook** — crashlooping the whole REST server, not just analytics.

This was observed in the dev k8s deployment: every uvicorn worker died with `Application startup failed. Exiting.` in a loop. Note the failing DB is the analytics service's *own* store, not the gbserver postgres metadata store.

This PR gates analytics on whether it should actually run, not merely on the package being present:

- **Add a master `GB_UI_ANALYTICS_ENABLED` switch** (`config.analytics_enabled`, tri-state) and an `analytics_is_enabled()` resolver: an explicit override always wins; otherwise auto-detect off the presence of compiled UI assets (an API-only server has no dashboard to serve analytics to).
- **Factor `gbserver_ui_dir()`** into `gbserver.types.constants` so the CLI parent process and each uvicorn worker resolve the UI path identically (honoring `GBSERVER_UI_DIR`) without importing the heavyweight `root_api` module.
- **`root_api`**: introduce `_ANALYTICS_ENABLED` gating both router mounting and the startup hook; wrap `init_analytics()` in try/except so a misconfigured/unwritable analytics DB can never take down the core REST API again (defense in depth).
- **`command_rest_server`**: skip the SQLite `GB_UI_DATABASE_URL` fallback entirely when analytics resolves off, so an API-only server never gets the crashing URL.
- Add regression tests for the resolver and the env-defaulting gate.

Precedence: explicit `GB_UI_ANALYTICS_ENABLED` wins; otherwise auto-detect off UI-assets presence.

> **Note on the env var name:** `GB_UI_ANALYTICS_ENABLED` is *derived*, not a string literal in the code. The `Config` class uses `env_prefix="GB_UI_"`, so pydantic-settings maps the field `analytics_enabled` to the env var `GB_UI_` + `ANALYTICS_ENABLED`. The literal token only appears in comments, one log message, and the tests.

## Deployment mitigation (no code)

The running pod can be unblocked immediately by either setting `GB_UI_DATABASE_URL` to a real (e.g. Postgres) URL, or — once this ships — setting `GB_UI_ANALYTICS_ENABLED=false`.

## Test plan

- `pytest test/unit/gb_ui_backend/` — 13 passed (includes 7 new gating tests).
- Reproduced the API-only pod condition (package installed, no `static/ui`, unwritable `GB_HOME_DIR`): before, import/startup crashed with the SQLite error; after, the server starts, logs analytics disabled, and does not open the analytics DB.
- Verified explicit opt-out (`GB_UI_ANALYTICS_ENABLED=false` with UI present) disables analytics, and normal UI mode still initializes analytics (no regression).
- Verified a forced `init_analytics()` failure is logged and swallowed rather than crashing startup.
- `isort`/`black`/`pylint` clean on changed files (test file 10.00/10); `mypy` clean on changed files (remaining findings are pre-existing in transitively-checked modules).