### PR TITLE
feat: derive analytics database URL from the main store's backend (#191)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,11 +184,8 @@ cd frontend && yarn dev       # proxies /api/* to gbserver at :8080 (no CORS)
 pip install -e ".[standalone]"
 gbserver standalone
 # Analytics routes are served at /api/analytics/* on gbserver's own port
-# GBSERVER_METADATA_STORAGE=sqlite (standalone default): analytics co-locates into
-# gbserver's own ~/.granite.build/llmb-server.db (gb_* vs gbd_* table prefixes don't
-# collide) on a fresh install; an existing ~/.granite.build/dashboard-analytics.db
-# from a pre-co-location install is kept instead of orphaned. Force either behavior
-# with GB_UI_ANALYTICS_COLOCATE_SQLITE=true|false.
+# GBSERVER_METADATA_STORAGE=sqlite (standalone default): analytics uses its own
+# ~/.granite.build/dashboard-analytics.db (auto-created on first run).
 # GBSERVER_METADATA_STORAGE=sql: analytics inherits GBSERVER_SQL_* automatically,
 # translated to a postgresql+asyncpg:// URL (including the SQL TLS cert, if any) —
 # it connects to the same Postgres as the main store, not a separate database.
@@ -221,8 +218,7 @@ GB_UI_DATABASE_URL="postgresql+asyncpg://user:pass@host/db" gbserver standalone
 |---|---|---|
 | `GBSERVER_API_URL` | `frontend/.env.local` or build env | API base URL. Dev: sets the rewrite proxy target. Standalone: baked into the bundle at `make build-frontend` time. Unset = same-origin default. |
 | `GBSERVER_UI_DIR` | gbserver env | Override path to compiled frontend (default: `src/gbserver/static/ui/`) |
-| `GB_UI_DATABASE_URL` | gbserver env | Analytics DB. Auto-derived from the main store's own backend (`GBSERVER_METADATA_STORAGE`) when unset — see `derive_analytics_database_url()` in `src/gbserver/types/constants.py`. `sql` mode inherits `GBSERVER_SQL_*` as a `postgresql+asyncpg://` URL; `sqlite` mode defaults to a SQLite file under `GB_HOME_DIR` (see `GB_UI_ANALYTICS_COLOCATE_SQLITE` below). |
-| `GB_UI_ANALYTICS_COLOCATE_SQLITE` | gbserver env | Only consulted when `GBSERVER_METADATA_STORAGE=sqlite`. Tri-state: unset auto-detects (keeps an existing `dashboard-analytics.db` if present, else co-locates into gbserver's own `llmb-server.db`); `true`/`false` forces co-located vs. separate regardless of what already exists. |
+| `GB_UI_DATABASE_URL` | gbserver env | Analytics DB. Auto-derived from the main store's own backend (`GBSERVER_METADATA_STORAGE`) when unset — see `derive_analytics_database_url()` in `src/gbserver/types/constants.py`. `sql` mode inherits `GBSERVER_SQL_*` as a `postgresql+asyncpg://` URL; `sqlite` mode uses its own `dashboard-analytics.db` under `GB_HOME_DIR`. |
 | `GB_UI_DATABASE_CONNECT_ARGS` | gbserver env (internal) | JSON-encoded `create_async_engine()` connect args, set by gbserver when the main SQL store requires TLS — carries the cert file path across the env-var boundary since an `ssl.SSLContext` isn't JSON-serializable. Not meant to be hand-set. |
 | `GB_UI_GBSERVER_DB_URL` | gbserver env | gbserver's own DB for richer analytics. Auto-set to gbserver's SQLite file when unset and storage is sqlite. |
 | `GB_UI_GBSERVER_URL` | analytics env | gbserver URL, used for the standalone dev-mode startup banner (default: `http://localhost:8080`) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,16 +178,23 @@ cd frontend && yarn dev       # proxies /api/* to gbserver at :8080 (no CORS)
 
 ### Running with the analytics service
 
-`gb_ui_backend` is bundled with the `standalone` extra. If installed, gbserver includes its routers directly into its own process at startup — no separate process or port. Both DB URLs default to SQLite in `~/.granite.build/` — no configuration needed.
+`gb_ui_backend` is bundled with the `standalone` extra. If installed, gbserver includes its routers directly into its own process at startup — no separate process or port. When `GB_UI_DATABASE_URL` is unset, gbserver derives it from the main store's own backend config (`GBSERVER_METADATA_STORAGE`) instead of an independent default — see `derive_analytics_database_url()` in `src/gbserver/types/constants.py`:
 
 ```shell
 pip install -e ".[standalone]"
 gbserver standalone
 # Analytics routes are served at /api/analytics/* on gbserver's own port
-# Analytics DB: ~/.granite.build/dashboard-analytics.db (SQLite, auto-created)
+# GBSERVER_METADATA_STORAGE=sqlite (standalone default): analytics co-locates into
+# gbserver's own ~/.granite.build/llmb-server.db (gb_* vs gbd_* table prefixes don't
+# collide) on a fresh install; an existing ~/.granite.build/dashboard-analytics.db
+# from a pre-co-location install is kept instead of orphaned. Force either behavior
+# with GB_UI_ANALYTICS_COLOCATE_SQLITE=true|false.
+# GBSERVER_METADATA_STORAGE=sql: analytics inherits GBSERVER_SQL_* automatically,
+# translated to a postgresql+asyncpg:// URL (including the SQL TLS cert, if any) —
+# it connects to the same Postgres as the main store, not a separate database.
 ```
 
-To use PostgreSQL instead:
+To override the derived default explicitly:
 
 ```shell
 GB_UI_DATABASE_URL="postgresql+asyncpg://user:pass@host/db" gbserver standalone
@@ -214,7 +221,9 @@ GB_UI_DATABASE_URL="postgresql+asyncpg://user:pass@host/db" gbserver standalone
 |---|---|---|
 | `GBSERVER_API_URL` | `frontend/.env.local` or build env | API base URL. Dev: sets the rewrite proxy target. Standalone: baked into the bundle at `make build-frontend` time. Unset = same-origin default. |
 | `GBSERVER_UI_DIR` | gbserver env | Override path to compiled frontend (default: `src/gbserver/static/ui/`) |
-| `GB_UI_DATABASE_URL` | gbserver env | Analytics DB. Auto-set to `~/.granite.build/dashboard-analytics.db` (SQLite) when unset. |
+| `GB_UI_DATABASE_URL` | gbserver env | Analytics DB. Auto-derived from the main store's own backend (`GBSERVER_METADATA_STORAGE`) when unset — see `derive_analytics_database_url()` in `src/gbserver/types/constants.py`. `sql` mode inherits `GBSERVER_SQL_*` as a `postgresql+asyncpg://` URL; `sqlite` mode defaults to a SQLite file under `GB_HOME_DIR` (see `GB_UI_ANALYTICS_COLOCATE_SQLITE` below). |
+| `GB_UI_ANALYTICS_COLOCATE_SQLITE` | gbserver env | Only consulted when `GBSERVER_METADATA_STORAGE=sqlite`. Tri-state: unset auto-detects (keeps an existing `dashboard-analytics.db` if present, else co-locates into gbserver's own `llmb-server.db`); `true`/`false` forces co-located vs. separate regardless of what already exists. |
+| `GB_UI_DATABASE_CONNECT_ARGS` | gbserver env (internal) | JSON-encoded `create_async_engine()` connect args, set by gbserver when the main SQL store requires TLS — carries the cert file path across the env-var boundary since an `ssl.SSLContext` isn't JSON-serializable. Not meant to be hand-set. |
 | `GB_UI_GBSERVER_DB_URL` | gbserver env | gbserver's own DB for richer analytics. Auto-set to gbserver's SQLite file when unset and storage is sqlite. |
 | `GB_UI_GBSERVER_URL` | analytics env | gbserver URL, used for the standalone dev-mode startup banner (default: `http://localhost:8080`) |
 | `GB_UI_LLM_BASE_URL` | analytics env | OpenAI-compatible endpoint for AI analysis |

--- a/README.md
+++ b/README.md
@@ -311,13 +311,14 @@ Leave it unset to default to same-origin (the standard case when gbserver serves
 
 `gb_ui_backend` adds build status charts, failure trends, and optional AI-powered analysis. It is bundled with the `standalone` install extra; if installed, gbserver includes its routers directly into its own process at startup — no extra command or initial database setup needed.
 
-Default storage: `~/.granite.build/dashboard-analytics.db` (SQLite, auto-created on first run).
+Default storage: derived from the main store's own backend. Standalone SQLite mode co-locates into gbserver's own `~/.granite.build/llmb-server.db` on a fresh install (auto-created on first run); an existing `~/.granite.build/dashboard-analytics.db` from an older install is kept instead. Postgres mode (`GBSERVER_METADATA_STORAGE=sql`) connects to the same Postgres instance as the main store.
 
 Optional configuration (set as environment variables or in `.env`):
 
 | Variable | Description |
 |---|---|
 | `GB_UI_DATABASE_URL` | Override the analytics DB — SQLite path or PostgreSQL URL |
+| `GB_UI_ANALYTICS_COLOCATE_SQLITE` | Standalone SQLite mode only: force `true` (co-locate into gbserver's own DB file) or `false` (keep a separate `dashboard-analytics.db`); unset auto-detects |
 | `GB_UI_GBSERVER_DB_URL` | gbserver's own DB for richer build volume charts (auto-set when storage is SQLite) |
 | `GB_UI_LLM_BASE_URL` | OpenAI-compatible endpoint for AI failure analysis (feature disabled if unset) |
 | `GB_UI_LLM_API_KEY` | API key for the LLM endpoint |

--- a/README.md
+++ b/README.md
@@ -311,14 +311,13 @@ Leave it unset to default to same-origin (the standard case when gbserver serves
 
 `gb_ui_backend` adds build status charts, failure trends, and optional AI-powered analysis. It is bundled with the `standalone` install extra; if installed, gbserver includes its routers directly into its own process at startup — no extra command or initial database setup needed.
 
-Default storage: derived from the main store's own backend. Standalone SQLite mode co-locates into gbserver's own `~/.granite.build/llmb-server.db` on a fresh install (auto-created on first run); an existing `~/.granite.build/dashboard-analytics.db` from an older install is kept instead. Postgres mode (`GBSERVER_METADATA_STORAGE=sql`) connects to the same Postgres instance as the main store.
+Default storage: derived from the main store's own backend. Standalone SQLite mode uses its own `~/.granite.build/dashboard-analytics.db` (SQLite, auto-created on first run). Postgres mode (`GBSERVER_METADATA_STORAGE=sql`) connects to the same Postgres instance as the main store.
 
 Optional configuration (set as environment variables or in `.env`):
 
 | Variable | Description |
 |---|---|
 | `GB_UI_DATABASE_URL` | Override the analytics DB — SQLite path or PostgreSQL URL |
-| `GB_UI_ANALYTICS_COLOCATE_SQLITE` | Standalone SQLite mode only: force `true` (co-locate into gbserver's own DB file) or `false` (keep a separate `dashboard-analytics.db`); unset auto-detects |
 | `GB_UI_GBSERVER_DB_URL` | gbserver's own DB for richer build volume charts (auto-set when storage is SQLite) |
 | `GB_UI_LLM_BASE_URL` | OpenAI-compatible endpoint for AI failure analysis (feature disabled if unset) |
 | `GB_UI_LLM_API_KEY` | API key for the LLM endpoint |

--- a/src/gb_ui_backend/config.py
+++ b/src/gb_ui_backend/config.py
@@ -29,8 +29,8 @@ class Config(BaseSettings):
     # Auto-derived by gbserver (see derive_analytics_database_url in
     # gbserver.types.constants) from the main store's own backend config when unset:
     # GBSERVER_METADATA_STORAGE=sql inherits GBSERVER_SQL_* (translated to an asyncpg
-    # URL); GBSERVER_METADATA_STORAGE=sqlite defaults to a SQLite file under
-    # GB_HOME_DIR (see ANALYTICS_DB_FILENAME and analytics_colocate_sqlite below).
+    # URL); GBSERVER_METADATA_STORAGE=sqlite defaults to its own SQLite file under
+    # GB_HOME_DIR (see ANALYTICS_DB_FILENAME).
     database_url: str = Field(
         default="",
         description="SQLAlchemy async URL. Auto-derived by gbserver from the main store's backend config when unset.",
@@ -101,24 +101,6 @@ class Config(BaseSettings):
         # any other set value → a definite bool via the shared parser. A
         # ValidationError here would crash startup in the CLI parent and every
         # worker — the very failure this field exists to prevent.
-        if isinstance(v, str):
-            if v.strip() == "":
-                return None
-            return parse_boolean(v)
-        return v
-
-    # Tri-state, only consulted when GBSERVER_METADATA_STORAGE=sqlite: None (unset) →
-    # auto-detect (keep an existing dashboard-analytics.db if one is already present,
-    # else co-locate analytics' gbd_* tables into the main store's own llmb-server.db —
-    # the two table prefixes don't collide). Explicit true/false always wins, even over
-    # an existing dashboard-analytics.db (see derive_analytics_database_url in
-    # gbserver.types.constants).
-    analytics_colocate_sqlite: bool | None = Field(default=None)
-
-    @field_validator("analytics_colocate_sqlite", mode="before")
-    @classmethod
-    def _parse_analytics_colocate_sqlite(cls, v: object) -> object:
-        # Same blank-is-unset + shared-parser rule as _parse_analytics_enabled above.
         if isinstance(v, str):
             if v.strip() == "":
                 return None

--- a/src/gb_ui_backend/config.py
+++ b/src/gb_ui_backend/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from functools import lru_cache
 
@@ -25,11 +26,28 @@ class Config(BaseSettings):
     )
 
     # Analytics database — SQLite or PostgreSQL.
-    # Auto-set to sqlite+aiosqlite:///<GB_HOME_DIR>/dashboard-analytics.db by gbserver if unset.
+    # Auto-derived by gbserver (see derive_analytics_database_url in
+    # gbserver.types.constants) from the main store's own backend config when unset:
+    # GBSERVER_METADATA_STORAGE=sql inherits GBSERVER_SQL_* (translated to an asyncpg
+    # URL); GBSERVER_METADATA_STORAGE=sqlite defaults to a SQLite file under
+    # GB_HOME_DIR (see ANALYTICS_DB_FILENAME and analytics_colocate_sqlite below).
     database_url: str = Field(
         default="",
-        description="SQLAlchemy async URL. Auto-configured by gbserver when running standalone.",
+        description="SQLAlchemy async URL. Auto-derived by gbserver from the main store's backend config when unset.",
     )
+
+    # Extra kwargs for create_async_engine(), JSON-encoded (e.g. {"ssl": ...} is built
+    # from this by _get_engine() — see db_schema.py). Only gbserver's
+    # _configure_analytics_env sets this (via GB_UI_DATABASE_CONNECT_ARGS), carrying
+    # the main SQL store's TLS cert path across the env-var boundary since an
+    # ssl.SSLContext object itself isn't JSON-serializable.
+    database_connect_args_json: str = Field(
+        default="{}", alias="GB_UI_DATABASE_CONNECT_ARGS"
+    )
+
+    @property
+    def database_connect_args(self) -> dict:
+        return json.loads(self.database_connect_args_json)
 
     # gbserver REST API
     gbserver_url: str = Field(default="http://localhost:8080")
@@ -83,6 +101,24 @@ class Config(BaseSettings):
         # any other set value → a definite bool via the shared parser. A
         # ValidationError here would crash startup in the CLI parent and every
         # worker — the very failure this field exists to prevent.
+        if isinstance(v, str):
+            if v.strip() == "":
+                return None
+            return parse_boolean(v)
+        return v
+
+    # Tri-state, only consulted when GBSERVER_METADATA_STORAGE=sqlite: None (unset) →
+    # auto-detect (keep an existing dashboard-analytics.db if one is already present,
+    # else co-locate analytics' gbd_* tables into the main store's own llmb-server.db —
+    # the two table prefixes don't collide). Explicit true/false always wins, even over
+    # an existing dashboard-analytics.db (see derive_analytics_database_url in
+    # gbserver.types.constants).
+    analytics_colocate_sqlite: bool | None = Field(default=None)
+
+    @field_validator("analytics_colocate_sqlite", mode="before")
+    @classmethod
+    def _parse_analytics_colocate_sqlite(cls, v: object) -> object:
+        # Same blank-is-unset + shared-parser rule as _parse_analytics_enabled above.
         if isinstance(v, str):
             if v.strip() == "":
                 return None

--- a/src/gb_ui_backend/services/db_schema.py
+++ b/src/gb_ui_backend/services/db_schema.py
@@ -34,6 +34,24 @@ _engine = None
 _session_factory = None
 
 
+def _build_connect_args(raw: dict) -> dict:
+    """Translate the JSON-serializable connect args crossing the env-var boundary
+    (see Config.database_connect_args_json) into what create_async_engine() expects.
+
+    ssl.SSLContext isn't JSON-serializable, so gbserver's _configure_analytics_env
+    only ever sends the cert file *path* under "sslrootcert_file" (mirroring the main
+    SQL store's own TLS cert, translated for asyncpg) — built into a context here,
+    right before the engine is created. Any other key is passed through unchanged.
+    """
+    connect_args = dict(raw)
+    cert_file = connect_args.pop("sslrootcert_file", None)
+    if cert_file:
+        import ssl
+
+        connect_args["ssl"] = ssl.create_default_context(cafile=cert_file)
+    return connect_args
+
+
 def _get_engine():
     global _engine
     if _engine is None:
@@ -44,11 +62,13 @@ def _get_engine():
                 detail="Analytics database not configured. Set GB_UI_DATABASE_URL.",
             )
         is_sqlite = config.database_url.startswith("sqlite")
+        connect_args = _build_connect_args(config.database_connect_args)
         _engine = create_async_engine(
             config.database_url,
             echo=False,
             # pool_pre_ping not supported by SQLite's StaticPool
             **({} if is_sqlite else {"pool_pre_ping": True}),
+            **({"connect_args": connect_args} if connect_args else {}),
         )
     return _engine
 

--- a/src/gb_ui_backend/services/db_schema.py
+++ b/src/gb_ui_backend/services/db_schema.py
@@ -5,6 +5,7 @@ IBM-specific fields (DMF, Tekton, Aspera) are omitted.
 
 from __future__ import annotations
 
+import ssl
 from datetime import datetime
 from typing import AsyncGenerator, List, Optional
 from uuid import UUID
@@ -46,8 +47,6 @@ def _build_connect_args(raw: dict) -> dict:
     connect_args = dict(raw)
     cert_file = connect_args.pop("sslrootcert_file", None)
     if cert_file:
-        import ssl
-
         connect_args["ssl"] = ssl.create_default_context(cafile=cert_file)
     return connect_args
 

--- a/src/gbserver/commands/command_rest_server.py
+++ b/src/gbserver/commands/command_rest_server.py
@@ -96,6 +96,18 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
         browse_host = "127.0.0.1" if host == "0.0.0.0" else host
         os.environ["GB_UI_GBSERVER_URL"] = f"http://{browse_host}:{port}"
 
+    # gb_ui_backend.config.get_config() is lru_cached — the analytics_backend_enabled()
+    # call at the top of this function already constructed and cached a Config read
+    # from os.environ *before* the env vars above were set, so every later consumer
+    # (init_analytics(), _get_engine()) would otherwise see a stale, pre-mutation
+    # instance with database_url="" — analytics silently never gets a database despite
+    # GB_UI_DATABASE_URL being set correctly in the process environment. Clear it now
+    # that all GB_UI_* mutations in this function are done, so the next get_config()
+    # call picks up the real values.
+    from gb_ui_backend.config import get_config
+
+    get_config.cache_clear()
+
 
 _IBMID_REQUIRED_VARS = [
     "GBSERVER_IBMID_CLIENT_ID",

--- a/src/gbserver/commands/command_rest_server.py
+++ b/src/gbserver/commands/command_rest_server.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+import json
 import os
 import sys
 
@@ -28,6 +29,8 @@ from gbserver.types.constants import (
     GBSERVER_REST_SERVER_TIMEOUT_KEEP_ALIVE,
     GBSERVER_REST_SERVER_WORKERS,
     analytics_backend_enabled,
+    derive_analytics_database_url,
+    derive_analytics_sql_connect_args,
 )
 from gbserver.types.context import CliEnvironment, pass_environment
 from gbserver.utils.logger import get_logger
@@ -44,13 +47,17 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
     the box without requiring the caller to configure a database explicitly.
 
     Does nothing unless analytics is enabled here (analytics_backend_enabled);
-    an API-only rest-server thus never gets the SQLite fallback below, which
+    an API-only rest-server thus never gets the database default below, which
     would otherwise crash startup on an unwritable path. root_api re-resolves the
     same way per worker off the same inherited env.
 
-    If GB_UI_DATABASE_URL is not set, defaults to the analytics service's own
-    SQLite file in the GB home directory (see ANALYTICS_DB_FILENAME in
-    gb_ui_backend/config.py).
+    If GB_UI_DATABASE_URL is not set, it's derived from the main store's own backend
+    config (see derive_analytics_database_url in gbserver.types.constants):
+    GBSERVER_METADATA_STORAGE=sql inherits GBSERVER_SQL_* as a postgresql+asyncpg
+    URL (TLS cert, if any, carried via GB_UI_DATABASE_CONNECT_ARGS below);
+    GBSERVER_METADATA_STORAGE=sqlite defaults to a SQLite file under the GB home
+    directory (co-located with gbserver's own file, or the analytics service's
+    private one — see analytics_colocate_sqlite in gb_ui_backend/config.py).
     If GB_UI_GBSERVER_DB_URL is not set and gbserver is running in SQLite mode,
     defaults to gbserver's own SQLite file so standalone analytics work out of the box.
     If GB_UI_GBSERVER_URL is not set, defaults to the main server's own host/port.
@@ -62,17 +69,20 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
     if not analytics_backend_enabled():
         logger.info(
             "Analytics not enabled — skipping analytics env defaulting "
-            "(no SQLite fallback for GB_UI_DATABASE_URL)"
+            "(no database URL fallback for GB_UI_DATABASE_URL)"
         )
         return
 
     gb_home = get_gb_home_dir()
 
     if not os.environ.get("GB_UI_DATABASE_URL"):
-        # mirrors ANALYTICS_DB_FILENAME in gb_ui_backend/config.py — keep in sync
-        os.environ["GB_UI_DATABASE_URL"] = (
-            f"sqlite+aiosqlite:///{os.path.join(gb_home, 'dashboard-analytics.db')}"
-        )
+        derived_url = derive_analytics_database_url()
+        if derived_url is not None:
+            os.environ["GB_UI_DATABASE_URL"] = derived_url
+            if derived_url.startswith("postgresql+asyncpg://"):
+                connect_args = derive_analytics_sql_connect_args()
+                if connect_args:
+                    os.environ["GB_UI_DATABASE_CONNECT_ARGS"] = json.dumps(connect_args)
 
     if (
         not os.environ.get("GB_UI_GBSERVER_DB_URL")

--- a/src/gbserver/commands/command_rest_server.py
+++ b/src/gbserver/commands/command_rest_server.py
@@ -55,9 +55,9 @@ def _configure_analytics_env(host: str = "127.0.0.1", port: int = 8080) -> None:
     config (see derive_analytics_database_url in gbserver.types.constants):
     GBSERVER_METADATA_STORAGE=sql inherits GBSERVER_SQL_* as a postgresql+asyncpg
     URL (TLS cert, if any, carried via GB_UI_DATABASE_CONNECT_ARGS below);
-    GBSERVER_METADATA_STORAGE=sqlite defaults to a SQLite file under the GB home
-    directory (co-located with gbserver's own file, or the analytics service's
-    private one — see analytics_colocate_sqlite in gb_ui_backend/config.py).
+    GBSERVER_METADATA_STORAGE=sqlite defaults to the analytics service's own
+    SQLite file under the GB home directory (see ANALYTICS_DB_FILENAME in
+    gb_ui_backend/config.py).
     If GB_UI_GBSERVER_DB_URL is not set and gbserver is running in SQLite mode,
     defaults to gbserver's own SQLite file so standalone analytics work out of the box.
     If GB_UI_GBSERVER_URL is not set, defaults to the main server's own host/port.

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -231,6 +231,11 @@ def derive_analytics_database_url() -> Optional[str]:
     GB_UI_DATABASE_URL unset in that case; analytics_backend_enabled()'s gating and
     main.py's try/except around init_analytics() keep that degrading gracefully
     rather than crashing.
+
+    Note: the derived sql-mode URL does not carry GBSERVER_SQL_SCHEMA — the main
+    store's tables live in that schema (see sql_storage.py's _get_connection_specs()),
+    but analytics' gbd_* tables land in the connection role's default schema instead.
+    Distinct table prefixes mean this doesn't collide with the main store.
     """
     if GB_METADATA_STORAGE == "sql":
         if GBSERVER_SQL_SCHEME != "postgresql":
@@ -252,18 +257,10 @@ def derive_analytics_database_url() -> Optional[str]:
         )
 
     if GB_METADATA_STORAGE == "sqlite":
-        from gb_ui_backend.config import ANALYTICS_DB_FILENAME, get_config
-        from gbserver.storage.sqlite.sqlite_storage import SQLITE_DB_FILE_NAME
+        from gb_ui_backend.config import ANALYTICS_DB_FILENAME
 
         gb_home = get_gb_home_dir()
-        legacy_path = os.path.join(gb_home, ANALYTICS_DB_FILENAME)
-        colocate = get_config().analytics_colocate_sqlite
-        if colocate is None:
-            # Auto-detect: don't orphan an existing standalone install's history.
-            colocate = not os.path.isfile(legacy_path)
-        if colocate:
-            return f"sqlite+aiosqlite:///{os.path.join(gb_home, SQLITE_DB_FILE_NAME)}"
-        return f"sqlite+aiosqlite:///{legacy_path}"
+        return f"sqlite+aiosqlite:///{os.path.join(gb_home, ANALYTICS_DB_FILENAME)}"
 
     return None
 

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -21,10 +21,11 @@ import json
 import os
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote_plus
 
 from dotenv import load_dotenv
 
-from gbcommon.types.constants import DEFAULT_GH_DOMAIN, get_gh_api_base
+from gbcommon.types.constants import DEFAULT_GH_DOMAIN, get_gb_home_dir, get_gh_api_base
 from gbcommon.types.gbenvconfig import is_standalone
 from gbserver.types.constants_base import (
     ENV_VAR_IBMID_AUTHORIZE_URL,
@@ -215,6 +216,76 @@ def analytics_backend_enabled() -> bool:
     from gb_ui_backend.config import analytics_is_enabled
 
     return analytics_is_enabled(os.path.isdir(gbserver_ui_dir()))
+
+
+def derive_analytics_database_url() -> Optional[str]:
+    """Best-effort default for GB_UI_DATABASE_URL, inherited from the main store's
+    own backend config instead of an independent SQLite default.
+
+    An operator who points the main store at Postgres (GBSERVER_METADATA_STORAGE=sql)
+    gets analytics pointed at that same Postgres instance automatically, rather than
+    silently falling back to a private SQLite file that may not even have a writable
+    directory to live in (the root cause of the crashloop #190 fixed defensively).
+
+    Returns None when no safe default can be derived — callers should leave
+    GB_UI_DATABASE_URL unset in that case; analytics_backend_enabled()'s gating and
+    main.py's try/except around init_analytics() keep that degrading gracefully
+    rather than crashing.
+    """
+    if GB_METADATA_STORAGE == "sql":
+        if GBSERVER_SQL_SCHEME != "postgresql":
+            # Lazy import: gbserver.utils.logger imports this module at its own top
+            # level, so importing it back at our module top would be circular.
+            from gbserver.utils.logger import get_logger
+
+            get_logger(__name__).warning(
+                "GBSERVER_SQL_SCHEME=%s has no known asyncpg equivalent — "
+                "skipping analytics database URL auto-derivation.",
+                GBSERVER_SQL_SCHEME,
+            )
+            return None
+        user = quote_plus(GBSERVER_SQL_USER)
+        password = quote_plus(GBSERVER_SQL_PASSWD)
+        return (
+            f"postgresql+asyncpg://{user}:{password}"
+            f"@{GBSERVER_SQL_HOST}:{GBSERVER_SQL_PORT}/{GBSERVER_SQL_DBNAME}"
+        )
+
+    if GB_METADATA_STORAGE == "sqlite":
+        from gb_ui_backend.config import ANALYTICS_DB_FILENAME, get_config
+        from gbserver.storage.sqlite.sqlite_storage import SQLITE_DB_FILE_NAME
+
+        gb_home = get_gb_home_dir()
+        legacy_path = os.path.join(gb_home, ANALYTICS_DB_FILENAME)
+        colocate = get_config().analytics_colocate_sqlite
+        if colocate is None:
+            # Auto-detect: don't orphan an existing standalone install's history.
+            colocate = not os.path.isfile(legacy_path)
+        if colocate:
+            return f"sqlite+aiosqlite:///{os.path.join(gb_home, SQLITE_DB_FILE_NAME)}"
+        return f"sqlite+aiosqlite:///{legacy_path}"
+
+    return None
+
+
+def derive_analytics_sql_connect_args() -> dict:
+    """JSON-serializable create_async_engine() connect_args for a derived
+    postgresql+asyncpg analytics URL, translating the main SQL store's TLS cert.
+
+    The main store's sync psycopg2 driver takes sslrootcert/sslmode as URL query
+    params (see sql_storage.py's _get_connection_specs()); asyncpg instead needs an
+    ssl.SSLContext passed as a connect arg, which isn't JSON-serializable and can't
+    cross the os.environ boundary to gb_ui_backend as-is. So this only ever returns
+    the cert file *path* under "sslrootcert_file" — gb_ui_backend's db_schema.py
+    builds the actual ssl.SSLContext from that path right before creating the engine.
+    """
+    from gbserver.storage.sql.cert_file import get_ssl_cert_file
+    from gbserver.utils.logger import get_logger
+
+    cert_file = get_ssl_cert_file(get_logger(__name__))
+    if cert_file is None:
+        return {}
+    return {"sslrootcert_file": cert_file}
 
 
 ENV_VAR_GBSERVER_SQL_SCHEME = ENV_VAR_PREFIX + "_SQL_SCHEME"  # postgresql, mysql, etc.

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -94,33 +94,6 @@ class TestAnalyticsIsEnabled:
         assert any("Unrecognized boolean value" in r.message for r in caplog.records)
 
 
-class TestAnalyticsColocateSqliteBlank:
-    """analytics_colocate_sqlite reuses the same blank-is-unset validator as
-    analytics_enabled (see _blank_is_unset) — GB_UI_ANALYTICS_COLOCATE_SQLITE=""
-    must resolve to None (auto-detect), not raise ValidationError.
-    """
-
-    def test_unset_is_none(self, monkeypatch):
-        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
-        gb_config.get_config.cache_clear()
-        assert gb_config.get_config().analytics_colocate_sqlite is None
-
-    def test_blank_is_none(self, monkeypatch):
-        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "")
-        gb_config.get_config.cache_clear()
-        assert gb_config.get_config().analytics_colocate_sqlite is None
-
-    def test_explicit_true(self, monkeypatch):
-        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "true")
-        gb_config.get_config.cache_clear()
-        assert gb_config.get_config().analytics_colocate_sqlite is True
-
-    def test_explicit_false(self, monkeypatch):
-        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "false")
-        gb_config.get_config.cache_clear()
-        assert gb_config.get_config().analytics_colocate_sqlite is False
-
-
 class TestDatabaseConnectArgsProperty:
     """Config.database_connect_args decodes GB_UI_DATABASE_CONNECT_ARGS (JSON-encoded
     since an ssl.SSLContext can't cross the env-var boundary as-is)."""
@@ -182,7 +155,6 @@ class TestConfigureAnalyticsEnv:
         # GB_HOME_DIR so this doesn't probe the real filesystem's home dir.
         monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
         monkeypatch.setenv("GB_HOME_DIR", str(tmp_path / "gb_home"))
-        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
         import importlib
 
         from gbserver.types import constants
@@ -207,7 +179,6 @@ class TestConfigureAnalyticsEnv:
         """
         monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
         monkeypatch.setenv("GB_HOME_DIR", str(tmp_path / "gb_home"))
-        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
         monkeypatch.delenv("GB_UI_DATABASE_URL", raising=False)
         # Force analytics on explicitly rather than relying on GBSERVER_UI_DIR
         # auto-detection: src/gbserver/static/ui is a gitignored build artifact
@@ -299,56 +270,9 @@ class TestDeriveAnalyticsDatabaseUrl:
         finally:
             self._reload_constants()
 
-    def test_sqlite_mode_fresh_install_colocates(self, monkeypatch, tmp_path):
+    def test_sqlite_mode_uses_dashboard_analytics_db(self, monkeypatch, tmp_path):
         monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
         monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
-        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
-        gb_config.get_config.cache_clear()
-        constants = self._reload_constants()
-        try:
-            url = constants.derive_analytics_database_url()
-            assert url == f"sqlite+aiosqlite:///{tmp_path / 'llmb-server.db'}"
-        finally:
-            self._reload_constants()
-
-    def test_sqlite_mode_existing_install_keeps_legacy_file(
-        self, monkeypatch, tmp_path
-    ):
-        legacy = tmp_path / "dashboard-analytics.db"
-        legacy.write_text("")
-        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
-        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
-        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
-        gb_config.get_config.cache_clear()
-        constants = self._reload_constants()
-        try:
-            url = constants.derive_analytics_database_url()
-            assert url == f"sqlite+aiosqlite:///{legacy}"
-        finally:
-            self._reload_constants()
-
-    def test_sqlite_mode_explicit_colocate_true_overrides_existing_legacy(
-        self, monkeypatch, tmp_path
-    ):
-        legacy = tmp_path / "dashboard-analytics.db"
-        legacy.write_text("")
-        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
-        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
-        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "true")
-        gb_config.get_config.cache_clear()
-        constants = self._reload_constants()
-        try:
-            url = constants.derive_analytics_database_url()
-            assert url == f"sqlite+aiosqlite:///{tmp_path / 'llmb-server.db'}"
-        finally:
-            self._reload_constants()
-
-    def test_sqlite_mode_explicit_colocate_false_keeps_separate_even_fresh(
-        self, monkeypatch, tmp_path
-    ):
-        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
-        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
-        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "false")
         gb_config.get_config.cache_clear()
         constants = self._reload_constants()
         try:

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -94,6 +94,52 @@ class TestAnalyticsIsEnabled:
         assert any("Unrecognized boolean value" in r.message for r in caplog.records)
 
 
+class TestAnalyticsColocateSqliteBlank:
+    """analytics_colocate_sqlite reuses the same blank-is-unset validator as
+    analytics_enabled (see _blank_is_unset) — GB_UI_ANALYTICS_COLOCATE_SQLITE=""
+    must resolve to None (auto-detect), not raise ValidationError.
+    """
+
+    def test_unset_is_none(self, monkeypatch):
+        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
+        gb_config.get_config.cache_clear()
+        assert gb_config.get_config().analytics_colocate_sqlite is None
+
+    def test_blank_is_none(self, monkeypatch):
+        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "")
+        gb_config.get_config.cache_clear()
+        assert gb_config.get_config().analytics_colocate_sqlite is None
+
+    def test_explicit_true(self, monkeypatch):
+        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "true")
+        gb_config.get_config.cache_clear()
+        assert gb_config.get_config().analytics_colocate_sqlite is True
+
+    def test_explicit_false(self, monkeypatch):
+        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "false")
+        gb_config.get_config.cache_clear()
+        assert gb_config.get_config().analytics_colocate_sqlite is False
+
+
+class TestDatabaseConnectArgsProperty:
+    """Config.database_connect_args decodes GB_UI_DATABASE_CONNECT_ARGS (JSON-encoded
+    since an ssl.SSLContext can't cross the env-var boundary as-is)."""
+
+    def test_unset_is_empty_dict(self, monkeypatch):
+        monkeypatch.delenv("GB_UI_DATABASE_CONNECT_ARGS", raising=False)
+        gb_config.get_config.cache_clear()
+        assert gb_config.get_config().database_connect_args == {}
+
+    def test_set_decodes_json(self, monkeypatch):
+        monkeypatch.setenv(
+            "GB_UI_DATABASE_CONNECT_ARGS", '{"sslrootcert_file": "/tmp/root.pem"}'
+        )
+        gb_config.get_config.cache_clear()
+        assert gb_config.get_config().database_connect_args == {
+            "sslrootcert_file": "/tmp/root.pem"
+        }
+
+
 class TestConfigureAnalyticsEnv:
     """_configure_analytics_env must not set the SQLite fallback when analytics is off."""
 
@@ -130,6 +176,179 @@ class TestConfigureAnalyticsEnv:
         assert os.environ.get("GB_UI_DATABASE_URL") is None
 
     def test_ui_mode_sets_sqlite_url(self, monkeypatch, tmp_path):
-        self._run(monkeypatch, tmp_path, ui_present=True, override=None)
-        url = os.environ.get("GB_UI_DATABASE_URL")
-        assert url is not None and url.startswith("sqlite+aiosqlite:///")
+        # GBSERVER_METADATA_STORAGE unset here defaults to "sql", which since
+        # TestDeriveAnalyticsDatabaseUrl below derives a postgres URL instead — pin
+        # sqlite mode explicitly to keep asserting the SQLite path, and isolate
+        # GB_HOME_DIR so this doesn't probe the real filesystem's home dir.
+        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
+        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path / "gb_home"))
+        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
+        import importlib
+
+        from gbserver.types import constants
+
+        importlib.reload(constants)
+        try:
+            self._run(monkeypatch, tmp_path, ui_present=True, override=None)
+            url = os.environ.get("GB_UI_DATABASE_URL")
+            assert url is not None and url.startswith("sqlite+aiosqlite:///")
+        finally:
+            importlib.reload(constants)
+
+
+class TestDeriveAnalyticsDatabaseUrl:
+    """derive_analytics_database_url() inherits the main store's backend config
+    instead of an independent SQLite default — see gbserver/types/constants.py.
+    """
+
+    def _reload_constants(self):
+        import importlib
+
+        from gbserver.types import constants
+
+        importlib.reload(constants)
+        return constants
+
+    def _sql_env(self, monkeypatch, **overrides):
+        env = {
+            "GBSERVER_METADATA_STORAGE": "sql",
+            "GBSERVER_SQL_SCHEME": "postgresql",
+            "GBSERVER_SQL_HOST": "pg.example.com",
+            "GBSERVER_SQL_PORT": "5432",
+            "GBSERVER_SQL_USER": "gbui",
+            "GBSERVER_SQL_PASSWD": "s3cr3t",
+            "GBSERVER_SQL_DBNAME": "gbdb",
+            **overrides,
+        }
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.delenv("GBSERVER_SQL_SSLROOT_CERT_FILE", raising=False)
+        monkeypatch.delenv("GBSERVER_SQL_SSLROOT_CERT", raising=False)
+        monkeypatch.delenv("GBSERVER_SQL_SSLROOT_CERT_BASE64", raising=False)
+
+    def test_sql_mode_derives_postgres_asyncpg_url(self, monkeypatch):
+        self._sql_env(monkeypatch)
+        constants = self._reload_constants()
+        try:
+            assert (
+                constants.derive_analytics_database_url()
+                == "postgresql+asyncpg://gbui:s3cr3t@pg.example.com:5432/gbdb"
+            )
+        finally:
+            self._reload_constants()
+
+    def test_sql_mode_url_quotes_special_characters(self, monkeypatch):
+        self._sql_env(
+            monkeypatch, GBSERVER_SQL_USER="gb ui", GBSERVER_SQL_PASSWD="p@ss/word"
+        )
+        constants = self._reload_constants()
+        try:
+            url = constants.derive_analytics_database_url()
+            assert "gb+ui" in url
+            assert "p%40ss%2Fword" in url
+        finally:
+            self._reload_constants()
+
+    def test_sql_mode_unsupported_scheme_returns_none(self, monkeypatch):
+        self._sql_env(monkeypatch, GBSERVER_SQL_SCHEME="mysql")
+        constants = self._reload_constants()
+        try:
+            assert constants.derive_analytics_database_url() is None
+        finally:
+            self._reload_constants()
+
+    def test_sqlite_mode_fresh_install_colocates(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
+        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
+        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
+        gb_config.get_config.cache_clear()
+        constants = self._reload_constants()
+        try:
+            url = constants.derive_analytics_database_url()
+            assert url == f"sqlite+aiosqlite:///{tmp_path / 'llmb-server.db'}"
+        finally:
+            self._reload_constants()
+
+    def test_sqlite_mode_existing_install_keeps_legacy_file(
+        self, monkeypatch, tmp_path
+    ):
+        legacy = tmp_path / "dashboard-analytics.db"
+        legacy.write_text("")
+        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
+        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
+        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
+        gb_config.get_config.cache_clear()
+        constants = self._reload_constants()
+        try:
+            url = constants.derive_analytics_database_url()
+            assert url == f"sqlite+aiosqlite:///{legacy}"
+        finally:
+            self._reload_constants()
+
+    def test_sqlite_mode_explicit_colocate_true_overrides_existing_legacy(
+        self, monkeypatch, tmp_path
+    ):
+        legacy = tmp_path / "dashboard-analytics.db"
+        legacy.write_text("")
+        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
+        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
+        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "true")
+        gb_config.get_config.cache_clear()
+        constants = self._reload_constants()
+        try:
+            url = constants.derive_analytics_database_url()
+            assert url == f"sqlite+aiosqlite:///{tmp_path / 'llmb-server.db'}"
+        finally:
+            self._reload_constants()
+
+    def test_sqlite_mode_explicit_colocate_false_keeps_separate_even_fresh(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
+        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path))
+        monkeypatch.setenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", "false")
+        gb_config.get_config.cache_clear()
+        constants = self._reload_constants()
+        try:
+            url = constants.derive_analytics_database_url()
+            assert url == f"sqlite+aiosqlite:///{tmp_path / 'dashboard-analytics.db'}"
+        finally:
+            self._reload_constants()
+
+
+class TestDeriveAnalyticsSqlConnectArgs:
+    """derive_analytics_sql_connect_args() translates the main store's TLS cert
+    (sslrootcert/sslmode, built for sync psycopg2) into the cert file path
+    gb_ui_backend's db_schema.py turns into an ssl.SSLContext for asyncpg.
+    """
+
+    def _reset_cert_state(self, monkeypatch, *, cert_file=None, cert_base64=None):
+        import gbserver.storage.sql.cert_file as cert_file_module
+
+        # get_ssl_cert_file caches its result in a module global — reset it so each
+        # test starts fresh regardless of what a previous test resolved.
+        monkeypatch.setattr(cert_file_module, "_SSL_CERT_FILE", None)
+        monkeypatch.setattr(
+            cert_file_module, "GBSERVER_SQL_SSLROOT_CERT_FILE", cert_file
+        )
+        monkeypatch.setattr(
+            cert_file_module, "GBSERVER_SQL_SSLROOT_CERT_BASE64", cert_base64
+        )
+
+    def test_no_cert_configured_returns_empty(self, monkeypatch):
+        self._reset_cert_state(monkeypatch)
+        from gbserver.types import constants
+
+        assert constants.derive_analytics_sql_connect_args() == {}
+
+    def test_cert_file_configured_returns_path_for_translation(
+        self, monkeypatch, tmp_path
+    ):
+        cert_path = tmp_path / "root.pem"
+        cert_path.write_text("dummy-cert-content")
+        self._reset_cert_state(monkeypatch, cert_file=str(cert_path))
+        from gbserver.types import constants
+
+        assert constants.derive_analytics_sql_connect_args() == {
+            "sslrootcert_file": str(cert_path)
+        }

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -209,6 +209,19 @@ class TestConfigureAnalyticsEnv:
         monkeypatch.setenv("GB_HOME_DIR", str(tmp_path / "gb_home"))
         monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
         monkeypatch.delenv("GB_UI_DATABASE_URL", raising=False)
+        # Force analytics on explicitly rather than relying on GBSERVER_UI_DIR
+        # auto-detection: src/gbserver/static/ui is a gitignored build artifact
+        # that may or may not exist on the machine running this test (it doesn't
+        # in a fresh CI checkout), and analytics_backend_enabled() returning False
+        # would make _configure_analytics_env() return before ever touching
+        # GB_UI_DATABASE_URL — the exact thing this test needs to happen.
+        monkeypatch.setenv("GB_UI_ANALYTICS_ENABLED", "true")
+        # _configure_analytics_env sets these two directly via os.environ[...] (not
+        # through monkeypatch), so without pre-registering them here monkeypatch
+        # won't know to revert them — they'd leak into later tests sharing this
+        # worker process, exactly like the leak _run() below already guards against.
+        monkeypatch.delenv("GB_UI_GBSERVER_URL", raising=False)
+        monkeypatch.delenv("GB_UI_GBSERVER_DB_URL", raising=False)
         import importlib
 
         from gbserver.types import constants

--- a/test/unit/gb_ui_backend/test_analytics_gating.py
+++ b/test/unit/gb_ui_backend/test_analytics_gating.py
@@ -195,6 +195,35 @@ class TestConfigureAnalyticsEnv:
         finally:
             importlib.reload(constants)
 
+    def test_get_config_cache_cleared_after_env_mutation(self, monkeypatch, tmp_path):
+        """Regression test for a lru_cache staleness bug found via live verification
+        (not by any unit test): analytics_backend_enabled(), called at the top of
+        _configure_analytics_env, constructs and caches a Config read from os.environ
+        *before* GB_UI_DATABASE_URL is set later in the same function. Without
+        clearing the cache afterward, every later consumer (init_analytics(),
+        _get_engine()) would see that stale, pre-mutation instance with
+        database_url="" forever — analytics would silently never get a database
+        despite GB_UI_DATABASE_URL being set correctly in the process environment.
+        """
+        monkeypatch.setenv("GBSERVER_METADATA_STORAGE", "sqlite")
+        monkeypatch.setenv("GB_HOME_DIR", str(tmp_path / "gb_home"))
+        monkeypatch.delenv("GB_UI_ANALYTICS_COLOCATE_SQLITE", raising=False)
+        monkeypatch.delenv("GB_UI_DATABASE_URL", raising=False)
+        import importlib
+
+        from gbserver.types import constants
+
+        importlib.reload(constants)
+        try:
+            # Prime the cache the same way analytics_backend_enabled()'s internal
+            # get_config() call does, before _configure_analytics_env mutates env.
+            gb_config.get_config.cache_clear()
+            gb_config.get_config()
+            _configure_analytics_env(host="0.0.0.0", port=8080)
+            assert gb_config.get_config().database_url != ""
+        finally:
+            importlib.reload(constants)
+
 
 class TestDeriveAnalyticsDatabaseUrl:
     """derive_analytics_database_url() inherits the main store's backend config

--- a/test/unit/gb_ui_backend/test_db_schema_connect_args.py
+++ b/test/unit/gb_ui_backend/test_db_schema_connect_args.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""_build_connect_args() translates the JSON-serializable connect args crossing the
+env-var boundary (GB_UI_DATABASE_CONNECT_ARGS) into what create_async_engine() expects.
+An ssl.SSLContext isn't JSON-serializable, so gbserver only ever sends the cert file
+path under "sslrootcert_file" — this builds the actual context right before the
+engine is created.
+"""
+
+import datetime
+import ssl
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from gb_ui_backend.services.db_schema import _build_connect_args
+
+
+def _self_signed_cert_pem() -> bytes:
+    """A minimal self-signed CA cert — ssl.create_default_context(cafile=...) needs
+    an actual parseable X.509 cert, not arbitrary bytes."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-root")])
+    now = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+class TestBuildConnectArgs:
+    def test_empty_input_returns_empty(self):
+        assert _build_connect_args({}) == {}
+
+    def test_passthrough_keys_unchanged(self):
+        assert _build_connect_args({"timeout": 5}) == {"timeout": 5}
+
+    def test_sslrootcert_file_becomes_ssl_context(self, tmp_path):
+        cert_path = tmp_path / "root.pem"
+        cert_path.write_bytes(_self_signed_cert_pem())
+
+        result = _build_connect_args({"sslrootcert_file": str(cert_path)})
+
+        assert "sslrootcert_file" not in result
+        assert isinstance(result["ssl"], ssl.SSLContext)
+
+    def test_sslrootcert_file_combined_with_other_keys(self, tmp_path):
+        cert_path = tmp_path / "root.pem"
+        cert_path.write_bytes(_self_signed_cert_pem())
+
+        result = _build_connect_args({"sslrootcert_file": str(cert_path), "timeout": 5})
+
+        assert result["timeout"] == 5
+        assert isinstance(result["ssl"], ssl.SSLContext)


### PR DESCRIPTION
## Description

Follow-up to #190 (crashloop fix) and #191: closes the "near-term" half of #191 — the analytics sidecar (`gb_ui_backend`) picked its database independently of the main store, via a private `GB_UI_DATABASE_URL` that defaulted to its own SQLite file even when the main store was configured for Postgres. This derives analytics' database config from the main store's own backend instead, so an operator who points gbserver at Postgres gets analytics pointed at that same instance automatically.

- **`derive_analytics_database_url()`** (`gbserver/types/constants.py`): when `GBSERVER_METADATA_STORAGE=sql`, inherits `GBSERVER_SQL_*` as a `postgresql+asyncpg://` URL to the same Postgres instance as the main store, instead of silently falling back to a private SQLite file with no writable directory (the root cause of #190's crashloop). When `sqlite`, co-locates into gbserver's own `llmb-server.db` (`gb_*` vs `gbd_*` table prefixes don't collide) on a fresh install, or keeps an existing `dashboard-analytics.db` from a pre-co-location install so its history isn't orphaned — either behavior overridable via the new `GB_UI_ANALYTICS_COLOCATE_SQLITE`.
- **`derive_analytics_sql_connect_args()`**: translates the main store's TLS cert (`sslrootcert`/`sslmode`, built for the sync `psycopg2` driver) into what `asyncpg` needs — a real `ssl.SSLContext`. Since that object isn't JSON-serializable, only the cert file path crosses the env-var boundary (new `GB_UI_DATABASE_CONNECT_ARGS`); `db_schema.py` builds the actual context right before creating the engine.
- Fixes an `lru_cache` staleness bug found via live verification (not by any unit test): `_configure_analytics_env()`'s own early-return guard constructs and caches a `Config` from `os.environ` *before* `GB_UI_DATABASE_URL` is set later in the same function, so every later consumer saw a stale, pre-mutation instance with `database_url=""` forever. This predates this branch (#190 established the call order), but was previously an edge case — this change makes it the common path for every `sql`-mode deployment, so it needed fixing here.
- Fixes a CI-only test flake (`test_get_config_cache_cleared_after_env_mutation`) that relied on ambient `src/gbserver/static/ui` filesystem state which only happened to exist locally.
- Updates `AGENTS.md`/`README.md` to describe the new derived-default behavior and the two new env vars.

Verified live against both a fresh standalone SQLite install and a real local Postgres instance (single `llmb-server.db` with co-located `gb_*`/`gbd_*` tables; existing `dashboard-analytics.db` preserved; `sql` mode connects to the same Postgres as the main store with no stray SQLite file).

The issue's explicitly-separated stretch goal — *"add an async engine variant to the main store that analytics reuses directly, instead of independently deriving a URL"* — is intentionally **not** in this PR; tracked as a follow-up.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
