### PR TITLE
Unified builds: job status and lineage across a retry chain (#222)

### DIFF
--- a/docs/builds/build-retry.md
+++ b/docs/builds/build-retry.md
@@ -80,6 +80,100 @@ after that first attempt has failed and the chain has moved on to a later retry.
 | `retry_of_build_id` | retry build | UUID of the original failed build (root of the chain) |
 | `retry_build_id` | original/previous build | UUID of the next retry build created for this build |
 
+## Unified job status
+
+Each attempt in a retry chain keeps its own status forever. The original build stays
+`FAILED` even after a later attempt finishes every remaining target, so no single build
+record answers the question a user actually asks — *did the build specification complete?*
+
+The **job view** answers that. It treats the whole retry chain as one logical job and derives
+an aggregate status on read from the same records the status endpoint already returns. Nothing
+is retro-relabelled: there is no schema change, and every `StoredBuild` retains its per-attempt
+status. The chain's root UUID is the job's stable identity — no new table or identifier.
+
+### Requesting the job view
+
+`GET /builds/{build_id}/status?follow_retries=true` adds a `job` object to the response
+(alongside the `retry_chain` list). Without `follow_retries` the field is absent and the
+response is unchanged. The `job` is a `JobSummary`:
+
+| Field | Meaning |
+|---|---|
+| `job_id` | UUID of the chain root — the job's stable identity |
+| `status` | The aggregate job status (see precedence below) |
+| `attempts` | Number of builds in the chain (1-based) |
+| `build_ids` | UUIDs of every chain member, root first |
+| `targets` | Per spec-target outcome (`name`, `status`, `build_id`, `target_run_id`, `attempt`) |
+| `counts` | Roll-up of the spec targets across the chain |
+
+`counts` partitions the spec targets so that `total == succeeded + failed + running + not_run`:
+
+| Count | Meaning |
+|---|---|
+| `total` | Number of spec targets |
+| `succeeded` | Targets that succeeded on some attempt |
+| `failed` | Targets that finished without succeeding |
+| `running` | Targets whose latest run has not finished |
+| `not_run` | Targets that were never dispatched (no run at all) |
+
+### Status precedence
+
+The job status is decided by the first matching rule, top to bottom:
+
+| # | Condition | Job status |
+|---|---|---|
+| 1 | Any member is `CANCEL_REQUESTED` | `CANCEL_REQUESTED` |
+| 2 | Any member is not finished | `RUNNING` |
+| 3 | `counts.total == 0` (nothing to aggregate) | The latest member's own status |
+| 4 | Every spec target succeeded (subject to the SUCCESS guard below) | `SUCCESS` |
+| 5 | Any member is `CANCELLED` | `CANCELLED` |
+| 6 | Any member is `INVALID` and nothing succeeded | `INVALID` |
+| 7 | Otherwise | `FAILED` |
+
+There is deliberately **no `PARTIAL` status**. A job that completed some but not all of its
+targets is `FAILED` with `counts.succeeded > 0` — read the counts to distinguish a total
+failure from a near miss. Adding a job-only status member to the shared status vocabulary would
+leak the concept into per-build status, so it is expressed through the counts instead.
+
+### The SUCCESS guard and the "never ran" limitation
+
+Rule 4 (`SUCCESS`) carries a guard tied to whether the target list is **authoritative**. A
+build submitted with an explicit `targets` list records exactly which targets were requested,
+so a target that was never dispatched (for example, because an upstream dependency failed) is
+known and counted as `not_run`. When the list is authoritative, "every spec target succeeded"
+is trustworthy on its own.
+
+When the build was submitted **without** an explicit `targets` list (the default), the job has
+no record of targets that never ran — the only spec targets it can see are the ones that
+actually produced a run. The `not_run` denominator is therefore incomplete: "every counted
+target succeeded" would be trivially true for a build that died before dispatching the rest. To
+avoid reporting `SUCCESS` for such a build, the guard additionally requires the **newest
+attempt's own build status** to be `SUCCESS`. If it is not, the verdict falls through to the
+member statuses and lands on `FAILED`.
+
+This "never ran" limitation is intentional: counting never-dispatched targets from an implicit
+target list would require parsing the build config on the read path, which the job view avoids.
+
+### CLI
+
+`gbcli build status` follows the retry chain by default. For a build that was actually retried
+(more than one attempt), the headline **Status** now reports the *job* status. The queried
+build's own status moves to a **This attempt** line, and a **Job result** line summarises the
+roll-up:
+
+```
+- **Status**: SUCCESS
+- **This attempt**: FAILED (attempt 1 of 2)
+- **Job result**: 2 of 2 targets succeeded
+```
+
+The **Job result** line appends any non-zero `failed`, `running`, and `never ran` counts (the
+CLI renders `not_run` as "never ran"). A build with a single attempt is unchanged: the headline
+is its own status and the extra lines are omitted.
+
+`gbcli build status --format json` includes a `job` object in the output (the same
+`JobSummary`), or `null` when the retry chain is not followed.
+
 ## Examples
 
 ### Single retry on failure
@@ -112,6 +206,21 @@ llm.build:
 ```
 
 `max_retries` defaults to `0`. A failure ends the build immediately with no retry.
+
+### Job status across a retry (worked example)
+
+A build has two targets, `targetA` and `targetB`, and `max_retries: 1`:
+
+1. The original build runs. `targetA` succeeds; `targetB` fails. The build ends `FAILED`.
+2. gbserver creates one retry. `targetA` is reused (skipped) from the original attempt;
+   `targetB` re-runs and succeeds. The retry build ends `SUCCESS`.
+
+The two build records keep their own statuses — the original stays `FAILED`, the retry is
+`SUCCESS`. Asking the retry chain for its job view returns `status = SUCCESS` with
+`counts = {total: 2, succeeded: 2, failed: 0, running: 0, not_run: 0}`: both spec targets
+succeeded somewhere in the chain, so the job specification completed. `gbcli build status`
+reports **Status: SUCCESS**, **This attempt: FAILED** (when queried on the original), and
+**Job result: 2 of 2 targets succeeded**.
 
 ## Target reuse across the retry chain
 

--- a/docs/builds/build-retry.md
+++ b/docs/builds/build-retry.md
@@ -103,6 +103,7 @@ response is unchanged. The `job` is a `JobSummary`:
 | `status` | The aggregate job status (see precedence below) |
 | `attempts` | Number of builds in the chain (1-based) |
 | `build_ids` | UUIDs of every chain member, root first |
+| `attempt_builds` | Every chain member, root first, each with its own per-attempt `status` (`build_id`, `status`) |
 | `targets` | Per spec-target outcome (`name`, `status`, `build_id`, `target_run_id`, `attempt`) |
 | `counts` | Roll-up of the spec targets across the chain |
 

--- a/docs/builds/lineage.md
+++ b/docs/builds/lineage.md
@@ -67,6 +67,34 @@ get_lineage_store().add_jobstats_for_original_artifact(artifact, input_artifacts
 
 The `GET /api/v1/lineage/build/{build_id}` and `GET /api/v1/lineage/target/{target_id}` endpoints call `create_jobstats_for_target()` to build lineage data on the fly without persisting it.
 
+#### Chain-spanning lineage (`follow_retries`)
+
+`GET /api/v1/lineage/build/{build_id}` accepts an optional `follow_retries` query parameter.
+
+**`follow_retries=false` (the default)** — unchanged: one lineage entry per target run of the
+single build named in the path.
+
+**`follow_retries=true`** — the whole retry chain is reported as one job. Instead of a build's
+own target runs, the response has one entry per spec target, using the **winning run** — the
+run that actually produced that target's artifacts. A target that was reused (skipped) from an
+earlier attempt is dereferenced to the run that executed, so it never appears as an empty
+skipped run. Targets that failed or were never dispatched are omitted — they produced nothing,
+so there is no provenance to report. The response also carries a `job_id` field set to the
+chain root's UUID (the job identity), letting a consumer tell a unified graph from a single
+build's.
+
+Two notes for consumers comparing the two views:
+
+- **Cross-name reuse.** The definition hash excludes the target name (see
+  [target-reuse.md](target-reuse.md)), so a target can legitimately be skipped for an
+  identically-configured target under a *different* name. A unified-lineage entry may therefore
+  reference a winning run whose own target name differs from the spec target it stands in for.
+- **Attribution.** Each entry is stamped with the winning run's **own build** — the attempt
+  that did the work — so its namespace and source facets stay truthful to where the work
+  happened. A reused target is attributed to a different `run.runId` than single-build lineage
+  (`follow_retries=false`) would report for the same spec target. Anyone diffing the two views
+  should expect this shift for reused targets.
+
 ---
 
 ## WandB/OpenLineage Backend

--- a/frontend/api/gbserver.ts
+++ b/frontend/api/gbserver.ts
@@ -220,7 +220,14 @@ export async function describeBuild(buildId: string): Promise<Build> {
   return getBuild(buildId)
 }
 
-export async function getBuildStatus(buildId: string): Promise<BuildStatusDetail> {
+// follow_retries walks the whole retry chain to compute the `job` roll-up.
+// Only pass it where `.job` is actually consumed (the build detail page); other
+// callers (e.g. the artifact lineage panel) don't read it and shouldn't pay for
+// the extra chain traversal.
+export async function getBuildStatus(
+  buildId: string,
+  followRetries = false,
+): Promise<BuildStatusDetail> {
   const { data } = await client.get<{
     status: {
       build: Record<string, unknown>
@@ -230,7 +237,7 @@ export async function getBuildStatus(buildId: string): Promise<BuildStatusDetail
       }>
     }
     job?: JobSummary
-  }>(`/builds/${buildId}/status`, { params: { follow_retries: true } })
+  }>(`/builds/${buildId}/status`, { params: { follow_retries: followRetries } })
 
   const s = data.status
   const build = adaptBuild(s.build)

--- a/frontend/api/gbserver.ts
+++ b/frontend/api/gbserver.ts
@@ -20,6 +20,7 @@ import type {
   BuildStatusDetail,
   BuildTargetRun,
   BuildStepRun,
+  JobSummary,
   Artifact,
   Space,
 } from '@/types'
@@ -228,7 +229,8 @@ export async function getBuildStatus(buildId: string): Promise<BuildStatusDetail
         steps: Record<string, unknown>[]
       }>
     }
-  }>(`/builds/${buildId}/status`)
+    job?: JobSummary
+  }>(`/builds/${buildId}/status`, { params: { follow_retries: true } })
 
   const s = data.status
   const build = adaptBuild(s.build)
@@ -256,6 +258,7 @@ export async function getBuildStatus(buildId: string): Promise<BuildStatusDetail
     },
     history: [],
     targets,
+    job: data.job,
   }
 }
 

--- a/frontend/app/dashboard/builds/[buildId]/BuildDetailPageClient.tsx
+++ b/frontend/app/dashboard/builds/[buildId]/BuildDetailPageClient.tsx
@@ -123,7 +123,7 @@ function BuildDetailContent() {
     error: statusError,
   } = useQuery({
     queryKey: ["build-status", buildId],
-    queryFn: () => getBuildStatus(buildId!),
+    queryFn: () => getBuildStatus(buildId!, true),
     refetchInterval: () =>
       build && ACTIVE_STATUSES.has(build.status) ? 30_000 : false,
     enabled: Boolean(buildId),

--- a/frontend/app/dashboard/builds/[buildId]/DetailsPanel.tsx
+++ b/frontend/app/dashboard/builds/[buildId]/DetailsPanel.tsx
@@ -78,14 +78,50 @@ export function DetailsPanel({ build, status, loading }: DetailsPanelProps) {
               {status.job.counts.running > 0 && `, ${status.job.counts.running} running`}
               {status.job.counts.not_run > 0 && `, ${status.job.counts.not_run} never ran`}
             </DetailField>
+            {status.job.targets.length > 0 && (
+              <DetailField label="Target results">
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+                  {status.job.targets.map((t) => (
+                    <span
+                      key={t.name}
+                      style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+                    >
+                      <code className={styles.wordBreakAll} style={{ fontSize: "0.875rem" }}>
+                        {t.name}
+                      </code>
+                      {t.status ? (
+                        <BuildStatusBadge status={t.status} />
+                      ) : (
+                        <span style={{ fontSize: "0.875rem", color: "#6f6f6f" }}>Never ran</span>
+                      )}
+                    </span>
+                  ))}
+                </div>
+              </DetailField>
+            )}
             <DetailField label="Attempt builds">
-              <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
-                {status.job.build_ids
-                  .filter((id) => id !== build.uuid)
-                  .map((id) => (
-                    <a key={id} href={`/dashboard/builds/${id}`} className={styles.wordBreakAll}>
-                      <code style={{ fontSize: "0.875rem" }}>{id}</code>
-                    </a>
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.375rem" }}>
+                {status.job.attempt_builds
+                  // Root-first by contract, so the ordinal is the position in
+                  // the full list — compute it before filtering out the build
+                  // currently being viewed.
+                  .map((ab, index) => ({ ...ab, attempt: index + 1 }))
+                  .filter((ab) => ab.build_id !== build.uuid)
+                  .map((ab) => (
+                    <span
+                      key={ab.build_id}
+                      style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+                    >
+                      <a
+                        href={`/dashboard/builds/_/?id=${ab.build_id}`}
+                        className={styles.wordBreakAll}
+                      >
+                        <code style={{ fontSize: "0.875rem" }}>
+                          Attempt {ab.attempt}: {ab.build_id}
+                        </code>
+                      </a>
+                      <BuildStatusBadge status={ab.status} showLabel={false} />
+                    </span>
                   ))}
               </div>
             </DetailField>

--- a/frontend/app/dashboard/builds/[buildId]/DetailsPanel.tsx
+++ b/frontend/app/dashboard/builds/[buildId]/DetailsPanel.tsx
@@ -66,6 +66,31 @@ export function DetailsPanel({ build, status, loading }: DetailsPanelProps) {
         <DetailField label="Updated">
           {new Date(build.updated_time).toLocaleString()}
         </DetailField>
+        {status?.job && status.job.attempts > 1 && (
+          <>
+            <DetailField label="Job status">
+              <BuildStatusBadge status={status.job.status} />
+            </DetailField>
+            <DetailField label="Attempts">{status.job.attempts}</DetailField>
+            <DetailField label="Targets">
+              {status.job.counts.succeeded} of {status.job.counts.total} succeeded
+              {status.job.counts.failed > 0 && `, ${status.job.counts.failed} failed`}
+              {status.job.counts.running > 0 && `, ${status.job.counts.running} running`}
+              {status.job.counts.not_run > 0 && `, ${status.job.counts.not_run} never ran`}
+            </DetailField>
+            <DetailField label="Attempt builds">
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+                {status.job.build_ids
+                  .filter((id) => id !== build.uuid)
+                  .map((id) => (
+                    <a key={id} href={`/dashboard/builds/${id}`} className={styles.wordBreakAll}>
+                      <code style={{ fontSize: "0.875rem" }}>{id}</code>
+                    </a>
+                  ))}
+              </div>
+            </DetailField>
+          </>
+        )}
         {build.finished_at && (
           <DetailField label="Finished">
             {new Date(build.finished_at).toLocaleString()}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -64,6 +64,33 @@ export interface BuildEvent {
   description: string
 }
 
+export interface JobTargetOutcome {
+  name: string
+  status: BuildStatus | null
+  build_id: string
+  target_run_id: string
+  reused_from_target_run_id: string
+  attempt: number
+}
+
+export interface JobTargetCounts {
+  total: number
+  succeeded: number
+  failed: number
+  running: number
+  not_run: number
+}
+
+/** A build and its retries aggregated into one job (see gbserver jobrollup). */
+export interface JobSummary {
+  job_id: string
+  status: BuildStatus
+  attempts: number
+  build_ids: string[]
+  targets: JobTargetOutcome[]
+  counts: JobTargetCounts
+}
+
 export interface BuildStatusDetail {
   details: {
     build_id: string
@@ -75,6 +102,8 @@ export interface BuildStatusDetail {
   }
   history: BuildEvent[]
   targets: Record<string, BuildTargetRun>
+  /** Present when the status was fetched with follow_retries=true. */
+  job?: JobSummary
 }
 
 // ── Artifacts ────────────────────────────────────────────────────────────────

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -81,12 +81,19 @@ export interface JobTargetCounts {
   not_run: number
 }
 
+/** One chain member with its own per-attempt status (root-first). */
+export interface AttemptBuild {
+  build_id: string
+  status: BuildStatus
+}
+
 /** A build and its retries aggregated into one job (see gbserver jobrollup). */
 export interface JobSummary {
   job_id: string
   status: BuildStatus
   attempts: number
   build_ids: string[]
+  attempt_builds: AttemptBuild[]
   targets: JobTargetOutcome[]
   counts: JobTargetCounts
 }

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -113,10 +113,12 @@ def _job_overview_lines(details: Any) -> tuple[str, str, str]:
         if details["build_id"] in build_ids
         else 0
     )
-    attempt_line = (
-        f"\n- **This attempt**: {build_headline} "
-        f"(attempt {position} of {job.get('attempts')})"
+    # Omit the ordinal when the queried build isn't found in the chain (defensive
+    # — it always is in practice); "attempt 0 of N" would read like a bug.
+    attempt_ordinal = (
+        f" (attempt {position} of {job.get('attempts')})" if position else ""
     )
+    attempt_line = f"\n- **This attempt**: {build_headline}{attempt_ordinal}"
 
     counts = job.get("counts") or {}
     extras = [

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -89,6 +89,53 @@ def get_status_emoji(status: str) -> str:
             return ""
 
 
+def _job_overview_lines(details: Any) -> tuple[str, str, str]:
+    """Build the status overview's headline plus, for a real retry chain, the
+    per-attempt and job-summary lines.
+
+    Returns ``(headline, attempt_line, summary_line)`` as markdown fragments.
+    For a single-attempt or job-less build the headline is just the build's own
+    status and the other two are empty, so the output is unchanged from before —
+    only a genuine multi-attempt job promotes the headline to the job status.
+    """
+    build_status = str(details["status"]).upper()
+    build_headline = f"{get_status_emoji(details['status'])} {build_status}"
+    job = details.get("job") or {}
+    if int(job.get("attempts") or 0) <= 1:
+        return build_headline, "", ""
+
+    job_status = str(job.get("status"))
+    headline = f"{get_status_emoji(job_status)} {job_status.upper()}"
+
+    build_ids = job.get("build_ids") or []
+    position = (
+        build_ids.index(details["build_id"]) + 1
+        if details["build_id"] in build_ids
+        else 0
+    )
+    attempt_line = (
+        f"\n- **This attempt**: {build_headline} "
+        f"(attempt {position} of {job.get('attempts')})"
+    )
+
+    counts = job.get("counts") or {}
+    extras = [
+        f"{counts.get(key, 0)} {label}"
+        for key, label in (
+            ("failed", "failed"),
+            ("running", "running"),
+            ("not_run", "never ran"),
+        )
+        if counts.get(key)
+    ]
+    suffix = f" — {', '.join(extras)}" if extras else ""
+    summary_line = (
+        f"\n- **Job result**: {counts.get('succeeded', 0)} of "
+        f"{counts.get('total', 0)} targets succeeded{suffix}"
+    )
+    return headline, attempt_line, summary_line
+
+
 def execution_status_plain_output(
     details: Any,
     targets: List[Any],
@@ -122,16 +169,17 @@ def execution_status_plain_output(
         if retried_by
         else ""
     )
+    headline, attempt_line, job_summary_line = _job_overview_lines(details)
     details_output = f"""
 # Build {details['build_id']}
 
 - **Build name**: {details['name']}
 - **Build description**: {details.get('description', '')}
-- **Status**: {get_status_emoji(details['status'])} {str(details['status']).upper()}
+- **Status**: {headline}{attempt_line}
 - **Started**: {datetime_to_string(details['started_at'])}
 - **Updated**: {datetime_to_string(details['updated_at'])}
 - **Status page**: <{WEB_UI_URL}/builds/{details['build_id']}>
-- **Build PR**: {source_pr}{retry_of_line}{retried_by_line}
+- **Build PR**: {source_pr}{retry_of_line}{retried_by_line}{job_summary_line}
 - **Targets**
 {"".join(targets_overview)}
     """

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -1274,6 +1274,10 @@ def build_status(
         return None, None, None, "Build status could not be retrieved."
     build_status = status_response["status"]
     retry_chain = status_response.get("retry_chain") if follow_retries else None
+    # The chain aggregated into one job: whether the build specification
+    # completed, regardless of which attempt did the work. Present only when
+    # following the retry chain (Task 4 populates it alongside retry_chain).
+    job = status_response.get("job") if follow_retries else None
 
     if id_format != "url":
         resolved_space_name = global_space.get("name")
@@ -1379,6 +1383,7 @@ def build_status(
         "description": build_status["build"]["description"],
         "retry_of_build_ids": retry_of_build_ids,
         "retried_by_build_ids": retried_by_build_ids,
+        "job": job,
     }
 
     return build_details, targets, build_history, None

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -38,6 +38,7 @@ from gbserver.api.utils import (
     is_super_admin,
     split_tags,
 )
+from gbserver.build.jobrollup import JobSummary, roll_up
 from gbserver.buildrunner.validation import BuildValidation
 from gbserver.buildwatcher.buildwatcher import BuildWatcher
 from gbserver.storage.artifact_registration import ArtifactRegistration
@@ -167,6 +168,10 @@ class BuildStatusResponse(BaseModel):
     status: BuildStatus
     # Populated (root-first) only when the request sets follow_retries=true.
     retry_chain: Optional[list[BuildChainMember]] = None
+    # The chain aggregated into one job view: whether the build specification
+    # completed, regardless of which attempt did the work. Set alongside
+    # retry_chain, since it is derived from exactly the same records.
+    job: Optional[JobSummary] = None
 
 
 class CancelBuildResponse(BaseModel):
@@ -480,6 +485,13 @@ def get_build_status(
                 records = __build_target_records(storage, member.uuid)
             chain.append(BuildChainMember(build=member, target_runs=records))
         resp.retry_chain = chain
+        # Reuses the records already assembled above, so this adds no queries.
+        resp.job = roll_up(
+            [
+                (member.build, [tr.target for tr in member.target_runs])
+                for member in chain
+            ]
+        )
     return resp
 
 

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -129,6 +129,10 @@ def get_build_jobstats(
         return BuildJobStatsResponse(build_id=build_id, targets=target_responses)
 
     members = get_retry_chain_members(storage.build_storage, build)
+    # Re-query each member's targets, including the queried build. Unlike the
+    # status endpoint (Task 4), there is no already-assembled record graph worth
+    # reusing here — each member's lineage input is one get_by_where — so the
+    # queried build is not special-cased.
     chain = [
         (
             member,

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, ConfigDict
 
 from gbserver.api.build_files_paths import authorize_build_read_access
 from gbserver.api.utils import has_space_member_access
+from gbserver.build.jobrollup import pick_winning_runs, resolve_spec_targets
 from gbserver.lineage.openlineage_models import (
     ArtifactGraphRequest,
     ArtifactGraphResponse,
@@ -38,7 +39,7 @@ from gbserver.lineage.openlineage_models import (
 from gbserver.lineage.openlineage_service import LineageService, LineageServiceFactory
 from gbserver.lineage.openlineage_utils import parse_hf_url
 from gbserver.storage.singleton_storage import get_admin_storage
-from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_build import StoredBuild, get_retry_chain_members
 from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.utils.logger import get_logger
 
@@ -80,17 +81,28 @@ class BuildJobStatsResponse(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     build_id: str
+    # The retry chain's root, set only when follow_retries=true, so a caller can
+    # tell a unified graph from a single build's.
+    job_id: Optional[str] = None
     targets: list[dict[str, list[Any]]]
 
 
 @lineage_api.get("/build/{build_id}")
-def get_build_jobstats(request: Request, build_id: str) -> BuildJobStatsResponse:
-    """Get JobStats for all targets in a build."""
+def get_build_jobstats(
+    request: Request, build_id: str, follow_retries: bool = False
+) -> BuildJobStatsResponse:
+    """Get JobStats for all targets in a build.
+
+    With follow_retries=true the whole retry chain is reported as one job: each
+    spec target contributes the run that actually produced its artifacts, so a
+    target reused from an earlier attempt is dereferenced to that attempt's run
+    rather than appearing as an empty skipped run. Targets that never succeeded
+    are omitted — they produced nothing, so they have no provenance.
+    """
     storage = get_admin_storage()
 
     from gbserver.lineage.jobstats import get_lineage_store
 
-    # Get the build
     build = storage.build_storage.get_by_uuid(build_id)
     if build is None:
         raise HTTPException(
@@ -98,24 +110,54 @@ def get_build_jobstats(request: Request, build_id: str) -> BuildJobStatsResponse
             detail=f"Build with id {build_id} not found",
         )
     assert isinstance(build, StoredBuild)
+    # Every member of a retry chain shares the original's space and username
+    # (see BuildRunner.__prepare_retry, pinned by test_should_retry.py), so
+    # authorizing the queried build authorizes the whole chain.
     authorize_build_read_access(request, build)
 
-    # Get all targets for this build
-    row_filter = {"build_id": build_id}
-    targets = storage.target_storage.get_by_where(row_filter)
-
-    # Collect JobStats for each target
     jobstats_storage = get_lineage_store()
     target_responses: list[dict[str, list[Any]]] = []
 
-    for target in targets:
-        assert isinstance(target, StoredTargetRun)
+    if not follow_retries:
+        targets = storage.target_storage.get_by_where({"build_id": build_id})
+        for target in targets:
+            assert isinstance(target, StoredTargetRun)
+            _, jobstats_dict = jobstats_storage.create_jobstats_for_target(
+                storage, target, build
+            )
+            target_responses.append(jobstats_dict)
+        return BuildJobStatsResponse(build_id=build_id, targets=target_responses)
+
+    members = get_retry_chain_members(storage.build_storage, build)
+    chain = [
+        (
+            member,
+            [
+                target
+                for target in storage.target_storage.get_by_where(
+                    {"build_id": member.uuid}
+                )
+                if isinstance(target, StoredTargetRun)
+            ],
+        )
+        for member in members
+    ]
+    winners = pick_winning_runs(chain)
+    for name in resolve_spec_targets(chain):
+        winner = winners.get(name)
+        if winner is None:
+            continue
+        # Stamp the jobstats with the run's own build, not the queried one, so
+        # the namespace and source facets stay truthful to where the work
+        # happened.
         _, jobstats_dict = jobstats_storage.create_jobstats_for_target(
-            storage, target, build
+            storage, winner.run, winner.build
         )
         target_responses.append(jobstats_dict)
 
-    return BuildJobStatsResponse(build_id=build_id, targets=target_responses)
+    return BuildJobStatsResponse(
+        build_id=build_id, job_id=members[0].uuid, targets=target_responses
+    )
 
 
 @lineage_api.get("/target/{target_id}")

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -55,12 +55,13 @@ class TargetOutcome(BaseModel):
     status: Optional[Status] = None
     build_id: str = ""
     target_run_id: str = ""
-    # Anomaly signal, not a reuse indicator. Normally empty: reuse only matches
-    # runs within the same chain, so the run that executed a reused target is
-    # present too and is selected directly. A value here means no executed
-    # success was found for this target and only a skip marker survived — the
-    # pointer is recorded so degraded provenance is visible rather than silently
-    # accepted.
+    # Set when the winning run is not this target's own run, so provenance is
+    # indirect. Two ways that happens, both real: the definition hash excludes
+    # the target name (see docs/builds/target-reuse.md), so a target can
+    # legitimately be skipped for an identically-configured target under a
+    # different name; or nothing but a skip marker survived for this target.
+    # Normally empty, since same-name reuse leaves the executed run in this
+    # target's own group where it is selected directly.
     reused_from_target_run_id: str = ""
     # Zero-based: the owning member's retry_count, so the root is attempt 0.
     # Display as `attempt + 1` against JobSummary.attempts, which is 1-based.
@@ -102,8 +103,8 @@ class JobSummary(BaseModel):
 class WinningRun(NamedTuple):
     """The run that actually produced a target's artifacts, plus how we got there.
 
-    ``reused_from_target_run_id`` is normally empty; see
-    ``TargetOutcome.reused_from_target_run_id`` for what a value means.
+    ``run.status`` is always SUCCESS. ``reused_from_target_run_id`` is normally
+    empty; see ``TargetOutcome.reused_from_target_run_id`` for what a value means.
     """
 
     build: StoredBuild
@@ -171,12 +172,18 @@ def _pick_winners(grouped: Dict[str, List[ChainRun]]) -> Dict[str, WinningRun]:
     Takes a precomputed grouping so a caller that already needs one (``roll_up``)
     does not have to build it twice.
     """
-    # Skip pointers are resolved by UUID across the whole chain, so this index
-    # deliberately spans every target name rather than one group.
+    # Skip pointers resolve by UUID across the whole chain, so this index
+    # deliberately spans every target name rather than one group. Restricted to
+    # successful runs purely defensively: the reuse lookup already selects on a
+    # non-empty target_hash and SUCCESS, so a pointee is a successful run in any
+    # healthy chain. The filter only bites on corrupt rows, where it keeps the
+    # postcondition that every WinningRun carries a SUCCESS run — a pointer to
+    # anything else falls back to the marker, which is SUCCESS by construction.
     by_uuid = {
         chain_run.run.uuid: chain_run
         for entries in grouped.values()
         for chain_run in entries
+        if chain_run.run.status == Status.SUCCESS
     }
 
     winners: Dict[str, WinningRun] = {}
@@ -186,7 +193,11 @@ def _pick_winners(grouped: Dict[str, List[ChainRun]]) -> Dict[str, WinningRun]:
             continue
 
         # Prefer the attempt that really executed. Entries are ordered earliest
-        # attempt first, so the first match is the earliest success.
+        # attempt first, so the first match is the earliest success. Earliest is
+        # chosen for determinism: when a target executes successfully more than
+        # once in a chain (reuse disabled, or the first run's artifacts were not
+        # fully registered) both runs derive their output URIs from the same
+        # target_hash, so they name the same artifacts and either would serve.
         executed = [
             entry for entry in successes if not entry.run.skipped_for_prerun_target_id
         ]
@@ -195,12 +206,14 @@ def _pick_winners(grouped: Dict[str, List[ChainRun]]) -> Dict[str, WinningRun]:
             winners[name] = WinningRun(build=winner.build, run=winner.run)
             continue
 
-        # Anomalous: nothing but skip markers survived, so no executed success is
-        # available to prefer. Fall back to following the pointer to the run that
-        # produced the artifacts, and to the build that owns it, so lineage still
-        # attributes them to the attempt that did the work. The pointer is kept
-        # either way, so degraded provenance stays visible even when the pointer
-        # itself cannot be resolved.
+        # This target has no executed success of its own, so the winner is the run
+        # the marker points at, together with the build that owns it so lineage
+        # attributes the artifacts to the attempt that did the work. One hop is
+        # provably enough: the reuse lookup selects on a non-empty target_hash,
+        # and a marker is stored with an empty one, so a marker can never be
+        # returned as a pointee and pointer chains cannot form. The pointer is
+        # recorded either way, so indirect provenance stays visible even when it
+        # cannot be resolved.
         skipped = successes[0]
         pointer = skipped.run.skipped_for_prerun_target_id
         resolved = by_uuid.get(pointer, skipped)
@@ -214,14 +227,16 @@ def _pick_winners(grouped: Dict[str, List[ChainRun]]) -> Dict[str, WinningRun]:
 
 def pick_winning_runs(chain: ChainInput) -> Dict[str, WinningRun]:
     """Map each target name that succeeded anywhere in the chain to the run that
-    actually produced its artifacts.
+    actually produced its artifacts. Every returned run has status SUCCESS.
 
     A target reused from an earlier attempt is recorded as SUCCESS with
     ``skipped_for_prerun_target_id`` set, but it dispatches no steps and produces
-    no artifacts of its own. Because reuse only matches runs within the same
-    chain, the run that did execute is normally present in the group too and is
-    selected directly. Following the pointer is the fallback for when it is not;
-    see ``TargetOutcome.reused_from_target_run_id``.
+    no artifacts of its own, so the run that executed has to be found instead.
+    Reuse only ever searches within the chain, so that run is always present;
+    under the same name it is in this target's own group and is selected directly.
+    The pointer is followed when it is not — which happens legitimately, because
+    the definition hash excludes the target name, so a target can be skipped for
+    an identically-configured target under a different name.
 
     Targets that never succeeded are absent from the result: they produced
     nothing, so they have no artifacts and no provenance to report.

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -86,6 +86,20 @@ class JobTargetCounts(BaseModel):
     not_run: int = 0
 
 
+class AttemptBuild(BaseModel):
+    """One chain member with its own honest per-attempt status.
+
+    The list is root-first, so the display ordinal is the entry's position + 1
+    against ``JobSummary.attempts``. ``build_ids`` carries the same ids in the
+    same order (kept for callers that only need the ids, e.g. the CLI ordinal
+    lookup); this adds the per-member status so a client can label each attempt
+    without a follow-up request per build.
+    """
+
+    build_id: str = ""
+    status: Status = Status.PENDING
+
+
 class JobSummary(BaseModel):
     """A retry chain aggregated into one job.
 
@@ -99,6 +113,8 @@ class JobSummary(BaseModel):
     # 1-based cardinality: the number of members in the chain.
     attempts: int = 0
     build_ids: List[str] = Field(default_factory=list)
+    # Same members as build_ids, root first, each paired with its own status.
+    attempt_builds: List[AttemptBuild] = Field(default_factory=list)
     targets: List[TargetOutcome] = Field(default_factory=list)
     counts: JobTargetCounts = Field(default_factory=JobTargetCounts)
 
@@ -380,6 +396,9 @@ def roll_up(chain: ChainInput) -> JobSummary:
         ),
         attempts=len(chain),
         build_ids=[build.uuid for build, _ in chain],
+        attempt_builds=[
+            AttemptBuild(build_id=build.uuid, status=build.status) for build, _ in chain
+        ],
         targets=outcomes,
         counts=counts,
     )

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aggregate a build retry chain into a single job view.
+
+A build-level retry creates a new StoredBuild linked to the original (see
+docs/builds/build-retry.md). Each member keeps its own per-attempt status, so no
+single member answers "did the job specification complete?" — the original stays
+FAILED even when a later attempt finished every remaining target.
+
+These functions derive that answer on read. They are pure: the caller fetches the
+chain members and their target runs and passes them in root-first order. Nothing
+here touches storage, so the whole rule is unit-testable without a database, and
+both the build-status and lineage endpoints can share it rather than growing two
+copies that drift apart.
+
+Every function here is total — there are no raising paths. The job summary is
+additive to endpoints that already work without it, so a malformed chain must
+degrade to a best-effort summary rather than fail the request.
+"""
+
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
+
+from pydantic import BaseModel, Field
+
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.types.status import Status
+
+# Chain members paired with their target runs, ordered root first — exactly what
+# get_retry_chain_members() returns, zipped with each member's runs.
+ChainInput = Sequence[Tuple[StoredBuild, List[StoredTargetRun]]]
+
+
+class TargetOutcome(BaseModel):
+    """One spec target's best outcome across the whole chain."""
+
+    name: str
+    # None means no run exists for this spec target: it was never dispatched,
+    # e.g. an upstream dependency failed. Modelled as None rather than a new
+    # Status member so the shared Status vocabulary stays untouched.
+    status: Optional[Status] = None
+    build_id: str = ""
+    target_run_id: str = ""
+    reused_from_target_run_id: str = ""
+    attempt: int = 0
+
+
+class JobTargetCounts(BaseModel):
+    total: int = 0
+    succeeded: int = 0
+    # Has a run that did not succeed. While the job is RUNNING this includes
+    # attempts still in flight.
+    failed: int = 0
+    not_run: int = 0
+
+
+class JobSummary(BaseModel):
+    job_id: str = ""
+    status: Status = Status.PENDING
+    attempts: int = 0
+    build_ids: List[str] = Field(default_factory=list)
+    targets: List[TargetOutcome] = Field(default_factory=list)
+    counts: JobTargetCounts = Field(default_factory=JobTargetCounts)
+
+
+class WinningRun(NamedTuple):
+    """The run that actually produced a target's artifacts, plus how we got there."""
+
+    build: StoredBuild
+    run: StoredTargetRun
+    reused_from_target_run_id: str = ""
+
+
+def _run_sort_key(run: StoredTargetRun) -> Tuple[int, str, str]:
+    """Order runs deterministically within one attempt.
+
+    A skipped run has no started_at, so sort missing starts first instead of
+    comparing None against a datetime. The UUID breaks remaining ties, keeping
+    API responses and test assertions stable.
+    """
+    return (0 if run.started_at is None else 1, str(run.started_at or ""), run.uuid)
+
+
+def _group_runs_by_name(
+    chain: ChainInput,
+) -> Dict[str, List[Tuple[int, StoredBuild, StoredTargetRun]]]:
+    """Group every run in the chain by target name, earliest attempt first."""
+    grouped: Dict[str, List[Tuple[int, StoredBuild, StoredTargetRun]]] = {}
+    for index, (build, runs) in enumerate(chain):
+        for run in sorted(runs, key=_run_sort_key):
+            grouped.setdefault(run.name, []).append((index, build, run))
+    return grouped
+
+
+def resolve_spec_targets(root: StoredBuild, chain: ChainInput) -> List[str]:
+    """The job's target names, in a stable order.
+
+    ``root.targets`` records the requested target subset and is authoritative
+    when set: it is the only way to know a target was never dispatched, since
+    such a target has no StoredTargetRun at all. When it is unset the names are
+    derived from observed runs, and never-dispatched targets are invisible —
+    an accepted limitation that keeps build-config parsing off the read path.
+    """
+    if root.targets:
+        return list(dict.fromkeys(root.targets))
+    return sorted(_group_runs_by_name(chain))

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -79,6 +79,9 @@ class JobTargetCounts(BaseModel):
     # Finished without succeeding. Kept distinct from `running` so an in-progress
     # job is never reported as having failed a target it has not actually failed.
     failed: int = 0
+    # Counts target-run statuses independently of the job's own status, so a
+    # finished job can still show running > 0 if a member's run rows were not
+    # finalized (e.g. a cross-member cancel updates build rows only).
     running: int = 0
     not_run: int = 0
 
@@ -145,6 +148,20 @@ def _group_runs_by_name(chain: ChainInput) -> Dict[str, List[ChainRun]]:
     return grouped
 
 
+def _spec_targets(
+    root_targets: Optional[List[str]], grouped: Dict[str, List[ChainRun]]
+) -> List[str]:
+    """Spec target names in a stable order, from an already-computed grouping.
+
+    ``root_targets`` is authoritative when set (it records the requested subset,
+    and is the only way to know a target was never dispatched); otherwise the
+    names are the sorted union of what actually ran.
+    """
+    if root_targets:
+        return list(dict.fromkeys(root_targets))
+    return sorted(grouped)
+
+
 def resolve_spec_targets(chain: ChainInput) -> List[str]:
     """The job's target names, in a stable order.
 
@@ -161,9 +178,7 @@ def resolve_spec_targets(chain: ChainInput) -> List[str]:
     keeps build-config parsing off the read path.
     """
     root_targets = chain[0][0].targets if chain else None
-    if root_targets:
-        return list(dict.fromkeys(root_targets))
-    return sorted(_group_runs_by_name(chain))
+    return _spec_targets(root_targets, _group_runs_by_name(chain))
 
 
 def _pick_winners(grouped: Dict[str, List[ChainRun]]) -> Dict[str, WinningRun]:
@@ -245,17 +260,18 @@ def pick_winning_runs(chain: ChainInput) -> Dict[str, WinningRun]:
 
 
 def _outcome_for(
-    name: str,
+    spec_name: str,
     grouped: Dict[str, List[ChainRun]],
     winners: Dict[str, WinningRun],
 ) -> TargetOutcome:
     """This spec target's best outcome across the whole chain."""
-    winner = winners.get(name)
+    winner = winners.get(spec_name)
     if winner is not None:
-        # `name` is the spec name, not winner.run.name: under cross-name reuse
-        # the winning run legitimately belongs to a differently-named target.
+        # `spec_name` is the spec name, not winner.run.name: under cross-name
+        # reuse the winning run legitimately belongs to a differently-named
+        # target.
         return TargetOutcome(
-            name=name,
+            name=spec_name,
             status=Status.SUCCESS,
             build_id=winner.build.uuid,
             target_run_id=winner.run.uuid,
@@ -263,16 +279,16 @@ def _outcome_for(
             attempt=winner.build.retry_count,
         )
 
-    entries = grouped.get(name) or []
+    entries = grouped.get(spec_name) or []
     if not entries:
         # No run at all: never dispatched, e.g. an upstream dependency failed.
-        return TargetOutcome(name=name)
+        return TargetOutcome(name=spec_name)
 
-    # Never succeeded anywhere, so the latest attempt's run is the outcome that
-    # represents this target.
+    # Never succeeded anywhere. Report the latest attempt's run: it is the one
+    # whose logs a user should open to see why the target is still failing.
     latest = entries[-1]
     return TargetOutcome(
-        name=name,
+        name=spec_name,
         status=latest.run.status,
         build_id=latest.build.uuid,
         target_run_id=latest.run.uuid,
@@ -282,7 +298,7 @@ def _outcome_for(
 
 
 def _job_status(  # pylint: disable=too-many-return-statements
-    statuses: List[Status], counts: JobTargetCounts
+    statuses: List[Status], counts: JobTargetCounts, targets_authoritative: bool
 ) -> Status:
     """The job's status. First match wins.
 
@@ -300,7 +316,14 @@ def _job_status(  # pylint: disable=too-many-return-statements
         # Nothing to aggregate, so defer to the most recent attempt rather than
         # inventing a verdict.
         return statuses[-1] if statuses else Status.PENDING
-    if counts.succeeded == counts.total:
+    if counts.succeeded == counts.total and (
+        targets_authoritative or (bool(statuses) and statuses[-1] == Status.SUCCESS)
+    ):
+        # When the target list is not authoritative (targets=None), the count
+        # denominator is only what actually ran, so "every counted target
+        # succeeded" is trivially true for a build that died before dispatching
+        # the rest. Trust that verdict only when the newest attempt itself
+        # succeeded; otherwise fall through to the member statuses below.
         return Status.SUCCESS
     if Status.CANCELLED in statuses:
         return Status.CANCELLED
@@ -322,33 +345,39 @@ def roll_up(chain: ChainInput) -> JobSummary:
         return JobSummary()
 
     root = chain[0][0]
-    # Grouped once and handed to _pick_winners, which exists in this shape so the
-    # chain is not walked twice.
+    # Group once; both the winners and the spec-target fallback reuse it.
     grouped = _group_runs_by_name(chain)
     winners = _pick_winners(grouped)
+    root_targets = root.targets
     outcomes = [
-        _outcome_for(name, grouped, winners) for name in resolve_spec_targets(chain)
+        _outcome_for(name, grouped, winners)
+        for name in _spec_targets(root_targets, grouped)
     ]
     counts = JobTargetCounts(
         total=len(outcomes),
-        succeeded=sum(1 for o in outcomes if o.status == Status.SUCCESS),
-        # Finished without succeeding. Kept separate from `running` so an
-        # in-progress job never reports having failed a target it has not failed.
+        succeeded=sum(1 for outcome in outcomes if outcome.status == Status.SUCCESS),
+        # finished without succeeding
         failed=sum(
             1
-            for o in outcomes
-            if o.status is not None
-            and o.status != Status.SUCCESS
-            and o.status.is_finished()
+            for outcome in outcomes
+            if outcome.status is not None
+            and outcome.status != Status.SUCCESS
+            and outcome.status.is_finished()
         ),
         running=sum(
-            1 for o in outcomes if o.status is not None and not o.status.is_finished()
+            1
+            for outcome in outcomes
+            if outcome.status is not None and not outcome.status.is_finished()
         ),
-        not_run=sum(1 for o in outcomes if o.status is None),
+        not_run=sum(1 for outcome in outcomes if outcome.status is None),
     )
     return JobSummary(
         job_id=root.uuid,
-        status=_job_status([build.status for build, _ in chain], counts),
+        status=_job_status(
+            [build.status for build, _ in chain],
+            counts,
+            targets_authoritative=bool(root_targets),
+        ),
         attempts=len(chain),
         build_ids=[build.uuid for build, _ in chain],
         targets=outcomes,

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -56,21 +56,37 @@ class TargetOutcome(BaseModel):
     build_id: str = ""
     target_run_id: str = ""
     reused_from_target_run_id: str = ""
+    # Zero-based: the owning member's retry_count, so the root is attempt 0.
+    # Display as `attempt + 1` against JobSummary.attempts, which is 1-based.
     attempt: int = 0
 
 
 class JobTargetCounts(BaseModel):
+    """How the job's spec targets ended up.
+
+    Partitioned so that ``total == succeeded + failed + running + not_run``.
+    """
+
     total: int = 0
     succeeded: int = 0
-    # Has a run that did not succeed. While the job is RUNNING this includes
-    # attempts still in flight.
+    # Finished without succeeding. Kept distinct from `running` so an in-progress
+    # job is never reported as having failed a target it has not actually failed.
     failed: int = 0
+    running: int = 0
     not_run: int = 0
 
 
 class JobSummary(BaseModel):
+    """A retry chain aggregated into one job.
+
+    Every field carries a default so an empty or unreadable chain can be
+    summarised as ``JobSummary()`` rather than raising: this type is additive to
+    endpoints that already work without it.
+    """
+
     job_id: str = ""
     status: Status = Status.PENDING
+    # 1-based cardinality: the number of members in the chain.
     attempts: int = 0
     build_ids: List[str] = Field(default_factory=list)
     targets: List[TargetOutcome] = Field(default_factory=list)
@@ -85,36 +101,55 @@ class WinningRun(NamedTuple):
     reused_from_target_run_id: str = ""
 
 
+class ChainRun(NamedTuple):
+    """A target run together with the chain member that owns it."""
+
+    build: StoredBuild
+    run: StoredTargetRun
+
+
 def _run_sort_key(run: StoredTargetRun) -> Tuple[int, str, str]:
     """Order runs deterministically within one attempt.
 
-    A skipped run has no started_at, so sort missing starts first instead of
-    comparing None against a datetime. The UUID breaks remaining ties, keeping
-    API responses and test assertions stable.
+    A skipped run has no started_at, so sort missing starts first rather than
+    comparing None against a datetime. The timestamp is stringified so a
+    naive/aware mix cannot raise; offsets are uniformly UTC in practice, so
+    lexicographic order matches chronological order. Do not turn this into a
+    datetime comparison — that reintroduces a raising path. The UUID breaks
+    remaining ties, keeping API responses and test assertions stable.
     """
     return (0 if run.started_at is None else 1, str(run.started_at or ""), run.uuid)
 
 
-def _group_runs_by_name(
-    chain: ChainInput,
-) -> Dict[str, List[Tuple[int, StoredBuild, StoredTargetRun]]]:
-    """Group every run in the chain by target name, earliest attempt first."""
-    grouped: Dict[str, List[Tuple[int, StoredBuild, StoredTargetRun]]] = {}
-    for index, (build, runs) in enumerate(chain):
+def _group_runs_by_name(chain: ChainInput) -> Dict[str, List[ChainRun]]:
+    """Group every run in the chain by target name, earliest attempt first.
+
+    List position carries the ordering callers rely on: the first entry is the
+    earliest attempt's run for that target and the last is the most recent.
+    """
+    grouped: Dict[str, List[ChainRun]] = {}
+    for build, runs in chain:
         for run in sorted(runs, key=_run_sort_key):
-            grouped.setdefault(run.name, []).append((index, build, run))
+            grouped.setdefault(run.name, []).append(ChainRun(build=build, run=run))
     return grouped
 
 
-def resolve_spec_targets(root: StoredBuild, chain: ChainInput) -> List[str]:
+def resolve_spec_targets(chain: ChainInput) -> List[str]:
     """The job's target names, in a stable order.
+
+    The chain is root-first by contract, so the root's ``targets`` list is read
+    from ``chain[0]``. Deriving it from the chain rather than accepting it as a
+    separate argument removes any chance of a caller passing a retry in place of
+    the root.
 
     ``root.targets`` records the requested target subset and is authoritative
     when set: it is the only way to know a target was never dispatched, since
-    such a target has no StoredTargetRun at all. When it is unset the names are
-    derived from observed runs, and never-dispatched targets are invisible —
-    an accepted limitation that keeps build-config parsing off the read path.
+    such a target has no StoredTargetRun at all. When it is unset — None or
+    empty — the names are derived from runs observed across every member, and
+    never-dispatched targets are invisible. That is an accepted limitation which
+    keeps build-config parsing off the read path.
     """
-    if root.targets:
-        return list(dict.fromkeys(root.targets))
+    root_targets = chain[0][0].targets if chain else None
+    if root_targets:
+        return list(dict.fromkeys(root_targets))
     return sorted(_group_runs_by_name(chain))

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -242,3 +242,115 @@ def pick_winning_runs(chain: ChainInput) -> Dict[str, WinningRun]:
     nothing, so they have no artifacts and no provenance to report.
     """
     return _pick_winners(_group_runs_by_name(chain))
+
+
+def _outcome_for(
+    name: str,
+    grouped: Dict[str, List[ChainRun]],
+    winners: Dict[str, WinningRun],
+) -> TargetOutcome:
+    """This spec target's best outcome across the whole chain."""
+    winner = winners.get(name)
+    if winner is not None:
+        # `name` is the spec name, not winner.run.name: under cross-name reuse
+        # the winning run legitimately belongs to a differently-named target.
+        return TargetOutcome(
+            name=name,
+            status=Status.SUCCESS,
+            build_id=winner.build.uuid,
+            target_run_id=winner.run.uuid,
+            reused_from_target_run_id=winner.reused_from_target_run_id,
+            attempt=winner.build.retry_count,
+        )
+
+    entries = grouped.get(name) or []
+    if not entries:
+        # No run at all: never dispatched, e.g. an upstream dependency failed.
+        return TargetOutcome(name=name)
+
+    # Never succeeded anywhere, so the latest attempt's run is the outcome that
+    # represents this target.
+    latest = entries[-1]
+    return TargetOutcome(
+        name=name,
+        status=latest.run.status,
+        build_id=latest.build.uuid,
+        target_run_id=latest.run.uuid,
+        reused_from_target_run_id=latest.run.skipped_for_prerun_target_id,
+        attempt=latest.build.retry_count,
+    )
+
+
+def _job_status(  # pylint: disable=too-many-return-statements
+    statuses: List[Status], counts: JobTargetCounts
+) -> Status:
+    """The job's status. First match wins.
+
+    There is deliberately no PARTIAL member: partial completion is FAILED with
+    ``counts.succeeded > 0``. Adding one to the shared Status enum would mean
+    auditing every comparison, exhaustive match and DB CHECK on it, and would leak
+    a job-only concept into per-build status.
+    """
+    if Status.CANCEL_REQUESTED in statuses:
+        # Cancelling any member cancels the whole chain.
+        return Status.CANCEL_REQUESTED
+    if any(not member_status.is_finished() for member_status in statuses):
+        return Status.RUNNING
+    if counts.total == 0:
+        # Nothing to aggregate, so defer to the most recent attempt rather than
+        # inventing a verdict.
+        return statuses[-1] if statuses else Status.PENDING
+    if counts.succeeded == counts.total:
+        return Status.SUCCESS
+    if Status.CANCELLED in statuses:
+        return Status.CANCELLED
+    if Status.INVALID in statuses and counts.succeeded == 0:
+        return Status.INVALID
+    return Status.FAILED
+
+
+def roll_up(chain: ChainInput) -> JobSummary:
+    """Aggregate a root-first retry chain into one job view.
+
+    The chain's root UUID is the job identity: it is already durable and already
+    what ``retry_of_build_id`` points at, so no new table or identifier is needed.
+
+    Spec targets are iterated rather than winners, because a target whose
+    dependency failed has no run at all and must still be reported as not run.
+    """
+    if not chain:
+        return JobSummary()
+
+    root = chain[0][0]
+    # Grouped once and handed to _pick_winners, which exists in this shape so the
+    # chain is not walked twice.
+    grouped = _group_runs_by_name(chain)
+    winners = _pick_winners(grouped)
+    outcomes = [
+        _outcome_for(name, grouped, winners) for name in resolve_spec_targets(chain)
+    ]
+    counts = JobTargetCounts(
+        total=len(outcomes),
+        succeeded=sum(1 for o in outcomes if o.status == Status.SUCCESS),
+        # Finished without succeeding. Kept separate from `running` so an
+        # in-progress job never reports having failed a target it has not failed.
+        failed=sum(
+            1
+            for o in outcomes
+            if o.status is not None
+            and o.status != Status.SUCCESS
+            and o.status.is_finished()
+        ),
+        running=sum(
+            1 for o in outcomes if o.status is not None and not o.status.is_finished()
+        ),
+        not_run=sum(1 for o in outcomes if o.status is None),
+    )
+    return JobSummary(
+        job_id=root.uuid,
+        status=_job_status([build.status for build, _ in chain], counts),
+        attempts=len(chain),
+        build_ids=[build.uuid for build, _ in chain],
+        targets=outcomes,
+        counts=counts,
+    )

--- a/src/gbserver/build/jobrollup.py
+++ b/src/gbserver/build/jobrollup.py
@@ -55,6 +55,12 @@ class TargetOutcome(BaseModel):
     status: Optional[Status] = None
     build_id: str = ""
     target_run_id: str = ""
+    # Anomaly signal, not a reuse indicator. Normally empty: reuse only matches
+    # runs within the same chain, so the run that executed a reused target is
+    # present too and is selected directly. A value here means no executed
+    # success was found for this target and only a skip marker survived — the
+    # pointer is recorded so degraded provenance is visible rather than silently
+    # accepted.
     reused_from_target_run_id: str = ""
     # Zero-based: the owning member's retry_count, so the root is attempt 0.
     # Display as `attempt + 1` against JobSummary.attempts, which is 1-based.
@@ -94,7 +100,11 @@ class JobSummary(BaseModel):
 
 
 class WinningRun(NamedTuple):
-    """The run that actually produced a target's artifacts, plus how we got there."""
+    """The run that actually produced a target's artifacts, plus how we got there.
+
+    ``reused_from_target_run_id`` is normally empty; see
+    ``TargetOutcome.reused_from_target_run_id`` for what a value means.
+    """
 
     build: StoredBuild
     run: StoredTargetRun
@@ -153,3 +163,67 @@ def resolve_spec_targets(chain: ChainInput) -> List[str]:
     if root_targets:
         return list(dict.fromkeys(root_targets))
     return sorted(_group_runs_by_name(chain))
+
+
+def _pick_winners(grouped: Dict[str, List[ChainRun]]) -> Dict[str, WinningRun]:
+    """Select each succeeding target's artifact-producing run from a grouping.
+
+    Takes a precomputed grouping so a caller that already needs one (``roll_up``)
+    does not have to build it twice.
+    """
+    # Skip pointers are resolved by UUID across the whole chain, so this index
+    # deliberately spans every target name rather than one group.
+    by_uuid = {
+        chain_run.run.uuid: chain_run
+        for entries in grouped.values()
+        for chain_run in entries
+    }
+
+    winners: Dict[str, WinningRun] = {}
+    for name, entries in grouped.items():
+        successes = [entry for entry in entries if entry.run.status == Status.SUCCESS]
+        if not successes:
+            continue
+
+        # Prefer the attempt that really executed. Entries are ordered earliest
+        # attempt first, so the first match is the earliest success.
+        executed = [
+            entry for entry in successes if not entry.run.skipped_for_prerun_target_id
+        ]
+        if executed:
+            winner = executed[0]
+            winners[name] = WinningRun(build=winner.build, run=winner.run)
+            continue
+
+        # Anomalous: nothing but skip markers survived, so no executed success is
+        # available to prefer. Fall back to following the pointer to the run that
+        # produced the artifacts, and to the build that owns it, so lineage still
+        # attributes them to the attempt that did the work. The pointer is kept
+        # either way, so degraded provenance stays visible even when the pointer
+        # itself cannot be resolved.
+        skipped = successes[0]
+        pointer = skipped.run.skipped_for_prerun_target_id
+        resolved = by_uuid.get(pointer, skipped)
+        winners[name] = WinningRun(
+            build=resolved.build,
+            run=resolved.run,
+            reused_from_target_run_id=pointer,
+        )
+    return winners
+
+
+def pick_winning_runs(chain: ChainInput) -> Dict[str, WinningRun]:
+    """Map each target name that succeeded anywhere in the chain to the run that
+    actually produced its artifacts.
+
+    A target reused from an earlier attempt is recorded as SUCCESS with
+    ``skipped_for_prerun_target_id`` set, but it dispatches no steps and produces
+    no artifacts of its own. Because reuse only matches runs within the same
+    chain, the run that did execute is normally present in the group too and is
+    selected directly. Following the pointer is the fallback for when it is not;
+    see ``TargetOutcome.reused_from_target_run_id``.
+
+    Targets that never succeeded are absent from the result: they produced
+    nothing, so they have no artifacts and no provenance to report.
+    """
+    return _pick_winners(_group_runs_by_name(chain))

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -322,6 +322,12 @@ class BuildRunner(AbstractBuildRunner):
             return None
         retry_build = StoredBuild(
             name=latest.name,
+            # A retry MUST inherit the original's space_name/username. The
+            # follow-retries status and lineage APIs authorize only the queried
+            # build and then read the rest of the chain unchecked, relying on
+            # every member sharing this owner/space. Changing this to retry into
+            # a different space or owner would turn that shortcut into a
+            # cross-tenant data leak.
             space_name=latest.space_name,
             source_uri="",
             username=latest.username,

--- a/test/integration/standalone/api/test_build_status_retry_chain.py
+++ b/test/integration/standalone/api/test_build_status_retry_chain.py
@@ -180,6 +180,11 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
         assert resp.job.job_id == root.uuid
         assert resp.job.attempts == 2
         assert resp.job.build_ids == [root.uuid, retry.uuid]
+        # Each attempt carries its own honest status, root first.
+        assert [(ab.build_id, ab.status) for ab in resp.job.attempt_builds] == [
+            (root.uuid, Status.FAILED),
+            (retry.uuid, Status.SUCCESS),
+        ]
         assert resp.job.counts.total == 2
         assert resp.job.counts.succeeded == 2
         # The queried build's own status is untouched and still honest.

--- a/test/integration/standalone/api/test_build_status_retry_chain.py
+++ b/test/integration/standalone/api/test_build_status_retry_chain.py
@@ -50,7 +50,11 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
     """get_build_status follows the retry chain only when asked to."""
 
     def _add_build(
-        self: Self, status: Status, retry_count: int, retry_of_build_id=None
+        self: Self,
+        status: Status,
+        retry_count: int,
+        retry_of_build_id=None,
+        targets=None,
     ) -> StoredBuild:
         build = StoredBuild(
             name="test",
@@ -60,6 +64,7 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
             status=status,
             retry_count=retry_count,
             retry_of_build_id=retry_of_build_id,
+            targets=targets,
         )
         self.storage.build_storage.add(build)
         return build
@@ -85,8 +90,13 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
 
     def _make_chain(self: Self):
         """root (succeeded targetA, failed targetB) -> retry (skipped targetA, ok targetB)."""
-        root = self._add_build(Status.FAILED, 0)
-        retry = self._add_build(Status.SUCCESS, 1, retry_of_build_id=root.uuid)
+        root = self._add_build(Status.FAILED, 0, targets=["targetA", "targetB"])
+        retry = self._add_build(
+            Status.SUCCESS,
+            1,
+            retry_of_build_id=root.uuid,
+            targets=["targetA", "targetB"],
+        )
         root.retry_build_id = retry.uuid
         self.storage.build_storage.update(root)
 
@@ -146,3 +156,58 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
         assert [m.build.uuid for m in alias.retry_chain] == [
             m.build.uuid for m in primary.retry_chain
         ]
+
+    def test_no_follow_omits_the_job_summary(self: Self):
+        _root, retry, _root_a = self._make_chain()
+
+        resp = get_build_status(_owner_request(), retry.uuid)
+
+        assert resp.job is None
+
+    def test_job_reports_success_when_queried_by_the_root_build(self: Self):
+        """Regression test for issue #222.
+
+        The root build failed and stays FAILED, but the retry completed every
+        remaining target, so the job as a whole succeeded. Querying by the root's
+        own id must say so.
+        """
+        root, retry, _root_a = self._make_chain()
+
+        resp = get_build_status(_owner_request(), root.uuid, follow_retries=True)
+
+        assert resp.job is not None
+        assert resp.job.status == Status.SUCCESS
+        assert resp.job.job_id == root.uuid
+        assert resp.job.attempts == 2
+        assert resp.job.build_ids == [root.uuid, retry.uuid]
+        assert resp.job.counts.total == 2
+        assert resp.job.counts.succeeded == 2
+        # The queried build's own status is untouched and still honest.
+        assert resp.status.build.status == Status.FAILED
+
+    def test_job_reports_partial_completion_for_an_exhausted_chain(self: Self):
+        root = self._add_build(
+            Status.FAILED, 0, targets=["targetA", "targetB", "targetC"]
+        )
+        self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+        self._add_target(
+            root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00.000Z"
+        )
+
+        resp = get_build_status(_owner_request(), root.uuid, follow_retries=True)
+
+        assert resp.job.status == Status.FAILED
+        assert resp.job.counts.succeeded == 1
+        assert resp.job.counts.failed == 1
+        # targetC never ran because it depended on the failed targetB.
+        assert resp.job.counts.not_run == 1
+
+    def test_status2_alias_returns_the_same_job(self: Self):
+        _root, retry, _root_a = self._make_chain()
+
+        primary = get_build_status(_owner_request(), retry.uuid, follow_retries=True)
+        alias = get_build_status2(_owner_request(), retry.uuid, follow_retries=True)
+
+        assert alias.job == primary.job

--- a/test/integration/standalone/api/test_build_status_retry_chain.py
+++ b/test/integration/standalone/api/test_build_status_retry_chain.py
@@ -198,6 +198,7 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
 
         resp = get_build_status(_owner_request(), root.uuid, follow_retries=True)
 
+        assert resp.job is not None
         assert resp.job.status == Status.FAILED
         assert resp.job.counts.succeeded == 1
         assert resp.job.counts.failed == 1
@@ -210,4 +211,67 @@ class TestBuildStatusRetryChain(AbstractSingletonStorageUsingTest):
         primary = get_build_status(_owner_request(), retry.uuid, follow_retries=True)
         alias = get_build_status2(_owner_request(), retry.uuid, follow_retries=True)
 
+        assert primary.job is not None
         assert alias.job == primary.job
+
+    def test_job_for_a_targets_none_chain_where_the_retry_completed_it(self: Self):
+        # The common production shape: no explicit target list, so the roll-up
+        # takes its non-authoritative branch and trusts SUCCESS only because the
+        # newest attempt (the retry) itself succeeded. Exercises Task 3's blocker
+        # fix end-to-end through the endpoint.
+        root = self._add_build(Status.FAILED, 0, targets=None)
+        retry = self._add_build(
+            Status.SUCCESS, 1, retry_of_build_id=root.uuid, targets=None
+        )
+        root.retry_build_id = retry.uuid
+        self.storage.build_storage.update(root)
+        root_a = self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+        self._add_target(
+            root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00.000Z"
+        )
+        self._add_target(
+            retry.uuid,
+            "targetA",
+            Status.SUCCESS,
+            None,
+            skipped_for_prerun_target_id=root_a.uuid,
+        )
+        self._add_target(
+            retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00.000Z"
+        )
+
+        resp = get_build_status(_owner_request(), root.uuid, follow_retries=True)
+
+        assert resp.job is not None
+        assert resp.job.status == Status.SUCCESS
+
+    def test_job_for_a_targets_none_failed_build_is_not_promoted_to_success(self: Self):
+        # The blocker: with targets=None the count denominator is only what ran,
+        # so a single failed build whose one dispatched target succeeded must NOT
+        # report SUCCESS through the endpoint.
+        root = self._add_build(Status.FAILED, 0, targets=None)
+        self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+
+        resp = get_build_status(_owner_request(), root.uuid, follow_retries=True)
+
+        assert resp.job is not None
+        assert resp.job.status == Status.FAILED
+
+    def test_job_for_a_single_build_with_no_retries(self: Self):
+        # Chain length 1: follow_retries=true on an un-retried build still yields
+        # a one-member job.
+        build = self._add_build(Status.SUCCESS, 0, targets=["targetA"])
+        self._add_target(
+            build.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+
+        resp = get_build_status(_owner_request(), build.uuid, follow_retries=True)
+
+        assert resp.job is not None
+        assert resp.job.attempts == 1
+        assert resp.job.build_ids == [build.uuid]
+        assert resp.job.status == Status.SUCCESS

--- a/test/integration/standalone/api/test_lineage_retry_chain.py
+++ b/test/integration/standalone/api/test_lineage_retry_chain.py
@@ -29,8 +29,10 @@ job_id, not on backend payload internals.
 
 from types import SimpleNamespace
 from typing import Self
+from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 from libgbtest.utils import AbstractSingletonStorageUsingTest
 
 from gbserver.api.lineage import get_build_jobstats
@@ -47,6 +49,17 @@ def _owner_request() -> SimpleNamespace:
     return SimpleNamespace(
         state=SimpleNamespace(
             data={"user": SimpleNamespace(login="tester", email="tester@example.com")}
+        )
+    )
+
+
+def _non_member_request() -> SimpleNamespace:
+    """A caller who is neither the owner 'tester' nor a member of 'testspace'."""
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            data={
+                "user": SimpleNamespace(login="intruder", email="intruder@example.com")
+            }
         )
     )
 
@@ -172,3 +185,56 @@ class TestLineageRetryChain(AbstractSingletonStorageUsingTest):
         # no provenance to report.
         assert resp.job_id == root.uuid
         assert len(resp.targets) == 1
+
+    def test_follow_reports_observed_winners_when_targets_are_unset(self: Self):
+        # targets=None: resolve_spec_targets falls back to the sorted union of
+        # observed run names, so the unified graph still has one entry per
+        # winning target (targetA from the root, targetB from the retry).
+        root = self._add_build(Status.FAILED, 0, targets=None)
+        retry = self._add_build(
+            Status.SUCCESS, 1, retry_of_build_id=root.uuid, targets=None
+        )
+        root.retry_build_id = retry.uuid
+        self.storage.build_storage.update(root)
+        root_a = self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+        self._add_target(
+            root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00.000Z"
+        )
+        self._add_target(
+            retry.uuid,
+            "targetA",
+            Status.SUCCESS,
+            None,
+            skipped_for_prerun_target_id=root_a.uuid,
+        )
+        self._add_target(
+            retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00.000Z"
+        )
+
+        resp = get_build_jobstats(_owner_request(), root.uuid, follow_retries=True)
+
+        assert resp.job_id == root.uuid
+        assert len(resp.targets) == 2
+
+    def test_follow_rejects_a_non_member(self: Self):
+        # The follow path authorizes only the queried build and then reads the
+        # rest of the chain unchecked, so the gate on the queried build is what
+        # protects the whole chain. The session autouse fixture stubs
+        # is_super_admin to True (mock mode), so the real rejection path is only
+        # reachable by locally overriding it False — the same pattern used in
+        # test/unit/api/test_lineage.py and test_builds.py.
+        root, _retry, _root_a = self._make_chain()
+
+        with (
+            patch("gbserver.api.utils.is_super_admin", return_value=False),
+            patch("gbserver.api.utils.is_space_admin", return_value=False),
+            patch("gbserver.api.utils.space_access_check", return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_build_jobstats(
+                    _non_member_request(), root.uuid, follow_retries=True
+                )
+
+        assert exc_info.value.status_code == 401

--- a/test/integration/standalone/api/test_lineage_retry_chain.py
+++ b/test/integration/standalone/api/test_lineage_retry_chain.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API tests for build lineage across a retry chain.
+
+GET /lineage/build/{id} reports only the queried build by default, so the root's
+graph is full of failures and a retry's graph has holes where targets were
+skipped for reuse. With follow_retries=true it reports one entry per spec target,
+taking the run that actually produced the artifacts; failed and never-dispatched
+targets are omitted.
+
+In standalone mode the lineage store is a no-op that returns an empty jobstats
+dict per target, so these tests assert on the number of emitted entries and on
+job_id, not on backend payload internals.
+"""
+
+from types import SimpleNamespace
+from typing import Self
+
+import pytest
+from libgbtest.utils import AbstractSingletonStorageUsingTest
+
+from gbserver.api.lineage import get_build_jobstats
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.types.status import Status
+
+pytestmark = pytest.mark.standalone
+
+
+def _owner_request() -> SimpleNamespace:
+    """A fake Request whose caller is 'tester', the owner of every build in
+    this test's chains, so authorize_build_read_access lets the calls through."""
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            data={"user": SimpleNamespace(login="tester", email="tester@example.com")}
+        )
+    )
+
+
+class TestLineageRetryChain(AbstractSingletonStorageUsingTest):
+    """get_build_jobstats follows the retry chain only when asked to."""
+
+    def _add_build(
+        self: Self,
+        status: Status,
+        retry_count: int,
+        retry_of_build_id=None,
+        targets=None,
+    ) -> StoredBuild:
+        build = StoredBuild(
+            name="test",
+            space_name="testspace",
+            source_uri="",
+            username="tester",
+            status=status,
+            retry_count=retry_count,
+            retry_of_build_id=retry_of_build_id,
+            targets=targets,
+        )
+        self.storage.build_storage.add(build)
+        return build
+
+    def _add_target(
+        self: Self,
+        build_id: str,
+        name: str,
+        status: Status,
+        started_at,
+        skipped_for_prerun_target_id: str = "",
+    ) -> StoredTargetRun:
+        target = StoredTargetRun(
+            name=name,
+            build_id=build_id,
+            environment_uri="space://environments/bash",
+            status=status,
+            started_at=started_at,
+            skipped_for_prerun_target_id=skipped_for_prerun_target_id,
+        )
+        self.storage.target_storage.add(target)
+        return target
+
+    def _make_chain(self: Self):
+        """root (succeeded targetA, failed targetB) -> retry (skipped targetA, ok targetB)."""
+        root = self._add_build(Status.FAILED, 0, targets=["targetA", "targetB"])
+        retry = self._add_build(
+            Status.SUCCESS,
+            1,
+            retry_of_build_id=root.uuid,
+            targets=["targetA", "targetB"],
+        )
+        root.retry_build_id = retry.uuid
+        self.storage.build_storage.update(root)
+
+        root_a = self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+        self._add_target(
+            root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00.000Z"
+        )
+        # targetA is reused (skipped) in the retry; skipped runs have no start time.
+        self._add_target(
+            retry.uuid,
+            "targetA",
+            Status.SUCCESS,
+            None,
+            skipped_for_prerun_target_id=root_a.uuid,
+        )
+        self._add_target(
+            retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00.000Z"
+        )
+        return root, retry, root_a
+
+    def test_no_follow_reports_only_the_queried_build(self: Self):
+        _root, retry, _root_a = self._make_chain()
+
+        resp = get_build_jobstats(_owner_request(), retry.uuid)
+
+        assert resp.job_id is None
+        # Unchanged behaviour: both of the retry's own runs, including the
+        # skipped one that produced nothing.
+        assert len(resp.targets) == 2
+
+    def test_follow_reports_one_entry_per_spec_target(self: Self):
+        root, retry, _root_a = self._make_chain()
+
+        resp = get_build_jobstats(_owner_request(), retry.uuid, follow_retries=True)
+
+        assert resp.job_id == root.uuid
+        assert resp.build_id == retry.uuid
+        # One entry per spec target, no duplicates across the two attempts.
+        assert len(resp.targets) == 2
+
+    def test_follow_reports_the_same_graph_regardless_of_which_member_queried(
+        self: Self,
+    ):
+        root, retry, _root_a = self._make_chain()
+
+        by_root = get_build_jobstats(_owner_request(), root.uuid, follow_retries=True)
+        by_retry = get_build_jobstats(_owner_request(), retry.uuid, follow_retries=True)
+
+        assert by_root.job_id == by_retry.job_id == root.uuid
+        assert len(by_root.targets) == len(by_retry.targets) == 2
+
+    def test_follow_omits_targets_that_produced_nothing(self: Self):
+        root = self._add_build(
+            Status.FAILED, 0, targets=["targetA", "targetB", "targetC"]
+        )
+        self._add_target(
+            root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00.000Z"
+        )
+        self._add_target(
+            root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00.000Z"
+        )
+
+        resp = get_build_jobstats(_owner_request(), root.uuid, follow_retries=True)
+
+        # Only targetA produced artifacts; the failed and never-run targets have
+        # no provenance to report.
+        assert resp.job_id == root.uuid
+        assert len(resp.targets) == 1

--- a/test/integration/standalone/lineage/test_openlineage_service.py
+++ b/test/integration/standalone/lineage/test_openlineage_service.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import random
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import patch
 
@@ -24,6 +25,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gbserver.lineage.openlineage_service import LineageService, LineageServiceFactory
+from gbserver.storage import singleton_storage
+from gbserver.storage.sqlite.storage_factory import SqliteStorageFactory
 
 pytestmark = pytest.mark.standalone
 
@@ -240,6 +243,16 @@ class TestOpenLineageAPI:
     @pytest.fixture(autouse=True)
     def _setup_client(self):
         self.mock_service = MockLineageService()
+        # The build/target endpoints query the process-global admin-storage
+        # singleton. Install an isolated, empty SQLite store so those endpoints
+        # deterministically return 404 for a missing id. Without this the test
+        # inherits whatever storage a prior test on this xdist worker left in the
+        # singleton, which may point at tables that have since been dropped and
+        # then surfaces as a 500 ("no such table") instead of a 404.
+        singleton_storage.set_storage_factory(SqliteStorageFactory())
+        singleton_storage.set_storage_prefix(
+            f"lineage_apitest_{random.randint(1, 1_000_000)}_"
+        )
         with (
             patch.dict(os.environ, _AUTH_ENV, clear=False),
             patch(

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -128,13 +128,16 @@ def test_winner_for_a_reused_target_is_the_run_that_executed():
 
 
 def test_winner_carries_the_build_that_owns_the_run():
-    # The owning build must be the one that did the work, not the member that
-    # skipped, otherwise lineage would attribute the artifacts to the wrong
-    # attempt.
+    # create_jobstats_for_target rejects a run whose build_id does not match the
+    # build passed alongside it, so the pairing must hold for every winner —
+    # including one reached through a pointer into an earlier attempt.
     chain, _root_a, _retry_b = _chain_root_failed_retry_succeeded()
-    root = chain[0][0]
 
-    assert pick_winning_runs(chain)["targetA"].build.uuid == root.uuid
+    winners = pick_winning_runs(chain)
+
+    assert winners
+    for name, winner in winners.items():
+        assert winner.run.build_id == winner.build.uuid, name
 
 
 def test_winner_for_a_rerun_target_is_the_successful_attempt():
@@ -165,11 +168,13 @@ def test_earliest_executing_success_wins_over_a_later_one():
     assert pick_winning_runs(chain)["targetA"].run.uuid == first.uuid
 
 
-def test_winner_is_dereferenced_when_only_a_skip_marker_survives():
-    # Anomalous but survivable: targetB's group holds nothing but a skip marker,
-    # so there is no executed success to prefer and the pointer must be followed
-    # to the run that produced the artifacts. The pointer is recorded to signal
-    # that this target's provenance came from a marker rather than a real run.
+def test_winner_is_dereferenced_for_a_cross_name_reuse():
+    # Legitimate, not anomalous: the definition hash excludes the target name, so
+    # targetB was skipped for an identically-configured targetA run. targetB's
+    # group therefore holds nothing but the skip marker and has no executed
+    # success of its own, so the pointer must be followed to the run that produced
+    # the artifacts. The pointer is recorded because provenance is indirect: the
+    # winning run is not targetB's own run.
     root = _build(Status.SUCCESS, targets=["targetA", "targetB"])
     retry = _build(Status.SUCCESS, retry_count=1, retry_of=root.uuid)
     produced = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
@@ -199,6 +204,31 @@ def test_unresolvable_skip_pointer_falls_back_without_losing_the_pointer():
 
     assert winner.run.uuid == orphan.uuid
     assert winner.reused_from_target_run_id == "missing-uuid"
+
+
+def test_winner_run_is_successful_even_when_the_pointer_is_not():
+    # Task 3's counts partition depends on a winner always meaning "this target
+    # succeeded", so a pointer into a failed run must not drag a FAILED run in.
+    root = _build(Status.FAILED, targets=["targetA"])
+    failed = _run(root.uuid, "targetB", Status.FAILED, "2020-01-01T00:00:00Z")
+    marker = _run(root.uuid, "targetA", Status.SUCCESS, None, skipped_for=failed.uuid)
+    chain = [(root, [failed, marker])]
+
+    winner = pick_winning_runs(chain)["targetA"]
+
+    assert winner.run.status == Status.SUCCESS
+    assert winner.reused_from_target_run_id == failed.uuid
+
+
+def test_duplicate_runs_in_one_member_pick_the_earliest():
+    # The grouping sorts within a member by start time, so the earlier run wins
+    # even when storage hands them back in the other order.
+    root = _build(Status.SUCCESS, targets=["targetA"])
+    later = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:05:00Z")
+    earlier = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    chain = [(root, [later, earlier])]
+
+    assert pick_winning_runs(chain)["targetA"].run.uuid == earlier.uuid
 
 
 def test_empty_chain_has_no_winners():

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -30,10 +30,6 @@ from gbserver.types.status import Status
 
 pytestmark = pytest.mark.standalone
 
-# pylint cannot see through pydantic's Field(default_factory=...) and infers such
-# attributes as FieldInfo, so reading JobSummary.counts trips a false no-member.
-# pylint: disable=no-member
-
 
 def _build(status=Status.SUCCESS, retry_count=0, retry_of=None, targets=None):
     return StoredBuild(
@@ -249,7 +245,9 @@ def test_chain_that_finished_every_target_is_a_successful_job():
     assert summary.job_id == chain[0][0].uuid
     assert summary.attempts == 2
     assert summary.build_ids == [chain[0][0].uuid, chain[1][0].uuid]
-    assert summary.counts.model_dump() == {
+    # pylint cannot see through pydantic's Field(default_factory=...) and infers
+    # summary.counts as FieldInfo, tripping a false no-member; disable per line.
+    assert summary.counts.model_dump() == {  # pylint: disable=no-member
         "total": 2,
         "succeeded": 2,
         "failed": 0,
@@ -278,7 +276,7 @@ def test_partial_completion_is_failed_with_a_nonzero_success_count():
     summary = roll_up(chain)
 
     assert summary.status == Status.FAILED
-    assert summary.counts.model_dump() == {
+    assert summary.counts.model_dump() == {  # pylint: disable=no-member
         "total": 3,
         "succeeded": 1,
         "failed": 1,
@@ -347,8 +345,8 @@ def test_a_running_target_is_counted_separately_from_failed():
     summary = roll_up(chain)
 
     assert summary.status == Status.RUNNING
-    assert summary.counts.running == 1
-    assert summary.counts.failed == 0
+    assert summary.counts.running == 1  # pylint: disable=no-member
+    assert summary.counts.failed == 0  # pylint: disable=no-member
 
 
 def test_cancel_requested_on_any_member_wins():
@@ -405,8 +403,107 @@ def test_attempt_records_the_owning_members_retry_count():
 
 def test_counts_always_partition_the_spec_targets():
     chain, _a, _b = _chain_root_failed_retry_succeeded()
-    counts = roll_up(chain).counts
+    counts = roll_up(chain).counts.model_dump()  # pylint: disable=no-member
 
-    assert counts.total == (
-        counts.succeeded + counts.failed + counts.running + counts.not_run
+    assert counts["total"] == (
+        counts["succeeded"] + counts["failed"] + counts["running"] + counts["not_run"]
     )
+
+
+def test_non_authoritative_targets_do_not_promote_a_failed_build_to_success():
+    # targets=None (build-everything default): counts.total is only what ran, so
+    # "all counted succeeded" must NOT win unless the newest attempt succeeded.
+    root = _build(Status.FAILED, targets=None)
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert roll_up(chain).status == Status.FAILED
+
+
+def test_non_authoritative_cancelled_build_with_a_succeeded_run_is_cancelled():
+    root = _build(Status.CANCELLED, targets=None)
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert roll_up(chain).status == Status.CANCELLED
+
+
+def test_non_authoritative_invalid_build_with_a_succeeded_run_is_failed():
+    # A build that produced a successful run but ended INVALID is reported FAILED,
+    # not INVALID: the INVALID row requires nothing to have succeeded.
+    root = _build(Status.INVALID, targets=None)
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert roll_up(chain).status == Status.FAILED
+
+
+def test_genuine_completion_still_succeeds_without_an_authoritative_target_list():
+    # The #222 fix must survive the guard: root FAILED, retry re-ran the failed
+    # target to SUCCESS, targets=None. The newest attempt is SUCCESS, so the job
+    # is SUCCESS even though the denominator is only what ran.
+    root = _build(Status.FAILED, targets=None)
+    retry = _build(Status.SUCCESS, retry_count=1, retry_of=root.uuid, targets=None)
+    root_a = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    root_b = _run(root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00Z")
+    retry_b = _run(retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00Z")
+    chain = [(root, [root_a, root_b]), (retry, [retry_b])]
+
+    assert roll_up(chain).status == Status.SUCCESS
+
+
+def test_a_completed_but_cancelled_job_is_success_when_targets_are_authoritative():
+    # Pins branch order: succeeded==total (row 4) beats CANCELLED (row 5). A
+    # cancel that landed after every spec target already succeeded is too late to
+    # remove anything from the result. Reachable: cancel on the root, the
+    # in-flight retry finishes the remaining target.
+    root = _build(Status.CANCELLED, retry_count=0, targets=["targetA", "targetB"])
+    retry = _build(
+        Status.SUCCESS,
+        retry_count=1,
+        retry_of=root.uuid,
+        targets=["targetA", "targetB"],
+    )
+    root_a = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    retry_b = _run(retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00Z")
+    chain = [(root, [root_a]), (retry, [retry_b])]
+
+    assert roll_up(chain).status == Status.SUCCESS
+
+
+def test_never_succeeded_target_reports_its_latest_attempt():
+    # Pins _outcome_for's entries[-1]: a target that failed in the root and again
+    # in the retry must report the retry's run (attempt 1), not the root's, so a
+    # user opens the most recent logs.
+    root = _build(Status.FAILED, retry_count=0, targets=["targetA"])
+    retry = _build(
+        Status.FAILED, retry_count=1, retry_of=root.uuid, targets=["targetA"]
+    )
+    root_a = _run(root.uuid, "targetA", Status.FAILED, "2020-01-01T00:00:00Z")
+    retry_a = _run(retry.uuid, "targetA", Status.FAILED, "2020-01-01T00:02:00Z")
+    chain = [(root, [root_a]), (retry, [retry_a])]
+
+    outcome = roll_up(chain).targets[0]
+
+    assert outcome.attempt == 1
+    assert outcome.target_run_id == retry_a.uuid
+
+
+def test_invalid_conjunct_only_wins_when_nothing_succeeded():
+    # Pins the `and counts.succeeded == 0` conjunct on the INVALID row: a chain
+    # with a success plus an INVALID member is FAILED (partial), not INVALID.
+    root = _build(Status.FAILED, retry_count=0, targets=["targetA", "targetB"])
+    retry = _build(
+        Status.INVALID,
+        retry_count=1,
+        retry_of=root.uuid,
+        targets=["targetA", "targetB"],
+    )
+    root_a = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    root_b = _run(root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00Z")
+    chain = [(root, [root_a, root_b]), (retry, [])]
+
+    assert roll_up(chain).status == Status.FAILED

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the retry-chain job roll-up.
+
+All collaborators are pure: tests build StoredBuild / StoredTargetRun objects by
+hand and pass them in root-first, so no storage or FastAPI is involved.
+"""
+
+import pytest
+
+from gbserver.build.jobrollup import resolve_spec_targets
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.types.status import Status
+
+pytestmark = pytest.mark.standalone
+
+
+def _build(status=Status.SUCCESS, retry_count=0, retry_of=None, targets=None):
+    return StoredBuild(
+        name="test",
+        space_name="testspace",
+        source_uri="",
+        username="tester",
+        status=status,
+        retry_count=retry_count,
+        retry_of_build_id=retry_of,
+        targets=targets,
+    )
+
+
+def _run(build_id, name, status=Status.SUCCESS, started_at=None, skipped_for=""):
+    return StoredTargetRun(
+        name=name,
+        build_id=build_id,
+        environment_uri="space://environments/bash",
+        status=status,
+        started_at=started_at,
+        skipped_for_prerun_target_id=skipped_for,
+    )
+
+
+def test_spec_targets_prefers_the_root_target_list():
+    # root.targets is authoritative: it is the only way to know targetC exists in
+    # the spec, since a target whose dependency failed has no run at all.
+    root = _build(targets=["targetB", "targetA", "targetC"])
+    chain = [(root, [_run(root.uuid, "targetA"), _run(root.uuid, "targetB")])]
+
+    assert resolve_spec_targets(root, chain) == ["targetB", "targetA", "targetC"]
+
+
+def test_spec_targets_fall_back_to_observed_names_sorted():
+    root = _build(targets=None)
+    chain = [(root, [_run(root.uuid, "targetB"), _run(root.uuid, "targetA")])]
+
+    assert resolve_spec_targets(root, chain) == ["targetA", "targetB"]
+
+
+def test_spec_targets_dedupes_the_root_list():
+    root = _build(targets=["targetA", "targetA", "targetB"])
+
+    assert resolve_spec_targets(root, [(root, [])]) == ["targetA", "targetB"]

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -17,7 +17,8 @@
 """Unit tests for the retry-chain job roll-up.
 
 All collaborators are pure: tests build StoredBuild / StoredTargetRun objects by
-hand and pass them in root-first, so no storage or FastAPI is involved.
+hand and pass them in root-first, so no database access and no HTTP layer is
+involved.
 """
 
 import pytest
@@ -60,17 +61,36 @@ def test_spec_targets_prefers_the_root_target_list():
     root = _build(targets=["targetB", "targetA", "targetC"])
     chain = [(root, [_run(root.uuid, "targetA"), _run(root.uuid, "targetB")])]
 
-    assert resolve_spec_targets(root, chain) == ["targetB", "targetA", "targetC"]
+    assert resolve_spec_targets(chain) == ["targetB", "targetA", "targetC"]
 
 
 def test_spec_targets_fall_back_to_observed_names_sorted():
     root = _build(targets=None)
     chain = [(root, [_run(root.uuid, "targetB"), _run(root.uuid, "targetA")])]
 
-    assert resolve_spec_targets(root, chain) == ["targetA", "targetB"]
+    assert resolve_spec_targets(chain) == ["targetA", "targetB"]
 
 
 def test_spec_targets_dedupes_the_root_list():
     root = _build(targets=["targetA", "targetA", "targetB"])
 
-    assert resolve_spec_targets(root, [(root, [])]) == ["targetA", "targetB"]
+    assert resolve_spec_targets([(root, [])]) == ["targetA", "targetB"]
+
+
+def test_spec_targets_treat_an_empty_root_list_like_none():
+    # [] and None both mean "not specified". Pinned so a future change to
+    # `if root.targets is not None` cannot silently zero out the denominator.
+    root = _build(targets=[])
+
+    assert resolve_spec_targets([(root, [_run(root.uuid, "targetA")])]) == ["targetA"]
+
+
+def test_spec_targets_fallback_unions_names_across_members():
+    root = _build(targets=None)
+    retry = _build(targets=None, retry_count=1, retry_of=root.uuid)
+    chain = [
+        (root, [_run(root.uuid, "targetB")]),
+        (retry, [_run(retry.uuid, "targetA"), _run(retry.uuid, "targetB")]),
+    ]
+
+    assert resolve_spec_targets(chain) == ["targetA", "targetB"]

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -23,7 +23,7 @@ involved.
 
 import pytest
 
-from gbserver.build.jobrollup import resolve_spec_targets
+from gbserver.build.jobrollup import pick_winning_runs, resolve_spec_targets
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.types.status import Status
@@ -94,3 +94,112 @@ def test_spec_targets_fallback_unions_names_across_members():
     ]
 
     assert resolve_spec_targets(chain) == ["targetA", "targetB"]
+
+
+def _chain_root_failed_retry_succeeded():
+    """The issue's scenario: root ran targetA (ok) + targetB (failed); the retry
+    skipped targetA for reuse and re-ran targetB successfully."""
+    root = _build(Status.FAILED, retry_count=0, targets=["targetA", "targetB"])
+    retry = _build(
+        Status.SUCCESS,
+        retry_count=1,
+        retry_of=root.uuid,
+        targets=["targetA", "targetB"],
+    )
+    root_a = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    root_b = _run(root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00Z")
+    # A reused target is SUCCESS with no start time and a pointer back to the run
+    # that really executed. It produces no artifacts of its own.
+    retry_a = _run(retry.uuid, "targetA", Status.SUCCESS, None, skipped_for=root_a.uuid)
+    retry_b = _run(retry.uuid, "targetB", Status.SUCCESS, "2020-01-01T00:02:00Z")
+    return [(root, [root_a, root_b]), (retry, [retry_a, retry_b])], root_a, retry_b
+
+
+def test_winner_for_a_reused_target_is_the_run_that_executed():
+    chain, root_a, _retry_b = _chain_root_failed_retry_succeeded()
+
+    winners = pick_winning_runs(chain)
+
+    # Reuse only ever matches a run inside the same chain, so the run that
+    # executed targetA is in the group alongside the retry's skip marker and is
+    # selected directly. No pointer had to be followed, so none is recorded.
+    assert winners["targetA"].run.uuid == root_a.uuid
+    assert winners["targetA"].reused_from_target_run_id == ""
+
+
+def test_winner_carries_the_build_that_owns_the_run():
+    # The owning build must be the one that did the work, not the member that
+    # skipped, otherwise lineage would attribute the artifacts to the wrong
+    # attempt.
+    chain, _root_a, _retry_b = _chain_root_failed_retry_succeeded()
+    root = chain[0][0]
+
+    assert pick_winning_runs(chain)["targetA"].build.uuid == root.uuid
+
+
+def test_winner_for_a_rerun_target_is_the_successful_attempt():
+    chain, _root_a, retry_b = _chain_root_failed_retry_succeeded()
+
+    winners = pick_winning_runs(chain)
+
+    assert winners["targetB"].run.uuid == retry_b.uuid
+    assert winners["targetB"].reused_from_target_run_id == ""
+
+
+def test_targets_that_never_succeeded_have_no_winner():
+    root = _build(Status.FAILED, targets=["targetA"])
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.FAILED, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert not pick_winning_runs(chain)
+
+
+def test_earliest_executing_success_wins_over_a_later_one():
+    root = _build(Status.FAILED, targets=["targetA"])
+    retry = _build(Status.SUCCESS, retry_count=1, retry_of=root.uuid)
+    first = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    second = _run(retry.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:05:00Z")
+    chain = [(root, [first]), (retry, [second])]
+
+    assert pick_winning_runs(chain)["targetA"].run.uuid == first.uuid
+
+
+def test_winner_is_dereferenced_when_only_a_skip_marker_survives():
+    # Anomalous but survivable: targetB's group holds nothing but a skip marker,
+    # so there is no executed success to prefer and the pointer must be followed
+    # to the run that produced the artifacts. The pointer is recorded to signal
+    # that this target's provenance came from a marker rather than a real run.
+    root = _build(Status.SUCCESS, targets=["targetA", "targetB"])
+    retry = _build(Status.SUCCESS, retry_count=1, retry_of=root.uuid)
+    produced = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    marker = _run(
+        retry.uuid, "targetB", Status.SUCCESS, None, skipped_for=produced.uuid
+    )
+    chain = [(root, [produced]), (retry, [marker])]
+
+    winner = pick_winning_runs(chain)["targetB"]
+
+    assert winner.run.uuid == produced.uuid
+    assert winner.build.uuid == root.uuid
+    assert winner.reused_from_target_run_id == produced.uuid
+
+
+def test_unresolvable_skip_pointer_falls_back_without_losing_the_pointer():
+    # The pointer normally targets a run in the same chain. If it cannot be
+    # resolved we must still report something rather than raise, and must not
+    # silently drop the pointer.
+    root = _build(Status.SUCCESS, targets=["targetA"])
+    orphan = _run(
+        root.uuid, "targetA", Status.SUCCESS, None, skipped_for="missing-uuid"
+    )
+    chain = [(root, [orphan])]
+
+    winner = pick_winning_runs(chain)["targetA"]
+
+    assert winner.run.uuid == orphan.uuid
+    assert winner.reused_from_target_run_id == "missing-uuid"
+
+
+def test_empty_chain_has_no_winners():
+    assert not pick_winning_runs([])

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -23,12 +23,16 @@ involved.
 
 import pytest
 
-from gbserver.build.jobrollup import pick_winning_runs, resolve_spec_targets
+from gbserver.build.jobrollup import pick_winning_runs, resolve_spec_targets, roll_up
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.types.status import Status
 
 pytestmark = pytest.mark.standalone
+
+# pylint cannot see through pydantic's Field(default_factory=...) and infers such
+# attributes as FieldInfo, so reading JobSummary.counts trips a false no-member.
+# pylint: disable=no-member
 
 
 def _build(status=Status.SUCCESS, retry_count=0, retry_of=None, targets=None):
@@ -233,3 +237,176 @@ def test_duplicate_runs_in_one_member_pick_the_earliest():
 
 def test_empty_chain_has_no_winners():
     assert not pick_winning_runs([])
+
+
+def test_chain_that_finished_every_target_is_a_successful_job():
+    # The bug in issue #222: the root stays FAILED, but the job did complete.
+    chain, _root_a, _retry_b = _chain_root_failed_retry_succeeded()
+
+    summary = roll_up(chain)
+
+    assert summary.status == Status.SUCCESS
+    assert summary.job_id == chain[0][0].uuid
+    assert summary.attempts == 2
+    assert summary.build_ids == [chain[0][0].uuid, chain[1][0].uuid]
+    assert summary.counts.model_dump() == {
+        "total": 2,
+        "succeeded": 2,
+        "failed": 0,
+        "running": 0,
+        "not_run": 0,
+    }
+    # Each build keeps its own honest per-attempt status; nothing was mutated.
+    assert chain[0][0].status == Status.FAILED
+
+
+def test_partial_completion_is_failed_with_a_nonzero_success_count():
+    # Exhausted chain: targetA succeeded, targetB never did, targetC never ran
+    # because it depended on targetB. "Partial" is FAILED with succeeded > 0
+    # rather than a new Status member.
+    root = _build(Status.FAILED, targets=["targetA", "targetB", "targetC"])
+    chain = [
+        (
+            root,
+            [
+                _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z"),
+                _run(root.uuid, "targetB", Status.FAILED, "2020-01-01T00:01:00Z"),
+            ],
+        )
+    ]
+
+    summary = roll_up(chain)
+
+    assert summary.status == Status.FAILED
+    assert summary.counts.model_dump() == {
+        "total": 3,
+        "succeeded": 1,
+        "failed": 1,
+        "running": 0,
+        "not_run": 1,
+    }
+    outcomes = {o.name: o for o in summary.targets}
+    assert outcomes["targetC"].status is None
+    assert outcomes["targetC"].target_run_id == ""
+    assert outcomes["targetA"].status == Status.SUCCESS
+
+
+def test_outcome_order_follows_the_spec_target_list():
+    root = _build(Status.FAILED, targets=["targetC", "targetA", "targetB"])
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.FAILED, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert [o.name for o in roll_up(chain).targets] == ["targetC", "targetA", "targetB"]
+
+
+def test_outcome_name_is_the_spec_name_not_the_winning_runs_name():
+    # Cross-name reuse is legitimate: the definition hash excludes the target
+    # name, so targetB can be skipped for an identically-configured targetA run.
+    # The outcome must still be reported under the spec name it satisfies.
+    root = _build(Status.SUCCESS, targets=["targetA", "targetB"])
+    retry = _build(Status.SUCCESS, retry_count=1, retry_of=root.uuid)
+    produced = _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")
+    marker = _run(
+        retry.uuid, "targetB", Status.SUCCESS, None, skipped_for=produced.uuid
+    )
+    chain = [(root, [produced]), (retry, [marker])]
+
+    outcomes = {o.name: o for o in roll_up(chain).targets}
+
+    assert set(outcomes) == {"targetA", "targetB"}
+    assert outcomes["targetB"].target_run_id == produced.uuid
+    assert outcomes["targetB"].reused_from_target_run_id == produced.uuid
+
+
+def test_an_in_flight_member_makes_the_job_running():
+    root = _build(Status.FAILED, targets=["targetA"])
+    retry = _build(Status.RETRY_PENDING, retry_count=1, retry_of=root.uuid)
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.FAILED, "2020-01-01T00:00:00Z")]),
+        (retry, []),
+    ]
+
+    assert roll_up(chain).status == Status.RUNNING
+
+
+def test_a_running_target_is_counted_separately_from_failed():
+    # An in-progress job must never report having failed a target it has not
+    # failed, which is why `running` is its own bucket.
+    root = _build(Status.RUNNING, targets=["targetA", "targetB"])
+    chain = [
+        (
+            root,
+            [
+                _run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z"),
+                _run(root.uuid, "targetB", Status.RUNNING, "2020-01-01T00:01:00Z"),
+            ],
+        )
+    ]
+
+    summary = roll_up(chain)
+
+    assert summary.status == Status.RUNNING
+    assert summary.counts.running == 1
+    assert summary.counts.failed == 0
+
+
+def test_cancel_requested_on_any_member_wins():
+    # Cancelling any member cancels the whole chain, so the job reports it even
+    # though that member is otherwise finished.
+    root = _build(Status.CANCEL_REQUESTED, targets=["targetA"])
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert roll_up(chain).status == Status.CANCEL_REQUESTED
+
+
+def test_cancelled_chain_is_not_reported_as_failed():
+    root = _build(Status.CANCELLED, targets=["targetA", "targetB"])
+    chain = [
+        (root, [_run(root.uuid, "targetA", Status.SUCCESS, "2020-01-01T00:00:00Z")])
+    ]
+
+    assert roll_up(chain).status == Status.CANCELLED
+
+
+def test_invalid_root_with_nothing_succeeded_is_invalid():
+    root = _build(Status.INVALID, targets=["targetA"])
+
+    assert roll_up([(root, [])]).status == Status.INVALID
+
+
+def test_job_with_no_spec_targets_defers_to_the_latest_attempt():
+    # Nothing to aggregate, so reporting FAILED would be a lie.
+    root = _build(Status.SUCCESS, targets=None)
+
+    assert roll_up([(root, [])]).status == Status.SUCCESS
+
+
+def test_empty_chain_returns_an_empty_summary_rather_than_raising():
+    # The roll-up is additive to endpoints that already work, so it must never
+    # turn a working request into a 500.
+    summary = roll_up([])
+
+    assert summary.job_id == ""
+    assert summary.targets == []
+
+
+def test_attempt_records_the_owning_members_retry_count():
+    chain, _root_a, _retry_b = _chain_root_failed_retry_succeeded()
+
+    outcomes = {o.name: o for o in roll_up(chain).targets}
+
+    # targetA succeeded in the root (attempt 0); targetB in the retry (attempt 1).
+    assert outcomes["targetA"].attempt == 0
+    assert outcomes["targetB"].attempt == 1
+
+
+def test_counts_always_partition_the_spec_targets():
+    chain, _a, _b = _chain_root_failed_retry_succeeded()
+    counts = roll_up(chain).counts
+
+    assert counts.total == (
+        counts.succeeded + counts.failed + counts.running + counts.not_run
+    )

--- a/test/unit/build/test_jobrollup.py
+++ b/test/unit/build/test_jobrollup.py
@@ -245,6 +245,12 @@ def test_chain_that_finished_every_target_is_a_successful_job():
     assert summary.job_id == chain[0][0].uuid
     assert summary.attempts == 2
     assert summary.build_ids == [chain[0][0].uuid, chain[1][0].uuid]
+    # attempt_builds carries the same members, root first, each with its own
+    # honest per-attempt status — the root stayed FAILED, the retry SUCCEEDED.
+    assert [(ab.build_id, ab.status) for ab in summary.attempt_builds] == [
+        (chain[0][0].uuid, Status.FAILED),
+        (chain[1][0].uuid, Status.SUCCESS),
+    ]
     # pylint cannot see through pydantic's Field(default_factory=...) and infers
     # summary.counts as FieldInfo, tripping a false no-member; disable per line.
     assert summary.counts.model_dump() == {  # pylint: disable=no-member

--- a/test/unit/buildrunner/test_should_retry.py
+++ b/test/unit/buildrunner/test_should_retry.py
@@ -1,4 +1,5 @@
 import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -52,6 +53,29 @@ llm.build:
       steps:
         - step_uri: space://steps/download
 """
+
+
+class _FakeBuildStorage:
+    """Minimal in-memory build storage for exercising __prepare_retry."""
+
+    def __init__(self, build: StoredBuild):
+        self._by_uuid = {build.uuid: build}
+        self.added: list[StoredBuild] = []
+
+    def get_by_uuid(self, uuid):
+        return self._by_uuid.get(uuid)
+
+    def add(self, build):
+        self._by_uuid[build.uuid] = build
+        self.added.append(build)
+
+    def update(self, build):
+        self._by_uuid[build.uuid] = build
+
+
+class _FakeStorage:
+    def __init__(self, build: StoredBuild):
+        self.build_storage = _FakeBuildStorage(build)
 
 
 class TestShouldRetry:
@@ -109,3 +133,28 @@ class TestShouldRetry:
         assert build.retry_of_build_id == original_id
         assert build.retry_count == 1
         assert self._runner()._should_retry(build)
+
+    def test_retry_copies_owner_and_space_from_the_original(self):
+        """The status and lineage endpoints authorize a whole retry chain by
+        checking only the queried build. That is safe only because every retry
+        shares the original's owner and space. If __prepare_retry ever stops
+        copying space_name/username, this must fail rather than the shortcut
+        silently becoming an access-control hole.
+        """
+        original = _make_stored_build_with_config(
+            _BUILD_YAML_MAX_RETRIES_2, status=Status.FAILED, retry_count=0
+        )
+        runner = self._runner()
+        runner.storage = _FakeStorage(original)
+        runner.stored_build = original
+        runner._retry_chain_lock = threading.Lock()
+        runner._retry_chain_build_ids = []
+
+        retry = runner._BuildRunner__prepare_retry()
+
+        assert retry is not None
+        assert retry.space_name == original.space_name
+        assert retry.username == original.username
+        # And it is a genuine new chain member, not the original returned back.
+        assert retry.uuid != original.uuid
+        assert retry.retry_of_build_id == original.uuid

--- a/test/unit/gbcli/commands/test_status_overview.py
+++ b/test/unit/gbcli/commands/test_status_overview.py
@@ -141,12 +141,17 @@ def test_missing_job_falls_back_to_the_build_status():
 
 def test_queried_build_not_in_chain_degrades_gracefully():
     # Defensive: if the queried build id somehow isn't in build_ids, don't crash;
-    # report attempt 0 rather than raising.
+    # drop the ordinal rather than raising or showing "attempt 0 of 2".
     _h, attempt_line, _s = _job_overview_lines(
         _details(status="failed", build_id="ghost", job=_job())
     )
 
-    assert "of 2" in attempt_line  # no exception; position degrades to 0
+    # No exception; the per-attempt status is still shown, but the ordinal is
+    # dropped rather than rendering a misleading "(attempt 0 of 2)". (The label
+    # "**This attempt**" itself still contains the word "attempt".)
+    assert "FAILED" in attempt_line
+    assert "(attempt" not in attempt_line
+    assert "of 2" not in attempt_line
 
 
 def test_full_output_renders_the_job_status_end_to_end():
@@ -167,4 +172,27 @@ def test_full_output_renders_the_job_status_end_to_end():
 
     rendered = execution_status_plain_output(details, {}, [], show_events=True)
 
+    assert "SUCCESS" in rendered
+
+
+def test_full_output_has_no_job_lines_for_an_unretried_build():
+    from gbcli.commands.command_build import execution_status_plain_output
+
+    details = {
+        "build_id": "solo",
+        "name": "b",
+        "description": "",
+        "status": "success",
+        "started_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:03:00Z",
+        "source_pr": "",
+        "retry_of_build_ids": [],
+        "retried_by_build_ids": [],
+        "job": None,
+    }
+
+    rendered = execution_status_plain_output(details, {}, [], show_events=True)
+
+    assert "This attempt" not in rendered
+    assert "Job result" not in rendered
     assert "SUCCESS" in rendered

--- a/test/unit/gbcli/commands/test_status_overview.py
+++ b/test/unit/gbcli/commands/test_status_overview.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the build-status overview headline.
+
+`_job_overview_lines` is the pure part of `execution_status_plain_output`: it
+turns the `details` dict (which carries the `job` summary the service threaded
+in) into the status headline plus, for a real retry chain, the per-attempt and
+job-summary lines. Testing it directly avoids the rich-rendered output of the
+full function, whose `**bold**` markers and ANSI are stripped/added at print
+time.
+"""
+
+import pytest
+
+from gbcli.commands.command_build import _job_overview_lines
+
+pytestmark = pytest.mark.standalone
+
+
+def _details(status="failed", build_id="root", job=None):
+    return {"build_id": build_id, "status": status, "job": job}
+
+
+def _job(
+    status="success",
+    attempts=2,
+    build_ids=None,
+    succeeded=2,
+    failed=0,
+    running=0,
+    not_run=0,
+    total=None,
+):
+    return {
+        "status": status,
+        "attempts": attempts,
+        "build_ids": build_ids if build_ids is not None else ["root", "retry"],
+        "counts": {
+            "total": (
+                total if total is not None else succeeded + failed + running + not_run
+            ),
+            "succeeded": succeeded,
+            "failed": failed,
+            "running": running,
+            "not_run": not_run,
+        },
+    }
+
+
+def test_headline_is_the_job_status_for_a_real_chain():
+    # Issue #222: queried build FAILED, but the retry finished the job.
+    headline, attempt_line, summary_line = _job_overview_lines(
+        _details(status="failed", build_id="root", job=_job())
+    )
+
+    assert "SUCCESS" in headline
+    assert "✅" in headline
+    # The per-attempt truth is not lost, just moved to its own line.
+    assert "FAILED" in attempt_line
+    assert "attempt 1 of 2" in attempt_line
+    assert "2 of 2" in summary_line
+
+
+def test_attempt_position_reflects_which_member_was_queried():
+    # Querying the retry (second member) says "attempt 2 of 2".
+    _headline, attempt_line, _summary = _job_overview_lines(
+        _details(status="success", build_id="retry", job=_job())
+    )
+
+    assert "attempt 2 of 2" in attempt_line
+
+
+def test_summary_lists_failed_and_never_ran_counts():
+    _h, _a, summary_line = _job_overview_lines(
+        _details(
+            status="failed",
+            build_id="root",
+            job=_job(status="failed", succeeded=1, failed=1, not_run=1),
+        )
+    )
+
+    assert "1 of 3" in summary_line
+    assert "1 failed" in summary_line
+    assert "1 never ran" in summary_line
+
+
+def test_running_count_is_shown_and_not_conflated_with_failed():
+    _h, _a, summary_line = _job_overview_lines(
+        _details(
+            status="running",
+            build_id="root",
+            job=_job(status="running", succeeded=1, failed=0, running=1, not_run=0),
+        )
+    )
+
+    assert "1 running" in summary_line
+    assert "failed" not in summary_line
+
+
+def test_single_attempt_job_leaves_the_output_unchanged():
+    # attempts == 1: the job status equals the build's own status, so headline is
+    # the build status and there are no extra lines — byte-identical to before.
+    headline, attempt_line, summary_line = _job_overview_lines(
+        _details(
+            status="failed",
+            build_id="root",
+            job=_job(
+                status="failed", attempts=1, build_ids=["root"], succeeded=0, failed=1
+            ),
+        )
+    )
+
+    assert "FAILED" in headline
+    assert attempt_line == ""
+    assert summary_line == ""
+
+
+def test_missing_job_falls_back_to_the_build_status():
+    headline, attempt_line, summary_line = _job_overview_lines(
+        _details(status="failed", build_id="root", job=None)
+    )
+
+    assert "FAILED" in headline
+    assert attempt_line == ""
+    assert summary_line == ""
+
+
+def test_queried_build_not_in_chain_degrades_gracefully():
+    # Defensive: if the queried build id somehow isn't in build_ids, don't crash;
+    # report attempt 0 rather than raising.
+    _h, attempt_line, _s = _job_overview_lines(
+        _details(status="failed", build_id="ghost", job=_job())
+    )
+
+    assert "of 2" in attempt_line  # no exception; position degrades to 0
+
+
+def test_full_output_renders_the_job_status_end_to_end():
+    from gbcli.commands.command_build import execution_status_plain_output
+
+    details = {
+        "build_id": "root",
+        "name": "b",
+        "description": "",
+        "status": "failed",
+        "started_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-01T00:03:00Z",
+        "source_pr": "",
+        "retry_of_build_ids": [],
+        "retried_by_build_ids": ["retry"],
+        "job": _job(),
+    }
+
+    rendered = execution_status_plain_output(details, {}, [], show_events=True)
+
+    assert "SUCCESS" in rendered


### PR DESCRIPTION
## Summary

Fixes #222. When a build target fails and a build-level retry runs, the original build stays `FAILED` forever — even if the retry completed every remaining target — so no single build reflects whether the job specification actually completed. This adds a **job** view derived **on read** over the existing retry-chain links (`retry_of_build_id` / `retry_build_id` / `retry_count`). Nothing is persisted, there is no schema change, and every build keeps its own honest per-attempt status.

- **`src/gbserver/build/jobrollup.py`** (new, pure, total — no storage access, no raising paths): walks a root-first retry chain and produces a `JobSummary` (aggregate `status`, `attempts`, `build_ids`, per-target outcomes, and a 5-bucket count partition `total = succeeded + failed + running + not_run`). Picks each spec target's artifact-producing "winning" run, dereferencing reuse-skips. Partial completion is `FAILED` with `succeeded > 0` — no new `Status` member.
- **Status API**: `GET /builds/{id}/status?follow_retries=true` gains a `job` field, populated from the chain the endpoint already assembles (zero extra queries). The SUCCESS verdict is guarded when the build was submitted without an explicit target list, so a failed build whose dispatched targets happened to succeed is not reported as SUCCESS.
- **Lineage API**: `GET /lineage/build/{id}?follow_retries=true` reports one entry per winning spec target plus the chain-root `job_id`.
- **gbcli `build status`**: for a retried build the `**Status**` headline now shows the job status, with the queried attempt on a `**This attempt**` line and a `**Job result**` roll-up. Un-retried builds are byte-identical to before.
- **Dashboard**: the build detail panel shows job status, attempts, target roll-up, and links to the other attempt builds.
- Docs in `docs/builds/build-retry.md` and `docs/builds/lineage.md`.

The whole feature is additive: `follow_retries=false` (the default) is unchanged, and new/old clients degrade safely against old/new servers.

**Follow-up (#244):** the chain-spanning lineage endpoint ships as server-only API for now — the CLI `build lineage` and the dashboard `LineagePanel` are not yet wired to it (deliberate scoping decision). The job-status path — the reported symptom — is fully wired through CLI and dashboard.

## Test plan

- [x] `jobrollup` unit tests — full status-precedence table, winner selection incl. skip-dereference, counts partition, totality on malformed input
- [x] Status API integration tests — incl. the #222 regression: querying a `FAILED` root whose retry finished returns `job.status == SUCCESS` while the build's own status stays `FAILED`; `targets=None` and single-build paths; `/status2` alias
- [x] Lineage API integration tests — one entry per winning target, failed/never-run omitted, `targets=None` chain, chain authz on the follow path
- [x] Retry owner/space authz invariant test (the chain-authz shortcut depends on it)
- [x] gbcli headline unit tests + un-retried byte-identity render check
- [x] Frontend TypeScript compiles clean (`tsc --noEmit`), static export builds
- [x] Full fast suite green (`make quick-tests`: 1832 passed), feature files pass pylint + mypy, `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)