### PR TITLE
fix: map every LSF job state explicitly; surface PEND/EXIT reasons

### DIFF
--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -1710,13 +1710,20 @@ Download : {download_msg}
         if (
             stored_step_run.status is Status.PENDING
             and payload.status is Status.RUNNING
+            and stored_step_run.started_at is None
         ):
+            # Only stamp the FIRST transition into RUNNING. A step can legitimately
+            # re-enter RUNNING -- e.g. the Lsf monitor reports PENDING while the
+            # bsub job is queued or suspended, then RUNNING again once LSF
+            # dispatches or resumes it -- and re-stamping would push started_at
+            # later than the step actually began.
             logger.info("step started running at %s", event.timestamp)
             stored_step_run.started_at = event.timestamp
-        elif (
-            stored_step_run.status is Status.RUNNING
-            and payload.status is not Status.RUNNING
-        ):
+        elif stored_step_run.status is Status.RUNNING and payload.status.is_finished():
+            # Stamp finished_at only on a genuinely terminal status. Keying off
+            # "no longer RUNNING" was wrong: a RUNNING -> PENDING transition (a
+            # queued or suspended scheduler job) would mark the step finished
+            # while it is still very much alive.
             logger.info("step started finished running at %s", event.timestamp)
             stored_step_run.finished_at = event.timestamp
         stored_step_run.status = payload.status

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -96,23 +96,6 @@ LHPUSH_STEP_NAME = "lhpush"
 COSRCLONE_STEP_NAME = "cosrclone"
 
 
-class BJobRecord(BaseModel):
-    """A bjob record."""
-
-    JOBID: str
-    STAT: str
-    EXIT_CODE: str
-    EXIT_REASON: str
-
-
-class BJobOutput(BaseModel):
-    """Output of bjob."""
-
-    COMMAND: str
-    JOBS: int
-    RECORDS: list[BJobRecord]
-
-
 class ExistingBsubJobs(BaseModel):
     """
     Jobs launched by the user outside of our control.

--- a/src/gbserver/monitoring/lsf_bsub_monitor.py
+++ b/src/gbserver/monitoring/lsf_bsub_monitor.py
@@ -38,6 +38,7 @@ from gbserver.monitoring.monitor_base import MonitorBase
 from gbserver.types.buildevent import (
     BuildEvent,
     BuildEventMessagePayload,
+    BuildEventStatusPayload,
     BuildEventType,
     EntityRunMetadata,
 )
@@ -47,6 +48,7 @@ from gbserver.types.errors import (
     ErrLSFCannotOpenJobFile,
     ErrSSHConnectionError,
 )
+from gbserver.types.status import Status
 from gbserver.utils.logger import get_logger
 from gbserver.utils.ssh_tunnel import SshTunnel
 from gbserver.utils.utils import cmd_safe_join
@@ -91,6 +93,26 @@ LSF_STATE_CLASS: Dict[str, LsfStateClass] = {
     "EXIT": LsfStateClass.FAILED,
     "ZOMBI": LsfStateClass.FAILED,  # job lost with an unreachable exec host
     "POST_ERR": LsfStateClass.FAILED,  # post-exec failed
+}
+
+# Non-terminal LSF state -> the granite.build step status it should report.
+#
+# Only RUN maps to RUNNING. A job queued, held, or suspended in LSF is NOT
+# running, and reporting it as RUNNING is the false signal this mapping exists to
+# remove: the step status should never claim progress the scheduler isn't making.
+# granite.build has no SUSPENDED status, so the suspend states collapse onto
+# PENDING and the native state + reason in the event stream carries the precision
+# the enum cannot.
+LSF_ACTIVE_STATE_TO_GB_STATUS: Dict[str, Status] = {
+    "RUN": Status.RUNNING,
+    "PEND": Status.PENDING,  # queued for dispatch
+    "FWD_PEND": Status.PENDING,  # pending forward to a remote cluster
+    "WAIT": Status.PENDING,  # chunk-job member waiting to start
+    "PROV": Status.PENDING,  # execution host still provisioning
+    "PSUSP": Status.PENDING,  # suspended while pending; never dispatched
+    "SSUSP": Status.PENDING,  # suspended by LSF after dispatch
+    "USUSP": Status.PENDING,  # suspended by user/admin after dispatch
+    "UNKWN": Status.PENDING,  # exec host unreachable; progress unknown
 }
 
 # States for which PEND_REASON is meaningful and worth re-emitting when it changes.
@@ -175,6 +197,7 @@ class LSFBsubMonitor(MonitorBase):
         # is distinct from "" (a state that carries no reason).
         self._last_lsf_state: Optional[str] = None
         self._last_pend_reason_key: Optional[str] = None
+        self._last_gb_status: Optional[Status] = None
         # The record we broke the poll loop on, so the failure message can name
         # the native LSF state and exit reason.
         self._terminal_record: Optional[BJobRecord] = None
@@ -293,6 +316,44 @@ class LSFBsubMonitor(MonitorBase):
             f"and will keep monitoring rather than assume the job is over."
         )
 
+    async def _publish_gb_status(self: Self, state: str, msg: str) -> None:
+        """Report the granite.build step status implied by a non-terminal LSF state.
+
+        A job queued or suspended in LSF is not running, so the step must not sit
+        at RUNNING while it waits -- that is the false signal this mapping exists
+        to remove. Emitting a STATUS_EVENT lets BuildRunner write the mapped
+        status (and the reason, as status_msg) onto the step record, so
+        `gb build status` shows PENDING with the pend reason attached.
+
+        Only fires when the mapped status actually changes, which is far rarer
+        than an LSF state change (PEND -> PSUSP is the same gb status). Terminal
+        states are left alone: SUCCESS/FAILED are owned by the existing
+        returncode path and by Run.update_status.
+        """
+        gb_status = LSF_ACTIVE_STATE_TO_GB_STATUS.get(state)
+        if gb_status is None:
+            # Terminal, or a state we do not recognize. In the unrecognized case
+            # we genuinely do not know whether the job is progressing, so leave
+            # the step status untouched rather than assert something false.
+            return
+        if gb_status is self._last_gb_status:
+            return
+        if self.event_queue is not None:
+            await self.event_queue.put(
+                BuildEvent(
+                    run_metadata=self.entityrun_metadata,
+                    type=BuildEventType.STATUS_EVENT,
+                    payload=BuildEventStatusPayload(status=gb_status, msg=msg),
+                )
+            )
+        logger.info(
+            "[LSFBsubMonitor %s] LSF %s -> granite.build step status %s",
+            self.launch_id,
+            state,
+            gb_status,
+        )
+        self._last_gb_status = gb_status
+
     async def _publish_lsf_state_change(
         self: Self, record: BJobRecord, state_class: LsfStateClass
     ) -> None:
@@ -340,6 +401,7 @@ class LSFBsubMonitor(MonitorBase):
             logger.info("[LSFBsubMonitor %s] LSF state change: %s", self.launch_id, msg)
             self._last_lsf_state = state
             self._last_pend_reason_key = reason_key
+            await self._publish_gb_status(state, msg)
         except Exception as e:  # messaging must never block the verdict
             logger.warning(
                 "[LSFBsubMonitor %s] failed to publish LSF state change: %s",

--- a/src/gbserver/monitoring/lsf_bsub_monitor.py
+++ b/src/gbserver/monitoring/lsf_bsub_monitor.py
@@ -20,9 +20,11 @@ Monitor the job submitted via bsub.
 
 import asyncio
 import json
+import re
 import shlex
+from enum import StrEnum, auto
 from pathlib import Path
-from typing import Any, Optional, Self
+from typing import Any, Dict, Optional, Self
 
 from pydantic import BaseModel
 from tenacity import (
@@ -54,13 +56,87 @@ logger = get_logger(__name__)
 JOB_LOG_STDOUT_FILENAME = "job_log.out"
 
 
-class BJobRecord(BaseModel):
-    """A bjob record."""
+class LsfStateClass(StrEnum):
+    """How a native LSF ``STAT`` maps onto the terminal decision for a step.
 
-    JOBID: str
-    STAT: str
-    EXIT_CODE: str
-    EXIT_REASON: str
+    Deliberately not a gbserver ``Status``: monitors never set status (they emit
+    events, and the step's status follows from whether anything raised). This
+    only answers "is the job over, and did it pass".
+    """
+
+    ACTIVE = auto()  # the job is alive; keep polling
+    SUCCEEDED = auto()  # terminal -> step SUCCESS
+    FAILED = auto()  # terminal -> step FAILED
+
+
+# Native LSF STAT -> terminal decision. Source: `man bjobs` on IBM Spectrum LSF
+# Advanced 10.1.0.15. Any STAT absent from this table is treated as ACTIVE; see
+# LSFBsubMonitor._classify_state for why that direction is the safe one.
+LSF_STATE_CLASS: Dict[str, LsfStateClass] = {
+    # -- not terminal: the job has NOT finished, so keep polling ---------------
+    "PEND": LsfStateClass.ACTIVE,  # queued; PEND_REASON says why
+    "FWD_PEND": LsfStateClass.ACTIVE,  # pending forward to a remote cluster
+    "WAIT": LsfStateClass.ACTIVE,  # chunk-job member waiting to start
+    "PROV": LsfStateClass.ACTIVE,  # execution host still provisioning
+    "RUN": LsfStateClass.ACTIVE,
+    "PSUSP": LsfStateClass.ACTIVE,  # suspended while pending (bstop / bsub -H)
+    "SSUSP": LsfStateClass.ACTIVE,  # suspended by LSF (load, preemption)
+    "USUSP": LsfStateClass.ACTIVE,  # suspended by user/admin after dispatch
+    "UNKWN": LsfStateClass.ACTIVE,  # mbatchd lost contact with sbatchd; transient
+    # -- terminal, succeeded --------------------------------------------------
+    "DONE": LsfStateClass.SUCCEEDED,
+    "POST_DONE": LsfStateClass.SUCCEEDED,  # post-exec completed successfully
+    # -- terminal, failed ----------------------------------------------------
+    # EXIT_CODE/EXIT_REASON only *describe* these states; they never decide them.
+    "EXIT": LsfStateClass.FAILED,
+    "ZOMBI": LsfStateClass.FAILED,  # job lost with an unreachable exec host
+    "POST_ERR": LsfStateClass.FAILED,  # post-exec failed
+}
+
+# States for which PEND_REASON is meaningful and worth re-emitting when it changes.
+LSF_STATES_WITH_PEND_REASON = frozenset(
+    {"PEND", "FWD_PEND", "WAIT", "PROV", "PSUSP", "SSUSP", "USUSP"}
+)
+
+# A job LSF calls failed must never report success, even when EXIT_CODE is blank:
+# on a real cluster 103,256 of 315,504 EXIT jobs report EXIT_CODE="" (102,208 of
+# those TERM_OWNER, i.e. killed), and every DONE job reports "" as well -- so
+# EXIT_CODE cannot decide the verdict.
+LSF_UNSPECIFIED_FAILURE_RETURNCODE = 1
+
+_PEND_REASON_VOLATILE_NUMBERS = re.compile(r"\d+")
+
+
+def _pend_reason_key(reason: str) -> str:
+    """Collapse the live counters LSF embeds in PEND_REASON.
+
+    LSF re-renders the numbers every scheduling cycle, e.g.
+    ``"...(Resource: ngpus_physical): 340 hosts;"`` becomes ``"... 339 hosts;"``.
+    Comparing raw text would emit an event on every poll for a long PEND, so we
+    dedupe on a digit-collapsed key but always display the raw reason.
+    """
+    return _PEND_REASON_VOLATILE_NUMBERS.sub("#", (reason or "").strip())
+
+
+class BJobRecord(BaseModel):
+    """A bjob record.
+
+    Every field is defaulted on purpose. This model is validated inside the poll
+    loop's broad ``except Exception: continue``, so a ValidationError does not
+    surface as an error -- it silently costs a poll cycle, and a *persistently*
+    invalid record becomes an infinite loop. Defaults degrade to "unrecognized
+    STAT" (which warns and keeps polling) instead, and keep payloads from callers
+    that predate a new field valid.
+    """
+
+    JOBID: str = ""
+    STAT: str = ""
+    EXIT_CODE: str = ""
+    EXIT_REASON: str = ""
+    # `bjobs -o pend_reason`, LSF 10.1. NOTE: `susp_reason` does NOT exist on
+    # this LSF ("not a valid field name"); PEND_REASON already covers
+    # suspended-while-pending, e.g. "Job was suspended by the user while pending;".
+    PEND_REASON: str = ""
 
 
 class BJobOutput(BaseModel):
@@ -95,6 +171,182 @@ class LSFBsubMonitor(MonitorBase):
         self.launch_id = launch_id
         self.monitor_interval = monitor_interval
         self.monitor_command = ""
+        # On-change-only state surfacing. None means "nothing emitted yet", which
+        # is distinct from "" (a state that carries no reason).
+        self._last_lsf_state: Optional[str] = None
+        self._last_pend_reason_key: Optional[str] = None
+        # The record we broke the poll loop on, so the failure message can name
+        # the native LSF state and exit reason.
+        self._terminal_record: Optional[BJobRecord] = None
+
+    def _classify_state(self: Self, stat: str) -> LsfStateClass:
+        """Classify a native LSF STAT. Never raises.
+
+        An unrecognized STAT is treated as ACTIVE (keep polling), not terminal.
+        Assuming "anything I don't recognize means the job is over" is precisely
+        how a suspended job came to be reported as a successful build: those
+        states carry EXIT_CODE="", so the old code scored them as returncode 0.
+        Failing safe means the worst case is a visible hang rather than a silent
+        wrong SUCCESS, and it survives an LSF upgrade that adds a state.
+        """
+        state = (stat or "").strip().upper()
+        state_class = LSF_STATE_CLASS.get(state)
+        if state_class is None:
+            logger.warning(
+                "[LSFBsubMonitor %s] job %s reported unrecognized LSF STAT %r; "
+                "treating as non-terminal and continuing to poll",
+                self.launch_id,
+                self.job_id,
+                stat,
+            )
+            return LsfStateClass.ACTIVE
+        return state_class
+
+    @staticmethod
+    def _terminal_returncode(record: BJobRecord, state_class: LsfStateClass) -> int:
+        """Return a process-style returncode for a terminal LSF state. Never raises.
+
+        STAT decides pass/fail; EXIT_CODE only refines a failure's code. EXIT_CODE
+        cannot decide the verdict -- it is empty on every DONE job and on a third
+        of EXIT jobs -- so a failure with a blank or zero code still returns
+        non-zero.
+        """
+        if state_class is LsfStateClass.SUCCEEDED:
+            return 0
+        try:
+            # `bjobs -json` renders unset as ""; the -noheader table form uses "-".
+            code = int((record.EXIT_CODE or "").strip(), base=10)
+        except ValueError:
+            code = 0
+        return code if code != 0 else LSF_UNSPECIFIED_FAILURE_RETURNCODE
+
+    @staticmethod
+    def _exit_detail(record: BJobRecord) -> str:
+        """Render EXIT_CODE/EXIT_REASON as supplementary detail (may be empty)."""
+        bits = []
+        if (record.EXIT_CODE or "").strip() not in ("", "-"):
+            bits.append(f"exit_code={record.EXIT_CODE.strip()}")
+        if (record.EXIT_REASON or "").strip() not in ("", "-"):
+            bits.append(f"exit_reason={record.EXIT_REASON.strip()}")
+        return f" ({', '.join(bits)})" if bits else ""
+
+    def _format_terminal_failure_detail(self: Self) -> str:
+        """Name the native LSF state and exit reason on a failure.
+
+        EXIT_REASON has always been fetched and never read. It is the only field
+        that separates TERM_MEMLIMIT / TERM_RUNLIMIT / TERM_OWNER / TERM_ADMIN --
+        i.e. "ask for more memory" from "ask for more time" from "someone killed
+        it" from "the admin drained the host".
+        """
+        record = self._terminal_record
+        if record is None:
+            return ""
+        bits = [f"LSF state {(record.STAT or '').strip().upper()}"]
+        if (record.EXIT_REASON or "").strip() not in ("", "-"):
+            bits.append(f"exit_reason={record.EXIT_REASON.strip()}")
+        return f" ({', '.join(bits)})"
+
+    def _format_lsf_state_change(
+        self: Self, record: BJobRecord, state_class: LsfStateClass
+    ) -> str:
+        """Build the one-line message for an LSF state or reason change.
+
+        Deliberately a single plain line, NOT a fenced ```json block: the CLI
+        strips backticks and drops this string into a two-column
+        ``tabulate(tablefmt="plain")`` table (the `gb build status --show-events`
+        build history), which a multi-line blob would wreck. Carrying no json
+        fence also means ``RetryHandler._is_terminal_failure_event`` cannot match
+        an informational event, so surfacing state can never fail the build.
+        """
+        state = (record.STAT or "").strip().upper() or "UNKNOWN"
+        reason = (record.PEND_REASON or "").strip().rstrip(";")
+        detail = f" - {reason}" if reason else ""
+        previous = self._last_lsf_state
+        if previous is None or previous == state:
+            # First sighting, or the state held and only the reason moved on --
+            # rendering "PEND -> PEND" for a reason-only change reads as a bug.
+            transition = f"LSF job {self.job_id} is {state}"
+        else:
+            transition = f"LSF job {self.job_id}: {previous} -> {state}"
+
+        if state in ("PEND", "FWD_PEND", "WAIT", "PROV"):
+            return f"⏳ {transition}{detail}"
+        if state in ("PSUSP", "SSUSP", "USUSP"):
+            return (
+                f"⏸️ {transition}{detail}. The job is suspended, not finished; "
+                f"granite.build will keep monitoring until it resumes or exits "
+                f"(bresume {self.job_id} to resume, or cancel the build)."
+            )
+        if state == "UNKWN":
+            return (
+                f"❓ {transition}. LSF has lost contact with the execution host; "
+                f"this is usually transient and granite.build will keep monitoring."
+            )
+        if state == "RUN":
+            return f"⚡ {transition}"
+        if state_class is LsfStateClass.SUCCEEDED:
+            return f"✅ {transition}"
+        if state_class is LsfStateClass.FAILED:
+            return f"❌ {transition}{self._exit_detail(record)}"
+        return (
+            f"⚠️ {transition} - granite.build does not recognize this LSF state "
+            f"and will keep monitoring rather than assume the job is over."
+        )
+
+    async def _publish_lsf_state_change(
+        self: Self, record: BJobRecord, state_class: LsfStateClass
+    ) -> None:
+        """Emit a MESSAGE_EVENT when the LSF state or its reason changes.
+
+        On change only -- not once, and not on every poll: a job can sit in PEND
+        for hours at a 5s cadence.
+
+        Best effort. This runs inside the poll loop's broad ``except Exception``,
+        so it swallows its own errors rather than risk delaying or hiding the
+        terminal verdict below it.
+        """
+        try:
+            state = (record.STAT or "").strip().upper()
+            reason_key = _pend_reason_key(record.PEND_REASON)
+            state_changed = state != self._last_lsf_state
+            reason_changed = (
+                state in LSF_STATES_WITH_PEND_REASON
+                and reason_key != self._last_pend_reason_key
+            )
+            if not state_changed and not reason_changed:
+                return
+
+            msg = self._format_lsf_state_change(record, state_class)
+            if state_class is LsfStateClass.FAILED:
+                level = "ERROR"
+            elif state not in LSF_STATE_CLASS or state in (
+                "PSUSP",
+                "SSUSP",
+                "USUSP",
+                "UNKWN",
+            ):
+                level = "WARNING"
+            else:
+                level = "INFO"
+
+            if self.event_queue is not None:
+                await self.event_queue.put(
+                    BuildEvent(
+                        run_metadata=self.entityrun_metadata,
+                        type=BuildEventType.MESSAGE_EVENT,
+                        payload=BuildEventMessagePayload(level=level, msg=msg),
+                    )
+                )
+            logger.info("[LSFBsubMonitor %s] LSF state change: %s", self.launch_id, msg)
+            self._last_lsf_state = state
+            self._last_pend_reason_key = reason_key
+        except Exception as e:  # messaging must never block the verdict
+            logger.warning(
+                "[LSFBsubMonitor %s] failed to publish LSF state change: %s",
+                self.launch_id,
+                e,
+                exc_info=True,
+            )
 
     @retry(
         stop=stop_after_attempt(3),
@@ -185,8 +437,9 @@ class LSFBsubMonitor(MonitorBase):
         bare_bjobs_command = " ".join(
             [
                 "bjobs",
+                "-a",  # also return a just-finished job's record
                 "-o",
-                '"jobid stat exit_code exit_reason"',
+                '"jobid stat exit_code exit_reason pend_reason"',
                 "-json",
                 self.job_id,
             ]
@@ -234,16 +487,30 @@ class LSFBsubMonitor(MonitorBase):
                     raise ValueError(f"failed to find the bsub job '{self.job_id}'")
                 record = bjobs_output.RECORDS[0]
                 logger.info("BSubLauncher.monitor_logs record: %s", record)
-                if record.STAT not in ("PEND", "RUN"):
-                    returncode = int(record.EXIT_CODE or "0", base=10)
-                    # If stop was requested externally (e.g. retry_workload signalled us
-                    # to stop before bkilling the job), treat this as a clean exit rather
-                    # than a real failure — we may have just detected the bkill's exit code.
-                    if self.stop_event.is_set():
-                        returncode = 0
-                    break
+
+                state_class = self._classify_state(record.STAT)
+
+                # Surface the native LSF state -- and, while the job is queued or
+                # suspended, WHY -- on every change.
+                await self._publish_lsf_state_change(record, state_class)
+
+                if state_class is LsfStateClass.ACTIVE:
+                    # PEND / RUN / PSUSP / SSUSP / USUSP / UNKWN / WAIT / PROV /
+                    # FWD_PEND, plus any STAT this gbserver does not recognize.
+                    continue
+
+                self._terminal_record = record
+                returncode = self._terminal_returncode(record, state_class)
+                # If stop was requested externally (e.g. retry_workload signalled us
+                # to stop before bkilling the job), treat this as a clean exit rather
+                # than a real failure — we may have just detected the bkill's exit code.
+                if self.stop_event.is_set():
+                    returncode = 0
+                break
             except Exception as e:
-                logger.error("failed to get the status of the job. error: %s", e)
+                logger.error(
+                    "failed to get the status of the job. error: %s", e, exc_info=True
+                )
                 continue
         if self.stop_event.is_set():
             logger.warning(
@@ -267,7 +534,10 @@ class LSFBsubMonitor(MonitorBase):
         await asyncio.sleep(GBSERVER_MONITORING_GRACE_PERIOD)
         self.stop()
         if is_error:
-            error_message = f"Job {self.job_id} failed with return code {returncode}"
+            error_message = (
+                f"Job {self.job_id} failed with return code {returncode}"
+                f"{self._format_terminal_failure_detail()}"
+            )
             logger.error("[LSFBsubMonitor %s] %s", self.launch_id, error_message)
 
             # Check for transient LSF errors that should trigger a retry

--- a/test/unit/monitoring/test_lsf_bsub_monitor.py
+++ b/test/unit/monitoring/test_lsf_bsub_monitor.py
@@ -36,6 +36,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gbserver.monitoring.lsf_bsub_monitor import (
+    LSF_ACTIVE_STATE_TO_GB_STATUS,
     LSF_STATE_CLASS,
     BJobRecord,
     LSFBsubMonitor,
@@ -48,6 +49,7 @@ from gbserver.types.buildevent import (
     BuildEventType,
     EntityRunMetadata,
 )
+from gbserver.types.status import Status
 
 # Short intervals keep the suite fast; the grace period is patched per test.
 MONITOR_INTERVAL = 0.02
@@ -152,11 +154,18 @@ async def _drive(monitor: LSFBsubMonitor, *, expect_terminates: bool) -> None:
 
 
 def _msgs(queue: asyncio.Queue) -> List[str]:
-    """Drain the queue to a list of event message strings."""
+    """Drain the queue to the MESSAGE_EVENT narrative lines.
+
+    Scoped to MESSAGE_EVENT on purpose: the monitor also emits STATUS_EVENTs
+    carrying the same text to drive the step status, and counting both would
+    double every assertion about how many narrative lines a poll sequence
+    produces.
+    """
     out = []
     while not queue.empty():
         event = queue.get_nowait()
-        out.append(getattr(event.payload, "msg", "") or "")
+        if event.type is BuildEventType.MESSAGE_EVENT:
+            out.append(getattr(event.payload, "msg", "") or "")
     return out
 
 
@@ -537,6 +546,81 @@ async def test_state_change_events_can_never_fail_the_build():
         event = _as_message_event(msg)
         assert _is_build_failing(event) is False, stat
         assert bool(strategy.should_retry(event)) is False, stat
+
+
+def _status_events(queue: asyncio.Queue) -> List[Status]:
+    """Drain the queue to the sequence of STATUS_EVENT statuses."""
+    out = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        if event.type is BuildEventType.STATUS_EVENT:
+            out.append(event.payload.status)
+    return out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stat", ["PEND", "FWD_PEND", "WAIT", "PROV", "PSUSP", "SSUSP", "USUSP", "UNKWN"]
+)
+async def test_non_running_lsf_states_report_gb_pending(stat):
+    """A job queued or suspended in LSF must NOT report the step as RUNNING.
+
+    This is the point of the mapping: gb should never claim progress the
+    scheduler isn't making. Only LSF RUN means RUNNING.
+    """
+    monitor, queue, _ = _make_monitor([_bjobs_json(stat)])
+    await _drive(monitor, expect_terminates=False)
+    statuses = _status_events(queue)
+    assert Status.PENDING in statuses, f"{stat} should report PENDING, got {statuses}"
+    assert Status.RUNNING not in statuses, f"{stat} must not report RUNNING"
+
+
+@pytest.mark.asyncio
+async def test_lsf_run_reports_gb_running():
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN")])
+    await _drive(monitor, expect_terminates=False)
+    assert _status_events(queue) == [Status.RUNNING]
+
+
+@pytest.mark.asyncio
+async def test_gb_status_is_emitted_only_when_the_mapped_status_changes():
+    """PEND -> PSUSP is the same gb status, so it must not re-emit.
+
+    The LSF-level narrative still gets an event per state change; the gb status
+    only moves on PENDING <-> RUNNING.
+    """
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND"),
+            _bjobs_json("PSUSP"),
+            _bjobs_json("USUSP"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    # PENDING once across PEND/PSUSP/USUSP, then RUNNING on dispatch. DONE is
+    # terminal and owned by the returncode path, so it emits no STATUS_EVENT.
+    assert _status_events(queue) == [Status.PENDING, Status.RUNNING]
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_state_does_not_assert_a_gb_status():
+    """If we don't know the LSF state, don't claim to know the step status."""
+    monitor, queue, _ = _make_monitor([_bjobs_json("FROBNICATE")])
+    await _drive(monitor, expect_terminates=False)
+    assert _status_events(queue) == []
+
+
+def test_every_active_state_has_a_gb_status_mapping():
+    """Keep the two tables in step: every ACTIVE LSF state maps to a gb status."""
+    active = {s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.ACTIVE}
+    assert set(LSF_ACTIVE_STATE_TO_GB_STATUS) == active
+    # Only RUN is RUNNING; everything else that isn't finished is PENDING.
+    assert LSF_ACTIVE_STATE_TO_GB_STATUS["RUN"] is Status.RUNNING
+    assert {
+        s for s, v in LSF_ACTIVE_STATE_TO_GB_STATUS.items() if v is Status.PENDING
+    } == (active - {"RUN"})
 
 
 def test_lsf_state_class_table_is_locked():

--- a/test/unit/monitoring/test_lsf_bsub_monitor.py
+++ b/test/unit/monitoring/test_lsf_bsub_monitor.py
@@ -1,0 +1,591 @@
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""State-machine tests for LSFBsubMonitor.
+
+These drive a real ``LSFBsubMonitor`` against a scripted sequence of ``bjobs``
+JSON responses (the same harness idiom as
+``test/unit/monitoring/test_log_draining.py``), which lets us replay LSF states
+that are awkward or impossible to produce on demand against a real cluster.
+
+Every test goes through :func:`_drive`, which bounds the monitor with
+``asyncio.wait_for``. That is deliberate: the monitor's poll loop wraps its whole
+body in ``except Exception: continue``, so a classification bug becomes an
+*infinite loop* rather than an error. The bounded wait converts that into a
+deterministic failure -- and for the non-terminal states, "it keeps polling" is
+itself the assertion.
+"""
+
+import asyncio
+import contextlib
+import json
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gbserver.monitoring.lsf_bsub_monitor import (
+    LSF_STATE_CLASS,
+    BJobRecord,
+    LSFBsubMonitor,
+    LsfStateClass,
+)
+from gbserver.resilience.retry_handler import RetryHandler
+from gbserver.types.buildevent import (
+    BuildEvent,
+    BuildEventMessagePayload,
+    BuildEventType,
+    EntityRunMetadata,
+)
+
+# Short intervals keep the suite fast; the grace period is patched per test.
+MONITOR_INTERVAL = 0.02
+GRACE = 0.02
+# Generous enough to absorb scheduler jitter, small enough to fail fast.
+TERMINATE_BUDGET = 3.0
+NON_TERMINAL_BUDGET = 0.4
+
+
+def _bjobs_json(
+    stat: str,
+    exit_code: str = "",
+    exit_reason: str = "",
+    pend_reason: str = "",
+    jobid: str = "12345",
+) -> str:
+    """One ``bjobs -o ... -json`` response carrying a single record."""
+    return json.dumps(
+        {
+            "COMMAND": "bjobs",
+            "JOBS": 1,
+            "RECORDS": [
+                {
+                    "JOBID": jobid,
+                    "STAT": stat,
+                    "EXIT_CODE": exit_code,
+                    "EXIT_REASON": exit_reason,
+                    "PEND_REASON": pend_reason,
+                }
+            ],
+        }
+    )
+
+
+def _make_monitor(
+    responses: List[str],
+    *,
+    stop_event: Optional[asyncio.Event] = None,
+    job_id: str = "12345",
+):
+    """Build a monitor over a scripted bjobs sequence.
+
+    The last response repeats forever (same clamping idiom as
+    ``test_log_draining.py``), so a monitor that never terminates keeps seeing a
+    consistent state rather than an IndexError.
+    """
+    mock_lsf = MagicMock()
+    mock_lsf.use_ssh = True
+    # Must be a real str: on the failure path the monitor does
+    # Path(log_path).parent, and Path(MagicMock()) raises TypeError *outside*
+    # the try block, which would escape monitor() instead of being swallowed.
+    mock_lsf.get_log_path.return_value = "/tmp/gbtest-lsf/job.log"
+
+    commands: List[str] = []
+
+    async def run_remote(command, raise_on_error=True):  # noqa: ANN001
+        commands.append(command)
+        return 0, responses[min(len(commands) - 1, len(responses) - 1)], ""
+
+    tunnel = AsyncMock()
+    tunnel.run_remote = run_remote
+    mock_lsf.get_ssh_tunnel.return_value = tunnel
+
+    queue: asyncio.Queue = asyncio.Queue()
+    monitor = LSFBsubMonitor(
+        lsf=mock_lsf,
+        job_id=job_id,
+        launch_id="test-launch",
+        event_queue=queue,
+        stop_event=stop_event,
+        monitor_interval=MONITOR_INTERVAL,
+    )
+    # Never let a test reach out to a cluster for the transient-error probe.
+    monitor._check_for_transient_lsf_error = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    return monitor, queue, commands
+
+
+async def _drive(monitor: LSFBsubMonitor, *, expect_terminates: bool) -> None:
+    """Run the monitor under a bounded wait.
+
+    ``expect_terminates=False`` asserts the monitor is still polling when the
+    budget expires -- i.e. it correctly treated the state as non-terminal.
+    """
+    task = asyncio.create_task(monitor.monitor())
+    if expect_terminates:
+        try:
+            await asyncio.wait_for(task, timeout=TERMINATE_BUDGET)
+        except asyncio.TimeoutError:  # pragma: no cover - failure path
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            pytest.fail(
+                "monitor did not terminate: a terminal LSF state was treated as "
+                "non-terminal (or the poll loop is stuck swallowing an exception)"
+            )
+    else:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=NON_TERMINAL_BUDGET)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+def _msgs(queue: asyncio.Queue) -> List[str]:
+    """Drain the queue to a list of event message strings."""
+    out = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        out.append(getattr(event.payload, "msg", "") or "")
+    return out
+
+
+def _as_message_event(msg: str) -> BuildEvent:
+    """Wrap a message string in a real MESSAGE_EVENT."""
+    return BuildEvent(
+        run_metadata=EntityRunMetadata(),
+        type=BuildEventType.MESSAGE_EVENT,
+        payload=BuildEventMessagePayload(level="ERROR", msg=msg),
+    )
+
+
+def _is_build_failing(event: BuildEvent) -> bool:
+    """Ask the real RetryHandler whether this event fails the build.
+
+    Called unbound with a dummy ``self``: the method only touches ``self`` for a
+    log line. Reusing the real predicate rather than reimplementing its regex
+    keeps these tests honest if that logic changes.
+    """
+    return bool(RetryHandler._is_terminal_failure_event(MagicMock(), event))
+
+
+def _has_terminal_failure(msgs: List[str]) -> bool:
+    """True if any message would make RetryHandler fail the build."""
+    return any(_is_build_failing(_as_message_event(msg)) for msg in msgs)
+
+
+@pytest.fixture(autouse=True)
+def _fast_grace():
+    with patch(
+        "gbserver.monitoring.lsf_bsub_monitor.GBSERVER_MONITORING_GRACE_PERIOD", GRACE
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Case L -- the hang trap. Keep this first.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_bjobs_payload_without_pend_reason_still_parses():
+    """A bjobs record with no PEND_REASON key must remain valid.
+
+    These are the exact byte strings used by
+    ``test/unit/monitoring/test_log_draining.py`` (see its ``bjobs_responses``).
+    If PEND_REASON were a *required* field, validation would raise, the poll
+    loop's ``except Exception: continue`` would swallow it, and the monitor would
+    spin forever -- hanging that test (and CI) rather than failing it. Keep
+    every BJobRecord field defaulted.
+    """
+    legacy = [
+        '{"COMMAND": "bjobs", "JOBS": 1, "RECORDS": [{"JOBID": "12345", "STAT": "RUN", "EXIT_CODE": "", "EXIT_REASON": ""}]}',
+        '{"COMMAND": "bjobs", "JOBS": 1, "RECORDS": [{"JOBID": "12345", "STAT": "DONE", "EXIT_CODE": "0", "EXIT_REASON": ""}]}',
+    ]
+    monitor, queue, _ = _make_monitor(legacy)
+    await _drive(monitor, expect_terminates=True)
+    assert not _has_terminal_failure(_msgs(queue))
+
+
+# ---------------------------------------------------------------------------
+# Case C / D / E -- EXIT must fail, whatever EXIT_CODE says
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exit_with_empty_exit_code_fails_the_build():
+    """EXIT with a blank EXIT_CODE must FAIL, not succeed.
+
+    Regression guard for the measured bug: on BlueVela, 103,256 of 315,504 EXIT
+    jobs report EXIT_CODE="" (102,208 of them TERM_OWNER, i.e. killed). The old
+    ``int(record.EXIT_CODE or "0")`` scored every one of those as returncode 0,
+    so a third of genuinely failed LSF jobs were reported as successful builds.
+    """
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="")]
+    )
+    await _drive(monitor, expect_terminates=True)
+    assert _has_terminal_failure(_msgs(queue)), "EXIT with empty EXIT_CODE must fail"
+
+
+@pytest.mark.asyncio
+async def test_exit_with_dash_exit_code_fails_the_build():
+    """The ``-noheader`` table form renders unset as "-"; it must not crash int()."""
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="-")]
+    )
+    await _drive(monitor, expect_terminates=True)
+    assert _has_terminal_failure(_msgs(queue))
+
+
+@pytest.mark.asyncio
+async def test_exit_reason_is_surfaced_in_the_failure_message():
+    """EXIT_REASON has always been fetched and never read -- surface it.
+
+    It is the only field distinguishing TERM_MEMLIMIT / TERM_RUNLIMIT /
+    TERM_OWNER / TERM_ADMIN, i.e. "ask for more memory" from "ask for more time"
+    from "someone killed it".
+    """
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("RUN"),
+            _bjobs_json(
+                "EXIT",
+                exit_code="137",
+                exit_reason="TERM_MEMLIMIT: job killed after reaching LSF memory usage limit",
+            ),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert _has_terminal_failure(msgs)
+    joined = "\n".join(msgs)
+    assert "137" in joined
+    assert "TERM_MEMLIMIT" in joined
+
+
+# ---------------------------------------------------------------------------
+# Case F / G -- suspended and unknown states are NOT terminal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stat", ["PSUSP", "SSUSP", "USUSP", "UNKWN", "WAIT", "PROV", "FWD_PEND"]
+)
+async def test_non_terminal_states_keep_polling(stat):
+    """A suspended/queued/unknown job has not finished -- keep monitoring.
+
+    Regression guard for the measured bug: these states all carry EXIT_CODE="",
+    so treating them as terminal made ``int("" or "0")`` == 0 and reported a
+    live job as a SUCCESSFUL build. Verified against a real cluster: a job
+    bstop'd 8 seconds into a 180-second workload produced a green build.
+    """
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN"), _bjobs_json(stat)])
+    await _drive(monitor, expect_terminates=False)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs), f"{stat} must not fail the build"
+    assert any(stat in m for m in msgs), f"{stat} should be surfaced to the user"
+    monitor._check_for_transient_lsf_error.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_suspend_and_resume_round_trip_succeeds():
+    """RUN -> USUSP -> RUN -> DONE is a success, with one event per transition."""
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("RUN"),
+            _bjobs_json("USUSP"),
+            _bjobs_json("USUSP"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs)
+    # 4 transitions, not 5 polls: the repeated USUSP must be deduped.
+    assert len(msgs) == 4, msgs
+
+
+# ---------------------------------------------------------------------------
+# Case H / I / J -- PEND reason surfacing, on change only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pend_reason_is_emitted_once_per_distinct_reason():
+    """The user must be able to find out WHY a job is pending -- without spam."""
+    reason_a = "Job's requirements for resource reservation not satisfied (Resource: ngpus_physical): 340 hosts;"
+    reason_b = "Not enough job slot(s): ;"
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND", pend_reason=reason_a),
+            _bjobs_json("PEND", pend_reason=reason_a),
+            _bjobs_json("PEND", pend_reason=reason_a),
+            _bjobs_json("PEND", pend_reason=reason_b),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert any("ngpus_physical" in m for m in msgs), msgs
+    assert any("Not enough job slot" in m for m in msgs), msgs
+    # PEND(a), PEND(b), RUN, DONE -- reason A emitted once despite three polls.
+    assert len(msgs) == 4, msgs
+
+
+@pytest.mark.asyncio
+async def test_pend_reason_host_counter_churn_does_not_spam():
+    """LSF re-renders live counters ("340 hosts" -> "339 hosts") every cycle.
+
+    Comparing raw reason text would emit an event on every poll for a long PEND,
+    flooding the events table, the CLI history and the PR comment. Dedup must
+    compare a digit-normalized key while still displaying the raw reason.
+    """
+    tmpl = "Job's requirements for resource reservation not satisfied (Resource: ngpus_physical): {} hosts;"
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND", pend_reason=tmpl.format(340)),
+            _bjobs_json("PEND", pend_reason=tmpl.format(339)),
+            _bjobs_json("PEND", pend_reason=tmpl.format(12)),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    # PEND (once), RUN, DONE -- the counter churn must not add events.
+    assert len(msgs) == 3, msgs
+
+
+@pytest.mark.asyncio
+async def test_reason_only_change_does_not_render_a_self_transition():
+    """A reason-only change must not read as "PEND -> PEND".
+
+    Observed on a real cluster: LSF reports "New job is waiting for scheduling"
+    and then replaces it with the real blocker, e.g. "Job has a specified start
+    time". The state never moved, so an arrow would look like a bug.
+    """
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND", pend_reason="New job is waiting for scheduling;"),
+            _bjobs_json("PEND", pend_reason="Job has a specified start time;"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    pend_msgs = [m for m in msgs if "start time" in m]
+    assert pend_msgs, msgs
+    assert "PEND -> PEND" not in pend_msgs[0], pend_msgs[0]
+    assert "is PEND" in pend_msgs[0], pend_msgs[0]
+    # A genuine transition still gets an arrow.
+    assert any("PEND -> RUN" in m for m in msgs), msgs
+
+
+@pytest.mark.asyncio
+async def test_pend_reason_appearing_later_is_emitted():
+    """LSF often reports PEND with no reason first, then fills it in."""
+    reason = "Job dependency condition not satisfied;"
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND"),
+            _bjobs_json("PEND"),
+            _bjobs_json("PEND", pend_reason=reason),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert any("dependency condition" in m for m in msgs), msgs
+    assert len(msgs) == 4, msgs
+
+
+# ---------------------------------------------------------------------------
+# Case A / K -- the terminal states
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pend_run_done_succeeds_with_one_event_per_transition():
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND"),
+            _bjobs_json("RUN"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs)
+    assert len(msgs) == 3, msgs  # PEND, RUN, DONE -- repeated RUN deduped
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stat,should_fail",
+    [("ZOMBI", True), ("POST_ERR", True), ("POST_DONE", False), ("DONE", False)],
+)
+async def test_terminal_states_map_to_the_right_verdict(stat, should_fail):
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN"), _bjobs_json(stat)])
+    await _drive(monitor, expect_terminates=True)
+    assert _has_terminal_failure(_msgs(queue)) is should_fail
+
+
+# ---------------------------------------------------------------------------
+# Case M -- unrecognized states fail safe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_state_is_non_terminal_and_warns(caplog):
+    """An unmodelled STAT must NOT be assumed terminal.
+
+    Defaulting unknown states to "terminal" is exactly how a suspended job
+    became a green build. Failing safe means the worst case is a visible hang
+    (loud, diagnosable) instead of a silent wrong SUCCESS (trusted).
+    """
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN"), _bjobs_json("FROBNICATE")])
+    with caplog.at_level("WARNING"):
+        await _drive(monitor, expect_terminates=False)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs)
+    assert any("FROBNICATE" in m for m in msgs), msgs
+    assert "unrecognized" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Case N / O -- the bkill/retry guard must not regress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_event_set_before_start_returns_cleanly():
+    """retry_workload sets the launch-stopped event *before* bkilling.
+
+    The monitor must then return without manufacturing a failure, or every
+    transient-error retry would turn into a hard build failure.
+    """
+    stop = asyncio.Event()
+    stop.set()
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="1")], stop_event=stop
+    )
+    await _drive(monitor, expect_terminates=True)
+    assert not _has_terminal_failure(_msgs(queue))
+    monitor._check_for_transient_lsf_error.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stop_event_set_during_terminal_poll_is_not_a_failure():
+    """The other retry branch: the bkill's own EXIT is observed after stop_event."""
+    stop = asyncio.Event()
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="1")], stop_event=stop
+    )
+
+    async def set_stop_soon():
+        await asyncio.sleep(MONITOR_INTERVAL * 1.5)
+        stop.set()
+
+    asyncio.create_task(set_stop_soon())
+    await _drive(monitor, expect_terminates=True)
+    assert not _has_terminal_failure(_msgs(queue))
+
+
+# ---------------------------------------------------------------------------
+# Case P / Q / R -- invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_change_events_can_never_fail_the_build():
+    """Informational state events must not trip the resilience layer.
+
+    ``RetryHandler._is_terminal_failure_event`` scrapes ```json blocks and fails
+    the build on ``state == "Failed"``. Locking this invariant means a future
+    reword of these messages cannot silently start failing or retrying builds.
+    """
+    from gbserver.resilience.strategies.lsf_transient_error import (
+        LsfTransientErrorRetryStrategy,
+    )
+
+    strategy = LsfTransientErrorRetryStrategy()
+    for stat in list(LSF_STATE_CLASS) + ["FROBNICATE"]:
+        state_class = LSF_STATE_CLASS.get(stat, LsfStateClass.ACTIVE)
+        if state_class is not LsfStateClass.ACTIVE:
+            continue  # terminal states legitimately do fail the build
+        monitor, queue, _ = _make_monitor([_bjobs_json(stat)])
+        record = BJobRecord(JOBID="1", STAT=stat, PEND_REASON="some reason;")
+        msg = monitor._format_lsf_state_change(record, state_class)
+        assert "```json" not in msg, f"{stat}: must not emit a fenced json block"
+        event = _as_message_event(msg)
+        assert _is_build_failing(event) is False, stat
+        assert bool(strategy.should_retry(event)) is False, stat
+
+
+def test_lsf_state_class_table_is_locked():
+    """Pin the agreed partition so any future edit is deliberate."""
+    active = {
+        "PEND",
+        "FWD_PEND",
+        "WAIT",
+        "PROV",
+        "RUN",
+        "PSUSP",
+        "SSUSP",
+        "USUSP",
+        "UNKWN",
+    }
+    succeeded = {"DONE", "POST_DONE"}
+    failed = {"EXIT", "ZOMBI", "POST_ERR"}
+    assert {
+        s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.ACTIVE
+    } == active
+    assert {
+        s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.SUCCEEDED
+    } == succeeded
+    assert {
+        s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.FAILED
+    } == failed
+
+
+@pytest.mark.parametrize(
+    "exit_code,state_class,expected",
+    [
+        ("", LsfStateClass.FAILED, 1),
+        ("0", LsfStateClass.FAILED, 1),
+        ("-", LsfStateClass.FAILED, 1),
+        ("garbage", LsfStateClass.FAILED, 1),
+        ("137", LsfStateClass.FAILED, 137),
+        ("", LsfStateClass.SUCCEEDED, 0),
+        ("0", LsfStateClass.SUCCEEDED, 0),
+        ("137", LsfStateClass.SUCCEEDED, 0),
+    ],
+)
+def test_terminal_returncode(exit_code, state_class, expected):
+    """STAT decides pass/fail; EXIT_CODE only refines a failure's code."""
+    record = BJobRecord(JOBID="1", STAT="EXIT", EXIT_CODE=exit_code)
+    assert LSFBsubMonitor._terminal_returncode(record, state_class) == expected
+
+
+def test_bjobs_record_fields_are_all_optional():
+    """Every field defaulted -- see the module docstring on the hang trap."""
+    record = BJobRecord()
+    assert record.STAT == ""
+    assert record.PEND_REASON == ""


### PR DESCRIPTION
## Summary

The bsub monitor collapsed the entire LSF state vocabulary into a single line:

```python
if record.STAT not in ("PEND", "RUN"):
    returncode = int(record.EXIT_CODE or "0", base=10)
```

Anything outside `PEND`/`RUN` was assumed terminal, and the pass/fail verdict came from `EXIT_CODE`. Both halves are wrong, and both fail in the same direction — **reporting failure as success.** Measured against a LSF cluster (LSF 10.1.0.15):

- **Suspended and unknown states aren't terminal, but were treated as such.** `PSUSP`/`SSUSP`/`USUSP`/`UNKWN` all carry `EXIT_CODE=""`, so `int("" or "0")` == 0 and the build went green while the job was still suspended on the cluster. Live counts when measured: `PSUSP` 200, `ZOMBI` 132, `SSUSP` 97, `USUSP` 2, `UNKWN` 1 — not hypothetical.
- **`EXIT_CODE` cannot decide the verdict.** ~⅓ of `EXIT` jobs report `EXIT_CODE=""` (103,256 of 315,504 when measured; the majority `TERM_OWNER`, i.e. killed), and *all* `DONE` jobs report `""` too. `STAT` has to drive it.

## Before / after: LSF state → granite.build status

Old behavior: terminal iff `STAT not in ("PEND","RUN")`, then verdict from `EXIT_CODE`. Since every non-`EXIT` state carries an empty `EXIT_CODE`, almost everything resolved to returncode 0 — i.e. SUCCESS. And the two states that *were* handled both reported **RUNNING**, so a job queued behind a dependency for hours was indistinguishable from one actually executing.

| LSF `STAT` | `EXIT_CODE` in practice | Before | After |
|---|---|---|---|
| `PEND` | empty | **RUNNING** ❌ *(queued ≠ running)* | **PENDING** ✅ *+ pend reason* |
| `FWD_PEND` | empty | **SUCCESS** ❌ | **PENDING** ✅ |
| `WAIT` | empty | **SUCCESS** ❌ | **PENDING** ✅ |
| `PROV` | empty | **SUCCESS** ❌ | **PENDING** ✅ |
| `PSUSP` | empty | **SUCCESS** ❌ | **PENDING** ✅ *+ reason* |
| `SSUSP` | empty | **SUCCESS** ❌ | **PENDING** ✅ *+ reason* |
| `USUSP` | empty | **SUCCESS** ❌ | **PENDING** ✅ *+ reason* |
| `UNKWN` | empty | **SUCCESS** ❌ | **PENDING** ✅ |
| `RUN` | empty | **RUNNING** ✅ | **RUNNING** ✅ |
| `DONE` | always empty | **SUCCESS** ✅ | **SUCCESS** ✅ |
| `POST_DONE` | empty | **SUCCESS** ✅ | **SUCCESS** ✅ |
| `EXIT` | has a code (~⅔) | **FAILED** ✅ | **FAILED** ✅ *+ exit reason* |
| `EXIT` | empty (~⅓) | **SUCCESS** ❌ | **FAILED** ✅ |
| `ZOMBI` | empty | **SUCCESS** ❌ | **FAILED** ✅ |
| `POST_ERR` | empty | **SUCCESS** ❌ | **FAILED** ✅ |
| *unrecognized* | — | **SUCCESS** ❌ | keeps polling, asserts no status, warns |

**12 of 16 rows produced the wrong status.** Fifteen erred toward false success; `PEND` erred toward false progress.

`PEND` is the headline: a job sitting in the LSF queue is **not running**, and reporting it as RUNNING is the same class of false signal as calling a suspended job successful. Only `RUN` maps to RUNNING now.

granite.build has no `SUSPENDED` status, so the suspend states collapse onto `PENDING` rather than extending the shared `Status` enum (which would ripple through storage, the REST models, CLI rendering, the dashboard, and every other environment class). The native LSF state and its reason ride along in the event stream, carrying the precision the enum cannot. An unrecognized state asserts **no** status — we genuinely don't know whether such a job is progressing, so claiming either would be a guess.

### Required fix to the shared step-status handler

`BuildRunner` stamped `finished_at` whenever a step left `RUNNING`, so a `RUNNING → PENDING` transition marked the step **finished** while it was still alive. It now keys off `Status.is_finished()` — exactly what that predicate is documented for — and only stamps `started_at` on the *first* entry into `RUNNING`, so a job resuming after a suspension doesn't push its start time later than it actually began.

## Changes

- Replace the negative allowlist with an explicit `LSF_STATE_CLASS` table covering all 14 documented states (`ACTIVE` / `SUCCEEDED` / `FAILED`).
- **Unrecognized states are non-terminal and warn.** Assuming an unmodelled state means "job over" is exactly what created these bugs, so the default now fails safe — a visible hang beats a silent wrong SUCCESS. This mirrors the Kubernetes environment, which already treats AppWrapper `Suspended` as keep-waiting.
- `STAT` drives success/failure; `EXIT_CODE` is supplementary. A failure with a blank or zero code still returns non-zero.
- **Surface why a job is waiting, and why it failed.** `EXIT_REASON` was already fetched and never read; `pend_reason` joins the existing `-o` list, so there is **no extra SSH round trip**. Published as `MESSAGE_EVENT`s **on change only**, deduped on a digit-collapsed reason key because LSF re-renders live counters (`340 hosts` → `339 hosts`) every scheduling cycle and raw-text comparison would emit an event every 5s.
- Single plain-line messages rather than fenced JSON: the CLI history renders them through `tabulate(tablefmt="plain")`, and carrying no json fence means an informational event structurally cannot trip `RetryHandler._is_terminal_failure_event`.
- Drop the byte-identical, unreferenced `BJobRecord`/`BJobOutput` copies in `environment/lsf.py` rather than let them drift from the live models.

The bkill/retry guard is unchanged — `retry_workload` still sets the launch-stopped event before `bkill`, so a deliberate kill isn't scored as a failure. Both branches are covered by tests.

## What users see

The step status itself now tells the truth, with the reason attached — verified through the storage-backed path on a real cluster:

```
$ curl .../api/v1/builds/<id>/status
status      : pending
status_msg  : ⏳ LSF job 621651 is PEND - New job is waiting for scheduling
started_at  : 2026-08-05T01:17:25Z
finished_at : None          # correctly NOT stamped while queued
```

And in `gb build status --show-events` (and the dashboard History tab / PR comments) — **no CLI or frontend changes required**:

```
⏳ LSF job 609750 is PEND - New job is waiting for scheduling
⏳ LSF job 609750 is PEND - Job has a specified start time
⏸️ LSF job 609485: RUN -> USUSP. The job is suspended, not finished;
   granite.build will keep monitoring until it resumes or exits
   (bresume 609485 to resume, or cancel the build).
⚡ LSF job 609485: USUSP -> RUN
✅ LSF job 609485: RUN -> DONE
```

## Test plan

**Unit** — new `test/unit/monitoring/test_lsf_bsub_monitor.py` (47 tests), a scripted-`bjobs` state-machine table. Every test runs under a bounded `asyncio.wait_for`: the poll loop's broad `except Exception: continue` turns a classification bug into an *infinite loop*, so the bounded wait makes that a deterministic failure instead of a hang. Covers `EXIT` with empty/`-`/garbage `EXIT_CODE`, all seven non-terminal states, suspend→resume round trips, reason-change dedup, counter churn, unrecognized states, both bkill-guard branches, and an invariant test asserting no informational event can trip the retry layer.

`test/unit/monitoring/test_log_draining.py` is **deliberately untouched** — its bjobs payloads omit `PEND_REASON`, making it a standing regression canary that every `BJobRecord` field stays defaulted. A required field would raise inside the poll loop's broad `except`, and the monitor would spin forever — hanging CI rather than failing it.

Covers the status mapping too: every non-`RUN` active state reports `PENDING` and never `RUNNING`, `RUN` reports `RUNNING`, the status event fires only when the *mapped* status changes (`PEND → PSUSP` is the same gb status, so it must not re-emit), an unrecognized state asserts no status, and the two tables are asserted to stay in step.

Gate: **406 passed, 2 skipped** across `test/unit/monitoring/`, `test/unit/resilience/`, `test/unit/buildrunner/`, `test/unit/build/`, `test_lsf_cleanup`, `test_lsf_hfstore`, `test_build_files` — the buildrunner and build suites specifically exercise the shared `finished_at` change. mypy clean on changed files; pylint 10.00/10.

**Live, on a real LSF cluster** — before/after on the identical scenario (job `bstop`'d 8s into a 180s workload):

| | before | after |
|---|---|---|
| monitor | `STAT='USUSP'` → `returncode: 0` | held through ~50s of `USUSP` (10 polls) |
| build | ✅ SUCCESS | kept running, then `✅ RUN -> DONE` on `bresume` |

PEND reasons verified with a genuinely-pending job (`bsub -b`, zero scheduling footprint): 18 polls → 2 messages. State surfacing verified across 64 polls → 4 messages.

## Notes for reviewers

- **Behavioral change:** states that previously ended a step now keep it polling. There is no step-level timeout anywhere in the tree, so an indefinitely-suspended job will poll until cancelled. This isn't a new *class* of problem (a job pending or running forever already polls forever) and it trades a silent false SUCCESS for a visible, self-explanatory hang — the suspend message names the state and tells the user to `bresume` or cancel. A configurable stuck-state timeout is worth filing separately.
- `MESSAGE_EVENT`s aren't forwarded to RabbitMQ/NATS (only `STATUS_EVENT` is), so event-bus subscribers won't see these; the events table, CLI, dashboard, and PR comments will.
- `susp_reason` does **not** exist on LSF 10.1 (`not a valid field name`); `PEND_REASON` already covers suspended-while-pending.
- Cluster counts above are point-in-time snapshots of a live cluster, so they drift; the proportions and the per-state `EXIT_CODE` emptiness are stable.
- Unrelated: `test/unit/standalone/test_regression_smoke.py::TestEnvironmentDiscovery` has two pre-existing ordering-dependent failures on `main` (they pass in isolation). Not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
