### PR TITLE
fix: don't require lakehouse lib for artifact push/copy with store=hf

### DIFF
--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -63,6 +63,20 @@ from gbcommon.utils.hf_utils import (
 logger = logging.getLogger(__name__)
 
 
+class _MissingLakehouseUnauthorizedException(Exception):
+    """Placeholder used when the optional `lakehouse` package is absent."""
+
+
+try:
+    # Lakehouse is an optional dependency: it is only required for the
+    # Lakehouse artifact store (--store lh). When it is not installed we fall
+    # back to a sentinel exception so `except UnauthorizedException` clauses
+    # remain valid without importing lakehouse (e.g. for --store hf).
+    from lakehouse.core import UnauthorizedException
+except ModuleNotFoundError:
+    UnauthorizedException = _MissingLakehouseUnauthorizedException
+
+
 @click.group("artifact")
 @click.pass_context
 def cli(ctx):
@@ -375,8 +389,6 @@ def push(
             update_artifact_status(artifact_id, status)
 
     try:
-        from lakehouse.core import UnauthorizedException
-
         total_steps = 6 if calculate_checksum else 5
 
         normalized_tags = []
@@ -2365,8 +2377,6 @@ def copy(
                 pass  # Ignore unknown events
 
     try:
-        from lakehouse.core import UnauthorizedException
-
         id_format = parse_artifact_identifier(artifact_id)
         if id_format in ["uuid", "uri"]:
             if not quiet:


### PR DESCRIPTION
## Summary

- `llmb artifact push --store hf` (and `copy`) no longer require the optional `lakehouse` library to be installed. Previously both commands imported `lakehouse.core.UnauthorizedException` unconditionally at the top of their `try` blocks, crashing with `ModuleNotFoundError: No module named 'lakehouse'` for the HuggingFace store even though lakehouse is only needed for `--store lh`.
- Moved the import to a single module-level guarded import with a placeholder-exception fallback, so the `except UnauthorizedException` handlers remain valid without lakehouse installed. The real exception can only be raised on the lakehouse path (where the lib is present), so the placeholder never fires spuriously.
- Removed the two redundant inline `from lakehouse.core import UnauthorizedException` statements.

## Test plan

- `pytest -m "not ibm" -s test` → 1768 passed, 35 skipped (exit 0)
- `make xformat` → no changes
- `make xcheck` / `mypy` on the changed file → no new errors (only the expected `import-not-found` for the optional lakehouse dep, which is exactly the case this change handles)
- Manually verified `artifact push --store hf` no longer imports lakehouse eagerly.

Generated with [Claude Code](https://claude.com/claude-code)
