### PR TITLE
Add build-array skill; GPU support + single-GPU pinning for bash steps

### DIFF
--- a/.claude/skills/build-array/SKILL.md
+++ b/.claude/skills/build-array/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: build-array
+description: Run and manage a large array of Granite.build builds — a hyperparameter sweep, a multi-model/multi-dataset fan-out, a per-item pipeline batch, seed-repro runs, an ablation, or a retry/heal campaign. Plans the array with the user, submits every build, monitors them to completion, records each outcome to a durable file that never goes stale, delegates failures to investigation subagents, and synthesizes results into next steps. Use when the user wants to run an array / batch / sweep of builds or tasks (more than a handful at once).
+argument-hint: "[array-name]"
+allowed-tools: Agent Monitor Read Write Bash(curl *) Bash(jq *) Bash(date *) Bash(mkdir *) Bash(ls *) Bash(cat *) Bash(test *) Bash(python3 *) mcp__gbmcp__gbserver_status mcp__gbmcp__gbserver_start mcp__gbmcp__build_start mcp__gbmcp__build_status mcp__gbmcp__build_log mcp__gbmcp__build_list mcp__gbmcp__build_describe mcp__gbmcp__build_job_log mcp__gbmcp__build_cancel
+---
+
+# Orchestrate an array of Granite.build builds
+
+Use this when the work is **not one build but many** — a sweep, a batch, a fan-out. The skill gives that work a repeatable spine: **plan → submit → monitor → record → synthesize**. It does **not** re-teach build authoring — a single build is authored with **`create-build`** (inline `command`) or **`create-step`** (packaged step); this skill is the layer *above* that, which takes a build template + a set of parameter points and runs the whole array well.
+
+Granite.build abstracts **submission** entirely: you call `build_start` and gb runs the build in whatever environment the build.yaml declares (bash, LSF, docker, …) — the skill never submits jobs to a scheduler itself and never reasons about queues or nodes. Its job is *organization*: deciding the array, running it under control, and turning a pile of build outcomes into an answer.
+
+## The model — one orchestrator, one monitor, investigation subagents
+
+- **You are the orchestrator** (main loop). You plan the array with the user, ensure the backend is up, **submit every build yourself** (a `build_start` loop — mechanical and fast, nothing to fan out), record each outcome, and synthesize.
+- **A single background monitor** watches all in-flight builds and notifies you as each reaches a terminal state (surfacing failures). You never poll builds in-context — the monitor is a background process, so the poll loop costs no tokens.
+- **Subagents are for investigation, not submission or polling.** When a build fails or flags anomalous, delegate a focused root-cause task to a subagent (it has the build_id, the point's params, and log access). That is where a subagent's judgment pays for itself.
+
+### Recovery is on disk, not in context
+
+The builds keep running under gbserver whether or not this session is alive — gb owns them. What a dropped session loses is the *record*, not the builds. So the load-bearing durability primitive is cheap: **write each `build_id` to disk the instant `build_start` returns it.** If CC drops and a fresh session resumes, it reads the run-state file, re-queries `build_status` for each `build_id`, rebuilds the record, and restarts the monitor for anything still in flight. The array-wide `array:<name>` tag is the belt-and-suspenders backstop: a resume can list every build via `GET /api/v1/builds/?tag=array:<name>` even if a `build_id` never made it to disk. Do not rely on in-context memory to resume — after a real drop it is gone.
+
+## Phase 0 — backend up
+
+`gbserver_status()`; if not `ready`, `gbserver_start()` (defer to **`run-gbserver`** for lifecycle, ports, install). The dashboard URL it returns is where the user watches the array live.
+
+## Phase 1 — PLAN (recommend, decide together, write it down)
+
+**Nothing launches in this phase.** Turn the user's intent into a concrete array and record it in `PLAN.md` *before* execution.
+
+1. **Establish the build template — authored elsewhere.** One base build.yaml that every point instantiates. **This skill does not author it:** a build.yaml (targets, steps, inputs, outputs, workload) is authored with **`create-build`** (inline `command`, or a shipped step like `space://steps/lora-finetune`) or **`create-step`**. If none exists, route there first, then return with the working build.yaml text. Make it **parameterized** so you hold one template, not N copies (see **Parameterize once**, below).
+2. **Establish the array shape (the matrix).** The axes and their values, plus any **exclusions**. Write axes as named lists; a "point" is one choice from each axis. Recommend sensible defaults and *prune known-bad combos up front* (e.g. a learning rate known to diverge, a config known to OOM) so the array doesn't burn compute rediscovering failures.
+3. **Recommend an analysis grouping, let the user decide.** Inspect the matrix shape and propose how results should be *grouped for comparison* (see **Grouping** below) — this is a **tag** recorded on each build, read at synthesis, **not** a way to split execution. State your recommendation and why; the user confirms or overrides. Record the choice in `PLAN.md`.
+4. **Declare the health check (workload-specific).** The built-in anomaly flags only verify artifact *integrity*, not whether the result is any good (see **Anomaly flags**). If a "successful" build can still be a bad result — a diverged training run, an eval that scores at the floor, an empty-but-well-formed output — name the concrete signal now: the log line or metric to parse and the threshold that means "distrust this" (e.g. "loss NaN or rising over the last 5 steps", "grad-norm > 100", "eval output empty or non-alphanumeric"). `none` is a valid answer for a pure pass/fail batch — say so explicitly rather than leaving it implicit.
+5. **Pick the run directory and write `PLAN.md`.** Default `./<array-name>/` under the user's cwd (or a path they give). Write `PLAN.md` from the template in `references/templates.md`: template, full point list (with resolved params), exclusions with reasons, grouping, the health check from step 4, output-location convention, submit mode (fan-out vs. max-in-flight — see **Local-bash arrays**), and **stop conditions** (e.g. "abort the array if the first N builds all fail").
+6. **Get explicit approval** of `PLAN.md` before Phase 2.
+
+### Parameterize once — one template, N submits
+
+The answer to "do I write N build.yamls?" is **no**. Author **one** base build.yaml with each swept knob as a **`$${NAME}`** placeholder, then submit that same text N times — each call carries only that point's overrides:
+
+```python
+build_start(file_content=<the one base yaml>, params=["LEARNING_RATE=2e-4", "LORA_RANK=16", "OUT=v1_x"], tags=["array:sweep1", "group:3b_lora"])
+```
+
+- **How to pass a parameter — the exact contract.** `params` is a `list[str]`, each entry `"KEY=value"`. gb splits on the **first** `=`; the key and value are each stripped of surrounding whitespace; the value is everything after (spaces and further `=` are allowed inside it). Dotted keys nest into the YAML tree: `config.bash.env.LR=2e-4`. In the template you mark where each value lands with **`$${KEY}`** (double-dollar, single closing brace) for a value and `<% … %>` for logic — delimiters chosen so they don't collide with gb's own `{{ binding }}` syntax.
+- **The value is spliced in as raw text, before YAML is parsed — it is not quoted or escaped for you.** Put the quotes in the *template*, around the placeholder, and prefer double quotes: `SUBJECT: "$${SUBJECT}"`. A value carrying a YAML-special character (an apostrophe, a `:`, a leading `#`) that lands in a *single*-quoted or unquoted spot yields invalid YAML and the submit fails (as `"null"`, below).
+- **`StrictUndefined`:** a `$${NAME}` with no matching param is a hard error *at submit* — a typo fails fast instead of running blank. There's no `build_validate` in standalone, so **canary the first point** and confirm it starts before submitting the rest.
+- **A `build_start` that returns the literal string `"null"` (instead of a build_id) is a *swallowed* render/validate error, not a mechanism failure.** gbmcp calls the client with no error callback, so every internal failure — bad param, template syntax, invalid YAML, unknown space, missing file — collapses to the same `null` with its reason discarded (a gbmcp defect, not just yours). Common causes, in order: an unmatched `$${NAME}` (missing/typo'd param — `StrictUndefined`); **a stray `$${`, `<% %>`, or `{# #}` anywhere in the raw text, including a YAML `#` comment** — the renderer runs *before* YAML, so comments do not hide it, and a comment that documents the syntax as `$${...}` is itself parsed and dies on the `.`; or a value that renders into invalid YAML. This is what the canary is for: it turns a fleet-wide `null` into one legible failure before fan-out.
+- You keep the base text in context **once**; each point is a short param list, not a rendered document.
+- Give each point a **distinct output** via a param (e.g. `OUT=…`) so artifacts don't collide.
+- **Step-agnostic — works with a shipped step or the inline `command` step alike.** Substitution runs on the raw build.yaml *text* before parsing, so it doesn't care which step you use. The clean spot for a swept knob is the same either way: a `config.bash.env` value written as `$${NAME}`, which the step (or the inline command, via `os.environ["NAME"]`) reads as an env var. The `$${…}` delimiter is double-dollar, so it never collides with an inline command's own shell `${VAR}` expansion (`${LLMB_BASH_OUTPUT_DIR:?}` stays literal). But because the renderer runs on the raw text, the param delimiters (`$${`, `<% %>`, `{# #}`) must not appear literally anywhere they aren't a real placeholder — comments and heredoc bodies included (see the `"null"` note above).
+
+*Where* a knob lives in the template is a `create-build` concern; this skill only fills it.
+
+## Phase 2 — SUBMIT (the orchestrator submits every build)
+
+1. Expand the matrix (cross product minus exclusions) into the point list — each point is a coord, its **param list** (the `key=value` overrides, including a distinct `OUT=…`), and its **tags** (an array-wide `array:<name>` plus the point's group tag from Phase 1).
+2. **Write the recovery anchor first.** Create `<run-dir>/run-state.json` listing every point (coord + params + output + empty `build_id`) before submitting anything — this is what a resumed session reads.
+3. **Idempotent skip:** if a point's declared output already exists **and is non-empty**, mark it `skipped` and don't relaunch. Makes reruns cheap.
+4. **Validate one build first — unless the template is already proven.** Before waiting, check: did an equivalent build already complete **this session** (a prior run of this template, even from the `create-build` step that authored it; the same step built in an earlier build; or a resume where its artifacts exist)? If so, the template is proven and — on bash — the shared venv is resolved, so **skip to the fan-out (step 5)** and reuse that build's wall-time and `device` as the baseline. Otherwise submit the first point alone and let it run **to completion**: one clean build proves the template end-to-end — rendered (a build_id, not `"null"`), succeeded, plausible-sized artifact — catching a broken template once instead of fleet-wide. Record its wall-time and `device` in `run-state.json` as the slow/stuck baseline (Phase 2.5); on bash it also resolves the shared venv (see **Why validate one build before the fan-out** below).
+5. **Send the rest off — in one batched message.** Fan out the remaining points with a `build_start(file_content=<base yaml>, params=<point's list>, tags=<point's tags>)` per point, issued as **parallel calls in a single message**, not one per turn. Each `build_start` is a synchronous ~3-round-trip call to gbserver (space lookup, static validation, submit), so a sequential loop pays that latency N times end-to-end while batched calls overlap. **Immediately** write each returned `build_id` into its `run-state.json` entry so a crash mid-submit still leaves a resumable record.
+6. Once all are submitted, start **one** monitor over the array (Phase 2.5).
+
+**Tag every build natively — it is the array's handle, not just a synthesis label.** `build_start` takes a `tags=` list, and gbserver's list/count endpoints filter by tag (`GET /api/v1/builds/?tag=array:<name>`). Passing `array:<name>` on every submit buys three things a private `group` field in `run-state.json` cannot: (a) the monitor polls the whole array in **one** request per tick instead of one `curl` per `build_id` (Phase 2.5); (b) a resumed session can rediscover every build by tag even if `run-state.json` lost a `build_id` mid-submit; (c) grouping at synthesis reads gb's own tags. Keep recording `group` in the record too, but let the native tag be the load-bearing handle.
+
+### Why validate one build before the fan-out
+
+The rule is one line — **validate one build to completion, then send the array** — but *why* the wait matters depends on the `environment_uri`:
+
+- **Scheduler backends (LSF, Slurm, docker, skypilot):** builds are isolated jobs with no shared local state. The first build is pure validation — prove the template before you queue N. Then fan out; the scheduler handles concurrency.
+- **Local bash:** builds share **one unlocked venv per step** (`~/.granite.build/.gb-venvs/<step>`). Fire N at a *cold* step and their `pip install`s race to rewrite the same `site-packages`; a build hitting `torch.cuda.is_available()` mid-rewrite gets a silent `dlopen` failure → trains on **CPU** with the GPU idle (looks hung, since the mamba CPU path is ~1000× slower). The first build **resolves the venv**, so every sibling after it finds `pip install` a no-op — nothing left to race. Hence: wait for it to *finish*, not just start.
+
+**Caveat (resource, not correctness):** if genuinely heavy builds outnumber the host's GPUs they'll contend or OOM. Then cap concurrency with a **max-in-flight window** (submit K, submit the next as each finishes), keeping `run-state.json` fresh on every transition so a resume sees the true frontier. LoRA-scale jobs co-reside fine — fan out.
+
+## Phase 2.5 — MONITOR + INVESTIGATE
+
+Start a single background monitor over the whole array. It emits terminal events (and `slow` events) as notifications while you keep working — and must surface failures, not only successes. **Poll the array's native tag in one request per tick, not one `curl` per `build_id`.** `build_start` tagged every point with `array:<name>` (Phase 2), so a single `GET /api/v1/builds/?tag=array:<name>` returns every build's `uuid` + `status` — one request whether the array is 5 builds or 500. A per-build loop would fire N requests per tick against gbserver, the poll storm this skill exists to avoid.
+
+Two facts the loop depends on, both verified against gbserver: the build's id is the **`uuid`** field of each list entry (not `build_id`), and `status` is a **lowercase** `StrEnum` value (`success`/`failed`/`invalid`/`cancelled` — the same casing the filter uses; ignore any docs showing `RUNNING`). Parse with `python3`, per the same reasoning as the Phase 3 fold — the datetime math for `slow` is a jq trap:
+
+```bash
+PORT=${GBSERVER_PORT:-8080}; TAG="array:<array-name>"
+# SLOW_SECS ≈ 2.5× the canary baseline wall_seconds (run-state.json → canary_baseline).
+python3 - "http://127.0.0.1:$PORT/api/v1/builds/" "$TAG" "<SLOW_SECS>" <<'PY'
+import json, sys, time, urllib.parse, urllib.request
+from datetime import datetime, timezone
+base, tag, slow = sys.argv[1], sys.argv[2], float(sys.argv[3])
+TERMINAL = {"success", "failed", "invalid", "cancelled"}
+url = base + "?" + urllib.parse.urlencode({"tag": tag})
+seen, flagged = set(), set()
+while True:
+    try:
+        builds = json.loads(urllib.request.urlopen(url, timeout=10).read()).get("builds", [])
+    except Exception:
+        time.sleep(30); continue          # transient error must not kill the monitor
+    now = datetime.now(timezone.utc)
+    for b in builds:
+        bid, st = b.get("uuid"), (b.get("status") or "").lower()
+        if st in TERMINAL:
+            if bid not in seen:
+                seen.add(bid); print(f"terminal {bid} {st}", flush=True)
+        elif bid not in flagged:          # alive but maybe pathological → slow
+            try:
+                started = datetime.fromisoformat((b.get("created_time") or "").replace("Z", "+00:00"))
+                if (now - started).total_seconds() > slow:
+                    flagged.add(bid); print(f"slow {bid} {int((now-started).total_seconds())}s", flush=True)
+            except Exception:
+                pass
+    # exit only once the array is non-empty AND every build is terminal
+    if builds and all((b.get("status") or "").lower() in TERMINAL for b in builds):
+        print("all-terminal", flush=True); break
+    time.sleep(30)
+PY
+```
+
+Run it as a **Monitor** (or a `run_in_background` bash loop) so events arrive as notifications while you keep working. The `slow` branch is **not** optional: a terminal-only monitor is blind to a build that is *alive but pathological* (e.g. silently training on CPU past ~2–3× the canary baseline), which then gives no signal until it finishes or hangs forever. **For a very large array, print one *summary* line per tick** (the batch of newly-terminal `uuid`s) rather than one line per build, so a burst of near-simultaneous completions stays under the Monitor event-rate cap. As each event arrives:
+
+1. Read the outcome with `build_status(build_id)` and `build_describe(build_id)`; compute the **anomaly flags** (below).
+2. **Append one JSON line** to `<run-dir>/builds.jsonl` (schema in `references/templates.md`) and update the point's status in `run-state.json`. Appending — not rewriting — is crash-safe and preserves the trajectory for synthesis.
+3. **On `failed`, a non-`ok` flag, a failed PLAN health check, or a `slow` event, investigate — and pull evidence *before* hypothesizing.** First read `build_job_log` (and device/utilization: is it actually on the GPU? is the GPU busy?), *then* form a theory — do not assert "contention" or "a race" from status alone (in the run, two wrong guesses preceded the first look at the log). For anything beyond a trivial read, spawn an investigation subagent (Agent tool) with the build_id, the point's params, and log access (`build_log`, `build_job_log`); its job is root cause + proposed fix (bad hyperparameter, OOM → needs other parallelism, full fileset → 0-byte artifact, cold-venv CPU fallback → warm-then-fan-out, transient infra → safe to retry). Fold the finding into the record's `note`. For a clear transient-infra failure, retry once or twice; do **not** blindly retry application failures.
+4. **Enforce the plan's stop conditions.** When one trips (e.g. "first N builds all failed"), stop launching new points and `build_cancel(build_id)` the still-running ones before surfacing the abort to the user — don't let a doomed array burn the rest of its compute.
+
+### Anomaly flags (compute at record time — this is where the value is)
+
+A build's status flag alone lies: Granite.build (and the guardian sweeps that motivated this skill) can report **`success` while writing a 0-byte artifact** when a fileset is full. So each record carries computed flags, not just the raw status. The **built-in flags check artifact integrity only** — is a well-formed, plausibly-sized artifact actually on disk:
+
+- `zero_byte_artifact` — a registered artifact path exists but is 0 bytes (classic full-disk checkpoint).
+- `empty_success` — status `success` but no artifact registered / output dir empty.
+- `missing_artifact` — an output declared in the target was never bound.
+- `ok` — terminal `success` with a non-empty artifact of plausible size **and no other flag set** (`ok` is *exclusive*: it never co-occurs with an anomaly flag).
+
+**These flags do not judge whether the artifact is any *good*.** A training run that diverges writes a normal-sized, well-formed, useless adapter and passes every integrity check as `ok` — this is the single most important failure mode for a training sweep, and artifact flags are blind to it. (Observed: two diverged LoRA adapters — grad-norm ~900, output collapsed to comma spam — were normal-sized and flagged `ok`; the divergence was caught only by hand.) **Quality/divergence is workload-specific, so the skill cannot hard-code it — the array declares its own health check in `PLAN.md`** (Phase 1): the log line or metric that signals a bad-but-well-formed result (loss NaN or non-monotonic, grad-norm spike, garbled/empty eval output, an accuracy floor). Compute that check at record time alongside the integrity flags, add its verdict to the point's `flags` (e.g. `diverged`, `unstable`), and record the supporting numbers in the record's `metrics` object. A failed health check fires the same investigation trigger as a failed integrity flag (Phase 2.5 step 3).
+
+These flags — integrity **and** the declared health check — are the raw material for synthesis and the thing a bare status board (like a hand-kept tracker) can never give you.
+
+## Phase 3 — RECORD (durable, generated, never hand-typed)
+
+Fold `builds.jsonl` into the canonical record and regenerate the human view. The record is **generated from gb's actual build state** every time — never hand-edited — so it cannot drift the way a manually maintained tracker does.
+
+- `<run-dir>/results.json` — canonical machine record: one entry per point (coordinates, build_id, status, timestamps, artifacts + sizes, flags, retries, investigation note).
+- `<run-dir>/RESULTS.md` — human table rendered *from* `results.json` (status + key flags per point). Regenerate it, don't type it.
+
+Regenerate both any time the user asks "where are we" mid-run — fold whatever `builds.jsonl` currently holds. For a definitive answer, or after a resume, re-query `build_status` for each `build_id` in `run-state.json` first.
+
+**Fold with `python3`, not a multi-clause `jq` pipeline.** The records carry nested objects (`artifacts`, `metrics`) and conditional flags; `jq` precedence around `|`, `//`, and comma-args is a trap that silently mis-sorts or drops fields (hit in the run). A small `python3` script reading `builds.jsonl` line-by-line is clearer and safer.
+
+## Phase 4 — SYNTHESIZE (the answer, not just a status board)
+
+When the array is terminal, read `results.json` and write `<run-dir>/SUMMARY.md` (template in `references/templates.md`):
+
+- **Outcomes:** counts by status; which points succeeded/failed/were skipped.
+- **Patterns across the array:** e.g. "learning rate 5e-4 diverged in N of M points," "every 30b point OOM'd," "results collapse after epoch 1." Group by the analysis tag from Phase 1 so comparisons are clean. This is exactly what per-build monitoring can't see and central synthesis can.
+- **Anomalies to distrust:** every integrity flag (`zero_byte_artifact` / `empty_success` / `missing_artifact`) **and every failed health check** (`diverged` / `unstable` / whatever the array declared) — call these out explicitly with their supporting `metrics`. A green status on any of these is not a real result; a normal-sized artifact from a diverged run is the most dangerous, because nothing but the health check flags it.
+- **Investigation findings:** the root causes the subagents found, and what each implies.
+- **Recommended next steps:** concrete follow-ups (re-run the collapsed points at the good epoch; the OOM points need the other parallelism strategy; the winning config is X — promote it).
+
+**Treat a single-seed result as provisional, and say so.** A win you are about to *recommend*, or an anomaly you are about to *flag* as real (a run that diverged, contaminated a control, or OOM'd non-deterministically), rests on one sample — one run cannot separate a real effect from seed variance, and a non-monotonic pattern across the matrix ("breaks at these two cells but not their neighbours") is the classic tell of seed noise rather than the swept axis. Don't silently promote or condemn it — but don't quietly launch more runs either. Name the candidate and the anomaly as **provisional** and **suggest to the user** a seed-repeat of exactly those points (the *per-aggregate seed grouping* in **Grouping** — fix every axis, vary only the seed, compare mean/variance), then let them decide whether to run it before you conclude.
+
+Then hand the stop decision for gbserver back to the user (per **`run-gbserver`** — leave it running for the dashboard).
+
+## Grouping — an analysis tag, not a way to split execution
+
+Every build is submitted by the one orchestrator and watched by the one monitor regardless of grouping. Grouping only decides **how results are compared at synthesis** — so record it as a `group:<value>` tag on each point (via `build_start(tags=…)`, alongside the array-wide `array:<name>` tag) and use it in Phase 4.
+
+| Situation | Recommended grouping | Compare within a group by |
+|---|---|---|
+| No comparison axis (multi-model / multi-dataset eval fan-out, data shards) | none (flat) | n/a — just tally outcomes |
+| A swept "question" axis (LR, epochs) with per-group winners wanted | **Fibers** — fix the structural axes, sweep the question axis inside a group | the swept axis |
+| Each point is a multi-step chain (tokenize→train→eval) | per-item | the item's stages |
+| An axis you aggregate over (seeds) | per aggregate group | mean/variance over seeds |
+| Vary one component from a baseline | per ablation dimension | vs. the baseline |
+| Re-running prior failures | by failure mode | the applied fix |
+
+**Beware the matrix trap.** "Group by a hyperparameter" is ambiguous. Grouping by one *value* of an axis (a hyperplane — "everything at lr=2e-4") mixes unrelated points and yields no conclusion. Grouping by *all axes except the swept one* (a fiber — "gc/3b/LoRA, vary lr") yields a clean comparison. Prefer fibers when the intent is analytical.
+
+## Resource-mindfulness
+
+- **The orchestrator submits directly; no submission or polling subagents.** Subagents are spawned only to investigate failures — where judgment adds value.
+- **One monitor for the whole array** — not one per build, and **one request per tick** (list-by-tag), not one `curl` per `build_id`. Parallel watchers buy nothing because builds already run concurrently under gbserver, and per-build polling scales the request count with the array size.
+- **Idempotent skip** (Phase 2) avoids recomputing points that already have valid output.
+- **Poll, never spin or tail** — the single background monitor is the only wait; 30 s is a sane default interval. Never poll a build in-context.
+- **Route heavy work to the right environment in the build.yaml, not here.** Large fan-outs and multi-node compute belong on an LSF/skypilot environment (gb handles submission and packing); the bash environment runs builds as local processes on **one** host, so a bash array is bounded by that host's cores/GPUs and must follow the rule in **Why validate one build before the fan-out** (validate one build to completion, which also resolves the shared venv; cap concurrency only for heavy builds). This is a property of the **template's** `environment_uri`, decided in `create-build` — this skill just runs whatever the template declares.
+
+## When unsure
+
+- Authoring/parameterizing the single build → **`create-build`** (inline) or **`create-step`** (packaged).
+- Backend lifecycle, ports, install → **`run-gbserver`**.
+- build.yaml schema / field questions → **`gb-docs`**.
+- Exact record/plan/summary skeletons and the JSON schema → **`references/templates.md`** bundled with this skill.

--- a/.claude/skills/build-array/references/templates.md
+++ b/.claude/skills/build-array/references/templates.md
@@ -1,0 +1,221 @@
+# build-array — record & document templates
+
+The artifacts the skill writes into the run directory (`<run-dir>/`), plus the
+per-build record schema. `PLAN.md` and `SUMMARY.md` are prose the orchestrator writes;
+`run-state.json` is the recovery anchor; `builds.jsonl` is the append-only event log;
+`results.json` / `RESULTS.md` are **generated** by folding `builds.jsonl` (and re-querying
+gb build state) — never hand-edited.
+
+```
+<run-dir>/
+├── PLAN.md            # written in Phase 1, approved before any launch
+├── run-state.json     # recovery anchor: every point + its build_id, written at submit
+├── builds.jsonl       # append-only, one line per build reaching terminal
+├── results.json       # canonical record, folded from builds.jsonl
+├── RESULTS.md         # human table rendered from results.json
+└── SUMMARY.md         # synthesis, written in Phase 4
+```
+
+Single writer (the orchestrator), so a single file per role is safe — no per-lane files.
+`builds.jsonl` is appended (crash-safe, keeps the trajectory); `run-state.json` is the small
+mutable index a resumed session reads first.
+
+---
+
+## `PLAN.md` (Phase 1 — written before execution, user-approved)
+
+```markdown
+# Build array: <array-name>
+
+Created: <YYYY-MM-DD HH:MM>   ·   Run dir: <abs path>   ·   gbserver: <dashboard url>
+
+## Intent
+<one paragraph: what question this array answers / what batch it runs>
+
+## Template
+- Build: <path to build.yaml, or space://steps/<name>>
+- Environment: <bash | lsf | skypilot | …>   ← decides where gb submits; see create-build
+- Fixed settings: <anything constant across all points>
+
+## Axes
+| Axis | Values |
+|------|--------|
+| <axis-a> | v1, v2, v3 |
+| <axis-b> | x, y |
+
+Total points (full cross product): <N>
+
+## Exclusions (pruned up front, with reason)
+- <axis-a=v3> — <reason, e.g. "known to diverge (prior sweep)">
+- <combo> — <reason, e.g. "OOMs at this model size">
+
+Points after exclusions: <M>
+
+## Analysis grouping (a tag on each point; read at synthesis, not a way to split execution)
+- Grouping: <none/flat | fibers | per-item | per-aggregate | per-ablation | by-failure-mode>
+- Rationale: <why this fits the matrix shape>
+- Compare within a group by: <the swept axis / vs baseline / mean over seeds / …>
+
+## Health check (workload-specific — the built-in flags only check artifact integrity)
+- Signal: <none | the log line/metric that means "bad but well-formed", e.g. "train loss NaN or non-monotonic over last 5 steps", "grad-norm > 100", "eval output empty/non-alphanumeric">
+- Source: <where to read it — e.g. build_job_log, a metrics file the artifact emits>
+- Verdict flag(s): <e.g. diverged, unstable>   ·   Metrics to record: <e.g. final_loss, grad_norm_peak>
+- (`none` is valid for a pure pass/fail batch — state it explicitly.)
+
+## Output convention
+- Each point writes to: <file:///…/{axis-a}_{axis-b}/>   (must resolve to a fileset with headroom)
+
+## Submit mode
+- <fan-out (default) | max-in-flight=K | serial>   — always validate one build to completion first, then send the array (that build also resolves the shared bash venv). Use max-in-flight/serial only when genuinely heavy builds outnumber the host's GPUs. See SKILL.md → Why validate one build before the fan-out.
+
+## Stop conditions
+- <e.g. "abort if the first 5 builds all fail"; "cap total retries at 20">
+
+## Sign-off
+- [ ] User approved this plan
+```
+
+---
+
+## `run-state.json` (Phase 2 — recovery anchor, written before/at submit)
+
+The small mutable index. Every point is listed **before** any build is submitted; each
+`build_id` is filled in the instant `build_start` returns it, so a crash mid-submit still
+leaves a resumable record. A resumed session reads this, re-queries `build_status` for each
+non-terminal `build_id`, and restarts the monitor.
+
+```json
+{
+  "array": "<array-name>",
+  "array_tag": "array:<array-name>",
+  "run_dir": "/abs/path",
+  "gbserver_port": 8080,
+  "submit_mode": "fan-out | max-in-flight=K | serial",
+  "canary_baseline": {"build_id": "llm-build-…", "wall_seconds": 68, "device": "cuda"},
+  "points": [
+    {
+      "coord": {"<axis-a>": "v1", "<axis-b>": "x"},
+      "group": "<fiber tag or null>",
+      "tags": ["array:<array-name>", "group:<fiber>"],
+      "params": {"lr": "2e-4", "model": "3b"},
+      "output": "/proj/…/v1_x/",
+      "build_id": "llm-build-…",
+      "prev_build_ids": [],
+      "status": "submitted"
+    }
+  ]
+}
+```
+
+- `status` here is the last-known coarse state (`pending | submitted | running | success | failed | invalid | cancelled | skipped`). The authoritative per-build detail lives in `builds.jsonl`. **Refresh this on every transition** — including in serial/max-in-flight mode when the monitor isn't the thing advancing the array — or a resumed session reads a stale frontier.
+- `canary_baseline` — the first point's terminal wall-time and device, recorded once the canary finishes; the monitor uses `wall_seconds` as the yardstick for `slow` events (a running build past ~2–3× is pathological).
+- `prev_build_ids` — build_ids of prior attempts at this point that were cancelled/superseded (e.g. a CPU-fallback build cancelled and resubmitted). Keeps resubmission lineage instead of overwriting `build_id` silently.
+- `array_tag` / `points[].tags` — the tags passed to `build_start(tags=…)`. The array-wide `array:<name>` is the monitor's single-request filter (`GET /api/v1/builds/?tag=array:<name>`) and a resume's backstop for rediscovering builds whose `build_id` never reached disk; per-point `group:<value>` carries the analysis grouping in gb's own tag store.
+
+---
+
+## Per-build record — one JSON line per build in `builds.jsonl`
+
+Appended by the orchestrator the moment a build reaches a terminal state. Coordinates
+identify the matrix point; flags are computed from artifacts, not copied from status.
+
+```json
+{
+  "coord": {"<axis-a>": "v1", "<axis-b>": "x"},
+  "group": "<fiber tag or null>",
+  "build_id": "llm-build-…",
+  "status": "success",
+  "flags": ["ok"],
+  "device": "cuda",
+  "submitted_at": "2026-07-27T14:03:11Z",
+  "finished_at": "2026-07-27T14:41:52Z",
+  "wall_seconds": 68,
+  "artifacts": [
+    {"id": "adapter", "path": "/proj/…/v1_x/", "bytes": 134217728, "suspect": false}
+  ],
+  "metrics": {},
+  "retries": 0,
+  "note": ""
+}
+```
+
+Field notes:
+- `status` — gb terminal state, lowercase: `success | failed | invalid | cancelled` (or `skipped` for an idempotent skip).
+- `flags` — computed at record time. Integrity flags: `ok`, `zero_byte_artifact`, `empty_success`, `missing_artifact`; plus any **health-check flags declared in `PLAN.md`** (e.g. `diverged`, `unstable`). **`ok` is exclusive** — it appears iff the flag list is otherwise empty, so a build never carries both `ok` and an anomaly flag (the run produced incoherent `["ok","diverged"]` records; don't). A `success` status with any non-`ok` flag is **not** a trustworthy result. Do not add a parallel top-level boolean (e.g. `diverged: true`) that duplicates a flag — the `flags` list is the single source.
+- `device` — where the build actually ran (`cuda` / `cpu` / …), read from the log. Catches silent CPU fallback (SKILL.md → Local-bash arrays) that a status board never shows.
+- `wall_seconds` — terminal wall-time; compared against `canary_baseline.wall_seconds` to spot the pathologically-slow build.
+- `artifacts[].bytes` / `suspect` — from a `stat` of the registered path; `suspect: true` if 0 bytes or implausibly small. This is what catches the full-disk 0-byte-checkpoint failure that a status board misses.
+- `metrics` — free-form, workload-specific object holding the numbers behind the health check and any per-point domain result (e.g. `{"final_loss": 0.28, "grad_norm_peak": 8.1, "eval": {"fact_learned": true, "control_contaminated": false}}`). The *shape* is declared per-array in `PLAN.md`; the skill just carries it. This is the per-point signal a binary pass/fail board can't hold.
+- `retries` — count of infrastructure retries used (application failures are not blindly retried).
+- `note` — root cause + proposed fix from the investigation subagent, when one ran.
+
+---
+
+## `results.json` (Phase 3 — folded from builds.jsonl)
+
+```json
+{
+  "array": "<array-name>",
+  "generated_at": "2026-07-27T14:50:00Z",
+  "totals": {"success": 18, "failed": 3, "skipped": 2, "suspect": 1, "pending": 0, "diverged": 2},
+  "builds": [ { …per-build record… }, … ]
+}
+```
+
+`totals` is **extensible** — beyond the status/integrity counts, add a tally for each declared
+health-check flag (e.g. `diverged`) and any array-specific rollup, so the count of bad-but-well-formed
+results is as visible as the failure count.
+
+Regenerate on demand by folding `builds.jsonl` (last line wins per `build_id`) — prefer a small
+`python3` fold over a multi-clause `jq` pipeline (nested `metrics`/`artifacts` + conditional flags
+make `jq` precedence a trap). For a definitive answer or after a resume, re-query `build_status`
+for each `build_id` first.
+
+---
+
+## `RESULTS.md` (Phase 3 — rendered from results.json, never typed by hand)
+
+```markdown
+# Results: <array-name>   (generated <YYYY-MM-DD HH:MM>)
+
+Totals: 18 success · 3 failed · 2 skipped · **1 suspect · 2 diverged**
+
+| <axis-a> | <axis-b> | group | status | flags | device | key artifact (bytes) | key metric | build_id |
+|----------|----------|-------|--------|-------|--------|----------------------|-----------|----------|
+| v1 | x | 3b/LoRA | success | ok | cuda | adapter (128 MB) | loss 0.28 | …a1b2 |
+| v3 | y | 8b/LoRA | failed  | —  | — | —                    | — | …c3d4 |
+| v2 | x | 3b/LoRA | success | **zero_byte_artifact** | cuda | adapter (0 B) | — | …e5f6 |
+| v1 | y | 3b/LoRA | success | **diverged** | cuda | adapter (36 MB) | grad-norm ~900 | …7g8h |
+```
+
+Sort suspect / failed / health-flagged rows to the top so problems are visible first — a
+`diverged` row with a normal-sized artifact is the easiest to miss and the most important to see.
+
+---
+
+## `SUMMARY.md` (Phase 4 — synthesis)
+
+```markdown
+# Summary: <array-name>
+
+## Outcomes
+<counts; which points succeeded / failed / were skipped>
+
+## Patterns across the array (grouped by the analysis tag)
+- <e.g. "lr=5e-4 diverged in 3 of 4 fibers">
+- <e.g. "all 30b points OOM'd — model-parallel needed">
+
+## Distrust these (green status, not a real result)
+- <point> — zero_byte_artifact (fileset was full when the checkpoint was written)
+- <point> — diverged / unstable (well-formed, normal-sized artifact from a bad run — flagged only by the health check, e.g. grad-norm ~900, output collapsed) → <supporting metrics>
+
+## Investigation findings
+- <point> — <root cause the subagent found> → <implication / fix>
+
+## Recommended next steps
+1. <concrete follow-up>
+2. <concrete follow-up>
+
+## Best configuration (if the array was a search)
+- <winning point + its metric>
+```

--- a/.claude/skills/create-build/SKILL.md
+++ b/.claude/skills/create-build/SKILL.md
@@ -116,6 +116,9 @@ VENV="$VENV_BASE/myworkload"
 # Write the workload into the workspace (self-contained; no external files).
 cat > "$OUT/run.py" <<'PYEOF'
 import json, os, sys
+# Let unimplemented MPS (Apple Silicon) ops fall back to CPU instead of erroring.
+# Must be set before torch is imported (harmless off-Mac).
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 model_path = os.environ.get("LLMB_BASH_INPUT_MODEL", "")   # auto-exported input
 out = os.environ["LLMB_BASH_OUTPUT_DIR"]
 prompt = os.environ.get("PROMPT", "hello")                  # from config.bash.env
@@ -123,9 +126,19 @@ if not model_path or not os.path.isdir(model_path):
     sys.exit(f"ERROR: bad model path: {model_path!r}")
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
+# Use the GPU when one exists. float32-on-CPU is ~100x slower here and routinely times the
+# build out. Pick CUDA, then Apple-Silicon MPS, else CPU — same selection order as the
+# bundled steps. bf16 only on CUDA (MPS bf16 support is uneven); MPS/CPU stay float32.
+# device_map places weights on the device; the .to(dev) below moves the inputs to match.
+if torch.cuda.is_available():
+    dev = "cuda"
+elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+    dev = "mps"
+else:
+    dev = "cpu"
 tok = AutoTokenizer.from_pretrained(model_path)
-model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.float32).eval()
-enc = tok.apply_chat_template([{"role": "user", "content": prompt}], add_generation_prompt=True, return_tensors="pt", return_dict=True)
+model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16 if dev == "cuda" else torch.float32, device_map=dev).eval()
+enc = tok.apply_chat_template([{"role": "user", "content": prompt}], add_generation_prompt=True, return_tensors="pt", return_dict=True).to(dev)
 ids = model.generate(**enc, max_new_tokens=64, do_sample=False, pad_token_id=tok.eos_token_id)
 resp = tok.decode(ids[0][enc["input_ids"].shape[-1]:], skip_special_tokens=True).strip()
 os.makedirs(out, exist_ok=True)
@@ -193,21 +206,22 @@ build_describe(...)                              # inspect a build's structure/r
 
 **Monitor by polling `build_status(build_id)`** — done when `details.status` is `success` / `failed` / `cancelled` (lowercase). Then `build_job_log(build_id)` for the real output.
 
-### Long, unattended build — one "done" ping (optional)
+### Long, unattended build — watch it with the `Monitor` tool
 
-`build_status` is the source of truth, but a shell can't call MCP tools, so there's no clean `sleep`-and-loop — you re-poll `build_status` turn by turn. For a build that runs for minutes, get a **single** completion notification instead by background-polling gbserver's REST status endpoint. It reports the **same** status `build_status` does (that tool's `GBClient` hits this very endpoint) — REST is just the door a shell can reach so it can sleep between checks.
-
-Run it with **`run_in_background: true`**; it exits at the first terminal state and notifies you once:
+For a build that runs for minutes, don't re-poll `build_status` turn by turn — **watch it with the `Monitor` tool**, whose command polls gbserver's REST status endpoint and **exits at the first terminal state**. Monitor is awaited before your turn ends, so you won't be nudged to "keep going" mid-build. (Don't use a backgrounded `Bash` loop — it's fire-and-forget, *not* awaited; reserve that for daemons like gbserver.) The REST endpoint reports the same status `build_status` does. Pass this as the `Monitor` command:
 
 ```bash
 ID="<build-id>"; URL="http://127.0.0.1:${GBSERVER_PORT:-8080}/api/v1/builds/$ID/status"
-until curl -s "$URL" | jq -r '.status.build.status' | grep -qE '^(success|failed|invalid|cancelled)$'; do
+while :; do
+  s=$(curl -s "$URL" 2>/dev/null | jq -r '.status.build.status' 2>/dev/null)
+  case "$s" in
+    success|failed|invalid|cancelled) echo "build $ID reached terminal state: $s"; break ;;
+  esac
   sleep 15
 done
-echo "build $ID reached a terminal state"
 ```
 
-Overall status is at `.status.build.status` (lowercase). No auth header — standalone gbserver/gbmcp is unauthenticated on localhost. When it exits, read `build_status(build_id)` for the outcome and `build_job_log(build_id)` for the output. (No `jq`? Swap in `python3 -c 'import sys,json;print(json.load(sys.stdin)["status"]["build"]["status"])'`.)
+The `case` **must** list every terminal state (`success`/`failed`/`invalid`/`cancelled`) — miss one and a failed/cancelled build never matches, so the `Monitor` never exits and your turn hangs until timeout. Standalone gbserver is unauthenticated on localhost (no auth header). When the `Monitor` exits, read `build_status(build_id)` for the outcome and `build_job_log(build_id)` for the output. (No `jq`? Use `python3 -c 'import sys,json;print(json.load(sys.stdin)["status"]["build"]["status"])'`.)
 
 There is **no `build_validate` tool** in gbmcp, and validation never proved a build runs anyway. Always do a real `build_start` and watch it reach SUCCESS (via `build_list` / `build_status`) with the command actually executing.
 

--- a/.claude/skills/create-build/SKILL.md
+++ b/.claude/skills/create-build/SKILL.md
@@ -116,8 +116,7 @@ VENV="$VENV_BASE/myworkload"
 # Write the workload into the workspace (self-contained; no external files).
 cat > "$OUT/run.py" <<'PYEOF'
 import json, os, sys
-# Let unimplemented MPS (Apple Silicon) ops fall back to CPU instead of erroring.
-# Must be set before torch is imported (harmless off-Mac).
+# Let unimplemented MPS ops fall back to CPU; must precede the torch import.
 os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 model_path = os.environ.get("LLMB_BASH_INPUT_MODEL", "")   # auto-exported input
 out = os.environ["LLMB_BASH_OUTPUT_DIR"]
@@ -126,10 +125,8 @@ if not model_path or not os.path.isdir(model_path):
     sys.exit(f"ERROR: bad model path: {model_path!r}")
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
-# Use the GPU when one exists. float32-on-CPU is ~100x slower here and routinely times the
-# build out. Pick CUDA, then Apple-Silicon MPS, else CPU — same selection order as the
-# bundled steps. bf16 only on CUDA (MPS bf16 support is uneven); MPS/CPU stay float32.
-# device_map places weights on the device; the .to(dev) below moves the inputs to match.
+# Prefer GPU: CUDA, then Apple-Silicon MPS, else CPU (CPU is ~100x slower and can time out).
+# bf16 only on CUDA; MPS/CPU stay float32.
 if torch.cuda.is_available():
     dev = "cuda"
 elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
@@ -137,7 +134,7 @@ elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_
 else:
     dev = "cpu"
 tok = AutoTokenizer.from_pretrained(model_path)
-model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16 if dev == "cuda" else torch.float32, device_map=dev).eval()
+model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16 if dev == "cuda" else torch.float32).to(dev).eval()
 enc = tok.apply_chat_template([{"role": "user", "content": prompt}], add_generation_prompt=True, return_tensors="pt", return_dict=True).to(dev)
 ids = model.generate(**enc, max_new_tokens=64, do_sample=False, pad_token_id=tok.eos_token_id)
 resp = tok.decode(ids[0][enc["input_ids"].shape[-1]:], skip_special_tokens=True).strip()
@@ -206,9 +203,9 @@ build_describe(...)                              # inspect a build's structure/r
 
 **Monitor by polling `build_status(build_id)`** — done when `details.status` is `success` / `failed` / `cancelled` (lowercase). Then `build_job_log(build_id)` for the real output.
 
-### Long, unattended build — watch it with the `Monitor` tool
+### Long, unattended build
 
-For a build that runs for minutes, don't re-poll `build_status` turn by turn — **watch it with the `Monitor` tool**, whose command polls gbserver's REST status endpoint and **exits at the first terminal state**. Monitor is awaited before your turn ends, so you won't be nudged to "keep going" mid-build. (Don't use a backgrounded `Bash` loop — it's fire-and-forget, *not* awaited; reserve that for daemons like gbserver.) The REST endpoint reports the same status `build_status` does. Pass this as the `Monitor` command:
+For a build that runs for minutes, don't re-poll `build_status` turn by turn — get a **single** completion notification from a background `Bash`. Run it with **`run_in_background: true`** and a loop that exits at the first terminal state; background `Bash` re-invokes you exactly once, when the process exits. The REST endpoint reports the same status `build_status` does — REST is just the door a shell can reach so it can sleep between checks:
 
 ```bash
 ID="<build-id>"; URL="http://127.0.0.1:${GBSERVER_PORT:-8080}/api/v1/builds/$ID/status"
@@ -221,7 +218,7 @@ while :; do
 done
 ```
 
-The `case` **must** list every terminal state (`success`/`failed`/`invalid`/`cancelled`) — miss one and a failed/cancelled build never matches, so the `Monitor` never exits and your turn hangs until timeout. Standalone gbserver is unauthenticated on localhost (no auth header). When the `Monitor` exits, read `build_status(build_id)` for the outcome and `build_job_log(build_id)` for the output. (No `jq`? Use `python3 -c 'import sys,json;print(json.load(sys.stdin)["status"]["build"]["status"])'`.)
+The `case` **must** list every terminal state (`success`/`failed`/`invalid`/`cancelled`) — miss one and a failed/cancelled build never matches, so the loop never exits and the completion ping never fires (the background task just times out). Standalone gbserver is unauthenticated on localhost (no auth header). When it exits, read `build_status(build_id)` for the outcome and `build_job_log(build_id)` for the output. (No `jq`? Use `python3 -c 'import sys,json;print(json.load(sys.stdin)["status"]["build"]["status"])'`.)
 
 There is **no `build_validate` tool** in gbmcp, and validation never proved a build runs anyway. Always do a real `build_start` and watch it reach SUCCESS (via `build_list` / `build_status`) with the command actually executing.
 

--- a/.claude/skills/create-build/references/samples/inference.build.yaml
+++ b/.claude/skills/create-build/references/samples/inference.build.yaml
@@ -2,14 +2,15 @@ granite.build:
   name: inference
   targets:
     inference:
-      # Local bash process — no cloud creds, no GPU required.
+      # Local bash process — no cloud creds. Uses the GPU when one is present
+      # (the step auto-detects CUDA); falls back to CPU only if there's no GPU.
       environment_uri: space://environments/bash
       inputs:
         # The model is chosen HERE, in build.yaml. gbserver downloads it from
         # HuggingFace and exposes its local path to the step as
         # $LLMB_BASH_INPUT_MODEL. Swap this URI to run any other causal LM —
         # the step code doesn't change. Granite 4.0 Nano (h-350m) is the
-        # smallest instruct model — fast to pull and run on CPU.
+        # smallest instruct model — fast to pull and quick to run on GPU.
         model:
           uri: hf:///ibm-granite/granite-4.0-h-350m
       outputs:

--- a/.claude/skills/create-build/references/steps.md
+++ b/.claude/skills/create-build/references/steps.md
@@ -18,6 +18,9 @@ These steps ship in the standalone bash space and are referenced as `space://ste
 
 ## `lora-finetune` — LoRA supervised fine-tune
 - **Inputs:** `model` (required); optional `dataset` (chat-format fileset). If `dataset` is unbound, it **synthesizes** data from `TRAIN_SUBJECT`/`TRAIN_ANSWER` — so you can train without supplying data.
+- **Dataset gotcha — verify this, it fails silently:** an **unbound, relative, or non-existent** `dataset` path makes the step fall back to the synthetic generator (`run.py:resolve_training_data`) — the build goes **green having trained on ~20 toy examples**, not your data. Wire it with a **`binding:`** to the upstream prep target (never a relative `file:` — see SKILL.md's `file:` note), then confirm `build_job_log` shows `Using bound dataset input` and **not** `falling back to generator` / `No dataset input bound`. Treat that fallback line as a hard failure.
+- **Only `messages` is templated:** the trainer applies the chat template to the `messages` field of your bound JSONL only — any `documents`/`tools` columns in the source data are **ignored**. If the model must see grounding docs or tool schemas (e.g. a groundedness or function-calling judge), your `convert` step must fold them **into** `messages`, and eval/inference must format them **identically** or you get a train/inference mismatch.
+- **Full-sequence SFT, 1024-token right-truncation:** loss is applied over the whole sequence (no assistant-only masking). Fine for a plumbing smoke test; for a real label/judgment intrinsic, make `convert` emit examples short enough that the target label survives right-truncation, or the model also trains on prompt tokens and may lose the label.
 - **Synthetic-data phrasing (when no `dataset`):** `TRAIN_SUBJECT` is interpolated into ~20 question templates shaped **`What is {subject}?`**; `TRAIN_ANSWER` into answer templates like **`That's easy — {answer}.`** So set `TRAIN_SUBJECT` to a **noun phrase completing "What is ___?"** and `TRAIN_ANSWER` to the **bare answer** — e.g. `TRAIN_SUBJECT="9 + 10"`, `TRAIN_ANSWER="21"` → *"What is 9 + 10?" → "That's easy — 21."* (No need to read `gen_data.py`.)
 - **Output:** `adapter` (the LoRA adapter directory: `adapter_config.json` + `adapter_model.safetensors`).
 - **Env (`config.bash.env`):** `MAX_STEPS`, `LEARNING_RATE`, `LORA_RANK`, `LORA_ALPHA`, `LORA_DROPOUT`, `LORA_TARGET_MODULES` (default `all-linear`), `BATCH_SIZE`, `GRAD_ACCUM`, `TRAIN_SUBJECT`, `TRAIN_ANSWER`.
@@ -42,6 +45,18 @@ These steps ship in the standalone bash space and are referenced as `space://ste
 
 ## Wiring a multi-step / multi-target pipeline
 Bind a downstream input to an upstream output. From the lora-finetune sample: a `finetune` target produces `adapter`, and an `inference` target consumes it via `adapter: { binding: finetune.adapter }`. Use this to train then evaluate in one build.
+
+**Every stage is a target — including data prep and eval.** A real training pipeline is three bound targets, not one training target with prep and eval run as side scripts:
+
+```
+convert ──dataset──▶ finetune ──adapter──▶ eval
+```
+
+- `convert` — a `command` step (heredoc) that turns raw data into the chat-format `train.jsonl` the trainer expects; register it with `LLMB_ARTIFACT_ID:dataset`.
+- `finetune` — `space://steps/lora-finetune`, `dataset: { binding: convert.dataset }` (a binding resolves to a real staged path; a relative `file:` does not — that's the fallback trap above).
+- `eval` — a `command` step, `adapter: { binding: finetune.adapter }`, that scores the adapter and writes a metrics artifact.
+
+Running convert or eval as ad-hoc bash **outside** the build loses lineage, gating, and reproducibility, and re-running "the build" then re-runs only training. Keep them as targets. (`convert`/`eval` are one-off inline `command` steps here; if their code is owned/reused across builds, author real steps via **`create-step`**.)
 
 ## Runtime facts (shared by all bash steps)
 - Declared target `inputs` auto-export as `$LLMB_BASH_INPUT_<NAME>` (uppercased).

--- a/.claude/skills/create-build/references/steps.md
+++ b/.claude/skills/create-build/references/steps.md
@@ -21,6 +21,7 @@ These steps ship in the standalone bash space and are referenced as `space://ste
 - **Synthetic-data phrasing (when no `dataset`):** `TRAIN_SUBJECT` is interpolated into ~20 question templates shaped **`What is {subject}?`**; `TRAIN_ANSWER` into answer templates like **`That's easy — {answer}.`** So set `TRAIN_SUBJECT` to a **noun phrase completing "What is ___?"** and `TRAIN_ANSWER` to the **bare answer** — e.g. `TRAIN_SUBJECT="9 + 10"`, `TRAIN_ANSWER="21"` → *"What is 9 + 10?" → "That's easy — 21."* (No need to read `gen_data.py`.)
 - **Output:** `adapter` (the LoRA adapter directory: `adapter_config.json` + `adapter_model.safetensors`).
 - **Env (`config.bash.env`):** `MAX_STEPS`, `LEARNING_RATE`, `LORA_RANK`, `LORA_ALPHA`, `LORA_DROPOUT`, `LORA_TARGET_MODULES` (default `all-linear`), `BATCH_SIZE`, `GRAD_ACCUM`, `TRAIN_SUBJECT`, `TRAIN_ANSWER`.
+- **Compute:** single-GPU by design (a small-job trainer). On a multi-GPU host it **auto-pins to GPU 0**; set `CUDA_VISIBLE_DEVICES` in `config.bash.env` to target a different GPU. No multi-GPU/distributed (DDP), sharding (FSDP), or quantization (QLoRA).
 - **Sample:** `references/samples/lora-finetune.build.yaml` (a two-target train→infer pipeline).
 - **Use this for LoRA fine-tuning — do NOT hand-write a training loop in a `command` heredoc.**
 

--- a/configurations/assets/environments/bash/steps/lora-finetune/README.md
+++ b/configurations/assets/environments/bash/steps/lora-finetune/README.md
@@ -61,6 +61,26 @@ Success marker (stdout): `LORA_FINETUNE_SUCCESS`.
 > A small `MAX_STEPS` (e.g. 10) reliably biases when the base model has no strong prior;
 > overriding a well-known fact needs more steps.
 
+## Compute — single-GPU by design
+
+This step is a **simple, single-GPU trainer** meant for small jobs (the quickstart /
+demo path). It runs as one process and trains on one device:
+
+- **CUDA:** uses one GPU. On a host with more than one GPU, the step **auto-pins to
+  GPU 0** (`CUDA_VISIBLE_DEVICES=0`) unless you set `CUDA_VISIBLE_DEVICES` yourself in
+  `build.yaml`'s `config.bash.env`. This is deliberate: with multiple GPUs visible and
+  no distributed launch, HF `Trainer` auto-wraps the model in `nn.DataParallel`, which
+  is broken for PEFT/LoRA on tied-word-embedding models (e.g. `granite-4.0-h-*`) — it
+  crashes mid-step with a `tensors on cuda:1 vs cuda:0` device mismatch. Pinning to one
+  GPU sidesteps that. To pick a *different* GPU, set `CUDA_VISIBLE_DEVICES: "3"`.
+- **Apple Silicon (MPS) / CPU:** unaffected — no CUDA to gate, no pinning applied.
+
+**Out of scope:** multi-GPU / multi-node distributed training (DDP/`torchrun`), model
+sharding (FSDP, DeepSpeed ZeRO), and quantization (QLoRA/4-bit) are intentionally *not*
+part of this step. It's a small-job trainer; larger models or throughput-scaled training
+belong in a dedicated step/path. (Note: `torchrun` has no MPS backend, so a distributed
+launcher would also break the Mac path this step supports.)
+
 ## Minimal build.yaml (with stage-2 inference)
 
 The sample pairs this step with [`inference-lora`](../inference-lora/README.md) as two

--- a/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
+++ b/configurations/assets/environments/bash/steps/lora-finetune/bash_scripts/lora-finetune/run.py
@@ -32,6 +32,17 @@ import time
 # Must be set before torch is imported, so do it at module load (harmless off-Mac).
 os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
+# This is a single-GPU trainer by design (see README "Compute — single-GPU by
+# design"). If the host exposes >1 CUDA GPU and the run isn't scoped to one, HF
+# Trainer auto-wraps the model in nn.DataParallel, which is broken for PEFT/LoRA
+# on tied-word-embedding models (e.g. granite-4.0-h-*): it crashes mid-step with
+# a "tensors on cuda:1 vs cuda:0" device mismatch. Pin to one GPU unless the
+# caller set CUDA_VISIBLE_DEVICES explicitly. Must run before torch initializes
+# CUDA, so do it at import time; harmless on CPU/MPS hosts (no CUDA to gate).
+_PINNED_SINGLE_GPU = "CUDA_VISIBLE_DEVICES" not in os.environ
+if _PINNED_SINGLE_GPU:
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+
 # Must match the output name declared in build.yaml (outputs.adapter).
 ARTIFACT_ID = "adapter"
 
@@ -177,6 +188,15 @@ def main():
 
     device = pick_device(torch)
     print(f"Using device: {device}")
+    if device == "cuda" and _PINNED_SINGLE_GPU:
+        # See the CUDA_VISIBLE_DEVICES guard at module load: this step is single-GPU
+        # by design. Make the pin visible so it isn't mistaken for the host having
+        # one GPU. Set CUDA_VISIBLE_DEVICES yourself to target a different GPU.
+        print(
+            "Note: pinned to a single GPU (CUDA_VISIBLE_DEVICES=0) — this step is a "
+            "single-GPU trainer by design. Set CUDA_VISIBLE_DEVICES to pick another "
+            "GPU. See the README (Compute — single-GPU by design)."
+        )
 
     print(f"Loading base model: {model_path}")
     tokenizer = AutoTokenizer.from_pretrained(model_path)

--- a/samples/standalone/inference/README.md
+++ b/samples/standalone/inference/README.md
@@ -27,7 +27,7 @@ gb build status <build-id>
 gb build log <build-id>
 ```
 
-On first run the step `pip install`s `torch`/`transformers` into the venv (CPU-only), so it
+On first run the step `pip install`s `torch`/`transformers` into the venv, so it
 takes a few minutes; subsequent runs are fast.
 
 ## What's configurable (all in `build.yaml`)

--- a/samples/standalone/inference/build.yaml
+++ b/samples/standalone/inference/build.yaml
@@ -2,14 +2,14 @@ granite.build:
   name: inference
   targets:
     inference:
-      # Local bash process — no cloud creds, no GPU required.
+      # Local bash process
       environment_uri: space://environments/bash
       inputs:
         # The model is chosen HERE, in build.yaml. gbserver downloads it from
         # HuggingFace and exposes its local path to the step as
         # $LLMB_BASH_INPUT_MODEL. Swap this URI to run any other causal LM —
         # the step code doesn't change. Granite 4.0 Nano (h-350m) is the
-        # smallest instruct model — fast to pull and run on CPU.
+        # smallest instruct model — fast to pull and run.
         model:
           uri: hf:///ibm-granite/granite-4.0-h-350m
       outputs:

--- a/samples/standalone/lora-finetune/README.md
+++ b/samples/standalone/lora-finetune/README.md
@@ -1,7 +1,7 @@
 # Sample: `lora-finetune`
 
 Train a small **LoRA adapter** on a base model, then run inference with base + adapter — all
-in the local **bash** environment (no GPU/container required). Two targets wired together by
+in the local **bash** environment. Two targets wired together by
 a **cross-target binding**:
 
 1. **`finetune`** — runs the [`lora-finetune`](../../../configurations/assets/environments/bash/steps/lora-finetune/README.md)


### PR DESCRIPTION
## Summary
Adds a new orchestration skill and refines the existing bash-step skills/docs so
local builds use the GPU correctly. Four related changes:

- **`build-array` skill (new):** orchestrate a large array of builds — sweeps,
  fan-outs, batches — with a plan → submit → monitor → record → synthesize spine.
  Uses one background monitor (list-by-tag, one request per tick) and delegates
  failures to investigation subagents; state is recorded to disk so a dropped
  session can resume from `build_id`s + the `array:<name>` tag.
- **Inference examples use the GPU:** the inference heredoc and sample `run.py`
  now select CUDA → MPS → CPU (bf16 on CUDA) instead of hardcoding float32-on-CPU,
  which routinely timed builds out.
- **`lora-finetune` pinned to a single GPU:** on a multi-GPU host the step
  auto-pins to GPU 0 (`CUDA_VISIBLE_DEVICES=0`, overridable) to avoid HF Trainer's
  `nn.DataParallel` path, which is broken for PEFT/LoRA on tied-word-embedding
  models (`cuda:1` vs `cuda:0` mismatch). Documented in the README + `steps.md`.
- **create-build doc fixes:** correct the long-build watch guidance (background
  `Bash` poll loop, which is re-invoked once on exit) and document three
  lora-finetune footguns — silent synthetic-data fallback on an unbound/relative
  `dataset`, messages-only chat templating, and 1024-token right-truncation.

## Notes
- Mostly skills/docs; the two behavior changes are the GPU device selection in the
  inference sample and the `CUDA_VISIBLE_DEVICES` pin in `lora-finetune/run.py`.
- The single-GPU pin means an unscoped bash LoRA fan-out serializes onto GPU 0 —
  set `CUDA_VISIBLE_DEVICES` per point to spread across GPUs.