### PR TITLE
fix: build logs & submission vulnerabilities

### DIFF
--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -317,7 +317,17 @@ def register_artifact(
     if len(sys_tags) > 0 and not is_super_admin(request):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 
-    # TODO: should we also make sure they have access to the space
+    # new_artifact.username is caller-supplied and becomes the artifact's
+    # attributed owner (including compliance flags like
+    # certified_no_restrictions) — bind it to the caller unless a space/super
+    # admin is explicitly registering on another user's behalf, the same gate
+    # update_artifact/archive_artifact already apply to the stored owner.
+    confirm_space_write_access(
+        request,
+        username_on_target=new_artifact.username,
+        space_name=new_artifact.space_name,
+    )
+
     storage = get_admin_storage().artifact_registry
 
     try:

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -291,7 +291,33 @@ def submit_build(request: Request, req: BuildSubmitRequest) -> BuildSubmitRespon
 
 
 @builds_api.post("/validate")
-def validate_build(req: BuildValidateRequest) -> JSONResponse:
+def validate_build(request: Request, req: BuildValidateRequest) -> JSONResponse:
+    # req.username drives real per-user secret resolution inside Space (see
+    # buildrunner/validation.py -> build/space.py), the same as submit_build's
+    # req.username does — bind it to the caller the same way.
+    if req.space_name:
+        storage = get_admin_storage()
+        stored_space = storage.space_storage.get_by_name(req.space_name)
+        if stored_space is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Space {req.space_name} not found in space storage",
+            )
+        confirm_space_write_access(
+            request, username_on_target=req.username, space_name=stored_space.name
+        )
+    else:
+        # space_uri bypasses space storage entirely (validate_build_archive
+        # builds a Space directly from the URI), so there is no stored space
+        # to check admin-ness against. Validating as someone else here can
+        # only be gated on being a caller-independent (super) admin.
+        user_id = request.state.data["user"].login
+        if req.username != user_id and not is_super_admin(request):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"User {user_id} cannot validate a build as {req.username}",
+            )
+
     errors = BuildValidation.validate_build_archive(
         build_archive=req.build_archive,
         username=req.username,

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -262,6 +262,14 @@ def submit_build(request: Request, req: BuildSubmitRequest) -> BuildSubmitRespon
     if len(sys_tags) > 0 and not is_super_admin(request):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 
+    # req.username is the identity the build will run under and whose per-user
+    # secrets get injected into it — bind it to the caller unless the caller
+    # is a space/super admin explicitly impersonating another user, the same
+    # gate PUT /builds/{id}/update already applies to build.username.
+    confirm_space_write_access(
+        request, username_on_target=req.username, space_name=stored_space.name
+    )
+
     stored_build = StoredBuild.create(
         name=req.name,
         space_name=stored_space.name,

--- a/src/gbserver/api/logs.py
+++ b/src/gbserver/api/logs.py
@@ -30,7 +30,7 @@ logs_api = FastAPI()
 
 
 @logs_api.post("/logquery")
-def logquery(query: Item) -> LogqueryResponse:
+def logquery(request: Request, query: Item) -> LogqueryResponse:
     log_manager = None
     try:
         log_manager = get_log_manager()
@@ -40,6 +40,33 @@ def logquery(query: Item) -> LogqueryResponse:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="the logs manager was not configured!",
         )
+
+    # This endpoint has no build_id path param, so the caller can point a
+    # free-form jsonObject filter at any build's logs. If the filter targets
+    # a specific build (the same "kubernetes.labels.granite-dot-build/build-id"
+    # key the client always sets for build-scoped queries), enforce the same
+    # per-build access check /logquery/server/{build_id} already applies.
+    query_params = query.queryDef.queryParams
+    json_object = query_params.jsonObject if query_params is not None else None
+    build_ids = (
+        json_object.get("kubernetes.labels.granite-dot-build/build-id", [])
+        if isinstance(json_object, dict)
+        else []
+    )
+    if build_ids:
+        username = request.state.data["user"].email
+        for build_id in build_ids:
+            has_access = build_id_access_check(username, build_id)
+            if not isinstance(has_access, bool):
+                return has_access
+            elif not has_access:
+                return JSONResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content={
+                        "detail": f"Unauthorized: no access to build {build_id}!",
+                    },
+                )
+
     try:
         logs = log_manager.query_cloud_logquery(query)
         return logs
@@ -111,6 +138,19 @@ def logquery(request: Request, build_id: str, query: Item) -> LogqueryResponse:
                 "detail": "Unauthorized: Server logs are available to LLM.Build users only!",
             },
         )
+
+    # The build_id above (from the path) is what was actually authorized.
+    # jsonObject is attacker-controlled request-body content — without this,
+    # a caller could pass their own build_id in the path (authorized) while
+    # smuggling a different, unauthorized build's id into the body filter and
+    # have that filter forwarded unmodified. Force it to the authorized build,
+    # preserving any other filter keys (step id/name, stream) the caller set.
+    if query.queryDef.queryParams.jsonObject is None:
+        query.queryDef.queryParams.jsonObject = {}
+    if isinstance(query.queryDef.queryParams.jsonObject, dict):
+        query.queryDef.queryParams.jsonObject[
+            "kubernetes.labels.granite-dot-build/build-id"
+        ] = [build_id]
 
     try:
         logs = log_server_manager.query_cloud_logquery(query)

--- a/src/gbserver/api/logs.py
+++ b/src/gbserver/api/logs.py
@@ -25,8 +25,56 @@ from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Cloud Logs identifies a build's logs by this k8s label key, set by the
+# client for build-scoped queries (see Item.get_logs_for_build). Defined once
+# here rather than duplicated per literal, since both handlers below key off
+# it for authorization, not just filtering.
+BUILD_ID_LABEL_KEY = "kubernetes.labels.granite-dot-build/build-id"
+
+# FREE_TEXT_SCOPE_ASSUMPTION: both routes below enforce the build-id
+# authorization check only against queryDef.queryParams.jsonObject, then send
+# the whole Item (jsonObject + queryParams.query free-text search + metadata)
+# to Cloud Logs in one request. This assumes Cloud Logs intersects (ANDs)
+# every field of a single query rather than treating queryParams.query as an
+# independent/OR'd match path — i.e. that the jsonObject build-id constraint
+# can only narrow what queryParams.query matches, never be bypassed by it.
+#
+# Accepted as of this change: one combined request body (not a "should"/
+# "must" split) is the standard shape for conjunctive multi-field query APIs,
+# and queryParams.query can't simply be stripped — it backs the documented
+# `gb build log --text` CLI flag (gbcli/utils/log_query.py's build_query_def
+# sets it alongside the build-id filter for a real, supported feature). Not
+# verified against IBM Cloud Logs' real behavior (no accessible docs, no test
+# backend for it in this repo) — revisit if that's ever obtained, or if this
+# endpoint's actual behavior in production ever contradicts it.
+
 
 logs_api = FastAPI()
+
+
+def _require_dict_json_object(query: Item) -> dict:
+    """Validate/normalize queryDef.queryParams.jsonObject to a dict.
+
+    jsonObject is typed Any and forwarded to Cloud Logs essentially verbatim.
+    A non-dict value (or one with a non-list build-id entry) would silently
+    bypass the per-key authorization checks below rather than fail closed, so
+    reject it outright instead of skipping the check.
+    """
+    query_params = query.queryDef.queryParams
+    if query_params is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="queryParams is required"
+        )
+    json_object = query_params.jsonObject
+    if json_object is None:
+        json_object = {}
+        query_params.jsonObject = json_object
+    if not isinstance(json_object, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="queryParams.jsonObject must be a JSON object",
+        )
+    return json_object
 
 
 @logs_api.post("/logquery")
@@ -41,31 +89,40 @@ def logquery(request: Request, query: Item) -> LogqueryResponse:
             detail="the logs manager was not configured!",
         )
 
-    # This endpoint has no build_id path param, so the caller can point a
-    # free-form jsonObject filter at any build's logs. If the filter targets
-    # a specific build (the same "kubernetes.labels.granite-dot-build/build-id"
-    # key the client always sets for build-scoped queries), enforce the same
-    # per-build access check /logquery/server/{build_id} already applies.
-    query_params = query.queryDef.queryParams
-    json_object = query_params.jsonObject if query_params is not None else None
-    build_ids = (
-        json_object.get("kubernetes.labels.granite-dot-build/build-id", [])
-        if isinstance(json_object, dict)
-        else []
-    )
-    if build_ids:
-        username = request.state.data["user"].email
-        for build_id in build_ids:
-            has_access = build_id_access_check(username, build_id)
-            if not isinstance(has_access, bool):
-                return has_access
-            elif not has_access:
-                return JSONResponse(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    content={
-                        "detail": f"Unauthorized: no access to build {build_id}!",
-                    },
-                )
+    # This endpoint has no build_id path param. Cloud Logs supports filtering
+    # by free text, other labels, or metadata, none of which are checked here
+    # — so rather than only checking when a build-id filter happens to be
+    # present (which a caller can simply omit to read any tenant's logs by
+    # some other dimension), every query must be scoped to a build id the
+    # caller can access.
+    json_object = _require_dict_json_object(query)
+    build_ids = json_object.get(BUILD_ID_LABEL_KEY, [])
+    if not isinstance(build_ids, list) or not build_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"queryParams.jsonObject must filter by {BUILD_ID_LABEL_KEY}",
+        )
+    # Force the query mode server-side rather than trusting the caller's
+    # value — the authorized-build-id constraint above assumes Cloud Logs
+    # intersects jsonObject with the rest of the query; an unpinned type
+    # could plausibly select a different query mode with different (unknown)
+    # combination semantics. This does not by itself prove queryParams.query
+    # (free text, kept — see FREE_TEXT_SCOPE_ASSUMPTION) can't independently
+    # surface unscoped results; that assumption is documented, not verified.
+    query.queryDef.type = "freeText"
+
+    username = request.state.data["user"].email
+    for build_id in build_ids:
+        has_access = build_id_access_check(username, build_id)
+        if not isinstance(has_access, bool):
+            return has_access
+        elif not has_access:
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                content={
+                    "detail": f"Unauthorized: no access to build {build_id}!",
+                },
+            )
 
     try:
         logs = log_manager.query_cloud_logquery(query)
@@ -124,6 +181,11 @@ def logquery(request: Request, build_id: str, query: Item) -> LogqueryResponse:
 
     username = request.state.data["user"].email
 
+    # Validate before use: jsonObject is attacker-controlled request-body
+    # content, and a non-dict value would previously skip the build-id
+    # override below entirely, re-opening the path/body smuggling bypass.
+    json_object = _require_dict_json_object(query)
+
     """ Set query model name to 'gbserver-build-runner' """
     query.queryDef.queryParams.metadata["subsystemName"] = ["gbserver-build-runner"]
 
@@ -140,17 +202,14 @@ def logquery(request: Request, build_id: str, query: Item) -> LogqueryResponse:
         )
 
     # The build_id above (from the path) is what was actually authorized.
-    # jsonObject is attacker-controlled request-body content — without this,
-    # a caller could pass their own build_id in the path (authorized) while
-    # smuggling a different, unauthorized build's id into the body filter and
-    # have that filter forwarded unmodified. Force it to the authorized build,
-    # preserving any other filter keys (step id/name, stream) the caller set.
-    if query.queryDef.queryParams.jsonObject is None:
-        query.queryDef.queryParams.jsonObject = {}
-    if isinstance(query.queryDef.queryParams.jsonObject, dict):
-        query.queryDef.queryParams.jsonObject[
-            "kubernetes.labels.granite-dot-build/build-id"
-        ] = [build_id]
+    # A caller could otherwise pass their own build_id in the path
+    # (authorized) while smuggling a different, unauthorized build's id into
+    # the body filter and have that filter forwarded unmodified. Force it to
+    # the authorized build, preserving any other filter keys (step id/name,
+    # stream) the caller set.
+    json_object[BUILD_ID_LABEL_KEY] = [build_id]
+    # See FREE_TEXT_SCOPE_ASSUMPTION above the module-level constants.
+    query.queryDef.type = "freeText"
 
     try:
         logs = log_server_manager.query_cloud_logquery(query)

--- a/test/unit/api/test_artifacts.py
+++ b/test/unit/api/test_artifacts.py
@@ -37,7 +37,7 @@ import pytest
 from fastapi import HTTPException
 
 from gbserver.api import artifacts as artifacts_module
-from gbserver.api.artifacts import decode_uri
+from gbserver.api.artifacts import decode_uri, register_artifact
 from gbserver.api.utils import (
     confirm_space_write_access as _real_confirm_space_write_access,
 )
@@ -155,3 +155,67 @@ def test_decode_uri_by_uri_requires_no_auth_and_touches_no_storage():
         )
     get_storage.assert_not_called()
     assert resp.uri == "hf://huggingface.co/models/anyone/anything"
+
+
+# ------------------------------------------------------------------ register_artifact
+
+
+def _new_artifact(username: str) -> ArtifactRegistration:
+    return ArtifactRegistration(
+        type=ArtifactType.MODEL,
+        uri="hf://huggingface.co/models/team-b/new-model",
+        space_name=VICTIM_SPACE,
+        username=username,
+    )
+
+
+def _registry_storage():
+    fake_storage = SimpleNamespace(
+        artifact_registry=SimpleNamespace(add=lambda a: None)
+    )
+    return patch.object(
+        artifacts_module, "get_admin_storage", return_value=fake_storage
+    )
+
+
+def test_register_artifact_rejects_forged_username():
+    with (
+        _registry_storage(),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            register_artifact(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                _new_artifact(VICTIM_OWNER),
+            )
+        assert exc.value.status_code == 401
+
+
+def test_register_artifact_allows_self_registration():
+    with (
+        _registry_storage(),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        resp = register_artifact(
+            _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+            _new_artifact(ATTACKER),
+        )
+    assert resp.registered.username == ATTACKER
+
+
+def test_register_artifact_allows_admin_impersonation():
+    with (
+        _registry_storage(),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=True),
+        patch("gbserver.api.utils.is_space_admin", return_value=True),
+    ):
+        resp = register_artifact(
+            _fake_request("admin_x", "admin_x@example.com"),
+            _new_artifact(VICTIM_OWNER),
+        )
+    assert resp.registered.username == VICTIM_OWNER

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for POST /builds/ identity binding (submit_build).
+
+req.username is the identity the submitted build runs as and whose per-user
+secrets get injected into it (HackerOne 3875452). submit_build must reject a
+caller submitting a build under a DIFFERENT username unless the caller is a
+space/super admin explicitly impersonating that user — the same
+confirm_space_write_access gate PUT /builds/{id}/update already applies.
+
+test/conftest.py's autouse `_mock_space_access` fixture stubs both
+confirm_space_write_access (in this module) and has_space_write_access (in
+utils) to an unconditional no-op/pass in mock mode, which would make every
+test here trivially pass regardless of the fix under test. `_real_authz`
+restores both real functions for the duration of each test below.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from gbserver.api import builds as builds_module
+from gbserver.api.builds import BuildSubmitRequest, submit_build
+from gbserver.api.utils import (
+    confirm_space_write_access as _real_confirm_space_write_access,
+)
+from gbserver.api.utils import has_space_write_access as _real_has_space_write_access
+from gbserver.storage.stored_space import StoredSpace
+
+SPACE = "space-B"
+VICTIM = "victim_b"
+ATTACKER = "attacker_a"
+
+
+@contextmanager
+def _real_authz():
+    """Restore the real confirm_space_write_access AND has_space_write_access,
+    undoing the autouse `_mock_space_access` fixture's unconditional bypass."""
+    with (
+        patch(
+            "gbserver.api.builds.confirm_space_write_access",
+            side_effect=_real_confirm_space_write_access,
+        ),
+        patch(
+            "gbserver.api.utils.has_space_write_access",
+            side_effect=_real_has_space_write_access,
+        ),
+    ):
+        yield
+
+
+def _fake_request(login: str, email: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(data={"user": SimpleNamespace(login=login, email=email)})
+    )
+
+
+def _submit_req(username: str) -> BuildSubmitRequest:
+    return BuildSubmitRequest(
+        name="poc",
+        build_archive="dGVzdA==",
+        space_name=SPACE,
+        username=username,
+        tags=[],
+    )
+
+
+def _patched_storage():
+    space = StoredSpace(name=SPACE, git_repo_uri="")
+    fake_storage = SimpleNamespace(
+        space_storage=SimpleNamespace(
+            get_by_name=lambda name: space if name == SPACE else None
+        ),
+        build_storage=SimpleNamespace(add=lambda b: b.uuid),
+    )
+    return patch.object(builds_module, "get_admin_storage", return_value=fake_storage)
+
+
+def test_submit_build_rejects_forged_username():
+    with (
+        _patched_storage(),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            submit_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                _submit_req(VICTIM),
+            )
+        assert exc.value.status_code == 401
+
+
+def test_submit_build_allows_self_submission():
+    with (
+        _patched_storage(),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        resp = submit_build(
+            _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+            _submit_req(ATTACKER),
+        )
+    assert resp.build_id
+
+
+def test_submit_build_allows_admin_impersonation():
+    with (
+        _patched_storage(),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=True),
+        patch("gbserver.api.utils.is_space_admin", return_value=True),
+    ):
+        resp = submit_build(
+            _fake_request("admin_x", "admin_x@example.com"),
+            _submit_req(VICTIM),
+        )
+    assert resp.build_id

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -14,13 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for POST /builds/ identity binding (submit_build).
+"""Unit tests for POST /builds/ and POST /builds/validate identity binding.
 
-req.username is the identity the submitted build runs as and whose per-user
-secrets get injected into it (HackerOne 3875452). submit_build must reject a
-caller submitting a build under a DIFFERENT username unless the caller is a
-space/super admin explicitly impersonating that user — the same
-confirm_space_write_access gate PUT /builds/{id}/update already applies.
+req.username is the identity a submitted or validated build runs/resolves
+secrets as (HackerOne 3875452 for submit_build; the same pattern was found
+unfixed in validate_build during a follow-up audit — validate_build had no
+Request param at all, so it couldn't check identity, and its space_uri path
+bypasses space storage entirely). Both must reject a caller acting under a
+DIFFERENT username unless the caller is a space/super admin explicitly
+impersonating that user — the same confirm_space_write_access gate
+PUT /builds/{id}/update already applies.
 
 test/conftest.py's autouse `_mock_space_access` fixture stubs both
 confirm_space_write_access (in this module) and has_space_write_access (in
@@ -31,13 +34,19 @@ restores both real functions for the duration of each test below.
 
 from contextlib import contextmanager
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 from gbserver.api import builds as builds_module
-from gbserver.api.builds import BuildSubmitRequest, submit_build
+from gbserver.api.builds import (
+    BuildSubmitRequest,
+    BuildValidateRequest,
+    BuildValidation,
+    submit_build,
+    validate_build,
+)
 from gbserver.api.utils import (
     confirm_space_write_access as _real_confirm_space_write_access,
 )
@@ -134,3 +143,83 @@ def test_submit_build_allows_admin_impersonation():
             _submit_req(VICTIM),
         )
     assert resp.build_id
+
+
+# ------------------------------------------------------------------ validate_build
+
+_NO_OP_VALIDATION = patch.object(
+    BuildValidation,
+    "validate_build_archive",
+    return_value=MagicMock(is_valid=lambda: True, model_dump=lambda: {}),
+)
+
+
+def _validate_req(username: str, space_name: str = "", space_uri: str = ""):
+    return BuildValidateRequest(
+        build_archive="dGVzdA==",
+        username=username,
+        space_name=space_name,
+        space_uri=space_uri,
+    )
+
+
+def test_validate_build_rejects_forged_username_via_space_name():
+    with (
+        _patched_storage(),
+        _real_authz(),
+        _NO_OP_VALIDATION,
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            validate_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                _validate_req(VICTIM, space_name=SPACE),
+            )
+        assert exc.value.status_code == 401
+
+
+def test_validate_build_rejects_forged_username_via_space_uri():
+    """space_uri bypasses space storage entirely, so there is no space to
+    check admin-ness against — only super-admin can impersonate here. This
+    path calls is_super_admin directly (bound into builds.py's own namespace
+    at import time, not utils.py's), so that's what must be patched."""
+    with (
+        _patched_storage(),
+        patch("gbserver.api.builds.is_super_admin", return_value=False),
+        _NO_OP_VALIDATION,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            validate_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                _validate_req(VICTIM, space_uri="git://example/space.git"),
+            )
+        assert exc.value.status_code == 401
+
+
+def test_validate_build_allows_self_validation_via_space_uri():
+    with (
+        _patched_storage(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        _NO_OP_VALIDATION,
+    ):
+        resp = validate_build(
+            _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+            _validate_req(ATTACKER, space_uri="git://example/space.git"),
+        )
+    assert resp.status_code == 200
+
+
+def test_validate_build_allows_admin_impersonation_via_space_name():
+    with (
+        _patched_storage(),
+        _real_authz(),
+        _NO_OP_VALIDATION,
+        patch("gbserver.api.utils.is_super_admin", return_value=True),
+        patch("gbserver.api.utils.is_space_admin", return_value=True),
+    ):
+        resp = validate_build(
+            _fake_request("admin_x", "admin_x@example.com"),
+            _validate_req(VICTIM, space_name=SPACE),
+        )
+    assert resp.status_code == 200

--- a/test/unit/api/test_logs.py
+++ b/test/unit/api/test_logs.py
@@ -21,6 +21,15 @@ checked access against the PATH build_id while the actual Cloud Logs filter
 came from the BODY's queryDef.queryParams.jsonObject, which could reference a
 different, unauthorized build. Both are fixed in gbserver/api/logs.py.
 
+A first pass at these fixes only checked the build-id label when it happened
+to be present under jsonObject as a dict — which left two gaps a review
+caught: (1) a caller filtering by any other dimension (or omitting the
+build-id key) skipped the check entirely on the plain route, and (2) a
+non-dict jsonObject skipped the build-id override on the server/{build_id}
+route, re-opening the smuggling bypass. Both routes now require jsonObject to
+be a dict (rejecting otherwise) and require the plain route's query to be
+scoped to an accessible build id rather than defaulting to allow.
+
 There are three functions literally named `logquery` in that module (one per
 route decorator), so plain `from gbserver.api.logs import logquery` or
 `logs_module.logquery` only resolves the last one defined. Each is pulled
@@ -28,6 +37,9 @@ directly off the FastAPI route table instead.
 """
 
 from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
 
 from gbserver.api import logs as logs_module
 from gbserver.types.logs import Item, QueryDef, QueryParams
@@ -52,12 +64,12 @@ def _fake_request(login: str, email: str):
     )
 
 
-def _item(json_object):
+def _item(json_object, query_type="freeText"):
     return Item(
         queryDef=QueryDef(
             startDate=0,
             endDate=1,
-            type="freeText",
+            type=query_type,
             queryParams=QueryParams(metadata={}, jsonObject=json_object),
         )
     )
@@ -100,20 +112,112 @@ def test_plain_logquery_allows_own_build_id_filter():
     assert resp == "ok"
 
 
-def test_plain_logquery_allows_query_with_no_build_id_filter():
-    """Pre-existing behavior for build-less queries is unchanged by this fix."""
-    log_manager = MagicMock(query_cloud_logquery=lambda q: "ok")
+def test_plain_logquery_pins_query_type_to_freetext():
+    """A caller-supplied queryDef.type is overwritten server-side, so an
+    unpinned type can't select a different query mode with unknown
+    combination semantics between jsonObject and any free-text filter."""
+    captured = {}
+
+    def fake_query(q):
+        captured["type"] = q.queryDef.type
+        return "ok"
+
     with (
         _mocked_access_manager(accessible_build_id="attacker-build"),
-        patch.object(logs_module, "get_log_manager", return_value=log_manager),
+        patch.object(
+            logs_module,
+            "get_log_manager",
+            return_value=MagicMock(query_cloud_logquery=fake_query),
+        ),
     ):
         resp = _plain_logquery(
-            _fake_request("attacker_a", "attacker_a@example.com"), _item({})
+            _fake_request("attacker_a", "attacker_a@example.com"),
+            _item({BUILD_LABEL_KEY: ["attacker-build"]}, query_type="somethingElse"),
         )
     assert resp == "ok"
+    assert captured["type"] == "freeText"
+
+
+def test_plain_logquery_rejects_query_with_no_build_id_filter():
+    """A caller could otherwise skip the check entirely by filtering on any
+    dimension other than the build-id label (or none at all) — every query
+    must be scoped to an accessible build id, not just checked when one
+    happens to be present."""
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=MagicMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _plain_logquery(
+                _fake_request("attacker_a", "attacker_a@example.com"), _item({})
+            )
+        assert exc.value.status_code == 400
+
+
+def test_plain_logquery_rejects_query_filtering_by_other_dimension_only():
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=MagicMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _plain_logquery(
+                _fake_request("attacker_a", "attacker_a@example.com"),
+                _item({"stream": ["stdout"]}),
+            )
+        assert exc.value.status_code == 400
+
+
+def test_plain_logquery_rejects_non_dict_json_object():
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=MagicMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _plain_logquery(
+                _fake_request("attacker_a", "attacker_a@example.com"),
+                _item(["not", "a", "dict"]),
+            )
+        assert exc.value.status_code == 400
+
+
+def test_plain_logquery_rejects_non_list_build_id_value():
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=MagicMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _plain_logquery(
+                _fake_request("attacker_a", "attacker_a@example.com"),
+                _item({BUILD_LABEL_KEY: "victim-build"}),
+            )
+        assert exc.value.status_code == 400
 
 
 # ---------------------------------------------------- /logquery/server/{build_id}
+
+
+def test_server_logquery_pins_query_type_to_freetext():
+    captured = {}
+
+    def fake_query(q):
+        captured["type"] = q.queryDef.type
+        return "ok"
+
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(
+            logs_module,
+            "get_log_server_manager",
+            return_value=MagicMock(query_cloud_logquery=fake_query),
+        ),
+    ):
+        resp = _server_logquery(
+            _fake_request("attacker_a", "attacker_a@example.com"),
+            "attacker-build",
+            _item({}, query_type="somethingElse"),
+        )
+    assert resp == "ok"
+    assert captured["type"] == "freeText"
 
 
 def test_server_logquery_overrides_smuggled_body_build_id():
@@ -150,6 +254,22 @@ def test_server_logquery_overrides_smuggled_body_build_id():
     sent = captured["jsonObject"]
     assert sent[BUILD_LABEL_KEY] == ["attacker-build"], sent
     assert sent["kubernetes.labels.granite-dot-build/build-step-name"] == ["train"]
+
+
+def test_server_logquery_rejects_non_dict_json_object():
+    """A non-dict jsonObject previously skipped the build-id override
+    entirely, forwarding whatever the body smuggled in unmodified."""
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_server_manager", return_value=MagicMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _server_logquery(
+                _fake_request("attacker_a", "attacker_a@example.com"),
+                "attacker-build",
+                _item(["not", "a", "dict"]),
+            )
+        assert exc.value.status_code == 400
 
 
 def test_server_logquery_rejects_victim_build_id_in_path():

--- a/test/unit/api/test_logs.py
+++ b/test/unit/api/test_logs.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for build-log query authorization (HackerOne 3875453).
+
+POST /logquery had no authorization at all; POST /logquery/server/{build_id}
+checked access against the PATH build_id while the actual Cloud Logs filter
+came from the BODY's queryDef.queryParams.jsonObject, which could reference a
+different, unauthorized build. Both are fixed in gbserver/api/logs.py.
+
+There are three functions literally named `logquery` in that module (one per
+route decorator), so plain `from gbserver.api.logs import logquery` or
+`logs_module.logquery` only resolves the last one defined. Each is pulled
+directly off the FastAPI route table instead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from gbserver.api import logs as logs_module
+from gbserver.types.logs import Item, QueryDef, QueryParams
+
+BUILD_LABEL_KEY = "kubernetes.labels.granite-dot-build/build-id"
+
+_plain_logquery = next(
+    r.endpoint for r in logs_module.logs_api.routes if r.path == "/logquery"
+)
+_server_logquery = next(
+    r.endpoint
+    for r in logs_module.logs_api.routes
+    if r.path == "/logquery/server/{build_id}"
+)
+
+
+def _fake_request(login: str, email: str):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        state=SimpleNamespace(data={"user": SimpleNamespace(login=login, email=email)})
+    )
+
+
+def _item(json_object):
+    return Item(
+        queryDef=QueryDef(
+            startDate=0,
+            endDate=1,
+            type="freeText",
+            queryParams=QueryParams(metadata={}, jsonObject=json_object),
+        )
+    )
+
+
+def _mocked_access_manager(accessible_build_id: str):
+    mgr = MagicMock()
+    mgr.has_build_access.side_effect = lambda username, bid: bid == accessible_build_id
+    return patch(
+        "gbserver.spaces.user_spaces_list.get_space_access_manager",
+        return_value=mgr,
+    )
+
+
+# --------------------------------------------------------------- plain /logquery
+
+
+def test_plain_logquery_rejects_victim_build_id_filter():
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=MagicMock()),
+    ):
+        resp = _plain_logquery(
+            _fake_request("attacker_a", "attacker_a@example.com"),
+            _item({BUILD_LABEL_KEY: ["victim-build"]}),
+        )
+    assert resp.status_code == 401
+
+
+def test_plain_logquery_allows_own_build_id_filter():
+    log_manager = MagicMock(query_cloud_logquery=lambda q: "ok")
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=log_manager),
+    ):
+        resp = _plain_logquery(
+            _fake_request("attacker_a", "attacker_a@example.com"),
+            _item({BUILD_LABEL_KEY: ["attacker-build"]}),
+        )
+    assert resp == "ok"
+
+
+def test_plain_logquery_allows_query_with_no_build_id_filter():
+    """Pre-existing behavior for build-less queries is unchanged by this fix."""
+    log_manager = MagicMock(query_cloud_logquery=lambda q: "ok")
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_manager", return_value=log_manager),
+    ):
+        resp = _plain_logquery(
+            _fake_request("attacker_a", "attacker_a@example.com"), _item({})
+        )
+    assert resp == "ok"
+
+
+# ---------------------------------------------------- /logquery/server/{build_id}
+
+
+def test_server_logquery_overrides_smuggled_body_build_id():
+    """Attacker passes their own build_id in the path (authorized) while
+    smuggling a victim build_id into the body filter. The forwarded filter
+    must be forced to the path-authorized build, not the smuggled one, while
+    other legitimate filter keys are preserved."""
+    captured = {}
+
+    def fake_query(query):
+        captured["jsonObject"] = query.queryDef.queryParams.jsonObject
+        return "ok"
+
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(
+            logs_module,
+            "get_log_server_manager",
+            return_value=MagicMock(query_cloud_logquery=fake_query),
+        ),
+    ):
+        resp = _server_logquery(
+            _fake_request("attacker_a", "attacker_a@example.com"),
+            "attacker-build",
+            _item(
+                {
+                    BUILD_LABEL_KEY: ["victim-build"],
+                    "kubernetes.labels.granite-dot-build/build-step-name": ["train"],
+                }
+            ),
+        )
+
+    assert resp == "ok"
+    sent = captured["jsonObject"]
+    assert sent[BUILD_LABEL_KEY] == ["attacker-build"], sent
+    assert sent["kubernetes.labels.granite-dot-build/build-step-name"] == ["train"]
+
+
+def test_server_logquery_rejects_victim_build_id_in_path():
+    with (
+        _mocked_access_manager(accessible_build_id="attacker-build"),
+        patch.object(logs_module, "get_log_server_manager", return_value=MagicMock()),
+    ):
+        resp = _server_logquery(
+            _fake_request("attacker_a", "attacker_a@example.com"),
+            "victim-build",
+            _item({}),
+        )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Description

Fixes two vulnerabilities reported via HackerOne against `ibm-granite/granite.build`:

- **[Critical] 3875452** — build submission accepts a forged `username`, runs the build as that victim's identity, and leaks the victim's per-user secrets. `POST /builds/` (`submit_build`) trusted a client-supplied `username` with zero binding to the authenticated caller; the BuildRunner then resolved *that* user's per-user secrets and injected them into the build's environment, readable back by the attacker through the build's own events.
- **[High] 3875453** — missing/mis-scoped authorization on build-log query endpoints lets any authenticated user read any tenant's build logs. `POST /logs/logquery` had no authorization check at all; `POST /logs/logquery/server/{build_id}` checked access against the **path** `build_id` while the actual Cloud Logs filter came from the **body**.

Both are fixed by binding/scoping identity the reports themselves suggested — reusing `confirm_space_write_access`/`build_id_access_check`, the same gates already proven on sibling routes in each file. No new authorization mechanism was introduced.

**Identity-forgery fixes** (same bug class as 3875452, found via follow-up audit and fixed alongside it):
- `submit_build` — `req.username` now bound to the caller via `confirm_space_write_access`. Self-submission and admin impersonation both still work.
- `validate_build` (`POST /builds/validate`) — had the identical gap, but worse: no `Request` parameter at all (structurally couldn't check identity), and its `space_uri` mode bypasses space storage entirely. With `validation_type=DYNAMIC` this could actually **execute** dry-run targets with a forged victim's secrets loaded. Now bound the same way, with a same-caller-or-super-admin check for the `space_uri` path (no space to check admin-ness against there).
- `register_artifact` (backing all 7 artifact-registration routes) — accepted a client-supplied `username` with no ownership check; the code even carried a `# TODO: should we also make sure they have access to the space` comment marking the known gap. Forged artifact attribution, including compliance flags like `certified_no_restrictions`. Now bound the same way.

**Log-query authorization fixes** (3875453, hardened over two review passes):
- `logquery` (plain route) — now **deny-by-default**: every query must be scoped to a build id the caller can access. An earlier pass only checked the build-id label when a caller happened to include one under a specific dict key — a reviewer correctly caught that filtering by any other dimension, or sending a non-dict body, skipped the check entirely. `queryParams.jsonObject` is now validated to be a dict (rejecting otherwise), and a missing/inaccessible build id is rejected rather than defaulting to allow.
- `logquery/server/{build_id}` — the outbound filter's build-id is forced to the **path-authorized** value after the access check passes (closing the original path/body smuggling bypass), and this override is now unconditional (previously skipped for non-dict bodies, which re-opened the same bypass).
- Both routes also now pin `queryDef.type` to `"freeText"` server-side, rather than trusting caller input, closing off the possibility of a different, unvalidated query mode.
- One known, explicitly documented residual assumption (`FREE_TEXT_SCOPE_ASSUMPTION` in `logs.py`): the fix constrains the build-id-bearing `jsonObject` field but not the sibling free-text `queryParams.query` field (which can't be stripped — it backs the documented `gb build log --text` CLI flag). This assumes Cloud Logs intersects (ANDs) all fields of one query rather than treating free-text search as an independent match path. That's the standard shape for conjunctive multi-field query APIs and is the accepted design going forward, but isn't verified against IBM Cloud Logs' real behavior — no accessible docs or test backend for it exist in this repo. Revisit if that's ever obtained.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
