### PR TITLE
Enable the skypilot/lsf/bluevela build cancel test

### DIFF
--- a/test-data/integration/ibm/buildrunner/skypilot/bluevela/1step-image/buildtest.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/bluevela/1step-image/buildtest.yaml
@@ -19,7 +19,8 @@ target_expectations:
 # Resolve space:// URIs (env + the shared `command` step) from the repo's local
 # space without cloning from GitHub. Relative to this YAML's directory.
 space_uri: ../../../../../../../configurations/spaces/local
-# A happy-path test — no simulated failure, and skip the cancellation run.
+# No simulated failure: the runner test exercises the happy path, and the
+# runner_cancellation test cancels a genuinely-running step.
 simulate_step_failure: false
 tests:
   - runner

--- a/test-data/integration/ibm/buildrunner/skypilot/bluevela/1step-image/buildtest.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/bluevela/1step-image/buildtest.yaml
@@ -23,4 +23,5 @@ space_uri: ../../../../../../../configurations/spaces/local
 simulate_step_failure: false
 tests:
   - runner
+  - runner_cancellation
 timeout_minutes: 20


### PR DESCRIPTION
## Description

Update build test for skypilot/lsf test definition to make the cancellation test run.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
