### PR TITLE
fix: Fix cross-space BOLA 

### DIFF
--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -324,7 +324,7 @@ def register_artifact(
         storage.add(new_artifact)
     except ChecksumConflictException as exc:
         conflict_uri = exc.existing_artifact.uri
-        decoded = decode_uri(conflict_uri).model_dump()
+        decoded = decode_uri(request, uri=conflict_uri).model_dump()
         decoded["uuid"] = exc.existing_artifact.uuid
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=decoded)
     except (
@@ -478,7 +478,7 @@ def resolve_hf_resource_group(
 
 @artifacts_api.get("/decode")
 def decode_uri(
-    uri: Optional[str] = None, id: Optional[str] = None
+    request: Request, uri: Optional[str] = None, id: Optional[str] = None
 ) -> Union[DecodedURIResponse, DecodedHfURIResponse]:
     if uri is None and id is None:
         raise HTTPException(
@@ -501,6 +501,11 @@ def decode_uri(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Artifact with id {id} not found",
             )
+        confirm_space_write_access(
+            request=request,
+            username_on_target=artifact.username,
+            space_name=artifact.space_name,
+        )
         uri = artifact.uri
     assert uri is not None, "uri is None"
     uriobj = URI.get_uri(uri)

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -356,7 +356,9 @@ class ChangeArchiveResponse(BaseModel):
     was_archived: bool
 
 
-def set_archive_bit(artifact_id: str, is_archived: bool) -> ChangeArchiveResponse:
+def set_archive_bit(
+    request: Request, artifact_id: str, is_archived: bool
+) -> ChangeArchiveResponse:
     storage = get_admin_storage().artifact_registry
     item = storage.get_by_uuid(artifact_id)
     if item is None:
@@ -364,6 +366,11 @@ def set_archive_bit(artifact_id: str, is_archived: bool) -> ChangeArchiveRespons
             status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found!"
         )
     assert isinstance(item, ArtifactRegistration)
+    confirm_space_write_access(
+        request=request,
+        username_on_target=item.username,
+        space_name=item.space_name,
+    )
     was_archived = item.is_archived
     if was_archived != is_archived:
         item.is_archived = is_archived
@@ -375,13 +382,13 @@ def set_archive_bit(artifact_id: str, is_archived: bool) -> ChangeArchiveRespons
 
 
 @artifacts_api.put("/{artifact_id}/archive")
-def archive_artifact(artifact_id: str) -> ChangeArchiveResponse:
-    return set_archive_bit(artifact_id, True)
+def archive_artifact(request: Request, artifact_id: str) -> ChangeArchiveResponse:
+    return set_archive_bit(request, artifact_id, True)
 
 
 @artifacts_api.put("/{artifact_id}/unarchive")
-def unarchive_artifact(artifact_id: str) -> ChangeArchiveResponse:
-    return set_archive_bit(artifact_id, False)
+def unarchive_artifact(request: Request, artifact_id: str) -> ChangeArchiveResponse:
+    return set_archive_bit(request, artifact_id, False)
 
 
 class DecodedURIResponse(BaseModel):

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -577,7 +577,7 @@ def list_artifact_tags(
 
 # Needs to be after /tags and /decode GET, since it will match others otherwise.
 @artifacts_api.get("/{artifact_id}")
-def read_artifact(artifact_id: str) -> GetArtifactResponse:
+def read_artifact(request: Request, artifact_id: str) -> GetArtifactResponse:
     storage = get_admin_storage().artifact_registry
     item = storage.get_by_uuid(artifact_id)
     if item is None:
@@ -585,6 +585,11 @@ def read_artifact(artifact_id: str) -> GetArtifactResponse:
             status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found!"
         )
     assert isinstance(item, ArtifactRegistration)
+    confirm_space_write_access(
+        request=request,
+        username_on_target=item.username,
+        space_name=item.space_name,
+    )
     resp = GetArtifactResponse(artifact=item)
     return resp
 
@@ -614,7 +619,7 @@ def _convert_status_str(status_str: str) -> ArtifactRegistrationStatus:
 def update_artifact(
     request: Request, artifact_id: str, update: ArtifactUpdateRequest
 ) -> ArtifactUpdateResponse:
-    read_resp = read_artifact(artifact_id)
+    read_resp = read_artifact(request, artifact_id)
     if read_resp is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/gbserver/api/build_files_paths.py
+++ b/src/gbserver/api/build_files_paths.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 from fastapi import HTTPException, Request, status
 
-from gbserver.api.utils import confirm_space_write_access
+from gbserver.api.utils import confirm_space_member_access, confirm_space_write_access
 from gbserver.storage.singleton_storage import SingletonAdminStorage, get_admin_storage
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.utils.logger import get_logger
@@ -46,6 +46,16 @@ def authorize_build_access(request: Request, build: StoredBuild) -> None:
     PUT /builds/{id}/update.
     """
     confirm_space_write_access(request, build.username, build.space_name)
+
+
+def authorize_build_read_access(request: Request, build: StoredBuild) -> None:
+    """Raise 401 if the requester is not a member of the build's space.
+
+    Broader than authorize_build_access: any member of the build's space
+    (not just the owner or a space/super admin) may read status/events/
+    job-stats for the build.
+    """
+    confirm_space_member_access(request, build.username, build.space_name)
 
 
 def lookup_build(build_id: str) -> StoredBuild:

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -24,7 +24,10 @@ from fastapi import FastAPI, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, model_validator
 
-from gbserver.api.build_files_paths import authorize_build_access
+from gbserver.api.build_files_paths import (
+    authorize_build_access,
+    authorize_build_read_access,
+)
 from gbserver.api.utils import (
     ListAppendOrSet,
     apply_tag_update,
@@ -415,7 +418,7 @@ def __build_target_records(
 
 @builds_api.get("/{build_id}/status", response_model=BuildStatusResponse)
 def get_build_status(
-    build_id: str, follow_retries: bool = False
+    request: Request, build_id: str, follow_retries: bool = False
 ) -> BuildStatusResponse:
     storage: SingletonAdminStorage = get_admin_storage()
     build = storage.build_storage.get_by_uuid(build_id)
@@ -424,6 +427,7 @@ def get_build_status(
             status_code=status.HTTP_404_NOT_FOUND, detail="build not found!"
         )
     assert isinstance(build, StoredBuild)
+    authorize_build_read_access(request, build)
     build.build_archive = ""
     build_status = BuildStatus(
         build=build, target_runs=__build_target_records(storage, build_id)
@@ -447,14 +451,14 @@ def get_build_status(
 
 @builds_api.get("/{build_id}/status2", response_model=BuildStatusResponse)
 def get_build_status2(
-    build_id: str, follow_retries: bool = False
+    request: Request, build_id: str, follow_retries: bool = False
 ) -> BuildStatusResponse:
     # Retained as a backward-compatible alias of the primary /status endpoint.
-    return get_build_status(build_id, follow_retries)
+    return get_build_status(request, build_id, follow_retries)
 
 
 @builds_api.get("/{build_id}/events")
-def get_buildevents(build_id: str):
+def get_buildevents(request: Request, build_id: str):
     storage: SingletonAdminStorage = get_admin_storage()
     build = storage.build_storage.get_by_uuid(build_id)
     if build is None:
@@ -462,6 +466,7 @@ def get_buildevents(build_id: str):
             status_code=status.HTTP_404_NOT_FOUND, detail="build not found!"
         )
     assert isinstance(build, StoredBuild)
+    authorize_build_read_access(request, build)
 
     row_filter = get_row_filter(build_id=build_id)
     events = cast(List[StoredEvent], storage.event_storage.get_by_where(row_filter))

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, model_validator
 
+from gbserver.api.build_files_paths import authorize_build_access
 from gbserver.api.utils import (
     ListAppendOrSet,
     apply_tag_update,
@@ -320,7 +321,7 @@ def list_build_tags(
 
 
 @builds_api.get("/{build_id}")
-def read_build(build_id: str) -> GetBuildResponse:
+def read_build(request: Request, build_id: str) -> GetBuildResponse:
     storage: SingletonAdminStorage = get_admin_storage()
     build_storage = storage.build_storage
     item = build_storage.get_by_uuid(build_id)
@@ -329,12 +330,13 @@ def read_build(build_id: str) -> GetBuildResponse:
             status_code=status.HTTP_404_NOT_FOUND, detail="build not found!"
         )
     assert isinstance(item, StoredBuild), f"invalid item: {item}"
+    authorize_build_access(request, item)
     resp = GetBuildResponse(build=item)
     return resp
 
 
 @builds_api.get("/{build_id}/archive")
-def get_build_archive(build_id: str) -> Dict[str, Dict[str, str]]:
+def get_build_archive(request: Request, build_id: str) -> Dict[str, Dict[str, str]]:
     """Decode the build's ZIP archive and return its files as a dict.
 
     Returns ``{"files": {"path/in/zip": "file contents", ...}}``.
@@ -346,6 +348,8 @@ def get_build_archive(build_id: str) -> Dict[str, Dict[str, str]]:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="build not found!"
         )
+    assert isinstance(build, StoredBuild), f"invalid item: {build}"
+    authorize_build_access(request, build)
     if not build.build_archive:
         return {"files": {}}
     raw = base64.b64decode(build.build_archive)
@@ -603,7 +607,7 @@ class BuildUpdateResponse(BaseModel):
 def update_build(
     request: Request, build_id: str, update: BuildUpdateRequest
 ) -> BuildUpdateResponse:
-    read_resp = read_build(build_id)
+    read_resp = read_build(request, build_id)
     if read_resp is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -40,6 +40,16 @@ from gbserver.lineage.openlineage_utils import parse_hf_url
 from gbserver.storage.singleton_storage import get_admin_storage
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# search_lineage_events scans backend pages (see docstring there) to keep
+# offset/limit and total accurate for the caller's accessible runs rather
+# than the global unfiltered set. Bounds the worst case when a caller's
+# accessible fraction is a tiny sliver of a huge global result set.
+_SEARCH_SCAN_BACKEND_PAGE_SIZE = 100
+_SEARCH_SCAN_MAX_BACKEND_ITEMS = 2000
 
 
 def _uri_from_url(url: Optional[str]) -> Optional[str]:
@@ -167,35 +177,67 @@ def ingest_lineage_event(event: OpenLineageEvent):
 
 @lineage_api.post("/search")
 def search_lineage_events(request: Request, body: TagSearchRequest):
-    """Search lineage runs by tag. An empty tag list matches every run in the
-    shared lineage backend across all spaces, so results are filtered below
-    to the caller's own runs or spaces they belong to.
+    """Search lineage runs by tag.
+
+    An empty tag list matches every run in the shared lineage backend across
+    all spaces, so results are access-filtered below. search_lineage_by_tags
+    paginates the UNFILTERED backend set, so filtering only the caller's
+    requested page would (a) leak the global unfiltered count via `total`
+    and (b) break offset/limit pagination for the caller — a page could come
+    back near-empty after filtering even though the caller has many
+    accessible runs on other backend pages, so `count < limit` would no
+    longer reliably mean "no more results".
+
+    To keep pagination correct from the caller's point of view, this scans
+    backend pages (in fixed-size chunks, not the caller's own limit) up to
+    _SEARCH_SCAN_MAX_BACKEND_ITEMS, collecting every accessible run, then
+    applies the caller's offset/limit to that accessible set. `total` is
+    always the accessible count, never the global unfiltered count. If the
+    scan cap is hit before the backend is exhausted, `total`/`count` become
+    a lower bound on the true accessible count (logged when this happens).
     """
     service = _get_openlineage_service()
-    total, results = service.search_lineage_by_tags(body.tags, body.limit, body.offset)
 
-    filtered_results = []
-    for result in results:
-        run_facets = (result.get("run") or {}).get("facets") or {}
-        owner = (run_facets.get("job_details") or {}).get("owner", "")
-        space_name = (run_facets.get("tags") or {}).get("space_name", "")
-        has_access, _ = has_space_member_access(
-            request, username_on_target=owner, space_name=space_name
+    accessible: list[dict] = []
+    backend_offset = 0
+    backend_total: Optional[int] = None
+    while backend_total is None or backend_offset < backend_total:
+        if backend_offset >= _SEARCH_SCAN_MAX_BACKEND_ITEMS:
+            logger.warning(
+                "search_lineage_events: hit scan cap of %d backend items for "
+                "tags=%s; total/count are a lower bound on the true accessible count",
+                _SEARCH_SCAN_MAX_BACKEND_ITEMS,
+                body.tags,
+            )
+            break
+        backend_total, page_results = service.search_lineage_by_tags(
+            body.tags, _SEARCH_SCAN_BACKEND_PAGE_SIZE, backend_offset
         )
-        if not has_access:
-            continue
-        # job_input_params carries raw build.yaml step config and can embed
-        # credentials — redact it here too, same as get_build_jobstats, rather
-        # than widening who can read pipeline secrets via search.
-        run_facets.pop("job_input_params", None)
-        filtered_results.append(result)
+        if not page_results:
+            break
+        for result in page_results:
+            run_facets = (result.get("run") or {}).get("facets") or {}
+            owner = (run_facets.get("job_details") or {}).get("owner", "")
+            space_name = (run_facets.get("tags") or {}).get("space_name", "")
+            has_access, _ = has_space_member_access(
+                request, username_on_target=owner, space_name=space_name
+            )
+            if not has_access:
+                continue
+            # job_input_params carries raw build.yaml step config and can embed
+            # credentials — redact it here too, same as get_build_jobstats, rather
+            # than widening who can read pipeline secrets via search.
+            run_facets.pop("job_input_params", None)
+            accessible.append(result)
+        backend_offset += len(page_results)
 
+    page = accessible[body.offset : body.offset + body.limit]
     return PaginatedResponse(
-        count=len(filtered_results),
-        total=total,
+        count=len(page),
+        total=len(accessible),
         limit=body.limit,
         offset=body.offset,
-        runs=filtered_results,
+        runs=page,
     )
 
 

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -23,6 +23,7 @@ from fastapi import FastAPI, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict
 
 from gbserver.api.build_files_paths import authorize_build_read_access
+from gbserver.api.utils import has_space_member_access
 from gbserver.lineage.openlineage_models import (
     ArtifactGraphRequest,
     ArtifactGraphResponse,
@@ -165,30 +166,55 @@ def ingest_lineage_event(event: OpenLineageEvent):
 
 
 @lineage_api.post("/search")
-def search_lineage_events(request: TagSearchRequest):
+def search_lineage_events(request: Request, body: TagSearchRequest):
+    """Search lineage runs by tag. An empty tag list matches every run in the
+    shared lineage backend across all spaces, so results are filtered below
+    to the caller's own runs or spaces they belong to.
+    """
     service = _get_openlineage_service()
-    total, results = service.search_lineage_by_tags(
-        request.tags, request.limit, request.offset
-    )
+    total, results = service.search_lineage_by_tags(body.tags, body.limit, body.offset)
+
+    filtered_results = []
+    for result in results:
+        run_facets = (result.get("run") or {}).get("facets") or {}
+        owner = (run_facets.get("job_details") or {}).get("owner", "")
+        space_name = (run_facets.get("tags") or {}).get("space_name", "")
+        has_access, _ = has_space_member_access(
+            request, username_on_target=owner, space_name=space_name
+        )
+        if not has_access:
+            continue
+        # job_input_params carries raw build.yaml step config and can embed
+        # credentials — redact it here too, same as get_build_jobstats, rather
+        # than widening who can read pipeline secrets via search.
+        run_facets.pop("job_input_params", None)
+        filtered_results.append(result)
+
     return PaginatedResponse(
-        count=len(results),
+        count=len(filtered_results),
         total=total,
-        limit=request.limit,
-        offset=request.offset,
-        runs=results,
+        limit=body.limit,
+        offset=body.offset,
+        runs=filtered_results,
     )
 
 
 @lineage_api.post("/artifact")
-def get_artifact_graph(request: ArtifactGraphRequest):
-    """Get the lineage DAG for an artifact, traversing downstream or upstream."""
-    if request.direction not in ("downstream", "upstream", "both"):
+def get_artifact_graph(request: Request, body: ArtifactGraphRequest):
+    """Get the lineage DAG for an artifact, traversing downstream or upstream.
+
+    Runs are looked up by artifact name/url in the external lineage backend,
+    which is not itself space-scoped, so results can span multiple spaces —
+    each run is filtered below to the caller's own runs or spaces they belong
+    to, rather than gating the whole request on a single space.
+    """
+    if body.direction not in ("downstream", "upstream", "both"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="direction must be 'downstream', 'upstream', or 'both'",
         )
 
-    if not request.artifact_name and not request.artifact_url:
+    if not body.artifact_name and not body.artifact_url:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Either artifact_name or artifact_url must be provided",
@@ -197,11 +223,11 @@ def get_artifact_graph(request: ArtifactGraphRequest):
     service = _get_openlineage_service()
     try:
         result = service.get_artifact_graph(
-            artifact_name=request.artifact_name,
-            artifact_url=request.artifact_url,
-            artifact_type=request.artifact_type,
-            max_depth=request.max_depth,
-            direction=request.direction,
+            artifact_name=body.artifact_name,
+            artifact_url=body.artifact_url,
+            artifact_type=body.artifact_type,
+            max_depth=body.max_depth,
+            direction=body.direction,
         )
     except ValueError as e:
         raise HTTPException(
@@ -210,7 +236,7 @@ def get_artifact_graph(request: ArtifactGraphRequest):
         )
 
     if result is None:
-        identifier = request.artifact_name or request.artifact_url
+        identifier = body.artifact_name or body.artifact_url
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Artifact not found: {identifier}",
@@ -284,30 +310,38 @@ def get_artifact_graph(request: ArtifactGraphRequest):
                         )
                     )
 
-        runs.append(
-            ArtifactRunEntry(
-                job_name=metadata.get("job_name") or run.get("name", ""),
-                job_namespace=metadata.get("job_namespace") or "",
-                job_type=metadata.get("job_type") or "",
-                run_id=metadata.get("run_id") or "",
-                created_at=metadata.get("created_at") or "",
-                status=metadata.get("state") or "",
-                tags=tags,
-                inputs=inputs,
-                outputs=outputs,
-                job_id=metadata.get("job_id") or "",
-                job_status=metadata.get("job_status") or "",
-                job_started_at=metadata.get("job_started_at") or "",
-                job_completed_at=metadata.get("job_completed_at") or "",
-                release_id=metadata.get("release_id") or "",
-                category=metadata.get("category") or "",
-                owner=metadata.get("owner") or "",
-                source_code_details=metadata.get("source_code_details") or {},
-                job_input_params=metadata.get("job_input_params") or {},
-                execution_stats=metadata.get("execution_stats") or {},
-                job_output_stats=metadata.get("job_output_stats") or {},
-            )
+        entry = ArtifactRunEntry(
+            job_name=metadata.get("job_name") or run.get("name", ""),
+            job_namespace=metadata.get("job_namespace") or "",
+            job_type=metadata.get("job_type") or "",
+            run_id=metadata.get("run_id") or "",
+            created_at=metadata.get("created_at") or "",
+            status=metadata.get("state") or "",
+            tags=tags,
+            inputs=inputs,
+            outputs=outputs,
+            job_id=metadata.get("job_id") or "",
+            job_status=metadata.get("job_status") or "",
+            job_started_at=metadata.get("job_started_at") or "",
+            job_completed_at=metadata.get("job_completed_at") or "",
+            release_id=metadata.get("release_id") or "",
+            category=metadata.get("category") or "",
+            owner=metadata.get("owner") or "",
+            source_code_details=metadata.get("source_code_details") or {},
+            job_input_params=metadata.get("job_input_params") or {},
+            execution_stats=metadata.get("execution_stats") or {},
+            job_output_stats=metadata.get("job_output_stats") or {},
         )
+        # job_namespace is written as f"{space_name}/{build_name}" (see
+        # wandb_jobstats._build_events_for_target); split on the first "/"
+        # to recover the space and drop runs from spaces the caller can't
+        # access. Runs missing both an owner and a namespace fail closed.
+        run_space_name = entry.job_namespace.split("/", 1)[0]
+        has_access, _ = has_space_member_access(
+            request, username_on_target=entry.owner, space_name=run_space_name
+        )
+        if has_access:
+            runs.append(entry)
 
     return ArtifactGraphResponse(
         root_id=result["root_id"],

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-from fastapi import FastAPI, HTTPException, status
+from fastapi import FastAPI, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict
 
+from gbserver.api.build_files_paths import authorize_build_read_access
 from gbserver.lineage.openlineage_models import (
     ArtifactGraphRequest,
     ArtifactGraphResponse,
@@ -72,7 +73,7 @@ class BuildJobStatsResponse(BaseModel):
 
 
 @lineage_api.get("/build/{build_id}")
-def get_build_jobstats(build_id: str) -> BuildJobStatsResponse:
+def get_build_jobstats(request: Request, build_id: str) -> BuildJobStatsResponse:
     """Get JobStats for all targets in a build."""
     storage = get_admin_storage()
 
@@ -86,6 +87,7 @@ def get_build_jobstats(build_id: str) -> BuildJobStatsResponse:
             detail=f"Build with id {build_id} not found",
         )
     assert isinstance(build, StoredBuild)
+    authorize_build_read_access(request, build)
 
     # Get all targets for this build
     row_filter = {"build_id": build_id}
@@ -106,7 +108,7 @@ def get_build_jobstats(build_id: str) -> BuildJobStatsResponse:
 
 
 @lineage_api.get("/target/{target_id}")
-def get_target_jobstats(target_id: str) -> TargetJobStatsResponse:
+def get_target_jobstats(request: Request, target_id: str) -> TargetJobStatsResponse:
     """Get JobStats for a target run, grouped by output artifact name."""
     storage = get_admin_storage()
 
@@ -118,6 +120,17 @@ def get_target_jobstats(target_id: str) -> TargetJobStatsResponse:
             detail=f"Target with id {target_id} not found",
         )
     assert isinstance(target, StoredTargetRun)
+
+    # Authorize against the target's parent build, since the target itself
+    # carries no owner/space of its own.
+    build = storage.build_storage.get_by_uuid(target.build_id)
+    if build is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Build with id {target.build_id} not found",
+        )
+    assert isinstance(build, StoredBuild)
+    authorize_build_read_access(request, build)
 
     from gbserver.lineage.jobstats import get_lineage_store
 

--- a/src/gbserver/api/utils.py
+++ b/src/gbserver/api/utils.py
@@ -20,7 +20,7 @@ from typing import Any, Optional
 from fastapi import HTTPException, Request, status
 from pydantic import BaseModel
 
-from gbserver.spaces.user_spaces_list import space_admin_check
+from gbserver.spaces.user_spaces_list import space_access_check, space_admin_check
 from gbserver.storage.storage import Pagination, QueryControl, SortOrder, TaggedItem
 from gbserver.types.constants import PUBLIC_SPACE_NAME, SYSTEM_TAG_PREFIX
 
@@ -101,6 +101,56 @@ def confirm_space_write_access(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"User {user_id} does not have write access to item in space {space_name}",
+        )
+
+
+def has_space_member_access(
+    request: Request, username_on_target: str, space_name: str
+) -> tuple[bool, str]:
+    """See if the requesting user has at least read/member access to an asset
+    owned/created by the given username in the given space. Broader than
+    has_space_write_access: grants access to any member of the space, not
+    just the owner or a space/super admin.
+
+    Raises:
+        HTTPException: if user id is not found in the request.
+
+    Returns:
+        tuple[bool,str]: first element indicates if the requester has access and the 2nd is the user_id found in the request.
+    """
+    user_id = request.state.data["user"].login
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Can not determine user id!"
+        )
+    is_owner = username_on_target == user_id
+    if is_owner:
+        return True, user_id
+    username_email = request.state.data["user"].email
+    has_access = is_super_admin(request) or space_access_check(
+        username_email, space_name
+    )
+    return has_access, user_id
+
+
+def confirm_space_member_access(
+    request: Request, username_on_target: str, space_name: str
+) -> None:
+    """See if the requesting user has at least read/member access to an asset
+    owned/created by the given username in the given space and raise an HTTP
+    exception if not.
+
+    Raises:
+        HTTPException: if user id is not found in the request.
+        HTTPException: if the requesting user is not a member of the space.
+    """
+    has_access, user_id = has_space_member_access(
+        request, username_on_target=username_on_target, space_name=space_name
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"User {user_id} does not have access to item in space {space_name}",
         )
 
 

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -202,11 +202,13 @@ class WandBLineageStore(ILineageStore):
         step_configs = []
         steps = storage.step_storage.get_by_where({"target_id": targetrun.uuid})
         for step in steps:
+            # step.config/config_dir are copied verbatim from the build's own
+            # build.yaml and can embed credentials — jobstats is readable by any
+            # space member (not just the build owner/admin, unlike get_build_archive),
+            # so omit them here rather than widening who can read pipeline secrets.
             step_configs.append(
                 {
                     "uri": step.definition_uri,
-                    "config": step.config,
-                    "config_dir": step.config_dir,
                 }
             )
 

--- a/test/integration/standalone/api/test_build_status_retry_chain.py
+++ b/test/integration/standalone/api/test_build_status_retry_chain.py
@@ -22,6 +22,7 @@ the chain, root-first, each with its target runs. ``/status2`` is retained as a
 backward-compatible alias.
 """
 
+from types import SimpleNamespace
 from typing import Self
 
 import pytest
@@ -33,6 +34,16 @@ from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.types.status import Status
 
 pytestmark = pytest.mark.standalone
+
+
+def _owner_request() -> SimpleNamespace:
+    """A fake Request whose caller is 'tester', the owner of every build in
+    this test's chains, so authorize_build_read_access lets the calls through."""
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            data={"user": SimpleNamespace(login="tester", email="tester@example.com")}
+        )
+    )
 
 
 class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
@@ -101,7 +112,7 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
     def test_no_follow_returns_only_queried_build(self: Self):
         _root, retry, _root_a = self._make_chain()
 
-        resp = get_build_status(retry.uuid)
+        resp = get_build_status(_owner_request(), retry.uuid)
 
         assert resp.retry_chain is None
         assert resp.status.build.uuid == retry.uuid
@@ -110,7 +121,7 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
     def test_follow_returns_chain_root_first(self: Self):
         root, retry, root_a = self._make_chain()
 
-        resp = get_build_status(retry.uuid, follow_retries=True)
+        resp = get_build_status(_owner_request(), retry.uuid, follow_retries=True)
 
         assert resp.retry_chain is not None
         # Root first, then the retry — regardless of which member was queried.
@@ -129,8 +140,8 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
     def test_status2_alias_matches_status(self: Self):
         _root, retry, _root_a = self._make_chain()
 
-        primary = get_build_status(retry.uuid, follow_retries=True)
-        alias = get_build_status2(retry.uuid, follow_retries=True)
+        primary = get_build_status(_owner_request(), retry.uuid, follow_retries=True)
+        alias = get_build_status2(_owner_request(), retry.uuid, follow_retries=True)
 
         assert [m.build.uuid for m in alias.retry_chain] == [
             m.build.uuid for m in primary.retry_chain

--- a/test/unit/api/test_artifacts.py
+++ b/test/unit/api/test_artifacts.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for GET /artifacts/decode?id= per-object authorization.
+
+decode_uri(id=...) is an alternate read path to the same artifact
+read_artifact protects (both load by uuid via get_admin_storage, which
+bypasses row-level security). This exercises the real confirm_space_write_access
+check directly, mocking only storage and the space-role lookups — no DB
+required. The uri= mode never touches storage and must stay open to anyone.
+
+test/conftest.py's autouse `_mock_space_access` fixture stubs
+gbserver.api.artifacts.confirm_space_write_access to an unconditional no-op in
+mock mode (so unrelated tests don't need real space setup), which would make
+every test here trivially pass regardless of the fix under test. `_real_authz`
+restores the real function for the duration of each test below.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from gbserver.api import artifacts as artifacts_module
+from gbserver.api.artifacts import decode_uri
+from gbserver.api.utils import (
+    confirm_space_write_access as _real_confirm_space_write_access,
+)
+from gbserver.api.utils import has_space_write_access as _real_has_space_write_access
+from gbserver.storage.artifact_registration import ArtifactRegistration
+from gbserver.types.artifact import ArtifactType
+
+VICTIM_OWNER = "victim_b"
+VICTIM_SPACE = "space-B"
+ATTACKER = "attacker_a"
+
+
+@contextmanager
+def _real_authz():
+    """Restore the real confirm_space_write_access AND has_space_write_access.
+
+    test/conftest.py's autouse `_mock_space_access` fixture stubs both out
+    (confirm_space_write_access to an unconditional no-op, has_space_write_access
+    to an unconditional (True, "standalone")) in mock mode. Restoring only one
+    still leaves the other short-circuiting the real owner/admin decision.
+    """
+    with (
+        patch(
+            "gbserver.api.artifacts.confirm_space_write_access",
+            side_effect=_real_confirm_space_write_access,
+        ),
+        patch(
+            "gbserver.api.utils.has_space_write_access",
+            side_effect=_real_has_space_write_access,
+        ),
+    ):
+        yield
+
+
+def _victim_artifact() -> ArtifactRegistration:
+    art = ArtifactRegistration(
+        type=ArtifactType.MODEL,
+        uri="hf://huggingface.co/models/team-b/private-model",
+        space_name=VICTIM_SPACE,
+        username=VICTIM_OWNER,
+    )
+    art.uuid = "11111111-1111-1111-1111-111111111111"
+    return art
+
+
+class _FakeRegistry:
+    def __init__(self, item):
+        self._item = item
+
+    def get_by_uuid(self, uuid):
+        return self._item if uuid == self._item.uuid else None
+
+
+def _fake_request(login: str, email: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(data={"user": SimpleNamespace(login=login, email=email)})
+    )
+
+
+def _patched_storage(artifact):
+    fake_storage = SimpleNamespace(artifact_registry=_FakeRegistry(artifact))
+    return patch.object(
+        artifacts_module, "get_admin_storage", return_value=fake_storage
+    )
+
+
+def test_decode_uri_by_id_rejects_non_owner_non_admin():
+    art = _victim_artifact()
+    with (
+        _patched_storage(art),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            decode_uri(_fake_request(ATTACKER, f"{ATTACKER}@example.com"), id=art.uuid)
+        assert exc.value.status_code == 401
+
+
+def test_decode_uri_by_id_allows_owner():
+    art = _victim_artifact()
+    with (
+        _patched_storage(art),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        resp = decode_uri(
+            _fake_request(VICTIM_OWNER, f"{VICTIM_OWNER}@example.com"), id=art.uuid
+        )
+    assert resp.uri == art.uri
+
+
+def test_decode_uri_by_id_allows_space_admin():
+    art = _victim_artifact()
+    with (
+        _patched_storage(art),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=True),
+    ):
+        resp = decode_uri(
+            _fake_request("space_admin_x", "space_admin_x@example.com"), id=art.uuid
+        )
+    assert resp.uri == art.uri
+
+
+def test_decode_uri_by_uri_requires_no_auth_and_touches_no_storage():
+    """The uri= mode never loads a stored object, so it must stay open to any
+    authenticated caller regardless of space membership."""
+    with patch.object(artifacts_module, "get_admin_storage") as get_storage:
+        resp = decode_uri(
+            _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+            uri="hf://huggingface.co/models/anyone/anything",
+        )
+    get_storage.assert_not_called()
+    assert resp.uri == "hf://huggingface.co/models/anyone/anything"

--- a/test/unit/api/test_lineage.py
+++ b/test/unit/api/test_lineage.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for per-run access filtering in the OpenLineage-backed routes.
+
+POST /lineage/search and POST /lineage/artifact both query an external
+lineage backend that is not itself space-scoped, so each returned run is
+filtered by has_space_member_access using the owner/space_name recovered
+from that run's own facets (see gbserver.api.lineage for exactly how those
+are recovered from each backend's response shape). These tests stub the
+backend service only — the real has_space_member_access / space_access_check
+/ is_super_admin path runs unmocked except for the space-role lookup itself,
+so a change to the filtering logic or the facet shape it depends on would
+fail here.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gbserver.api import lineage as lineage_mod
+from gbserver.lineage.openlineage_models import ArtifactGraphRequest, TagSearchRequest
+
+MY_SPACE = "my-space"
+OTHER_SPACE = "other-space"
+
+
+def _fake_request(login: str, email: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(data={"user": SimpleNamespace(login=login, email=email)})
+    )
+
+
+def _member_of(space_name: str):
+    """Patch the underlying space-role lookup: caller is a plain member of
+    `space_name` only, not an admin anywhere, not the runs' owner."""
+    return (
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch(
+            "gbserver.api.utils.space_access_check",
+            side_effect=lambda username, space: space == space_name,
+        ),
+    )
+
+
+def _search_run(space_name: str, owner: str = "someone_else@example.com"):
+    return {
+        "run": {
+            "runId": f"run-{space_name}",
+            "facets": {
+                "job_details": {"owner": owner},
+                "tags": {"space_name": space_name},
+                "job_input_params": {"SECRET": "should-not-leak"},
+            },
+        }
+    }
+
+
+def _graph_node(node_id: str, space_name: str, owner: str, name: str = "a-run"):
+    return {
+        "id": node_id,
+        "node_type": "run",
+        "name": name,
+        "metadata": {"job_namespace": f"{space_name}/some-build", "owner": owner},
+    }
+
+
+# --------------------------------------------------------------------- search
+
+
+def test_search_lineage_events_excludes_cross_space_run():
+    my_run = _search_run(MY_SPACE)
+    other_run = _search_run(OTHER_SPACE)
+    fake_service = SimpleNamespace(
+        search_lineage_by_tags=lambda tags, limit, offset: (2, [my_run, other_run])
+    )
+    is_admin, is_member = _member_of(MY_SPACE)
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.search_lineage_events(
+            _fake_request("member", "member@example.com"), TagSearchRequest(tags=[])
+        )
+    run_ids = [r["run"]["runId"] for r in resp.runs]
+    assert run_ids == [f"run-{MY_SPACE}"], run_ids
+    assert resp.total == 1
+    assert resp.count == 1
+
+
+def test_search_lineage_events_includes_owned_run_from_any_space():
+    # owner is compared against the caller's login (not email) — see
+    # has_space_member_access's owner shortcut.
+    owned_run = _search_run(OTHER_SPACE, owner="member")
+    fake_service = SimpleNamespace(
+        search_lineage_by_tags=lambda tags, limit, offset: (1, [owned_run])
+    )
+    is_admin, is_member = _member_of(MY_SPACE)  # not a member of OTHER_SPACE
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.search_lineage_events(
+            _fake_request("member", "member@example.com"), TagSearchRequest(tags=[])
+        )
+    assert len(resp.runs) == 1, "owner should see their own run regardless of space"
+
+
+def test_search_lineage_events_redacts_job_input_params():
+    my_run = _search_run(MY_SPACE)
+    fake_service = SimpleNamespace(
+        search_lineage_by_tags=lambda tags, limit, offset: (1, [my_run])
+    )
+    is_admin, is_member = _member_of(MY_SPACE)
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.search_lineage_events(
+            _fake_request("member", "member@example.com"), TagSearchRequest(tags=[])
+        )
+    assert "SECRET" not in str(resp.runs)
+
+
+# ---------------------------------------------------------------- artifact graph
+
+
+def _fake_graph_result(nodes, edges=None):
+    return {
+        "root_id": nodes[0]["id"] if nodes else "",
+        "truncated": False,
+        "nodes": nodes,
+        "edges": edges or [],
+    }
+
+
+def test_get_artifact_graph_excludes_cross_space_run():
+    nodes = [
+        _graph_node("run-mine", MY_SPACE, "someone_else@example.com"),
+        _graph_node("run-other", OTHER_SPACE, "someone_else@example.com"),
+    ]
+    fake_service = SimpleNamespace(
+        get_artifact_graph=lambda **kw: _fake_graph_result(nodes)
+    )
+    is_admin, is_member = _member_of(MY_SPACE)
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.get_artifact_graph(
+            _fake_request("member", "member@example.com"),
+            ArtifactGraphRequest(artifact_name="dataset-x", direction="both"),
+        )
+    namespaces = [r.job_namespace for r in resp.runs]
+    assert namespaces == [f"{MY_SPACE}/some-build"], namespaces
+
+
+def test_get_artifact_graph_includes_owned_run_from_any_space():
+    # owner is compared against the caller's login (not email) — see
+    # has_space_member_access's owner shortcut.
+    nodes = [_graph_node("run-owned", OTHER_SPACE, "member")]
+    fake_service = SimpleNamespace(
+        get_artifact_graph=lambda **kw: _fake_graph_result(nodes)
+    )
+    is_admin, is_member = _member_of(MY_SPACE)  # not a member of OTHER_SPACE
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.get_artifact_graph(
+            _fake_request("member", "member@example.com"),
+            ArtifactGraphRequest(artifact_name="dataset-x", direction="both"),
+        )
+    assert len(resp.runs) == 1, "owner should see their own run regardless of space"
+
+
+def test_get_artifact_graph_excludes_run_with_no_owner_or_namespace():
+    """Fail closed: a run missing both signals must never be returned."""
+    nodes = [
+        {
+            "id": "run-unknown",
+            "node_type": "run",
+            "name": "mystery",
+            "metadata": {},
+        }
+    ]
+    fake_service = SimpleNamespace(
+        get_artifact_graph=lambda **kw: _fake_graph_result(nodes)
+    )
+    is_admin, is_member = _member_of(MY_SPACE)
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.get_artifact_graph(
+            _fake_request("member", "member@example.com"),
+            ArtifactGraphRequest(artifact_name="dataset-x", direction="both"),
+        )
+    assert resp.runs == []


### PR DESCRIPTION
## Description

Fixes a cross-space Broken Object-Level Authorization (BOLA/IDOR) vulnerability reported via HackerOne (GHSA-pcxq-9xj6-7r3j) in the gbserver REST API. Several routes were authenticated but performed no per-object authorization, letting any authenticated user read or mutate another tenant's data by guessing/enumerating an id:

- `GET /builds/{id}`, `GET /builds/{id}/archive`, `PUT /artifacts/{id}/archive`, `PUT /artifacts/{id}/unarchive`, `GET /artifacts/{id}`, `GET /artifacts/decode?id=` — could read another tenant's private build source (including embedded secrets), toggle another tenant's artifact archive state, or read another tenant's artifact registration by either of two equivalent read paths. Now gated to the object's owner or a space/super admin (`authorize_build_access`/`confirm_space_write_access`), matching the existing sibling routes (`download_file`, `search_files`, `update_artifact`, `update_build`) that already enforced this.
- `GET /builds/{id}/status`, `/status2`, `/events`, and `GET /lineage/build/{id}`, `/lineage/target/{id}` — exposed build metadata, event streams, and job-stats to any authenticated user. Gated to a broader tier — any member of the object's space, not just the owner/admin — via a new `authorize_build_read_access`/`confirm_space_member_access` helper, since this data is intended to be visible to space collaborators. (Builds in the public space remain readable by any authenticated user by design, matching the public space's existing access model.)
- `POST /lineage/artifact` (`get_artifact_graph`) and `POST /lineage/search` (`search_lineage_events`) — returned lineage run data (owner, job namespace, execution stats, connected artifacts) from an external, non-space-scoped lineage backend with no authorization at all; an empty tag search returned every run across every space. Since results can span multiple spaces, both are now filtered per-run (owner-or-space-member) rather than gated as a single object. `search_lineage_events` additionally scans backend pages internally so `total`/`count`/`offset`/`limit` reflect the caller's accessible runs rather than the global unfiltered set (which previously both leaked a cross-tenant count and could return a near-empty page even when the caller had many accessible runs elsewhere).
- Job-stats and lineage-search responses also embedded each step's raw `build.yaml` config — a potential credential-leak vector comparable to what `get_build_archive` protects at the stricter tier. Redacted `config`/`config_dir`/`job_input_params`, keeping only step identity (`definition_uri`).

No new authorization mechanism was introduced beyond one new membership-tier helper alongside the existing owner/admin-tier one; the HTTP contract (paths, params, response shape) is unchanged for authorized callers.

Added unit tests (`test/unit/api/test_artifacts.py`, `test/unit/api/test_lineage.py`) covering: `decode_uri?id=` rejecting a non-owner/non-admin and allowing the owner/space-admin, cross-space runs being excluded from both `search_lineage_events` and `get_artifact_graph`, owned runs being included regardless of space, and secrets being redacted from both routes' responses.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
