### PR TITLE
fix(api): allow sub-app Swagger docs paths without auth

### DIFF
--- a/src/gbserver/api/auth.py
+++ b/src/gbserver/api/auth.py
@@ -16,6 +16,7 @@
 
 import hmac
 import os
+import re
 from datetime import timedelta
 from typing import List, Optional, Self, Tuple
 
@@ -42,6 +43,9 @@ logger = get_logger(__name__)
 _LOCALHOST_HOSTS = {"127.0.0.1", "::1", "localhost", "testclient"}
 
 # Exact paths that never require authentication, regardless of auth mode.
+# These are the top-level app's own Swagger/OpenAPI doc pages plus the API
+# root welcome route (see root_api.read_root). Sub-app docs are matched by
+# _PUBLIC_DOCS_RE below, not enumerated here.
 #
 # Next.js's static export also emits a 404/index.html, but it's unreachable
 # in practice: root_api's SPA-fallback 404 handler always serves
@@ -66,6 +70,19 @@ _PUBLIC_EXACT_PATHS = frozenset(
 # auth_routes.py) — deliberately public.
 _PUBLIC_PATH_PREFIXES = ("/api/v1/auth", "/dashboard", "/_next")
 
+# Every mounted sub-app owns its own Swagger/OpenAPI doc pages directly under
+# its mount point (e.g. /api/v1/builds/docs, /api/v1/builds/openapi.json) — see
+# openapi_security.enable_api. Match those exactly: a versioned mount root
+# (/api/v1/<one-segment>) immediately followed by a doc endpoint and nothing
+# else. Anchoring to a *single* mount segment before the doc name is what keeps
+# this from matching a data route whose trailing path parameter merely happens
+# to be "docs"/"redoc"/"openapi.json" — e.g. GET /api/v1/secrets/user_secrets/
+# redoc (a secret literally named "redoc") has an extra segment and must stay
+# authenticated. The `$` anchor forbids anything after the doc name.
+_PUBLIC_DOCS_RE = re.compile(
+    r"^/api/v\d+/[^/]+/(docs|docs/oauth2-redirect|openapi\.json|redoc)$"
+)
+
 
 def _is_public_path(path: str) -> bool:
     """Authenticate everything except this explicit allow-list.
@@ -74,13 +91,23 @@ def _is_public_path(path: str) -> bool:
     inverse of an allow-everything-except-/api/ check — a future endpoint
     registered outside this allow-list requires auth by default instead of
     silently being public.
+
+    Runs on every request, so checks are ordered cheapest-first: a set
+    membership test, then string prefix tests (which short-circuit all
+    frontend/static/login traffic), and only then the sub-app-docs regex —
+    reached only by the small slice of paths still unresolved. The regex is
+    compiled once at import (``_PUBLIC_DOCS_RE``); its ``^``-anchor already
+    rejects non-matching paths in C, so no Python-level pre-filter is added
+    (measured: a startswith/endswith guard around it is slower, not faster).
     """
     if path in _PUBLIC_EXACT_PATHS:
         return True
-    return any(
+    if any(
         path == prefix or path.startswith(prefix + "/") or path.startswith(prefix + ".")
         for prefix in _PUBLIC_PATH_PREFIXES
-    )
+    ):
+        return True
+    return _PUBLIC_DOCS_RE.match(path) is not None
 
 
 def _make_synthetic_user(login: str) -> User:

--- a/test/unit/api/test_auth.py
+++ b/test/unit/api/test_auth.py
@@ -75,6 +75,39 @@ def _make_app() -> FastAPI:
         user = request.state.data["user"]
         return JSONResponse(content={"login": user.login})
 
+    # Simulate the doc endpoints a mounted sub-app owns (see
+    # openapi_security.enable_api) — e.g. builds_api mounted at /api/v1/builds.
+    @app.get("/api/v1/builds/docs")
+    async def subapp_docs_endpoint():
+        return JSONResponse(content={"docs": True})
+
+    @app.get("/api/v1/builds/openapi.json")
+    async def subapp_openapi_endpoint():
+        return JSONResponse(content={"openapi": "3.0.0"})
+
+    @app.get("/api/v1/builds/redoc")
+    async def subapp_redoc_endpoint():
+        return JSONResponse(content={"redoc": True})
+
+    @app.get("/api/v1/builds/docs/oauth2-redirect")
+    async def subapp_oauth2_redirect_endpoint():
+        return JSONResponse(content={"oauth2_redirect": True})
+
+    # A regular sub-app data endpoint that must stay protected.
+    @app.get("/api/v1/builds")
+    async def subapp_data_endpoint(request: Request):
+        user = request.state.data["user"]
+        return JSONResponse(content={"login": user.login})
+
+    # A data route whose trailing segment is a user-controlled path parameter,
+    # mirroring GET /api/v1/secrets/user_secrets/{secret_name}. If the docs
+    # exemption matched by suffix, a resource literally named "redoc"/"docs"/
+    # "openapi.json" would slip past auth — this endpoint must stay protected.
+    @app.get("/api/v1/secrets/user_secrets/{secret_name}")
+    async def subapp_secret_endpoint(request: Request, secret_name: str):
+        user = request.state.data["user"]
+        return JSONResponse(content={"login": user.login, "secret": secret_name})
+
     return app
 
 
@@ -293,6 +326,61 @@ class TestAuthMiddlewareApiKeyMode:
             app = _make_app()
             client = TestClient(app)
             response = client.get("/some/unregistered/path")
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/v1/builds/docs",
+            "/api/v1/builds/openapi.json",
+            "/api/v1/builds/redoc",
+            "/api/v1/builds/docs/oauth2-redirect",
+        ],
+    )
+    def test_subapp_docs_paths_always_allowed(self, path):
+        """A mounted sub-app's own Swagger/OpenAPI doc endpoints (e.g.
+        /api/v1/builds/docs) must be public in every auth mode, just like the
+        top-level /docs. This is the regression fix — only the top-level docs
+        were exempted before, so sub-path docs started demanding a token."""
+        env = {
+            "GBSERVER_AUTH_MODE": "apikey",
+            "GBSERVER_API_KEY": "test-key-123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            app = _make_app()
+            client = TestClient(app)
+            response = client.get(path)  # no Authorization header
+        assert response.status_code == 200
+
+    def test_subapp_non_docs_api_path_requires_auth(self):
+        """The docs exemption must not leak to real data routes —
+        /api/v1/builds (not a docs path) still requires a token."""
+        env = {
+            "GBSERVER_AUTH_MODE": "apikey",
+            "GBSERVER_API_KEY": "test-key-123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            app = _make_app()
+            client = TestClient(app)
+            response = client.get("/api/v1/builds")  # no Authorization header
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize("name", ["docs", "redoc", "openapi.json"])
+    def test_data_route_ending_in_doc_name_requires_auth(self, name):
+        """A resource whose name equals a doc endpoint (e.g. a secret named
+        "redoc") must NOT bypass auth. The docs exemption is anchored to a
+        single mount segment before the doc name — /api/v1/secrets/user_secrets/
+        redoc has an extra segment, so it stays protected. Regression guard for
+        the suffix-match auth bypass."""
+        env = {
+            "GBSERVER_AUTH_MODE": "apikey",
+            "GBSERVER_API_KEY": "test-key-123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            app = _make_app()
+            client = TestClient(app)
+            # no Authorization header
+            response = client.get(f"/api/v1/secrets/user_secrets/{name}")
         assert response.status_code == 401
 
     def test_post_to_public_frontend_path_requires_auth(self):


### PR DESCRIPTION
## Summary

- Sub-app Swagger/OpenAPI doc endpoints (e.g. `/api/v1/builds/docs`, `.../openapi.json`, `.../redoc`, `.../docs/oauth2-redirect`) regressed to requiring authentication — only the top-level `/docs` and friends were on the public allow-list, so every mounted sub-app's docs page started demanding a token.
- `AuthMiddleware._is_public_path` now matches sub-app docs with an anchored regex, `^/api/v<N>/<one-segment>/<doc-endpoint>$`, so any mounted sub-app's docs are public automatically without enumerating one exact path per app.
- The top-level docs stay in the existing `_PUBLIC_EXACT_PATHS` allow-list (they don't have the `/api/v<N>/<seg>/` shape).

## Why anchored, not a suffix match

A naive `path.endswith(("/docs", "/redoc", "/openapi.json", ...))` check is an **auth bypass**: several sub-app GET routes end in a user-controlled path segment (e.g. `GET /api/v1/secrets/user_secrets/{secret_name}`). A secret literally named `redoc` would make `/api/v1/secrets/user_secrets/redoc` end in `/redoc` and slip past authentication on a secrets endpoint.

Anchoring to a **single** mount segment before the doc name and terminating with `$` keeps that from happening — the secrets path has an extra segment and stays authenticated. Enforcement itself is unchanged; this only governs which paths skip the auth check.

## Test plan

- `test/unit/api/test_auth.py` — new cases:
  - `test_subapp_docs_paths_always_allowed` (parametrized over `docs`/`openapi.json`/`redoc`/`docs/oauth2-redirect`) — sub-app docs are public without a token.
  - `test_data_route_ending_in_doc_name_requires_auth` (parametrized over `docs`/`redoc`/`openapi.json`) — a secret named after a doc endpoint still returns 401 (bypass regression guard).
  - `test_subapp_non_docs_api_path_requires_auth` — a normal `/api/v1/builds` data route still requires auth.
- All 25 tests in `test/unit/api/test_auth.py` pass (`GB_ENVIRONMENT=DEV`); adjacent `test_openapi_security.py` / `test_auth_providers.py` unaffected.
- `isort` / `black` clean; `pylint` / `mypy` report only pre-existing findings unrelated to this change.

Generated with [Claude Code](https://claude.com/claude-code)