### PR TITLE
remove build files api download size limit

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -124,7 +124,7 @@ Used when `GBSERVER_DEFAULT_BUILDRUNNER_TYPE=job`.
 
 ## Build-files API caps
 
-Limits on the build-files REST endpoints: `GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES` (1 GiB),
+Limits on the build-files REST endpoints: `GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES` (uncapped),
 `_LIST_MAX_ENTRIES` (10000), `_GREP_MAX_HITS` (5000), `_GREP_LINE_MAX_BYTES` (512),
 `_GREP_MAX_CONTEXT` (50), `_PEEK_MAX_LINES` (10000), `_PEEK_MAX_BYTES` (256 KiB),
 `_STAT_BATCH_MAX` (500).

--- a/src/gbserver/api/build_files.py
+++ b/src/gbserver/api/build_files.py
@@ -689,9 +689,10 @@ async def download_file(
     """Download or peek at a remote file.
 
     Default (no peek param): streams the file as
-    ``application/octet-stream``. Rejects directories with 400 and files
-    larger than ``BUILD_FILES_DOWNLOAD_MAX_BYTES`` with 413 before any
-    bytes are streamed.
+    ``application/octet-stream``. Rejects directories with 400. Downloads
+    are uncapped by default; set ``GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES``
+    to reject files larger than that many bytes with 413 before any bytes
+    are streamed.
 
     Peek mode (set exactly one of ``head=N``, ``tail=N``, ``range=A-B``):
     returns ``text/plain; charset=utf-8`` with the requested slice of
@@ -753,7 +754,10 @@ async def download_file(
                 status.HTTP_400_BAD_REQUEST,
                 "download endpoint requires a file, not a directory",
             )
-        if size > BUILD_FILES_DOWNLOAD_MAX_BYTES:
+        if (
+            BUILD_FILES_DOWNLOAD_MAX_BYTES is not None
+            and size > BUILD_FILES_DOWNLOAD_MAX_BYTES
+        ):
             raise HTTPException(
                 status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                 f"file exceeds download cap: size={size} "

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -325,9 +325,16 @@ ENV_VAR_GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES = (
     ENV_VAR_PREFIX + "_BUILD_FILES_DOWNLOAD_MAX_BYTES"
 )
 
-# Default: 1 GiB cap on streamed file downloads.
-BUILD_FILES_DOWNLOAD_MAX_BYTES = int(
-    os.getenv(ENV_VAR_GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES, str(1 * 1024**3))
+# Default: no cap on streamed file downloads. Downloads stream over SFTP in
+# bounded memory, so size poses no integrity/memory risk — but a large transfer
+# holds one of the tunnel's limited SFTP session slots (see SshTunnel
+# max_sessions) for its full duration, has no mid-stream resume (the endpoint
+# has no Range support), and may run into a fronting proxy/ingress body-time or
+# size limit. Set GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES to reintroduce a byte
+# ceiling (pre-flight 413) if any of those become a problem.
+_download_max = os.getenv(ENV_VAR_GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES)
+BUILD_FILES_DOWNLOAD_MAX_BYTES: Optional[int] = (
+    int(_download_max) if _download_max else None
 )
 
 ENV_VAR_GBSERVER_BUILD_FILES_LIST_MAX_ENTRIES = (

--- a/test/unit/api/test_build_files.py
+++ b/test/unit/api/test_build_files.py
@@ -1033,15 +1033,44 @@ class TestDownloadFile:
         assert r.status_code == 400
 
     def test_download_too_large_returns_413(self, client):
-        # 2 GiB > default 1 GiB cap
+        # Downloads are uncapped by default; only 413 when an operator has set
+        # GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES. Patch a finite 1 GiB cap and
+        # stat a 2 GiB file to exercise the over-cap path.
         tunnel = self._tunnel_with_file(size=2 * 1024**3, body=b"x" * 100)
         lb, tun, auth, env = _patches(tunnel)
-        with lb, tun, auth, env:
+        with (
+            lb,
+            tun,
+            auth,
+            env,
+            patch.object(
+                build_files_mod, "BUILD_FILES_DOWNLOAD_MAX_BYTES", 1 * 1024**3
+            ),
+        ):
             r = client.get(
                 "/api/v1/builds/B1/file/download",
                 params={"path": "big.bin"},
             )
         assert r.status_code == 413
+
+    def test_download_uncapped_by_default(self, client):
+        # With no cap configured (the default), even a 2 GiB file streams
+        # instead of 413ing. The stream is still bounded by the declared size.
+        tunnel = self._tunnel_with_file(size=2 * 1024**3, body=b"x" * 100)
+        lb, tun, auth, env = _patches(tunnel)
+        with (
+            lb,
+            tun,
+            auth,
+            env,
+            patch.object(build_files_mod, "BUILD_FILES_DOWNLOAD_MAX_BYTES", None),
+        ):
+            r = client.get(
+                "/api/v1/builds/B1/file/download",
+                params={"path": "big.bin"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.headers["content-length"] == str(2 * 1024**3)
 
     def test_download_caps_at_declared_size(self, client):
         # Live-log race: the file grew from 100 bytes (at stat time) to 200

--- a/test/unit/api/test_build_files.py
+++ b/test/unit/api/test_build_files.py
@@ -1281,11 +1281,21 @@ class TestDownloadPeek:
         assert any("sed -n " in c and "5,7p" in c for c in cmds)
 
     def test_peek_skips_size_cap(self, client):
-        # 50 GiB file — way over BUILD_FILES_DOWNLOAD_MAX_BYTES (1 GiB).
-        # Peek mode should still succeed because the cap doesn't apply.
+        # Patch a finite 1 GiB cap so this actually exercises skipping it: with
+        # the default (no cap) the request would succeed either way. The 50 GiB
+        # file is way over the cap, but peek mode returns before the size check
+        # — tailing the last 100 lines of a huge log is the use case.
         tunnel = _tunnel_for_peek("tail content\n", size=50 * 1024**3)
         lb, tun, auth, env = _patches(tunnel)
-        with lb, tun, auth, env:
+        with (
+            lb,
+            tun,
+            auth,
+            env,
+            patch.object(
+                build_files_mod, "BUILD_FILES_DOWNLOAD_MAX_BYTES", 1 * 1024**3
+            ),
+        ):
             r = client.get(
                 "/api/v1/builds/B1/file/download",
                 params={"path": "huge.log", "tail": 100},


### PR DESCRIPTION
## Description

Removes the hard-cap for downloading build files from LSF. We can still cap the file size via configurable env var `GBSERVER_BUILD_FILES_DOWNLOAD_MAX_BYTES` - if unset, then there isn't a hard-cap

unblocks the need to be able to download large files in internally deployed granite.build 

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
