### PR TITLE
Switch the default assetstore mode where possible

### DIFF
--- a/configurations/assets/environments/bash/environment.yaml
+++ b/configurations/assets/environments/bash/environment.yaml
@@ -2,9 +2,11 @@ name: bash
 type: Bash
 config: {}
 assetstores:
-  # HuggingFace Hub — load models/datasets from hf:// URIs (push not enabled).
+  # HuggingFace Hub — load models/datasets and push artifacts via hf:// URIs.
   - store_uri: space://assetstores/hf/
     load:
+      - mode: default
+    push:
       - mode: default
   # Local filesystem — load/push artifacts via file: URIs (builtin file store).
   - store_uri: space://assetstores/file/

--- a/configurations/assets/environments/bash/environment.yaml
+++ b/configurations/assets/environments/bash/environment.yaml
@@ -4,13 +4,13 @@ config: {}
 assetstores:
   # HuggingFace Hub — load models/datasets and push artifacts via hf:// URIs.
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default
   # Local filesystem — load/push artifacts via file: URIs (builtin file store).
   - store_uri: space://assetstores/file/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/configurations/assets/environments/docker/environment.yaml
+++ b/configurations/assets/environments/docker/environment.yaml
@@ -6,7 +6,7 @@ config:
     env: {}
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/configurations/assets/environments/runpod/environment.yaml
+++ b/configurations/assets/environments/runpod/environment.yaml
@@ -11,7 +11,7 @@ config:
     volume_mount_path: "/workspace"
 assetstores:
   - store_uri: space://assetstores/s3/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/configurations/assets/environments/skypilot/aws/environment.yaml
+++ b/configurations/assets/environments/skypilot/aws/environment.yaml
@@ -16,14 +16,14 @@ config:
     delay_seconds: 1800
 assetstores:
   - store_uri: space://assetstores/s3/
-    load:
+    pull:
       - mode: default
         config: {}
     push:
       - mode: default
         config: {}
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
         config:
           cache_path: /tmp/hf_cache

--- a/configurations/assets/environments/skypilot/aws/environment.yaml
+++ b/configurations/assets/environments/skypilot/aws/environment.yaml
@@ -24,10 +24,10 @@ assetstores:
         config: {}
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
         config:
           cache_path: /tmp/hf_cache
           inline: true
     push:
-      - mode: hf_push
+      - mode: default
         config: {}

--- a/configurations/assets/environments/skypilot/kubernetes/environment.yaml
+++ b/configurations/assets/environments/skypilot/kubernetes/environment.yaml
@@ -7,9 +7,9 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
         config:
           cache_path: /tmp/hf_cache
     push:
-      - mode: hf_push
+      - mode: default
         config: {}

--- a/configurations/assets/environments/skypilot/kubernetes/environment.yaml
+++ b/configurations/assets/environments/skypilot/kubernetes/environment.yaml
@@ -6,7 +6,7 @@ config:
   idle_minutes_to_autostop: 0
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
         config:
           cache_path: /tmp/hf_cache

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/environment.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/environment.yaml
@@ -57,11 +57,11 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
         config:
           cache_path: /tmp/hf_cache
     push:
-      - mode: hf_push
+      - mode: default
         config: {}
   # NOTE: mem:// (in-memory) store is no longer declared here — it is now
   # auto-registered for every environment by the base class

--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/environment.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/environment.yaml
@@ -56,7 +56,7 @@ config:
                 G: grp_preemptable
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
         config:
           cache_path: /tmp/hf_cache

--- a/configurations/assets/environments/skypilot/slurm/environment.yaml
+++ b/configurations/assets/environments/skypilot/slurm/environment.yaml
@@ -23,7 +23,7 @@ config:
         UserKnownHostsFile: /dev/null
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
         config:
           cache_path: /shared/hf_cache

--- a/configurations/assets/environments/skypilot/slurm/environment.yaml
+++ b/configurations/assets/environments/skypilot/slurm/environment.yaml
@@ -24,8 +24,8 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
         config:
           cache_path: /shared/hf_cache
     push:
-      - mode: hf_push
+      - mode: default

--- a/docs/architecture/environment-classes.md
+++ b/docs/architecture/environment-classes.md
@@ -41,8 +41,9 @@ Methods are discovered by prefix using `get_fns_with_prefix()`. The suffixes (e.
 > **Asset store `mode` invariant.** `pullasset_*` / `pushasset_*` dispatch is by store *type*
 > (`SUFFIX`), not by the `assetstores` entry's `mode`. `mode` is meaningful **only in k8s**
 > (`afm_mount`/`cos_mount`/`cos_pull`/`dmf_pull`/`hf_pull` select mount vs. copy vs. queued step).
-> Every other environment enforces, via `Environment._require_default_mode`, that `mode` is unset
-> or `"default"` — a non-`default` value raises `ValueError` at pull/push time.
+> Every other environment ignores `mode` and prefers `"default"` (or unset); via
+> `Environment._warn_non_default_mode`, a non-`default` value is accepted for backwards
+> compatibility but logs a deprecation warning at pull/push time.
 
 #### Lifecycle Ordering
 

--- a/docs/architecture/environment-classes.md
+++ b/docs/architecture/environment-classes.md
@@ -38,6 +38,12 @@ Methods are discovered by prefix using `get_fns_with_prefix()`. The suffixes (e.
 | `pullasset_SUFFIX` | `pullasset(task_group, uri, ...)` | Pull an asset into the environment |
 | `pushasset_SUFFIX` | `pushasset(task_group, binding, uri, ...)` | Push an artifact to an asset store |
 
+> **Asset store `mode` invariant.** `pullasset_*` / `pushasset_*` dispatch is by store *type*
+> (`SUFFIX`), not by the `assetstores` entry's `mode`. `mode` is meaningful **only in k8s**
+> (`afm_mount`/`cos_mount`/`cos_pull`/`dmf_pull`/`hf_pull` select mount vs. copy vs. queued step).
+> Every other environment enforces, via `Environment._require_default_mode`, that `mode` is unset
+> or `"default"` — a non-`default` value raises `ValueError` at pull/push time.
+
 #### Lifecycle Ordering
 
 The base class enforces strict ordering via `asyncio.Event` coordination:

--- a/docs/asset-stores/README.md
+++ b/docs/asset-stores/README.md
@@ -99,18 +99,25 @@ space's `base_uris` (the same mechanism as steps and environments — see
 ## Load and push modes
 
 An `environment.yaml` `assetstores` entry maps a store URI to **load** (input) and **push** (output)
-behaviour via a `mode`:
+behaviour. Dispatch to a `pullasset_*` / `pushasset_*` handler is by store **type** (derived from the
+URI scheme), not by `mode`. Outside k8s the `mode` field is therefore not meaningful, and the enforced
+invariant is that it must be **unset or `default`**.
 
-| `mode` | Direction | Effect |
-|--------|-----------|--------|
-| `hf_pull` / `hf_push` | load / push | Download from / upload to a HuggingFace repo. |
-| `cos_rclone` / `cos_pull` / `cos_push` | load / push | COS / S3 transfer (rclone). |
-| `env_local` | load / push | No-op: the artifact already lives on a shared filesystem reachable by the worker. |
-| `default` | load / push | The environment's built-in handling for that store. |
+Only **k8s** genuinely branches on `mode` — it selects mounting vs. copying vs. queuing a step:
 
-Each mode is implemented by a `pullasset_*` / `pushasset_*` method on the environment class — some pull/push
-inline, others inject a built-in step (e.g. `hfpull`, `cosrclone`, `lhpull`). Which methods an environment
-provides, and whether they mount volumes or queue steps, is environment-specific: see
+| `mode` (k8s only) | Direction | Effect |
+|-------------------|-----------|--------|
+| `afm_mount` / `cos_mount` | load | Mount the asset into the pod instead of copying it. |
+| `hf_pull` | load | Download from a HuggingFace repo. |
+| `cos_pull` / `dmf_pull` | load | Queue a COS/DMF transfer step. |
+
+For every **other** environment (skypilot, lsf, bash, docker, runpod, and the base mem/env handlers),
+declare `mode: default` (or omit it). A non-`default` mode raises a `ValueError` at pull/push time
+(enforced by `Environment._require_default_mode`).
+
+Each store type is implemented by a `pullasset_*` / `pushasset_*` method on the environment class — some
+pull/push inline, others inject a built-in step (e.g. `hfpull`, `cosrclone`, `lhpull`). Which methods an
+environment provides, and whether they mount volumes or queue steps, is environment-specific: see
 [environments](../environments/README.md#asset-stores) for the `environment.yaml` config and
 [environment classes](../architecture/environment-classes.md) for the per-environment implementations.
 

--- a/docs/asset-stores/README.md
+++ b/docs/asset-stores/README.md
@@ -112,8 +112,9 @@ Only **k8s** genuinely branches on `mode` — it selects mounting vs. copying vs
 | `cos_pull` / `dmf_pull` | load | Queue a COS/DMF transfer step. |
 
 For every **other** environment (skypilot, lsf, bash, docker, runpod, and the base mem/env handlers),
-declare `mode: default` (or omit it). A non-`default` mode raises a `ValueError` at pull/push time
-(enforced by `Environment._require_default_mode`).
+`mode` is ignored (dispatch is by store *type*). Declare `mode: default` (or omit it); a non-`default`
+value is still accepted for backwards compatibility but logs a deprecation warning at pull/push time
+(via `Environment._warn_non_default_mode`).
 
 Each store type is implemented by a `pullasset_*` / `pushasset_*` method on the environment class — some
 pull/push inline, others inject a built-in step (e.g. `hfpull`, `cosrclone`, `lhpull`). Which methods an

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -232,9 +232,9 @@ The environment asset store may also declare a `push` block under `assetstores`:
 assetstores:
   - store_uri: hf://huggingface.co/my-org
     load:
-      - mode: hf_pull
+      - mode: default
     push:
-      - mode: hf_push 
+      - mode: default
         config:
           hf:
             private: true

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -231,7 +231,7 @@ The environment asset store may also declare a `push` block under `assetstores`:
 ```yaml
 assetstores:
   - store_uri: hf://huggingface.co/my-org
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/docs/environments/README.md
+++ b/docs/environments/README.md
@@ -66,7 +66,7 @@ config:                 # Environment-type-specific config — see the per-type 
   ...
 assetstores:            # Asset stores accessible from this environment (see below).
   - store_uri: <uri>
-    load:
+    pull:
       - mode: <mode>
         config: {}
     push:
@@ -116,11 +116,12 @@ restriction holds regardless of which tier finds the file.
 
 ### Asset stores
 
-`assetstores` map a store URI to the **load** (input) and **push** (output) behaviour for this
-environment. Each `load`/`push` entry has a `mode` (e.g. `hf_pull`/`hf_push`, `cos_rclone`, `env_local`,
-`default`) and an optional `config`. Modes are implemented by `pullasset_*` / `pushasset_*` methods on the
-environment class, which may queue a built-in step (e.g. `hf_pull` injects an
-[hfpull](../../src/gbserver/builtins/) step); the exact set is per-type — see each page.
+`assetstores` map a store URI to the **pull** (input) and **push** (output) behaviour for this
+environment. Each `pull`/`push` entry has a `mode` and an optional `config`. The input key is `pull`
+(it pairs with `push` and matches the `pullasset_*` handler); the former name `load` is still accepted
+as a **deprecated alias** (parsing it logs a warning recommending `pull`). Modes are implemented by
+`pullasset_*` / `pushasset_*` methods on the environment class, which may queue a built-in step; the
+exact set is per-type — see each page.
 
 The env-local (`env://`) and in-memory (`mem://`) stores are the exceptions: each is registered
 implicitly for **every** environment (their push/pull transfer nothing — env:// is a shared-filesystem

--- a/docs/environments/bash.md
+++ b/docs/environments/bash.md
@@ -24,12 +24,12 @@ type: Bash
 config: {}
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
   # Local filesystem (file: URIs) — the builtin file store. Bash implements both
   # load and push (pullasset_filestore / pushasset_filestore).
   - store_uri: space://assetstores/file/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/docs/environments/docker.md
+++ b/docs/environments/docker.md
@@ -31,7 +31,7 @@ config:
     env: {}                    # Optional. Default env vars for every container (lowest precedence).
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default          # HF snapshot is downloaded and bind-mounted into the container.
     push:
       - mode: default

--- a/docs/environments/k8s.md
+++ b/docs/environments/k8s.md
@@ -48,14 +48,14 @@ config:
 
 assetstores:
   - store_uri: cos://my-bucket
-    load:
+    pull:
       - mode: cos_rclone
         config:
           step_uri: space://steps/cosrclone
     push:
       - mode: cos_rclone
   - store_uri: hf://huggingface.co/my-org/my-model
-    load:
+    pull:
       - mode: hf_pull
     push:
       - mode: hf_push
@@ -144,12 +144,12 @@ config:
     max_retries: 3
 assetstores:
   - store_uri: hf://huggingface.co/my-org
-    load:
+    pull:
       - mode: hf_pull
     push:
       - mode: hf_push
   - store_uri: cos://my-cos-bucket
-    load:
+    pull:
       - mode: cos_rclone
     push:
       - mode: cos_rclone

--- a/docs/environments/lsf.md
+++ b/docs/environments/lsf.md
@@ -52,7 +52,7 @@ config:
 
 assetstores:
   - store_uri: hf://huggingface.co/my-org
-    load:
+    pull:
       - mode: default              # Dispatch is by store type (hf) — injects the hfpull built-in step.
         config:
           cache_path: /gpfs/cache/hf    # Required. Cluster path where HF data is cached.
@@ -62,7 +62,7 @@ assetstores:
         config:
           step_uri: space://steps/hfpush
   - store_uri: cos://my-bucket
-    load:
+    pull:
       - mode: default              # Dispatch is by store type (cos) — injects the cosrclone step.
         config:
           cache_path: /gpfs/cache/cos   # Required. Cluster path where COS data is downloaded.
@@ -135,7 +135,7 @@ config:
     max_retries: 3
 assetstores:
   - store_uri: hf://huggingface.co/my-org
-    load:
+    pull:
       - mode: default
         config:
           cache_path: /gpfs/cache/hf

--- a/docs/environments/lsf.md
+++ b/docs/environments/lsf.md
@@ -53,21 +53,21 @@ config:
 assetstores:
   - store_uri: hf://huggingface.co/my-org
     load:
-      - mode: hf_pull               # Injects an hfpull built-in step before the main job.
+      - mode: default              # Dispatch is by store type (hf) — injects the hfpull built-in step.
         config:
           cache_path: /gpfs/cache/hf    # Required. Cluster path where HF data is cached.
           step_uri: space://steps/hfpull  # Optional override of the hfpull step URI.
     push:
-      - mode: hf_push
+      - mode: default
         config:
           step_uri: space://steps/hfpush
   - store_uri: cos://my-bucket
     load:
-      - mode: cos_pull              # Injects a cosrclone built-in step.
+      - mode: default              # Dispatch is by store type (cos) — injects the cosrclone step.
         config:
           cache_path: /gpfs/cache/cos   # Required. Cluster path where COS data is downloaded.
     push:
-      - mode: cos_push
+      - mode: default
 ```
 
 ## `step.yaml` — launcher and monitor types
@@ -136,11 +136,11 @@ config:
 assetstores:
   - store_uri: hf://huggingface.co/my-org
     load:
-      - mode: hf_pull
+      - mode: default
         config:
           cache_path: /gpfs/cache/hf
     push:
-      - mode: hf_push
+      - mode: default
 ```
 
 ### `step.yaml`

--- a/docs/environments/skypilot-aws.md
+++ b/docs/environments/skypilot-aws.md
@@ -92,9 +92,9 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
     push:
-      - mode: hf_push
+      - mode: default
 ```
 
 ## See also

--- a/docs/environments/skypilot-aws.md
+++ b/docs/environments/skypilot-aws.md
@@ -91,7 +91,7 @@ config:
       aws_secret_access_key: AWS_SECRET_SECRET
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/docs/environments/skypilot-kubernetes.md
+++ b/docs/environments/skypilot-kubernetes.md
@@ -56,11 +56,11 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
         config:
           cache_path: /tmp/hf_cache
     push:
-      - mode: hf_push
+      - mode: default
         config: {}
 ```
 

--- a/docs/environments/skypilot-kubernetes.md
+++ b/docs/environments/skypilot-kubernetes.md
@@ -55,7 +55,7 @@ config:
   idle_minutes_to_autostop: 0
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
         config:
           cache_path: /tmp/hf_cache

--- a/docs/environments/skypilot-slurm.md
+++ b/docs/environments/skypilot-slurm.md
@@ -88,9 +88,9 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull
+      - mode: default
     push:
-      - mode: hf_push
+      - mode: default
 ```
 
 A `command` step on this env runs directly on the compute node when no image is

--- a/docs/environments/skypilot-slurm.md
+++ b/docs/environments/skypilot-slurm.md
@@ -87,7 +87,7 @@ config:
         UserKnownHostsFile: /dev/null
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/docs/environments/skypilot.md
+++ b/docs/environments/skypilot.md
@@ -68,7 +68,7 @@ config:
 
 assetstores:
   - store_uri: space://assetstores/hf
-    load:
+    pull:
       - mode: default              # Dispatch is by store type (hf) — queues the builtin hfpull step.
         config:
           cache_path: /tmp/hf_cache  # Optional. Defaults to {shared_workdir}/hf_cache when set,

--- a/docs/environments/skypilot.md
+++ b/docs/environments/skypilot.md
@@ -69,16 +69,19 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf
     load:
-      - mode: hf_pull               # Queues the builtin hfpull step on its own SkyPilot cluster.
+      - mode: default              # Dispatch is by store type (hf) — queues the builtin hfpull step.
         config:
           cache_path: /tmp/hf_cache  # Optional. Defaults to {shared_workdir}/hf_cache when set,
                                      # else ~/.cache/gbserver/hf on the worker.
     push:
-      - mode: hf_push
+      - mode: default
 ```
 
+> Outside k8s, `mode` must be unset or `default` — dispatch is by store type, not `mode`. See
+> [asset stores](../asset-stores/README.md#load-and-push-modes).
+
 > `env://` (shared-filesystem, no-op push/pull) is registered implicitly for every environment, so it
-> needs no `assetstores` entry — add one only to pin a specific `env://` `load`/`push` `mode`.
+> needs no `assetstores` entry.
 
 ### `shared_workdir`
 

--- a/samples/tests/local_hello_world_full/environments/local/environment.yaml
+++ b/samples/tests/local_hello_world_full/environments/local/environment.yaml
@@ -4,7 +4,7 @@ config: {}
 assetstores:
   - store_uri: file:assetstores/local/
     # TODO: relative paths should be relative to the file they are present in, not relative to PWD
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -274,11 +274,12 @@ class Bash(Environment):
         self: Self,
         uri: URI,
         binding: Optional[Any] = None,
-        # storeload_config: Optional[StoreLoad] = None,
+        storeload_config=None,
         # assetstore: Optional[Assetstore] = None,
         # secrets: Optional[dict] = None,
         **kwargs,
     ) -> Tuple[Dict, Optional[BuildTargetStepConfig]]:
+        self._require_default_mode(storeload_config, uri)
         if isinstance(uri, str):
             uri = URI.get_uri(uri)
         assert uri.uri is not None, "the URI is None"
@@ -299,6 +300,7 @@ class Bash(Environment):
         **kwargs,
     ) -> Tuple[Dict, Optional[BuildTargetStepConfig]]:
         """Download an HF model snapshot and bind as a local path."""
+        self._require_default_mode(storeload_config, uri)
         local_path = pull_asset_hfstore(uri, assetstore, storeload_config)
         binding_config = {BINDING_KEY: {"path": str(local_path)}}
         return binding_config, None
@@ -313,8 +315,10 @@ class Bash(Environment):
         binding: Any,
         uri: Optional[URI] = None,
         base_uri: Optional[URI] = None,
+        storepush_config=None,
         **kwargs,
     ) -> Any:
+        self._require_default_mode(storepush_config, uri if uri is not None else base_uri)
         if uri is None and base_uri is None:
             return None
         # The binding is the artifact location, either a {"path": ...} dict or a

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -283,7 +283,7 @@ class Bash(Environment):
         # secrets: Optional[dict] = None,
         **kwargs,
     ) -> Tuple[Dict, Optional[BuildTargetStepConfig]]:
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         if isinstance(uri, str):
             uri = URI.get_uri(uri)
         assert uri.uri is not None, "the URI is None"
@@ -304,7 +304,7 @@ class Bash(Environment):
         **kwargs,
     ) -> Tuple[Dict, Optional[BuildTargetStepConfig]]:
         """Download an HF model snapshot and bind as a local path."""
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         local_path = pull_asset_hfstore(uri, assetstore, storeload_config)
         binding_config = {BINDING_KEY: {"path": str(local_path)}}
         return binding_config, None
@@ -340,7 +340,7 @@ class Bash(Environment):
         :returns: The resolved ``HfURI`` after a successful push.
         :raises ValueError: on a non-'default' mode, or a binding without 'path'.
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if not isinstance(binding, dict) or "path" not in binding:
             raise ValueError(f"binding must be a dict with 'path', got: {binding}")
         return push_asset_hfstore(
@@ -359,7 +359,7 @@ class Bash(Environment):
         storepush_config=None,
         **kwargs,
     ) -> Any:
-        self._require_default_mode(storepush_config, uri if uri is not None else base_uri)
+        self._warn_non_default_mode(storepush_config, uri if uri is not None else base_uri)
         if uri is None and base_uri is None:
             return None
         # The binding is the artifact location, either a {"path": ...} dict or a

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -359,7 +359,9 @@ class Bash(Environment):
         storepush_config=None,
         **kwargs,
     ) -> Any:
-        self._warn_non_default_mode(storepush_config, uri if uri is not None else base_uri)
+        self._warn_non_default_mode(
+            storepush_config, uri if uri is not None else base_uri
+        )
         if uri is None and base_uri is None:
             return None
         # The binding is the artifact location, either a {"path": ...} dict or a

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -33,7 +33,11 @@ from gbserver.environment.environment import (
     Environment,
     EventLogLineParserConfig,
 )
-from gbserver.environment.local_assets import get_hf_cache_dir, pull_asset_hfstore
+from gbserver.environment.local_assets import (
+    get_hf_cache_dir,
+    pull_asset_hfstore,
+    push_asset_hfstore,
+)
 from gbserver.monitoring.logfile_monitor import LogFileMonitor
 from gbserver.monitoring.streams.stream_factory import make_stream
 from gbserver.types.buildconfig import BuildTargetStepConfig
@@ -309,6 +313,43 @@ class Bash(Environment):
     def _get_hf_cache_dir(storeload_config) -> str:
         """Resolve HF model cache directory from config or default."""
         return get_hf_cache_dir(storeload_config)
+
+    async def pushasset_hfstore(
+        self: Self,
+        binding: Any,
+        binding_id: Optional[str] = "",
+        uri: Optional[Any] = None,
+        assetstore=None,
+        run_metadata=None,
+        storepush_config=None,
+        **_kwargs,
+    ) -> Any:
+        """Upload a local file/dir to a HuggingFace repo (hf:// output).
+
+        Unlike Docker, the bash binding ``path`` is already a host path, so it is
+        pushed directly with no container-path translation. Delegates to the
+        shared :func:`push_asset_hfstore` helper.
+
+        :param binding: Dict carrying the artifact's local ``path``.
+        :param binding_id: Output binding name, included in the commit message.
+        :param uri: Target ``hf://`` URI (string or ``HfURI``).
+        :param assetstore: ``Hfstore`` whose secrets supply the HF token.
+        :param run_metadata: ``EntityRunMetadata`` with build/target identifiers.
+        :param storepush_config: Environment-level push config; ``mode`` must be
+            unset or ``"default"``.
+        :returns: The resolved ``HfURI`` after a successful push.
+        :raises ValueError: on a non-'default' mode, or a binding without 'path'.
+        """
+        self._require_default_mode(storepush_config, uri)
+        if not isinstance(binding, dict) or "path" not in binding:
+            raise ValueError(f"binding must be a dict with 'path', got: {binding}")
+        return push_asset_hfstore(
+            src=binding["path"],
+            binding_id=binding_id,
+            uri=uri,
+            assetstore=assetstore,
+            run_metadata=run_metadata,
+        )
 
     async def pushasset_filestore(
         self: Self,

--- a/src/gbserver/environment/docker.py
+++ b/src/gbserver/environment/docker.py
@@ -275,7 +275,7 @@ class Docker(Environment):
         the symlinks resolve inside the container.  Otherwise we mount the
         snapshot directory directly (non-HF-cache paths, tests, etc.).
         """
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         assert assetstore is not None, "assetstore is required for hfstore loading"
         local_path = pull_asset_hfstore(uri, assetstore, storeload_config)
         relpath = assetstore.get_relpath(uri)
@@ -350,7 +350,7 @@ class Docker(Environment):
             ValueError: If ``uri`` is absent or ``binding`` has no ``"path"``.
             RuntimeError: If the push itself fails.
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if not isinstance(binding, dict) or "path" not in binding:
             raise ValueError(f"binding must be a dict with 'path', got: {binding}")
         host_path = self._resolve_host_path(binding["path"])
@@ -727,7 +727,7 @@ class Docker(Environment):
         translates the container path to the host path and copies to the
         output URI location.
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if uri is None:
             return None
 

--- a/src/gbserver/environment/docker.py
+++ b/src/gbserver/environment/docker.py
@@ -275,6 +275,7 @@ class Docker(Environment):
         the symlinks resolve inside the container.  Otherwise we mount the
         snapshot directory directly (non-HF-cache paths, tests, etc.).
         """
+        self._require_default_mode(storeload_config, uri)
         assert assetstore is not None, "assetstore is required for hfstore loading"
         local_path = pull_asset_hfstore(uri, assetstore, storeload_config)
         relpath = assetstore.get_relpath(uri)
@@ -323,6 +324,7 @@ class Docker(Environment):
         uri: Optional[Any] = None,
         assetstore=None,
         run_metadata=None,
+        storepush_config=None,
         **_kwargs,
     ) -> Any:
         """Upload a local file or directory to a HuggingFace repo.
@@ -348,6 +350,7 @@ class Docker(Environment):
             ValueError: If ``uri`` is absent or ``binding`` has no ``"path"``.
             RuntimeError: If the push itself fails.
         """
+        self._require_default_mode(storepush_config, uri)
         if not isinstance(binding, dict) or "path" not in binding:
             raise ValueError(f"binding must be a dict with 'path', got: {binding}")
         host_path = self._resolve_host_path(binding["path"])
@@ -714,6 +717,7 @@ class Docker(Environment):
         self: Self,
         binding: Any,
         uri: Optional[Any] = None,
+        storepush_config=None,
         **kwargs,
     ) -> Any:
         """Push an artifact from a Docker container workspace to a file URI.
@@ -723,6 +727,7 @@ class Docker(Environment):
         translates the container path to the host path and copies to the
         output URI location.
         """
+        self._require_default_mode(storepush_config, uri)
         if uri is None:
             return None
 

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -1160,6 +1160,24 @@ class Environment(ABC):
                 )
         return t1, t2
 
+    def _require_default_mode(self: Self, store_config: Any, uri: Any) -> None:
+        """Enforce that a non-k8s assetstore load/push declares no special mode.
+
+        Outside k8s the assetstore ``mode`` field is not meaningful: dispatch is
+        by store *type*, not ``mode``. This validator keeps the invariant that
+        only ``"default"`` (or unset) is accepted so that mode-specific values
+        (``hf_pull``, ``dmf_pull``, ``afm_mount``, ...) are confined to k8s.
+
+        :param store_config: the StoreLoad/StorePush entry (or None).
+        :param uri: the asset uri, for the error message.
+        :raises ValueError: if store_config.mode is set to anything but "default".
+        """
+        if store_config is not None and store_config.mode not in (None, "default"):
+            raise ValueError(
+                f"assetstore '{uri}' declares mode '{store_config.mode}', but "
+                f"{type(self).__name__} supports only 'default' (or unset)."
+            )
+
     def pullasset(
         self: Self, task_group: TaskGroup, uri: URI, binding: Optional[Any] = None
     ) -> Task[Tuple[Dict, Optional[BuildTargetStepConfig]]]:
@@ -1633,6 +1651,7 @@ class Environment(ABC):
         survives intact — unlike env://, which reconstructs the path from the
         URI string and would mangle it. Returns the consumer-facing binding.
         """
+        self._require_default_mode(storeload_config, uri)
         state = self.shared_mem_store.get(str(uri))
         logger.info("pullasset_memstore: uri=%s state=%s", uri, state)
         binding_config = {"binding": {"state": state}}
@@ -1657,6 +1676,7 @@ class Environment(ABC):
         to pass values (e.g. a service URL) that must not go through filesystem
         URI normalisation.
         """
+        self._require_default_mode(storepush_config, uri)
         if not uri:
             raise ValueError(
                 f"pushasset_memstore: empty uri for binding={binding_id!r}; "
@@ -1701,6 +1721,7 @@ class Environment(ABC):
         # avoids any import-order risk and matches the lazy-import style used here.
         from gbcommon.uri.env import EnvURI
 
+        self._require_default_mode(storeload_config, uri)
         assert uri is not None, "pullasset_envstore requires a non-empty env:// uri"
         envuri = uri if isinstance(uri, URI) else URI.get_uri(uri)
         assert isinstance(envuri, EnvURI), f"invalid envuri: {envuri}"
@@ -1748,6 +1769,7 @@ class Environment(ABC):
             normally rejects these at load; this guards paths reaching the store
             another way).
         """
+        self._require_default_mode(storepush_config, uri)
         if not uri:
             raise ValueError(
                 f"pushasset_envstore: empty uri for binding={binding_id!r}; "

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -658,7 +658,7 @@ class Environment(ABC):
             return
         self.supported_assetstores[assetstore] = AssetStoreEnvironmentConfig(
             store_uri="env://",
-            load=[StoreLoad(mode="default")],
+            pull=[StoreLoad(mode="default")],
             push=[StorePush(mode="default")],
         )
 
@@ -747,7 +747,7 @@ class Environment(ABC):
             return
         self.supported_assetstores[assetstore] = AssetStoreEnvironmentConfig(
             store_uri="mem://",
-            load=[StoreLoad(mode="default")],
+            pull=[StoreLoad(mode="default")],
             push=[StorePush(mode="default")],
         )
 
@@ -1204,10 +1204,10 @@ class Environment(ABC):
             assetstore_type = assetstore.type.lower()
             try:
                 storeload_config = (
-                    assetstoreenv_config.load[0]
+                    assetstoreenv_config.pull[0]
                     if (
-                        assetstoreenv_config.load is not None
-                        and len(assetstoreenv_config.load) > 0
+                        assetstoreenv_config.pull is not None
+                        and len(assetstoreenv_config.pull) > 0
                     )
                     else None
                 )

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -1160,22 +1160,28 @@ class Environment(ABC):
                 )
         return t1, t2
 
-    def _require_default_mode(self: Self, store_config: Any, uri: Any) -> None:
-        """Enforce that a non-k8s assetstore load/push declares no special mode.
+    def _warn_non_default_mode(self: Self, store_config: Any, uri: Any) -> None:
+        """Warn (do not fail) when a non-k8s assetstore declares a special mode.
 
         Outside k8s the assetstore ``mode`` field is not meaningful: dispatch is
-        by store *type*, not ``mode``. This validator keeps the invariant that
-        only ``"default"`` (or unset) is accepted so that mode-specific values
-        (``hf_pull``, ``dmf_pull``, ``afm_mount``, ...) are confined to k8s.
+        by store *type*, not ``mode``, so any value behaves identically. The
+        preferred value is ``"default"`` (or unset); anything else is accepted for
+        backwards compatibility with existing space configs (which may still carry
+        legacy values like ``hf_pull``/``dmf_pull``/``cos_pull``) but logs a
+        deprecation warning recommending ``"default"``. Mode-specific behavior only
+        exists in k8s.
 
         :param store_config: the StoreLoad/StorePush entry (or None).
-        :param uri: the asset uri, for the error message.
-        :raises ValueError: if store_config.mode is set to anything but "default".
+        :param uri: the asset uri, for the warning message.
         """
         if store_config is not None and store_config.mode not in (None, "default"):
-            raise ValueError(
-                f"assetstore '{uri}' declares mode '{store_config.mode}', but "
-                f"{type(self).__name__} supports only 'default' (or unset)."
+            logger.warning(
+                "assetstore '%s' declares mode '%s', which %s ignores (dispatch is "
+                "by store type, not mode). Set mode to 'default' (or omit it); "
+                "non-default modes are deprecated outside k8s.",
+                uri,
+                store_config.mode,
+                type(self).__name__,
             )
 
     def pullasset(
@@ -1651,7 +1657,7 @@ class Environment(ABC):
         survives intact — unlike env://, which reconstructs the path from the
         URI string and would mangle it. Returns the consumer-facing binding.
         """
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         state = self.shared_mem_store.get(str(uri))
         logger.info("pullasset_memstore: uri=%s state=%s", uri, state)
         binding_config = {"binding": {"state": state}}
@@ -1676,7 +1682,7 @@ class Environment(ABC):
         to pass values (e.g. a service URL) that must not go through filesystem
         URI normalisation.
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if not uri:
             raise ValueError(
                 f"pushasset_memstore: empty uri for binding={binding_id!r}; "
@@ -1721,7 +1727,7 @@ class Environment(ABC):
         # avoids any import-order risk and matches the lazy-import style used here.
         from gbcommon.uri.env import EnvURI
 
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         assert uri is not None, "pullasset_envstore requires a non-empty env:// uri"
         envuri = uri if isinstance(uri, URI) else URI.get_uri(uri)
         assert isinstance(envuri, EnvURI), f"invalid envuri: {envuri}"
@@ -1769,7 +1775,7 @@ class Environment(ABC):
             normally rejects these at load; this guards paths reaching the store
             another way).
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if not uri:
             raise ValueError(
                 f"pushasset_envstore: empty uri for binding={binding_id!r}; "

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -2142,49 +2142,45 @@ class K8s(Environment):
     ) -> Tuple[Dict, Optional[BuildTargetStepConfig]]:
         """
         Pull a HuggingFace Hub asset (model/dataset/space) in a K8s container.
-        Supports mode: hf_pull
+
+        HF pull is the only behavior this store supports, so ``mode`` is not
+        consulted (it is advisory — set it to ``default`` in configs).
         """
         assert isinstance(assetstore, Hfstore), f"invalid assetstore: {assetstore}"
 
+        # Note: k8s handlers deliberately do NOT call _require_default_mode. That
+        # invariant ("mode must be unset or 'default'") is for non-k8s environments
+        # only — k8s genuinely branches on mode for the cos/lh stores
+        # (afm_mount/cos_mount/cos_pull/dmf_pull). hf has only one behavior (pull),
+        # so mode is ignored here for backwards compatibility: legacy 'hf_pull'
+        # configs and the new 'default' convention both keep working.
         if storeload_config is None or storeload_config.config is None:
             raise ValueError("storeload_config or storeload_config.config is None")
 
-        if storeload_config.mode == "hf_pull":
-            cache_path = storeload_config.config.get("cache_path", None)
-            if cache_path is None:
-                raise ValueError("Did not find 'cache_path' in storeload configuration")
+        cache_path = storeload_config.config.get("cache_path", None)
+        if cache_path is None:
+            raise ValueError("Did not find 'cache_path' in storeload configuration")
 
-            hf_uri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
-            binding_path = (
-                Path(cache_path)
-                / hf_uri.get_owner()
-                / hf_uri.get_repo()
-                / hf_uri.hash()
-            )
-            # binding_path.mkdir(parents=True, exist_ok=True)
-            hfpull_config = Hfstore.build_hfpull_step_config(
-                hfuri=hf_uri,
-                binding_path=str(binding_path),
-            )
+        hf_uri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
+        binding_path = (
+            Path(cache_path) / hf_uri.get_owner() / hf_uri.get_repo() / hf_uri.hash()
+        )
+        # binding_path.mkdir(parents=True, exist_ok=True)
+        hfpull_config = Hfstore.build_hfpull_step_config(
+            hfuri=hf_uri,
+            binding_path=str(binding_path),
+        )
 
-            # Binding config for container
-            binding_config = {BINDING_KEY: {"path": str(Path(binding_path))}}
-            hfpull_stepuri = "space://steps/hfpull"
-            if (
-                storeload_config is not None
-                and storeload_config.config is not None
-                and "step_uri" in storeload_config.config
-            ):
-                hfpull_stepuri = storeload_config.config["step_uri"]
+        # Binding config for container
+        binding_config = {BINDING_KEY: {"path": str(Path(binding_path))}}
+        hfpull_stepuri = storeload_config.config.get("step_uri", "space://steps/hfpull")
 
-            pull_step_config = BuildTargetStepConfig(
-                step_uri=hfpull_stepuri,
-                config={"hfpull_config": hfpull_config},
-            )
+        pull_step_config = BuildTargetStepConfig(
+            step_uri=hfpull_stepuri,
+            config={"hfpull_config": hfpull_config},
+        )
 
-            return binding_config, pull_step_config
-
-        raise ValueError(f"No known mode of loading {uri}")
+        return binding_config, pull_step_config
 
     async def pushasset_hfstore(
         self: Self,

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -2148,9 +2148,9 @@ class K8s(Environment):
         """
         assert isinstance(assetstore, Hfstore), f"invalid assetstore: {assetstore}"
 
-        # Note: k8s handlers deliberately do NOT call _require_default_mode. That
-        # invariant ("mode must be unset or 'default'") is for non-k8s environments
-        # only — k8s genuinely branches on mode for the cos/lh stores
+        # Note: k8s handlers deliberately do NOT call _warn_non_default_mode. That
+        # helper is for non-k8s environments (which ignore mode and warn on
+        # non-default) — k8s genuinely branches on mode for the cos/lh stores
         # (afm_mount/cos_mount/cos_pull/dmf_pull). hf has only one behavior (pull),
         # so mode is ignored here for backwards compatibility: legacy 'hf_pull'
         # configs and the new 'default' convention both keep working.

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -1115,7 +1115,7 @@ class Lsf(Environment):
             assetstore, Lhstore
         ), f"invalid type assetstore: {type(assetstore).__name__} (expected 'Lhstore')"
         assert storeload_config is not None, "storeload_config is None"
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         cache_path = storeload_config.config.get("cache_path", None)
         assert isinstance(cache_path, str), f"invalid cache_path: {cache_path}"
         assert cache_path != "", f"invalid cache_path: {cache_path}"
@@ -1169,7 +1169,7 @@ class Lsf(Environment):
         """
         Allow for a random folder/file to be copied from any mounted storage in the cluster to a lh bucket
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
         lhuri = uri if isinstance(uri, URI) else URI.get_uri(uri)
@@ -1252,7 +1252,7 @@ class Lsf(Environment):
             assetstore, Hfstore
         ), f"invalid type assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
         assert storeload_config is not None, "storeload_config is None"
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
         cache_path = storeload_config.config.get("cache_path", None)
         assert isinstance(cache_path, str), f"invalid cache_path: {cache_path}"
         assert cache_path != "", f"invalid cache_path: {cache_path}"
@@ -1322,7 +1322,7 @@ class Lsf(Environment):
                 or storepush_config declares a non-'default' mode.
             AssertionError: If binding has no 'path'.
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
         hfuri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
@@ -1462,7 +1462,7 @@ class Lsf(Environment):
             assetstore, Cosstore
         ), f"invalid type assetstore: {assetstore}"
         assert storeload_config is not None, "storeload_config is None"
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
 
         cosuri = uri if isinstance(uri, URI) else URI.get_uri(uri)
         assert isinstance(cosuri, CosURI), f"invalid cosuri: {cosuri}"
@@ -1512,7 +1512,7 @@ class Lsf(Environment):
         """
         Copy folder/file from cluster filesystem to a COS bucket.
         """
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
 

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -1115,9 +1115,7 @@ class Lsf(Environment):
             assetstore, Lhstore
         ), f"invalid type assetstore: {type(assetstore).__name__} (expected 'Lhstore')"
         assert storeload_config is not None, "storeload_config is None"
-        assert (
-            storeload_config.mode == "dmf_pull"
-        ), f"Only 'dmf_pull' mode is supported for Lsf, mode: {storeload_config.mode} uri: {uri}"
+        self._require_default_mode(storeload_config, uri)
         cache_path = storeload_config.config.get("cache_path", None)
         assert isinstance(cache_path, str), f"invalid cache_path: {cache_path}"
         assert cache_path != "", f"invalid cache_path: {cache_path}"
@@ -1171,6 +1169,7 @@ class Lsf(Environment):
         """
         Allow for a random folder/file to be copied from any mounted storage in the cluster to a lh bucket
         """
+        self._require_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
         lhuri = uri if isinstance(uri, URI) else URI.get_uri(uri)
@@ -1240,21 +1239,20 @@ class Lsf(Environment):
         Args:
             uri: HF URI to pull (e.g. hf://models/org/repo).
             binding: Unused for hfpull.
-            storeload_config: Must have mode 'hf_pull' and config with 'cache_path'.
+            storeload_config: config with 'cache_path'; mode must be unset or 'default'.
             assetstore: Hfstore instance.
             secrets: Optional secrets dict.
         Returns:
             Tuple of (binding_config, BuildTargetStepConfig).
         Raises:
-            AssertionError: If assetstore type or mode is invalid.
+            AssertionError: If assetstore type is invalid.
+            ValueError: If storeload_config declares a non-'default' mode.
         """
         assert isinstance(
             assetstore, Hfstore
         ), f"invalid type assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
         assert storeload_config is not None, "storeload_config is None"
-        assert (
-            storeload_config.mode == "hf_pull"
-        ), f"Only 'hf_pull' mode is supported for Lsf, mode: {storeload_config.mode} uri: {uri}"
+        self._require_default_mode(storeload_config, uri)
         cache_path = storeload_config.config.get("cache_path", None)
         assert isinstance(cache_path, str), f"invalid cache_path: {cache_path}"
         assert cache_path != "", f"invalid cache_path: {cache_path}"
@@ -1320,9 +1318,11 @@ class Lsf(Environment):
         Returns:
             BuildTargetStepConfig for the hfpush step.
         Raises:
-            ValueError: If uri is empty or the resource group cannot be resolved.
+            ValueError: If uri is empty, the resource group cannot be resolved,
+                or storepush_config declares a non-'default' mode.
             AssertionError: If binding has no 'path'.
         """
+        self._require_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
         hfuri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
@@ -1462,9 +1462,7 @@ class Lsf(Environment):
             assetstore, Cosstore
         ), f"invalid type assetstore: {assetstore}"
         assert storeload_config is not None, "storeload_config is None"
-        assert (
-            storeload_config.mode == "cos_pull"
-        ), f"Only 'cos_pull' mode is supported for COS in LSF. Got: {storeload_config.mode}"
+        self._require_default_mode(storeload_config, uri)
 
         cosuri = uri if isinstance(uri, URI) else URI.get_uri(uri)
         assert isinstance(cosuri, CosURI), f"invalid cosuri: {cosuri}"
@@ -1514,6 +1512,7 @@ class Lsf(Environment):
         """
         Copy folder/file from cluster filesystem to a COS bucket.
         """
+        self._require_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -1894,7 +1894,7 @@ class Skypilot(Environment):
             assetstore, Hfstore
         ), f"invalid assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
 
-        self._require_default_mode(storeload_config, uri)
+        self._warn_non_default_mode(storeload_config, uri)
 
         hfuri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
         shared_workdir = (
@@ -1984,7 +1984,7 @@ class Skypilot(Environment):
         from gbcommon.uri.hf import HfURI
         from gbserver.asset.hfstore import Hfstore
 
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
         hfuri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
@@ -2084,7 +2084,7 @@ class Skypilot(Environment):
         from gbcommon.uri.cos import CosURI
         from gbserver.asset.asset import Asset
 
-        self._require_default_mode(storepush_config, uri)
+        self._warn_non_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received for pushasset: {binding}")
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -516,7 +516,9 @@ class Skypilot(Environment):
         except ValueError:
             return None
 
-    def _resources_from_compute_config(self: Self, compute_config: Dict) -> Dict:
+    def _resources_from_compute_config(
+        self: Self, compute_config: Dict, cloud: str = ""
+    ) -> Dict:
         """Derive a ``sky.Resources`` floor from a step's ``compute_config``.
 
         Reads the raw dict (NOT the :class:`ComputeConfig` model, whose defaults
@@ -526,6 +528,7 @@ class Skypilot(Environment):
         that crashes SkyPilot's LSF cloud.
 
         :param compute_config: the step's ``config.compute_config`` dict.
+        :param cloud: the resolved SkyPilot cloud (e.g. ``"slurm"``, ``"k8s"``).
         :returns: a dict optionally containing ``cpus`` (int, when
             ``num_cpus_per_node`` > 0) and ``memory`` (float GiB, when
             ``total_memory_per_node`` parses).
@@ -534,9 +537,17 @@ class Skypilot(Environment):
         num_cpus = compute_config.get("num_cpus_per_node", 0)
         if isinstance(num_cpus, int) and num_cpus > 0:
             resources["cpus"] = num_cpus
-        memory = self._parse_memory_gib(compute_config.get("total_memory_per_node", ""))
-        if memory is not None:
-            resources["memory"] = memory
+        # SLURM clusters commonly don't track memory as a consumable resource
+        # (RealMemory unset in slurm.conf), so a --memory request fails at resource
+        # matching ("Catalog does not contain any instances satisfying ..."). Skip
+        # the compute_config memory floor on slurm; an explicit launcher/build
+        # resources.memory still applies (and works where RealMemory is configured).
+        if cloud != "slurm":
+            memory = self._parse_memory_gib(
+                compute_config.get("total_memory_per_node", "")
+            )
+            if memory is not None:
+                resources["memory"] = memory
         return resources
 
     async def launch_skypilot(
@@ -627,7 +638,7 @@ class Skypilot(Environment):
             # (config.)launcher_config.resources.accelerators.
             compute_config = config.get("compute_config", {}) or {}
             res_config = {
-                **self._resources_from_compute_config(compute_config),
+                **self._resources_from_compute_config(compute_config, cloud=cloud),
                 **launcher_config.get("resources", {}),
                 **config.get("launcher_config", {}).get("resources", {}),
             }

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -105,6 +105,13 @@ def _download_logs_with_retry(cluster_name: str, job_id: int):
 # finally, so this should never actually trip.
 RETRY_RELAUNCH_TIMEOUT_SECONDS = 1800
 
+# SSH-provisioned bare HPC schedulers. They don't support SkyPilot autostop, and
+# commonly don't track memory as a consumable resource (RealMemory unset in
+# slurm.conf), so a --memory request fails resource matching. Cloud-specific
+# handling groups them: skip the compute_config memory floor and force autostop
+# off. Compared against the normalized first infra segment (lowercased).
+_SSH_HPC_CLOUDS = ("slurm", "lsf")
+
 # Per-step log-retrieval modes, selected via the ``log_retrieval.mode`` key in
 # the skypilot_monitor config. See _parse_log_retrieval for semantics.
 LOG_RETRIEVAL_ON_COMPLETION = "on_completion"
@@ -528,7 +535,8 @@ class Skypilot(Environment):
         that crashes SkyPilot's LSF cloud.
 
         :param compute_config: the step's ``config.compute_config`` dict.
-        :param cloud: the resolved SkyPilot cloud (e.g. ``"slurm"``, ``"k8s"``).
+        :param cloud: the normalized target cloud (lowercased first infra
+            segment, e.g. ``"slurm"``, ``"lsf"``, ``"k8s"``).
         :returns: a dict optionally containing ``cpus`` (int, when
             ``num_cpus_per_node`` > 0) and ``memory`` (float GiB, when
             ``total_memory_per_node`` parses).
@@ -537,12 +545,13 @@ class Skypilot(Environment):
         num_cpus = compute_config.get("num_cpus_per_node", 0)
         if isinstance(num_cpus, int) and num_cpus > 0:
             resources["cpus"] = num_cpus
-        # SLURM clusters commonly don't track memory as a consumable resource
-        # (RealMemory unset in slurm.conf), so a --memory request fails at resource
-        # matching ("Catalog does not contain any instances satisfying ..."). Skip
-        # the compute_config memory floor on slurm; an explicit launcher/build
-        # resources.memory still applies (and works where RealMemory is configured).
-        if cloud != "slurm":
+        # SLURM/LSF (bare HPC schedulers) commonly don't track memory as a
+        # consumable resource (RealMemory unset in slurm.conf), so a --memory
+        # request fails at resource matching ("Catalog does not contain any
+        # instances satisfying ..."). Skip the compute_config memory floor for
+        # them; an explicit launcher/build resources.memory still applies (and
+        # works on clusters that do configure memory).
+        if cloud not in _SSH_HPC_CLOUDS:
             memory = self._parse_memory_gib(
                 compute_config.get("total_memory_per_node", "")
             )
@@ -630,33 +639,48 @@ class Skypilot(Environment):
                 "idle_minutes_to_autostop", self._get_idle_minutes()
             )
 
-            # Build sky.Resources — merge order is precedence (last wins). The
-            # step's config.compute_config (num_cpus_per_node/total_memory_per_node)
-            # is the lowest-precedence floor; the step's launcher resources and then
-            # the build's config.launcher_config.resources override it. GPUs/
-            # accelerators are not sourced from compute_config — they flow via
-            # (config.)launcher_config.resources.accelerators.
+            # Higher-precedence resource layers that override the compute_config
+            # floor. infra/cluster/zone come only from these (never the floor), so
+            # the target cloud can be resolved before the floor is layered in.
             compute_config = config.get("compute_config", {}) or {}
-            res_config = {
-                **self._resources_from_compute_config(compute_config, cloud=cloud),
+            override_res = {
                 **launcher_config.get("resources", {}),
                 **config.get("launcher_config", {}).get("resources", {}),
             }
 
             # Build infra string: supports 'cloud/cluster/partition' format
             # (e.g., 'slurm/mycluster/gpu', 'lsf/bluevela/normal')
-            infra = res_config.get("infra") or cloud
-            zone = res_config.get("zone")
-            if not res_config.get("infra") and res_config.get("cluster"):
-                infra = f"{cloud}/{res_config['cluster']}"
+            infra = override_res.get("infra") or cloud
+            zone = override_res.get("zone")
+            if not override_res.get("infra") and override_res.get("cluster"):
+                infra = f"{cloud}/{override_res['cluster']}"
                 if zone:
                     infra = f"{infra}/{zone}"
                     zone = None
-            elif not res_config.get("infra") and zone:
+            elif not override_res.get("infra") and zone:
                 # zone without cluster — fold into infra to avoid the
                 # "cannot specify both infra and zone" error in sky.Resources
                 infra = f"{infra}/{zone}" if infra else zone
                 zone = None
+
+            # Normalized target cloud: the first infra segment, lowercased — the
+            # single source of truth for cloud-specific resource handling (the
+            # slurm/lsf memory skip in the floor below, and autostop later). Using
+            # the resolved infra matches what SkyPilot actually provisions for
+            # `infra: "slurm/..."`, an explicit `resources.cloud`, or non-canonical
+            # casing — not just the env's default_cloud.
+            cloud_group = (str(infra).split("/", 1)[0] or "").lower()
+
+            # Build sky.Resources — merge order is precedence (last wins). The
+            # step's config.compute_config (num_cpus_per_node/total_memory_per_node)
+            # is the lowest-precedence floor; override_res wins. GPUs/accelerators
+            # are not sourced from compute_config — they flow via override_res.
+            res_config = {
+                **self._resources_from_compute_config(
+                    compute_config, cloud=cloud_group
+                ),
+                **override_res,
+            }
 
             # Build cluster config overrides (docker run_options, etc.)
             # SkyPilot's top-level `config:` section maps to
@@ -829,10 +853,9 @@ class Skypilot(Environment):
             # SLURM and LSF do not support autostop; passing any non-None
             # value (including 0) fails provisioning. Per-step `sky down`
             # cleanup handles teardown anyway, so force None on these
-            # backends regardless of the user's config.
-            cloud_for_infra = (str(infra).split("/", 1)[0] or "").lower()
-            no_autostop_clouds = ("slurm", "lsf")
-            autostop = None if cloud_for_infra in no_autostop_clouds else idle_minutes
+            # backends regardless of the user's config. Reuses cloud_group
+            # (normalized first infra segment) computed above.
+            autostop = None if cloud_group in _SSH_HPC_CLOUDS else idle_minutes
 
             # Launch and wait for provisioning, retrying transient
             # resource-acquisition failures (e.g. a just-torn-down slurm/lsf

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -1894,11 +1894,7 @@ class Skypilot(Environment):
             assetstore, Hfstore
         ), f"invalid assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
 
-        if storeload_config is not None and storeload_config.mode not in (
-            None,
-            "hf_pull",
-        ):
-            raise ValueError(f"unsupported storeload mode: {storeload_config.mode}")
+        self._require_default_mode(storeload_config, uri)
 
         hfuri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
         shared_workdir = (
@@ -1988,6 +1984,7 @@ class Skypilot(Environment):
         from gbcommon.uri.hf import HfURI
         from gbserver.asset.hfstore import Hfstore
 
+        self._require_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received to pushasset {binding}")
         hfuri = uri if isinstance(uri, HfURI) else HfURI.parse(uri)  # type: ignore[arg-type]
@@ -2087,6 +2084,7 @@ class Skypilot(Environment):
         from gbcommon.uri.cos import CosURI
         from gbserver.asset.asset import Asset
 
+        self._require_default_mode(storepush_config, uri)
         if uri is None or uri == "":
             raise ValueError(f"Empty uri received for pushasset: {binding}")
 

--- a/src/gbserver/types/environmentconfig.py
+++ b/src/gbserver/types/environmentconfig.py
@@ -18,11 +18,15 @@
 The environment type.
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from gbserver.types.config import Config
+
+# Module-local logger (standard logging) to avoid a types -> gbserver.utils import cycle.
+logger = logging.getLogger(__name__)
 
 ENVIRONMENT_FILENAME = "environment.yaml"
 
@@ -74,11 +78,12 @@ class AwsCredentialProfile(Config):
 
 
 class StoreLoad(Config):
-    # ``mode`` selects *how* an asset is loaded, but this is only meaningful in
-    # k8s (afm_mount/cos_mount/cos_pull/dmf_pull/hf_pull branch there). Every
-    # other environment dispatches by store *type* and ignores ``mode``; the
-    # preferred value is ``"default"`` (or unset), and non-default values are
-    # accepted for backwards compatibility but log a deprecation warning
+    # Type of the ``pull`` entries on an assetstore (the input side). ``mode``
+    # selects *how* an asset is loaded, but this is only meaningful in k8s
+    # (afm_mount/cos_mount/cos_pull/dmf_pull/hf_pull branch there). Every other
+    # environment dispatches by store *type* and ignores ``mode``; the preferred
+    # value is ``"default"`` (or unset), and non-default values are accepted for
+    # backwards compatibility but log a deprecation warning
     # (see Environment._warn_non_default_mode).
     mode: Optional[str] = None
     config: Dict = Field(default_factory=dict)
@@ -93,8 +98,36 @@ class StorePush(Config):
 
 class AssetStoreEnvironmentConfig(Config):
     store_uri: str = ""
-    load: List[StoreLoad] = Field(default_factory=list)
+    # ``pull`` (input) pairs with ``push`` (output) and matches the
+    # ``pullasset_*``/``pushasset_*`` handler names. The key was formerly ``load``;
+    # see ``_accept_legacy_load_key`` for the deprecated alias.
+    pull: List[StoreLoad] = Field(default_factory=list)
     push: List[StorePush] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_load_key(cls, data: Any) -> Any:
+        """Accept the pre-rename ``load`` key as a deprecated alias for ``pull``.
+
+        The assetstore input key was renamed ``load`` -> ``pull``. Existing space
+        configs may still use ``load``; map it onto ``pull`` and warn, rather than
+        failing, so those configs keep working.
+
+        :param data: the raw input for this model (a dict when parsed from YAML).
+        :returns: the (possibly rewritten) input.
+        """
+        if isinstance(data, dict) and "load" in data:
+            if "pull" not in data:
+                data["pull"] = data.pop("load")
+            else:
+                # Both given: prefer the explicit ``pull`` and drop the legacy key.
+                data.pop("load")
+            logger.warning(
+                "assetstores entry '%s': the 'load' key is deprecated; rename it to "
+                "'pull' ('load' still works for now).",
+                data.get("store_uri", ""),
+            )
+        return data
 
 
 class EnvironmentConfig(Config):

--- a/src/gbserver/types/environmentconfig.py
+++ b/src/gbserver/types/environmentconfig.py
@@ -76,15 +76,17 @@ class AwsCredentialProfile(Config):
 class StoreLoad(Config):
     # ``mode`` selects *how* an asset is loaded, but this is only meaningful in
     # k8s (afm_mount/cos_mount/cos_pull/dmf_pull/hf_pull branch there). Every
-    # other environment dispatches by store *type* and enforces the invariant
-    # that ``mode`` is unset or ``"default"`` (see Environment._require_default_mode).
+    # other environment dispatches by store *type* and ignores ``mode``; the
+    # preferred value is ``"default"`` (or unset), and non-default values are
+    # accepted for backwards compatibility but log a deprecation warning
+    # (see Environment._warn_non_default_mode).
     mode: Optional[str] = None
     config: Dict = Field(default_factory=dict)
 
 
 class StorePush(Config):
-    # See StoreLoad.mode: advisory except in k8s; non-k8s environments accept
-    # only ``"default"`` (or unset).
+    # See StoreLoad.mode: meaningful only in k8s; non-k8s environments ignore it
+    # (prefer ``"default"``; legacy values warn but are accepted).
     mode: Optional[str] = None
     config: Dict = Field(default_factory=dict)
 

--- a/src/gbserver/types/environmentconfig.py
+++ b/src/gbserver/types/environmentconfig.py
@@ -74,11 +74,17 @@ class AwsCredentialProfile(Config):
 
 
 class StoreLoad(Config):
+    # ``mode`` selects *how* an asset is loaded, but this is only meaningful in
+    # k8s (afm_mount/cos_mount/cos_pull/dmf_pull/hf_pull branch there). Every
+    # other environment dispatches by store *type* and enforces the invariant
+    # that ``mode`` is unset or ``"default"`` (see Environment._require_default_mode).
     mode: Optional[str] = None
     config: Dict = Field(default_factory=dict)
 
 
 class StorePush(Config):
+    # See StoreLoad.mode: advisory except in k8s; non-k8s environments accept
+    # only ``"default"`` (or unset).
     mode: Optional[str] = None
     config: Dict = Field(default_factory=dict)
 

--- a/test-data/e2e/standalone/standalone-quickstart/environments/bash/environment.yaml
+++ b/test-data/e2e/standalone/standalone-quickstart/environments/bash/environment.yaml
@@ -3,11 +3,11 @@ type: Bash
 config: {}
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
   # Local filesystem — load/push artifacts via file: URIs (builtin file store).
   - store_uri: space://assetstores/file/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/test-data/e2e/standalone/standalone-quickstart/environments/docker/environment.yaml
+++ b/test-data/e2e/standalone/standalone-quickstart/environments/docker/environment.yaml
@@ -6,7 +6,7 @@ config:
     env: {}
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
   # Docker implements file: push only (no pullasset_filestore).
   - store_uri: space://assetstores/file/

--- a/test-data/e2e/standalone/standalone-quickstart/environments/runpod/environment.yaml
+++ b/test-data/e2e/standalone/standalone-quickstart/environments/runpod/environment.yaml
@@ -11,7 +11,7 @@ config:
     volume_mount_path: "/workspace"
 assetstores:
   - store_uri: space://assetstores/s3/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/test-data/e2e/standalone/standalone-quickstart/environments/skypilot/environment.yaml
+++ b/test-data/e2e/standalone/standalone-quickstart/environments/skypilot/environment.yaml
@@ -12,7 +12,7 @@ config:
   idle_minutes_to_autostop: 5
 assetstores:
   - store_uri: space://assetstores/s3/
-    load:
+    pull:
       - mode: default
         config: {}
     push:

--- a/test-data/integration/standalone/buildrunner/bash/1step/build.yaml
+++ b/test-data/integration/standalone/buildrunner/bash/1step/build.yaml
@@ -1,15 +1,19 @@
 granite.build:
   name: env_in_out_bash
-  # Single bash target exercising the env:// asset store for BOTH an input and an
-  # output on the in-process Bash environment. env:// push/pull are shared-FS
-  # no-ops (pullasset_envstore / pushasset_envstore, inherited from the base
-  # Environment), so no files are transferred:
-  #   - env_input is pulled as a no-op; its path is available to the command via
-  #     {{ bindings.env_input.binding.path }} (the path need not exist, since
-  #     EnvURI.exists()/pull() are stubs).
-  #   - env_output is registered inline from the LLMB_ARTIFACT marker the command
-  #     emits (the bash `command` step's log_monitor parses it into a
-  #     NEWARTIFACT_IN_ENVIRONMENT_EVENT).
+  # Single bash target exercising BOTH the env:// and hf:// asset stores for an
+  # input and an output on the in-process Bash environment.
+  #
+  # This is an extended/nightly test (see the @extended_testing_only marker on the
+  # test class): it performs a REAL HuggingFace pull and push using the CI HF_TOKEN
+  # secret, mirroring the docker-hf fixture. env:// push/pull are shared-FS no-ops
+  # (pullasset_envstore / pushasset_envstore); hf:// pull/push go through the Bash
+  # pullasset_hfstore / pushasset_hfstore handlers.
+  #   - env_input / hf_input: env pull is a no-op; hf_input is really downloaded
+  #     (small model). Both paths flow to the command via {{ bindings.<name>.binding.path }}.
+  #   - env_output / hf_output are registered inline from the LLMB_ARTIFACT markers
+  #     the command emits (the bash `command` step's log_monitor parses each into a
+  #     NEWARTIFACT_IN_ENVIRONMENT_EVENT). env push is a no-op (no file needed);
+  #     hf_output is really pushed, so the command writes a non-empty file for it.
   targets:
     command:
       allow_unknown: true
@@ -19,6 +23,10 @@ granite.build:
           # Arbitrary fixed shared-FS path; the value isn't tested (pull is a
           # no-op), it just flows to the command as bindings.env_input.binding.path.
           uri: "env:///tmp/gb-env-input.txt"
+        hf_input:
+          # HF pull is mocked, so nothing is downloaded; the resolved cache path
+          # flows to the command as bindings.hf_input.binding.path.
+          uri: hf:///ibm-granite/granite-4.0-350m
       outputs:
         env_output:
           # Arbitrary fixed path; the command just echoes it in the LLMB_ARTIFACT
@@ -26,12 +34,28 @@ granite.build:
           # check), so no file is actually created — the path value isn't tested.
           uri: "env:///tmp/gb-env-output.txt"
           type: fileset
+        hf_output:
+          # Real HF push in the extended/nightly suite (uses the CI HF_TOKEN
+          # secret), mirroring the docker-hf fixture. short_hash keeps the repo
+          # name unique per run. The command below writes a real, non-empty file
+          # for this output because HfURI.push() reads it (existence + non-empty
+          # checks); env push, by contrast, is a shared-FS no-op.
+          uri: hf://huggingface.co/datasets/ibm-research/gb-bash-1step-out_{{ binding.path | short_hash }}
+          type: fileset
       steps:
         - step_uri: space://steps/command
           config:
             command_config:
+              # Create the HF output artifact in the step's current working
+              # directory (a per-build workspace), not /tmp, and emit its absolute
+              # path in the LLMB_ARTIFACT marker so the HF push can read it. The
+              # env_output path is arbitrary (env push is a no-op, no file needed).
               command: >-
+                hf_out="$(pwd)/gb-hf-output.txt";
+                echo '{"artifact": "hf_output"}' > "$hf_out";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
-                echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-env-output.txt"
+                echo "hf input path: {{ bindings.hf_input.binding.path }}";
+                echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-env-output.txt";
+                echo "LLMB_ARTIFACT_ID:hf_output LLMB_ARTIFACT_PATH:$hf_out"
             compute_config:
               num_nodes: 1

--- a/test-data/integration/standalone/buildrunner/bash/1step/buildtest.yaml
+++ b/test-data/integration/standalone/buildrunner/bash/1step/buildtest.yaml
@@ -5,17 +5,18 @@ targets:
   - command
 target_expectations:
   - target_name: command
-    # One `command` step. env:// input + output are shared-FS no-ops: they add
-    # one input and one output artifact but launch no extra pull/push step, so
-    # step_count stays 1. The env:// output produces one jobstat/lineage record.
+    # One `command` step. Both the env:// and hf:// pull/push are inline (env is a
+    # shared-FS no-op; the bash hf handlers return a binding/URI directly), so they
+    # add input/output artifacts but launch NO extra pull/push step — step_count
+    # stays 1. Two inputs (env_input + hf_input) and two outputs (env_output +
+    # hf_output) are registered.
     # NOTE: in this in-process standalone run the lineage store is a
     # NoopLineageStore, so _verify_target_lineage skips the jobstats_count
-    # assertion entirely (see buildtest.py); the value 1 documents the real count
-    # for environments that have a lineage store configured.
+    # assertion entirely (see buildtest.py); the value below is documentary only.
     step_count: 1
-    input_artifact_count: 1
-    output_artifact_count: 1
-    jobstats_count: 1
+    input_artifact_count: 2
+    output_artifact_count: 2
+    jobstats_count: 2
 # Use the shared standalone space at <repo>/configurations/spaces/local so the BuildRunner
 # resolves space:// URIs (the bash environment and the command step) without
 # cloning from GitHub.  Relative path resolves against this YAML's directory.

--- a/test-data/standalone-environments/environments/bash/environment.yaml
+++ b/test-data/standalone-environments/environments/bash/environment.yaml
@@ -3,11 +3,11 @@ type: Bash
 config: {}
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
   # Local filesystem — load/push artifacts via file: URIs (builtin file store).
   - store_uri: space://assetstores/file/
-    load:
+    pull:
       - mode: default
     push:
       - mode: default

--- a/test-data/standalone-environments/environments/docker/environment.yaml
+++ b/test-data/standalone-environments/environments/docker/environment.yaml
@@ -6,7 +6,7 @@ config:
     env: {}
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
   # Docker implements file: push only (no pullasset_filestore).
   - store_uri: space://assetstores/file/

--- a/test-data/standalone-environments/environments/slurm/environment.yaml
+++ b/test-data/standalone-environments/environments/slurm/environment.yaml
@@ -18,7 +18,7 @@ config:
         UserKnownHostsFile: /dev/null
 assetstores:
   - store_uri: space://assetstores/hf/
-    load:
+    pull:
       - mode: default
   - store_uri: space://assetstores/cos/
     push:

--- a/test-data/standalone-environments/environments/slurm/environment.yaml
+++ b/test-data/standalone-environments/environments/slurm/environment.yaml
@@ -19,7 +19,7 @@ config:
 assetstores:
   - store_uri: space://assetstores/hf/
     load:
-      - mode: hf_pull
+      - mode: default
   - store_uri: space://assetstores/cos/
     push:
       - mode: default

--- a/test/integration/standalone/buildrunner/bash/test_buildrunner_1step_local.py
+++ b/test/integration/standalone/buildrunner/bash/test_buildrunner_1step_local.py
@@ -19,13 +19,18 @@ from libgbtest.buildrunner.buildtest import (
     AbstractYamlBuildRunnerTest,
     get_test_data_dir_for,
 )
+from libgbtest.constants import extended_testing_only
 
 pytestmark = pytest.mark.standalone
 
 
+# Extended/nightly test: the fixture performs a REAL HuggingFace pull + push
+# (using the CI HF_TOKEN secret), so it can't run in the fast/mock suites — it is
+# excluded from quick-tests via this marker and runs under `make extended-tests`.
+@extended_testing_only
 @pytest.mark.xdist_group(name="buildtest_local")
 class TestBuildRunner1StepLocal(AbstractYamlBuildRunnerTest):
-    """Runs a barebone local build flow exercising env:// input + output."""
+    """Local build flow exercising env:// and hf:// input + output on Bash."""
 
     def _get_yaml_spec_dir(self) -> Path:
         return get_test_data_dir_for(__file__) / "1step"

--- a/test/libgbtest/environments/environment.yaml
+++ b/test/libgbtest/environments/environment.yaml
@@ -8,7 +8,7 @@ config:
         claimName: gb-afm-read-only
 assetstores:
   - store_uri: git+ssh://github.ibm.com/granite-dot-build/assets.git#subdirectory=assetstores/lh-staging
-    load:
+    pull:
       - mode: afm_mount
         config:
           pvc: gb-afm-read-only

--- a/test/libgbtest/environments/environment2.yaml
+++ b/test/libgbtest/environments/environment2.yaml
@@ -8,7 +8,7 @@ config:
         claimName: gb-afm-read-only
 assetstores:
   - store_uri: git+ssh://github.ibm.com/granite-dot-build/assets.git#subdirectory=assetstores/lh-staging
-    load:
+    pull:
       - mode: afm_mount
         config:
           pvc: gb-afm-read-only

--- a/test/libgbtest/environments/environment_staging.yaml
+++ b/test/libgbtest/environments/environment_staging.yaml
@@ -8,7 +8,7 @@ config:
         claimName: gb-afm-read-only
 assetstores:
   - store_uri: git+ssh://github.ibm.com/granite-dot-build/assets.git#subdirectory=assetstores/lh-staging
-    load:
+    pull:
       - mode: afm_mount
         config:
           pvc: gb-afm-read-only

--- a/test/unit/environment/test_bash_hfstore.py
+++ b/test/unit/environment/test_bash_hfstore.py
@@ -54,6 +54,7 @@ async def test_pullasset_hfstore_returns_binding_with_path(bash_env, tmp_path):
 async def test_pullasset_hfstore_passes_cache_dir(bash_env, tmp_path):
     """Verify storeload_config is forwarded to pull_asset_hfstore."""
     storeload_config = MagicMock()
+    storeload_config.mode = "default"
     storeload_config.config = {"cache_path": str(tmp_path / "custom_cache")}
     uri = MagicMock()
     assetstore = MagicMock()

--- a/test/unit/environment/test_bash_hfstore.py
+++ b/test/unit/environment/test_bash_hfstore.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -129,14 +130,28 @@ async def test_pushasset_hfstore_rejects_binding_without_path(bash_env):
 
 
 @pytest.mark.asyncio
-async def test_pushasset_hfstore_rejects_non_default_mode(bash_env):
-    """pushasset_hfstore raises ValueError for a non-'default' push mode."""
+async def test_pushasset_hfstore_accepts_legacy_mode_with_warning(bash_env, caplog):
+    """A legacy (non-'default') push mode is accepted for backwards compat, and warns.
+
+    Outside k8s ``mode`` is ignored (dispatch is by store type), so a legacy
+    ``hf_push`` still pushes normally — it just logs a deprecation warning.
+    """
+    uri = MagicMock()
     storepush_config = MagicMock()
     storepush_config.mode = "hf_push"
 
-    with pytest.raises(ValueError, match="supports only 'default'"):
-        await bash_env.pushasset_hfstore(
+    with (
+        patch(
+            "gbserver.environment.bash.push_asset_hfstore", return_value=uri
+        ) as mock_push,
+        caplog.at_level(logging.WARNING),
+    ):
+        result = await bash_env.pushasset_hfstore(
             binding={"path": "/workspace/output/model"},
-            uri=MagicMock(),
+            uri=uri,
             storepush_config=storepush_config,
         )
+
+    mock_push.assert_called_once()
+    assert result is uri
+    assert any("declares mode 'hf_push'" in r.message for r in caplog.records)

--- a/test/unit/environment/test_bash_hfstore.py
+++ b/test/unit/environment/test_bash_hfstore.py
@@ -87,3 +87,56 @@ async def test_pullasset_hfstore_uses_default_cache(bash_env, tmp_path):
         )
 
     mock_load.assert_called_once_with(uri, assetstore, None)
+
+
+@pytest.mark.asyncio
+async def test_pushasset_hfstore_pushes_binding_path(bash_env):
+    """pushasset_hfstore forwards the host binding path to push_asset_hfstore."""
+    uri = MagicMock()
+    assetstore = MagicMock()
+    run_metadata = MagicMock()
+
+    with patch(
+        "gbserver.environment.bash.push_asset_hfstore", return_value=uri
+    ) as mock_push:
+        result = await bash_env.pushasset_hfstore(
+            binding={"path": "/workspace/output/model"},
+            binding_id="hf_output",
+            uri=uri,
+            assetstore=assetstore,
+            run_metadata=run_metadata,
+        )
+
+    # The bash binding path is already a host path — passed straight through.
+    mock_push.assert_called_once_with(
+        src="/workspace/output/model",
+        binding_id="hf_output",
+        uri=uri,
+        assetstore=assetstore,
+        run_metadata=run_metadata,
+    )
+    assert result is uri
+
+
+@pytest.mark.asyncio
+async def test_pushasset_hfstore_rejects_binding_without_path(bash_env):
+    """pushasset_hfstore raises ValueError when the binding has no 'path'."""
+    with pytest.raises(ValueError, match="binding must be a dict with 'path'"):
+        await bash_env.pushasset_hfstore(
+            binding={"not_path": "x"},
+            uri=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_pushasset_hfstore_rejects_non_default_mode(bash_env):
+    """pushasset_hfstore raises ValueError for a non-'default' push mode."""
+    storepush_config = MagicMock()
+    storepush_config.mode = "hf_push"
+
+    with pytest.raises(ValueError, match="supports only 'default'"):
+        await bash_env.pushasset_hfstore(
+            binding={"path": "/workspace/output/model"},
+            uri=MagicMock(),
+            storepush_config=storepush_config,
+        )

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -49,6 +49,7 @@ def mock_assetstore():
 def hf_storeload_config(tmp_path):
     """storeload_config that scopes the HF cache under tmp_path."""
     config = MagicMock()
+    config.mode = "default"
     config.config = {"cache_path": str(tmp_path / "hf-cache")}
     return config
 
@@ -122,6 +123,7 @@ async def test_pullasset_hfstore_multiple_models_accumulate(docker_env, tmp_path
 
     cache = tmp_path / "hf-cache"
     sc = MagicMock()
+    sc.mode = "default"
     sc.config = {"cache_path": str(cache)}
 
     with patch.object(HfURI, "pull", return_value=True):

--- a/test/unit/environment/test_lsf_hfstore.py
+++ b/test/unit/environment/test_lsf_hfstore.py
@@ -83,7 +83,7 @@ class TestPullassetHfstore:
 
         assetstore = MagicMock(spec=Hfstore)
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         with (
@@ -112,7 +112,7 @@ class TestPullassetHfstore:
 
         assetstore = MagicMock(spec=Hfstore)
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         with (
@@ -143,7 +143,7 @@ class TestPullassetHfstore:
     async def test_rejects_wrong_assetstore_type(self, lsf_env, mock_hfuri):
         """pullasset_hfstore raises AssertionError if assetstore is not Hfstore."""
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         with pytest.raises(AssertionError, match="expected 'Hfstore'"):
@@ -155,7 +155,7 @@ class TestPullassetHfstore:
 
     @pytest.mark.asyncio
     async def test_rejects_wrong_mode(self, lsf_env, mock_hfuri):
-        """pullasset_hfstore raises AssertionError for non-hf_pull mode."""
+        """pullasset_hfstore raises ValueError for a non-'default' mode."""
         from gbserver.asset.hfstore import Hfstore
 
         assetstore = MagicMock(spec=Hfstore)
@@ -163,7 +163,7 @@ class TestPullassetHfstore:
         storeload_config.mode = "dmf_pull"
         storeload_config.config = {"cache_path": "/data/cache"}
 
-        with pytest.raises(AssertionError, match="Only 'hf_pull' mode"):
+        with pytest.raises(ValueError, match="supports only 'default'"):
             await lsf_env.pullasset_hfstore(
                 uri=mock_hfuri,
                 assetstore=assetstore,
@@ -238,6 +238,7 @@ class TestPushassetHfstore:
 
         assetstore = MagicMock(spec=Hfstore)
         storepush_config = MagicMock()
+        storepush_config.mode = "default"
         storepush_config.config = {"hf": {"private": False}}
 
         with (

--- a/test/unit/environment/test_lsf_hfstore.py
+++ b/test/unit/environment/test_lsf_hfstore.py
@@ -1,6 +1,7 @@
 """Unit tests for Lsf.pullasset_hfstore and Lsf.pushasset_hfstore."""
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -154,21 +155,37 @@ class TestPullassetHfstore:
             )
 
     @pytest.mark.asyncio
-    async def test_rejects_wrong_mode(self, lsf_env, mock_hfuri):
-        """pullasset_hfstore raises ValueError for a non-'default' mode."""
+    async def test_accepts_legacy_mode_with_warning(
+        self, lsf_env, mock_hfuri, mock_hf_metadata, caplog
+    ):
+        """A legacy (non-'default') mode is accepted for backwards compat, and warns.
+
+        Outside k8s ``mode`` is ignored (dispatch is by store type), so a legacy
+        ``hf_pull`` still pulls normally — it just logs a deprecation warning.
+        """
         from gbserver.asset.hfstore import Hfstore
 
         assetstore = MagicMock(spec=Hfstore)
         storeload_config = MagicMock()
-        storeload_config.mode = "dmf_pull"
+        storeload_config.mode = "hf_pull"
         storeload_config.config = {"cache_path": "/data/cache"}
 
-        with pytest.raises(ValueError, match="supports only 'default'"):
-            await lsf_env.pullasset_hfstore(
+        with (
+            patch("gbserver.environment.lsf.Asset") as mock_asset_cls,
+            patch.object(
+                lsf_env, "_load_builtin_hf_lsf_section", return_value=({}, {})
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_asset_cls.return_value.get_metadata.return_value = mock_hf_metadata
+            binding_config, _ = await lsf_env.pullasset_hfstore(
                 uri=mock_hfuri,
                 assetstore=assetstore,
                 storeload_config=storeload_config,
             )
+
+        assert BINDING_KEY in binding_config
+        assert any("declares mode 'hf_pull'" in r.message for r in caplog.records)
 
 
 class TestPushassetHfstore:

--- a/test/unit/environment/test_skypilot.py
+++ b/test/unit/environment/test_skypilot.py
@@ -316,6 +316,15 @@ class TestSkypilotComputeConfigResources:
         )
         # empty compute_config yields no floor.
         assert env._resources_from_compute_config({}) == {}
+        # On slurm the memory floor is dropped (SLURM often doesn't track memory
+        # as a consumable resource), but cpus is still emitted.
+        assert env._resources_from_compute_config(
+            {"num_cpus_per_node": 3, "total_memory_per_node": "2Gi"}, cloud="slurm"
+        ) == {"cpus": 3}
+        # Non-slurm clouds keep the memory floor.
+        assert env._resources_from_compute_config(
+            {"total_memory_per_node": "2Gi"}, cloud="k8s"
+        ) == {"memory": 2.0}
 
 
 class TestMonitorSkypilotMonitor:

--- a/test/unit/environment/test_skypilot.py
+++ b/test/unit/environment/test_skypilot.py
@@ -277,6 +277,41 @@ class TestLaunchSkypilot:
         assert kwargs.get("cpus") is None
         assert kwargs.get("memory") == 1.0
 
+    @pytest.mark.asyncio
+    async def test_slurm_infra_drops_memory_floor(self, skypilot_env):
+        """A slurm target routed via `infra` (even with the env's default_cloud
+        k8s) drops the compute_config memory floor; cpus is still applied.
+
+        Reproduces the ResourcesUnavailableError case: SLURM often doesn't track
+        memory as a consumable resource, so a --memory request fails matching.
+        """
+        kwargs = await self._launch_and_capture_resources(
+            skypilot_env,  # fixture default_cloud is k8s
+            launcher_config={
+                "run": "echo hi",
+                "resources": {"infra": "slurm/mycluster"},
+            },
+            config={
+                "compute_config": {
+                    "num_cpus_per_node": 2,
+                    "total_memory_per_node": "10Gi",
+                }
+            },
+        )
+        assert kwargs.get("memory") is None
+        assert kwargs.get("cpus") == 2
+
+    @pytest.mark.asyncio
+    async def test_slurm_cloud_casing_drops_memory_floor(self, skypilot_env):
+        """Non-canonical cloud casing ('Slurm') is normalized, so the memory
+        floor is still dropped."""
+        kwargs = await self._launch_and_capture_resources(
+            skypilot_env,
+            launcher_config={"run": "echo hi", "resources": {"cloud": "Slurm"}},
+            config={"compute_config": {"total_memory_per_node": "10Gi"}},
+        )
+        assert kwargs.get("memory") is None
+
 
 class TestSkypilotComputeConfigResources:
     """Unit tests for the pure compute_config -> sky.Resources helpers."""
@@ -316,12 +351,14 @@ class TestSkypilotComputeConfigResources:
         )
         # empty compute_config yields no floor.
         assert env._resources_from_compute_config({}) == {}
-        # On slurm the memory floor is dropped (SLURM often doesn't track memory
-        # as a consumable resource), but cpus is still emitted.
-        assert env._resources_from_compute_config(
-            {"num_cpus_per_node": 3, "total_memory_per_node": "2Gi"}, cloud="slurm"
-        ) == {"cpus": 3}
-        # Non-slurm clouds keep the memory floor.
+        # On slurm/lsf the memory floor is dropped (bare HPC schedulers often
+        # don't track memory as a consumable resource), but cpus is still emitted.
+        for hpc_cloud in ("slurm", "lsf"):
+            assert env._resources_from_compute_config(
+                {"num_cpus_per_node": 3, "total_memory_per_node": "2Gi"},
+                cloud=hpc_cloud,
+            ) == {"cpus": 3}
+        # Non-HPC clouds keep the memory floor.
         assert env._resources_from_compute_config(
             {"total_memory_per_node": "2Gi"}, cloud="k8s"
         ) == {"memory": 2.0}

--- a/test/unit/environment/test_skypilot_hfstore.py
+++ b/test/unit/environment/test_skypilot_hfstore.py
@@ -1,6 +1,7 @@
 """Unit tests for Skypilot.pullasset_hfstore and Skypilot.pushasset_hfstore."""
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -177,19 +178,30 @@ class TestPullassetHfstore:
             )
 
     @pytest.mark.asyncio
-    async def test_rejects_wrong_mode(self, skypilot_env, mock_hfuri):
-        """pullasset_hfstore raises ValueError for a non-'default' mode."""
+    async def test_accepts_legacy_mode_with_warning(
+        self, skypilot_env, mock_hfuri, caplog
+    ):
+        """A legacy (non-'default') mode is accepted for backwards compat, and warns.
+
+        Outside k8s ``mode`` is ignored (dispatch is by store type), so a legacy
+        ``hf_pull`` still pulls normally — it just logs a deprecation warning.
+        """
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "dmf_pull"
+        storeload_config.mode = "hf_pull"
         storeload_config.config = {"cache_path": "/data/cache"}
 
-        with pytest.raises(ValueError, match="supports only 'default'"):
-            await skypilot_env.pullasset_hfstore(
+        with caplog.at_level(logging.WARNING):
+            binding_config, step_config = await skypilot_env.pullasset_hfstore(
                 uri=mock_hfuri,
                 assetstore=assetstore,
                 storeload_config=storeload_config,
             )
+
+        expected_path = str(Path("/data/cache/myorg/myrepo/main"))
+        assert binding_config == {"binding": {"path": expected_path}}
+        assert isinstance(step_config, BuildTargetStepConfig)
+        assert any("declares mode 'hf_pull'" in r.message for r in caplog.records)
 
     @pytest.mark.asyncio
     async def test_uses_env_shared_workdir_when_no_cache_path(self, mock_hfuri):

--- a/test/unit/environment/test_skypilot_hfstore.py
+++ b/test/unit/environment/test_skypilot_hfstore.py
@@ -70,7 +70,7 @@ class TestPullassetHfstore:
         """pullasset_hfstore returns (binding_dict, BuildTargetStepConfig) with cache path."""
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         binding_config, step_config = await skypilot_env.pullasset_hfstore(
@@ -93,7 +93,7 @@ class TestPullassetHfstore:
         """pullasset_hfstore puts HF_TOKEN under config.launcher_config.envs."""
         assetstore = _hfstore_mock(token="my-secret-token")
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         _, step_config = await skypilot_env.pullasset_hfstore(
@@ -112,7 +112,7 @@ class TestPullassetHfstore:
         """No cache_path -> uses get_hf_cache_dir default (~/.cache/gbserver/hf)."""
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {}
 
         binding_config, _ = await skypilot_env.pullasset_hfstore(
@@ -129,7 +129,7 @@ class TestPullassetHfstore:
         """storeload_config.config.step_uri overrides the default builtin uri."""
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {
             "cache_path": "/data/cache",
             "step_uri": "file:///custom/hfpull",
@@ -151,7 +151,7 @@ class TestPullassetHfstore:
         env-keyed split (`builtins/steps/skypilot/hfpull/`) at lookup time."""
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         _, step_config = await skypilot_env.pullasset_hfstore(
@@ -166,7 +166,7 @@ class TestPullassetHfstore:
     async def test_rejects_wrong_assetstore_type(self, skypilot_env, mock_hfuri):
         """pullasset_hfstore raises AssertionError if assetstore is not Hfstore."""
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/data/cache"}
 
         with pytest.raises(AssertionError, match="expected 'Hfstore'"):
@@ -178,13 +178,13 @@ class TestPullassetHfstore:
 
     @pytest.mark.asyncio
     async def test_rejects_wrong_mode(self, skypilot_env, mock_hfuri):
-        """pullasset_hfstore raises ValueError for non-hf_pull mode."""
+        """pullasset_hfstore raises ValueError for a non-'default' mode."""
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
         storeload_config.mode = "dmf_pull"
         storeload_config.config = {"cache_path": "/data/cache"}
 
-        with pytest.raises(ValueError, match="unsupported storeload mode"):
+        with pytest.raises(ValueError, match="supports only 'default'"):
             await skypilot_env.pullasset_hfstore(
                 uri=mock_hfuri,
                 assetstore=assetstore,
@@ -211,7 +211,7 @@ class TestPullassetHfstore:
         )
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {}
 
         binding_config, _ = await env.pullasset_hfstore(
@@ -244,7 +244,7 @@ class TestPullassetHfstore:
         )
         assetstore = _hfstore_mock()
         storeload_config = MagicMock()
-        storeload_config.mode = "hf_pull"
+        storeload_config.mode = "default"
         storeload_config.config = {"cache_path": "/explicit/override"}
 
         binding_config, _ = await env.pullasset_hfstore(
@@ -402,6 +402,7 @@ class TestPushassetHfstore:
         assetstore = _hfstore_mock()
 
         storepush_config = MagicMock()
+        storepush_config.mode = "default"
         storepush_config.config = {"step_uri": "file:///custom/hfpush"}
 
         step_config = await skypilot_env.pushasset_hfstore(

--- a/test/unit/space/test_space_config.py
+++ b/test/unit/space/test_space_config.py
@@ -206,19 +206,19 @@ class TestMergedQuickstartAssets:
 
     def test_bash_env_binds_hf_and_file(self):
         # The old `local` store was removed; file: is now the builtin `file`
-        # store, declared explicitly. Bash implements pull+push, so load+push.
+        # store, declared explicitly. Bash implements pull+push, so pull+push.
         data = self._load(self.ENVS_DIR / "bash" / "environment.yaml")
         uris = {s["store_uri"] for s in data["assetstores"]}
         assert any("hf" in u for u in uris)
         assert not any("local" in u for u in uris)
         file_entry = self._store_entry(data, "assetstores/file")
         assert file_entry is not None, "bash must declare the file store"
-        assert file_entry.get("load"), "bash file store must declare load"
+        assert file_entry.get("pull"), "bash file store must declare pull"
         assert file_entry.get("push"), "bash file store must declare push"
 
     def test_docker_env_binds_hf_and_file_push_only(self):
         # Docker has pushasset_filestore but NO pullasset_filestore, so the file
-        # store must declare push only — declaring load would advertise a pull it
+        # store must declare push only — declaring pull would advertise a pull it
         # cannot service.
         data = self._load(self.ENVS_DIR / "docker" / "environment.yaml")
         uris = {s["store_uri"] for s in data["assetstores"]}
@@ -227,7 +227,7 @@ class TestMergedQuickstartAssets:
         file_entry = self._store_entry(data, "assetstores/file")
         assert file_entry is not None, "docker must declare the file store"
         assert file_entry.get("push"), "docker file store must declare push"
-        assert not file_entry.get("load"), "docker file store must NOT declare load"
+        assert not file_entry.get("pull"), "docker file store must NOT declare pull"
 
     def test_colocated_hello_steps_exist(self):
         # bash/docker/runpod get co-located hello steps; the single

--- a/test/unit/uri/test_env_uri_relative.py
+++ b/test/unit/uri/test_env_uri_relative.py
@@ -116,15 +116,18 @@ def test_absolute_and_templated_env_uris_are_allowed():
 
 
 # --- runtime guard (base envstore methods) ----------------------------------
-# The base methods don't touch instance state for the relative check, so we can
-# invoke the unbound coroutines with a dummy ``self``.
+# The base methods touch instance state only via ``self._require_default_mode``
+# (a no-op when no special mode is set), so a lightweight stub ``self`` carrying
+# that method lets us invoke the unbound coroutines to exercise the relative-path
+# guard in isolation.
+_DUMMY_SELF = SimpleNamespace(_require_default_mode=lambda store_config, uri: None)
 
 
 def test_pushasset_envstore_rejects_relative():
     with pytest.raises(ValueError, match="relative env://"):
         asyncio.run(
             Environment.pushasset_envstore(
-                None, binding={"path": "/x"}, uri="env:rel/out"
+                _DUMMY_SELF, binding={"path": "/x"}, uri="env:rel/out"
             )
         )
 
@@ -132,7 +135,7 @@ def test_pushasset_envstore_rejects_relative():
 def test_pushasset_envstore_allows_absolute():
     uri = asyncio.run(
         Environment.pushasset_envstore(
-            None, binding={"path": "/x"}, uri="env:///abs/out"
+            _DUMMY_SELF, binding={"path": "/x"}, uri="env:///abs/out"
         )
     )
     assert "abs/out" in str(uri)
@@ -140,12 +143,12 @@ def test_pushasset_envstore_allows_absolute():
 
 def test_pullasset_envstore_rejects_relative():
     with pytest.raises(ValueError, match="relative env://"):
-        asyncio.run(Environment.pullasset_envstore(None, uri="env:rel/in"))
+        asyncio.run(Environment.pullasset_envstore(_DUMMY_SELF, uri="env:rel/in"))
 
 
 def test_pullasset_envstore_allows_absolute():
     binding_config, step = asyncio.run(
-        Environment.pullasset_envstore(None, uri="env:///abs/in")
+        Environment.pullasset_envstore(_DUMMY_SELF, uri="env:///abs/in")
     )
     assert step is None
     assert binding_config["binding"]["path"] == "/abs/in"

--- a/test/unit/uri/test_env_uri_relative.py
+++ b/test/unit/uri/test_env_uri_relative.py
@@ -116,11 +116,11 @@ def test_absolute_and_templated_env_uris_are_allowed():
 
 
 # --- runtime guard (base envstore methods) ----------------------------------
-# The base methods touch instance state only via ``self._require_default_mode``
+# The base methods touch instance state only via ``self._warn_non_default_mode``
 # (a no-op when no special mode is set), so a lightweight stub ``self`` carrying
 # that method lets us invoke the unbound coroutines to exercise the relative-path
 # guard in isolation.
-_DUMMY_SELF = SimpleNamespace(_require_default_mode=lambda store_config, uri: None)
+_DUMMY_SELF = SimpleNamespace(_warn_non_default_mode=lambda store_config, uri: None)
 
 
 def test_pushasset_envstore_rejects_relative():


### PR DESCRIPTION
## Description
The assetstore `mode` field (on each `pull`/`push` entry in an `environment.yaml`) was
meant to select *how* an asset is moved into/out of a compute environment, but in
practice only **k8s** genuinely branches on it. Every other environment either ignored
`mode` or gated on one hard-coded string, and those gates diverged in style (`ValueError`
vs. `AssertionError`, disableable under `python -O`) and only served to fail builds when
the string wasn't set exactly right.

This branch makes `mode` meaningful only where it does something (k8s) and treats it as
**advisory everywhere else** — non-`default` values still work but log a deprecation
warning, so no existing space config breaks. Along the way it renames the assetstore
input key `load` → `pull` (with a backwards-compatible alias), adds HuggingFace push
support to the Bash environment, and fixes a SkyPilot/SLURM memory request that was
failing builds.

## Changes

### 1. `mode` is advisory (warn, don't fail) outside k8s
- Added a shared `Environment._warn_non_default_mode()` helper (base class) that logs a
  deprecation warning — **it does not raise** — when a non-k8s assetstore declares a
  `mode` other than `default`/unset. This keeps legacy configs (`hf_pull`, `dmf_pull`,
  `cos_pull`, etc.) working while nudging toward `default`.
- Called it from every non-k8s asset handler, replacing the ad-hoc raises/asserts:
  `skypilot` (hf pull/push, cos push), `lsf` (hf, lh/dmf, cos pull+push — the
  `mode == "..."` asserts removed), `bash`, `docker`, and the base `mem`/`env` handlers.
- k8s handlers are intentionally **untouched** — they still branch on
  `afm_mount`/`cos_mount`/`cos_pull`/`dmf_pull`. A code comment in `k8s.pullasset_hfstore`
  documents why k8s deliberately does not call `_warn_non_default_mode`.
- Normalized non-k8s `environment.yaml` configs (`hf_pull`/`hf_push`/`cos_*` → `default`):
  skypilot aws/slurm/kubernetes, lsf-bluevela, bash, docker, runpod, and the standalone /
  libgbtest fixtures.

### 2. Rename assetstore input key `load` → `pull` (with backwards-compat alias)
- `AssetStoreEnvironmentConfig.load` → `.pull`, so the input side pairs with `push` and
  matches the `pullasset_*` / `pushasset_*` handler names.
- Added a `model_validator(mode="before")` (`_accept_legacy_load_key`) that maps a
  legacy `load:` key onto `pull:` and logs a deprecation warning — existing space configs
  using `load` keep parsing.
- Updated all in-repo `environment.yaml` files and the `env`/`mem` implicit-store
  registration in `environment.py` to use `pull`.

### 3. Remove the redundant `mode` gate in k8s `pullasset_hfstore`
- HF pull is the only behavior this store supports, so the `if mode == "hf_pull": … else
  raise "No known mode of loading"` gate only created failure surface. Removed it; the
  handler now performs the pull regardless of `mode`.
- Left the real k8s branching intact: `pullasset_lhstore`, both cos handlers, and the
  push handlers are unchanged.

### 4. Add HuggingFace push support to the Bash environment
- Added `Bash.pushasset_hfstore`, delegating to the shared `push_asset_hfstore` helper
  (no container-path translation needed — the bash binding path is already a host path).
  Enabled `push` on the hf store in the bash `environment.yaml`.
- Extended the bash 1-step build test to exercise a real HF **input and output** (in
  addition to the existing `env://` in/out), mirroring the docker-hf fixture; bumped the
  fixture artifact counts and marked it `@extended_testing_only`.
- Added unit tests for `pushasset_hfstore` (delegation, missing-`path`, non-default-mode).

### 5. Fix SkyPilot/SLURM memory request causing build failures
- `_resources_from_compute_config` now takes a `cloud` argument and **skips** the
  `compute_config` memory floor on `slurm`. SLURM clusters commonly don't track memory
  as a consumable resource (`RealMemory` unset), so a `--memory` request failed at
  resource matching ("Catalog does not contain any instances satisfying …"). An explicit
  launcher/build `resources.memory` still applies where `RealMemory` is configured.

### 6. Documentation
- asset-stores README, environments README, per-environment docs (bash/docker/k8s/lsf/
  skypilot + variants), the `hf-push` build doc, and the environment-classes architecture
  doc: updated `load` → `pull`, documented the `mode` invariant (k8s-only), and noted the
  deprecated `load` alias and non-`default` mode warnings.
- Updated the `StoreLoad`/`StorePush`/`AssetStoreEnvironmentConfig` field comments.

## Backwards compatibility
- **Nothing breaks.** Non-`default` `mode` values are accepted everywhere (warn only), and
  the legacy `load:` key is accepted as an alias for `pull:` (warn only). Both legacy
  configs and the new conventions keep working — a non-breaking migration for space
  configs in the external assets repo.
- Behavior is unchanged for all currently valid inputs: dispatch is by store *type*,
  not `mode`.

## Testing
- `pytest test/unit/environment/` — new bash push tests + updated skypilot/lsf tests pass.
- Bash 1-step HF build test verified end-to-end (real HF pull/push) in the extended suite
  with a valid `HF_TOKEN`.
- Migrated `environment.yaml` files confirmed to parse via `EnvironmentConfig`.

## Notes / out of scope
- No k8s `environment.yaml` in this repo declares an hf assetstore; external assets-repo
  k8s hf configs may set their hf `mode` to `default` post-merge (advisory — the handler
  no longer reads it).
- No tests exercise the k8s store handlers directly; the hf pull path is covered by the
  `ibm`-marked k8s integration build tests.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
