### PR TITLE
Fix cicd nightly

### DIFF
--- a/test/unit/api/test_artifact_prod_gate.py
+++ b/test/unit/api/test_artifact_prod_gate.py
@@ -56,7 +56,9 @@ class TestRegisterArtifactProdGate:
         """HF artifacts register in PROD (the feature this gate enables)."""
         with patch.object(artifacts_module, "is_super_admin", return_value=True):
             with patch.object(artifacts_module, "confirm_space_write_access"):
-                with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
+                with patch.object(
+                    artifacts_module, "get_admin_storage"
+                ) as mock_storage:
                     mock_storage.return_value.artifact_registry.add = MagicMock()
                     resp = _call_gate("hf://huggingface.co/models/ibm-granite/granite")
 
@@ -66,7 +68,9 @@ class TestRegisterArtifactProdGate:
         """LhURI pointing at the production Lakehouse host is allowed in PROD."""
         with patch.object(artifacts_module, "is_super_admin", return_value=True):
             with patch.object(artifacts_module, "confirm_space_write_access"):
-                with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
+                with patch.object(
+                    artifacts_module, "get_admin_storage"
+                ) as mock_storage:
                     mock_storage.return_value.artifact_registry.add = MagicMock()
                     resp = _call_gate("lh://prod/namespace0/models/table0/label0/rev0")
 

--- a/test/unit/api/test_artifact_prod_gate.py
+++ b/test/unit/api/test_artifact_prod_gate.py
@@ -55,18 +55,20 @@ class TestRegisterArtifactProdGate:
     def test_hf_uri_allowed_in_prod(self):
         """HF artifacts register in PROD (the feature this gate enables)."""
         with patch.object(artifacts_module, "is_super_admin", return_value=True):
-            with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
-                mock_storage.return_value.artifact_registry.add = MagicMock()
-                resp = _call_gate("hf://huggingface.co/models/ibm-granite/granite")
+            with patch.object(artifacts_module, "confirm_space_write_access"):
+                with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
+                    mock_storage.return_value.artifact_registry.add = MagicMock()
+                    resp = _call_gate("hf://huggingface.co/models/ibm-granite/granite")
 
         assert resp.registered.uri == "hf://huggingface.co/models/ibm-granite/granite"
 
     def test_lh_uri_prod_host_allowed_in_prod(self):
         """LhURI pointing at the production Lakehouse host is allowed in PROD."""
         with patch.object(artifacts_module, "is_super_admin", return_value=True):
-            with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
-                mock_storage.return_value.artifact_registry.add = MagicMock()
-                resp = _call_gate("lh://prod/namespace0/models/table0/label0/rev0")
+            with patch.object(artifacts_module, "confirm_space_write_access"):
+                with patch.object(artifacts_module, "get_admin_storage") as mock_storage:
+                    mock_storage.return_value.artifact_registry.add = MagicMock()
+                    resp = _call_gate("lh://prod/namespace0/models/table0/label0/rev0")
 
         assert resp.registered.uri.startswith("lh://prod/")
 


### PR DESCRIPTION
## Description

Fixes two failing nightly tests in `test/unit/api/test_artifact_prod_gate.py`. PR #208 added a `confirm_space_write_access` ownership/space-admin check to `register_artifact` to close a cross-space BOLA gap. The existing allow-path tests (`test_hf_uri_allowed_in_prod`, `test_lh_uri_prod_host_allowed_in_prod`) only mocked `is_super_admin`, which doesn't reach the new check — `confirm_space_write_access` resolves its own `is_super_admin` reference inside `utils.py`'s namespace, not the one patched on `artifacts_module`. As a result the mocked request (with no matching owner/admin identity) was correctly rejected with a 401, failing the tests.

Mocked `confirm_space_write_access` directly in both allow-path tests, the same way `get_admin_storage` is already mocked. No production code changed — the authorization fix itself is working as intended.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
