### PR TITLE
Fix LSF job-state mapping, retry races, and transient transport failures

### DIFF
--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -1678,11 +1678,15 @@ Download : {download_msg}
         ``stored_run.status`` afterward. Shared by the step-run and target-run
         status handlers so both obey identical transition rules.
 
-        started_at is stamped only on the FIRST entry into RUNNING: a run can
-        legitimately re-enter RUNNING (the Lsf monitor reports PENDING while a
+        started_at is stamped on the FIRST entry into RUNNING, regardless of the
+        prior status. Keying off "was PENDING" would drop started_at on a
+        non-linear first transition -- e.g. a target run created SUBMITTED (with
+        started_at still None) that goes straight to RUNNING. The
+        started_at-is-None guard alone provides the "first entry" semantics: a run
+        can legitimately re-enter RUNNING (the Lsf monitor reports PENDING while a
         bsub job is queued or suspended, then RUNNING again once LSF dispatches or
-        resumes it), and re-stamping would push started_at later than the run
-        actually began.
+        resumes it), and the guard keeps that from pushing started_at later than
+        the run actually began.
 
         finished_at is stamped on the FIRST entry into any terminal status
         (``Status.is_finished()``), regardless of the prior status. Keying off
@@ -1701,11 +1705,7 @@ Download : {download_msg}
         :param timestamp: The event timestamp to record.
         :param run_label: Noun used in log lines ("step" or "target").
         """
-        if (
-            stored_run.status is Status.PENDING
-            and new_status is Status.RUNNING
-            and stored_run.started_at is None
-        ):
+        if new_status is Status.RUNNING and stored_run.started_at is None:
             logger.info("%s started running at %s", run_label, timestamp)
             stored_run.started_at = timestamp
         elif new_status.is_finished() and stored_run.finished_at is None:

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -29,6 +29,7 @@ import time
 import traceback
 from asyncio import Event, Queue
 from base64 import b64decode
+from datetime import datetime
 from pathlib import Path
 from typing import Callable, List, Optional, Self, Union
 
@@ -1276,25 +1277,21 @@ Download : {download_msg}
     ) -> None:
         """Update an existing StoredTargetRun in storage from a status event.
 
-        Sets started_at/finished_at timestamps on PENDING→RUNNING and RUNNING→* transitions,
-        merges input artifacts, updates status, and writes target_hash only on SUCCESS
-        (keeping the partial unique index invariant that only successful runs hold a hash).
+        Stamps started_at on first entry into RUNNING and finished_at on first
+        entry into a terminal status (via the shared _apply_run_timestamps),
+        merges input artifacts, updates status, and writes target_hash only on
+        SUCCESS (keeping the partial unique index invariant that only successful
+        runs hold a hash).
         """
         payload = event.payload
         assert isinstance(payload, BuildEventStatusPayload)
         logger.info("stored_target_run %s", stored_target_run)
-        if (
-            stored_target_run.status is Status.PENDING
-            and payload.status is Status.RUNNING
-        ):
-            logger.info("target started running at %s", event.timestamp)
-            stored_target_run.started_at = event.timestamp
-        if (
-            stored_target_run.status is Status.RUNNING
-            and payload.status is not Status.RUNNING
-        ):
-            logger.info("target started finished running at %s", event.timestamp)
-            stored_target_run.finished_at = event.timestamp
+        self._apply_run_timestamps(
+            stored_run=stored_target_run,
+            new_status=payload.status,
+            timestamp=event.timestamp,
+            run_label="target",
+        )
         stored_target_run.status = payload.status
         for key, item in input_artifacts.items():
             stored_target_run.input_artifacts[key] = item
@@ -1667,6 +1664,54 @@ Download : {download_msg}
                     e,
                 )
 
+    @staticmethod
+    def _apply_run_timestamps(
+        stored_run: Union[StoredStepRun, StoredTargetRun],
+        new_status: Status,
+        timestamp: datetime,
+        run_label: str = "step",
+    ) -> None:
+        """Stamp started_at/finished_at on a step or target run for a transition.
+
+        Mutates ``stored_run`` in place based on its CURRENT (pre-transition)
+        status and the incoming ``new_status``; the caller updates
+        ``stored_run.status`` afterward. Shared by the step-run and target-run
+        status handlers so both obey identical transition rules.
+
+        started_at is stamped only on the FIRST entry into RUNNING: a run can
+        legitimately re-enter RUNNING (the Lsf monitor reports PENDING while a
+        bsub job is queued or suspended, then RUNNING again once LSF dispatches or
+        resumes it), and re-stamping would push started_at later than the run
+        actually began.
+
+        finished_at is stamped on the FIRST entry into any terminal status
+        (``Status.is_finished()``), regardless of the prior status. Keying off
+        "was RUNNING" was wrong in both directions: a RUNNING -> PENDING transition
+        (a queued or suspended scheduler job) must NOT be marked finished, and a
+        run that terminates straight from a PENDING-mapped state must still be
+        marked finished -- e.g. the Lsf monitor reports PENDING for a suspended job
+        (PSUSP/SSUSP/USUSP/UNKWN), the job is then killed while suspended, and the
+        terminal FAILED arrives from PENDING rather than RUNNING. The
+        finished_at-is-None guard keeps a redelivered terminal event from
+        overwriting the original timestamp.
+
+        :param stored_run: The step or target run to mutate; its ``status`` field
+            still holds the pre-transition status.
+        :param new_status: The status arriving with this event.
+        :param timestamp: The event timestamp to record.
+        :param run_label: Noun used in log lines ("step" or "target").
+        """
+        if (
+            stored_run.status is Status.PENDING
+            and new_status is Status.RUNNING
+            and stored_run.started_at is None
+        ):
+            logger.info("%s started running at %s", run_label, timestamp)
+            stored_run.started_at = timestamp
+        elif new_status.is_finished() and stored_run.finished_at is None:
+            logger.info("%s finished running at %s", run_label, timestamp)
+            stored_run.finished_at = timestamp
+
     def __process_build_target_step_info_type_event(self: Self, event: BuildEvent):
         logger.info("run_info is a TargetStep")
         payload = event.payload
@@ -1707,25 +1752,12 @@ Download : {download_msg}
                 status_msg=payload.msg,
                 started_at=event.timestamp,
             )
-        if (
-            stored_step_run.status is Status.PENDING
-            and payload.status is Status.RUNNING
-            and stored_step_run.started_at is None
-        ):
-            # Only stamp the FIRST transition into RUNNING. A step can legitimately
-            # re-enter RUNNING -- e.g. the Lsf monitor reports PENDING while the
-            # bsub job is queued or suspended, then RUNNING again once LSF
-            # dispatches or resumes it -- and re-stamping would push started_at
-            # later than the step actually began.
-            logger.info("step started running at %s", event.timestamp)
-            stored_step_run.started_at = event.timestamp
-        elif stored_step_run.status is Status.RUNNING and payload.status.is_finished():
-            # Stamp finished_at only on a genuinely terminal status. Keying off
-            # "no longer RUNNING" was wrong: a RUNNING -> PENDING transition (a
-            # queued or suspended scheduler job) would mark the step finished
-            # while it is still very much alive.
-            logger.info("step started finished running at %s", event.timestamp)
-            stored_step_run.finished_at = event.timestamp
+        self._apply_run_timestamps(
+            stored_run=stored_step_run,
+            new_status=payload.status,
+            timestamp=event.timestamp,
+            run_label="step",
+        )
         stored_step_run.status = payload.status
         stored_step_run.status_msg = payload.msg
         logger.info("stored_step_run %s", stored_step_run)

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -1710,13 +1710,20 @@ Download : {download_msg}
         if (
             stored_step_run.status is Status.PENDING
             and payload.status is Status.RUNNING
+            and stored_step_run.started_at is None
         ):
+            # Only stamp the FIRST transition into RUNNING. A step can legitimately
+            # re-enter RUNNING -- e.g. the Lsf monitor reports PENDING while the
+            # bsub job is queued or suspended, then RUNNING again once LSF
+            # dispatches or resumes it -- and re-stamping would push started_at
+            # later than the step actually began.
             logger.info("step started running at %s", event.timestamp)
             stored_step_run.started_at = event.timestamp
-        elif (
-            stored_step_run.status is Status.RUNNING
-            and payload.status is not Status.RUNNING
-        ):
+        elif stored_step_run.status is Status.RUNNING and payload.status.is_finished():
+            # Stamp finished_at only on a genuinely terminal status. Keying off
+            # "no longer RUNNING" was wrong: a RUNNING -> PENDING transition (a
+            # queued or suspended scheduler job) would mark the step finished
+            # while it is still very much alive.
             logger.info("step started finished running at %s", event.timestamp)
             stored_step_run.finished_at = event.timestamp
         stored_step_run.status = payload.status

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -278,8 +278,15 @@ class Lsf(Environment):
                 cleanup_error,
             )
 
-        # Clear the stop event so the next monitor loop iteration starts fresh.
-        self._get_launch_stopped_event(launch_id).clear()
+        # NOTE: The stop event is intentionally left SET here. bkill above only
+        # returns once the kill request is accepted; LSF reflects the resulting
+        # EXIT state in `bjobs` several seconds later. If we cleared the event
+        # now, the still-running previous monitor iteration could observe that
+        # delayed bkill-induced EXIT with the event already cleared, defeating
+        # the clean-exit guard in LSFBsubMonitor.monitor() and misreporting the
+        # bkill as a genuine terminal failure. The event is cleared instead at
+        # the top of the next monitor_bsub_monitor loop iteration, once the
+        # previous monitors have fully wound down.
 
         try:
             task = self.launch_bsub(launch_id, **original_kwargs)
@@ -875,6 +882,13 @@ class Lsf(Environment):
                     stop_event = self._get_launch_stopped_event(
                         launch_id=current_launch_id
                     )
+                    # Reset the shared stop event for this fresh iteration. On a
+                    # retry, retry_workload leaves the event SET (so the previous
+                    # iteration's monitors treat the bkill-induced EXIT as a clean
+                    # stop); we clear it here, only after those monitors have fully
+                    # wound down, so the new monitors below start unstopped. On the
+                    # first iteration this is a harmless no-op.
+                    stop_event.clear()
                     job_id = self._launched_jobs[current_launch_id]
                     log_file_path = self.get_log_path(launch_id=current_launch_id)
 

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -96,23 +96,6 @@ LHPUSH_STEP_NAME = "lhpush"
 COSRCLONE_STEP_NAME = "cosrclone"
 
 
-class BJobRecord(BaseModel):
-    """A bjob record."""
-
-    JOBID: str
-    STAT: str
-    EXIT_CODE: str
-    EXIT_REASON: str
-
-
-class BJobOutput(BaseModel):
-    """Output of bjob."""
-
-    COMMAND: str
-    JOBS: int
-    RECORDS: list[BJobRecord]
-
-
 class ExistingBsubJobs(BaseModel):
     """
     Jobs launched by the user outside of our control.

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -19,6 +19,7 @@ LSF based environments.
 """
 
 import asyncio
+import contextlib
 import os
 import random
 import re
@@ -1024,6 +1025,11 @@ class Lsf(Environment):
             )
         finally:
             retry_waiter.cancel()
+            # Await the cancellation so the task fully unwinds before we return;
+            # otherwise a still-pending waiter can surface a noisy "Task was
+            # destroyed but it is pending" warning under some loop timings.
+            with contextlib.suppress(asyncio.CancelledError):
+                await retry_waiter
         if not done:
             logger.error(
                 "RetryHandler did not adjudicate the emitted error within %ss; "

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -959,7 +959,10 @@ class Lsf(Environment):
                         # A relaunch the RetryHandler owns landed while we waited;
                         # loop to monitor the freshly launched job.
                         continue
-                    if lsf_bsub_monitor.emitted_error_event and _handler_task is not None:
+                    if (
+                        lsf_bsub_monitor.emitted_error_event
+                        and _handler_task is not None
+                    ):
                         # The RetryHandler finished without relaunching (gave up /
                         # retries exhausted). Stop looping; _with_retry_handler's
                         # __aexit__ awaits the handler task and re-raises its

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -58,6 +58,7 @@ from gbserver.types.buildevent import (
 from gbserver.types.constants import (
     DEFAULT_ROOT_WORKSPACE_DIR,
     ENABLE_SSH_HOST_KEY_VERIFICATION,
+    GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT,
     LSF_USE_ASPERA,
     STEP_FILE_NAME,
 )
@@ -67,6 +68,7 @@ from gbserver.types.environmentconfig import (
     StoreLoad,
     StorePush,
 )
+from gbserver.types.errors import WorkloadFailedException
 from gbserver.types.stepconfig import StepConfig
 from gbserver.utils.filesystem import sync_or_copy
 from gbserver.utils.launch import (
@@ -992,6 +994,13 @@ class Lsf(Environment):
         return SUCCESS while a relaunch is still in flight — orphaning the new job
         and dropping its ARTIFACT_PUSHED marker. This blocks on the outcome instead.
 
+        The wait is bounded by ``GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT`` as a
+        backstop. The handler normally relaunches or raises well within one retry,
+        and it now treats a retriable-but-exhausted error as terminal (so it
+        always resolves). The timeout only guards a pathological case the handler
+        neither retries nor recognizes as terminal; on expiry we fail the step
+        loudly rather than hang forever or silently succeed.
+
         :param lsf_bsub_monitor: The monitor that just finished this iteration.
         :param retry_complete_event: Event the handler sets once it has relaunched.
         :param handler_task: The RetryHandler task, or ``None`` when retries are
@@ -999,6 +1008,8 @@ class Lsf(Environment):
         :returns: ``True`` if a relaunch completed (caller should loop to monitor
             the new job); ``False`` if there is nothing to wait for or the handler
             finished without relaunching.
+        :raises WorkloadFailedException: if neither a relaunch nor the handler task
+            resolves within the backstop timeout.
         """
         if not lsf_bsub_monitor.emitted_error_event or handler_task is None:
             return False
@@ -1006,12 +1017,24 @@ class Lsf(Environment):
         # or the handler task finishing (it gave up and will raise on await).
         retry_waiter = asyncio.create_task(retry_complete_event.wait())
         try:
-            await asyncio.wait(
+            done, _ = await asyncio.wait(
                 {retry_waiter, handler_task},
+                timeout=GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT,
                 return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
             retry_waiter.cancel()
+        if not done:
+            logger.error(
+                "RetryHandler did not adjudicate the emitted error within %ss; "
+                "failing the step instead of waiting indefinitely.",
+                GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT,
+            )
+            raise WorkloadFailedException(
+                "LSF retry adjudication timed out: the RetryHandler neither "
+                "relaunched the job nor terminated within "
+                f"{GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT}s."
+            )
         return retry_complete_event.is_set()
 
     def ssh_no_verification_flags(self: Self) -> List[str]:

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -951,14 +951,65 @@ class Lsf(Environment):
                         # triggered retry_workload which set this event. Loop for the
                         # next iteration with the same launch_id.
                         continue
+                    if await self._retry_pending_after_monitor(
+                        lsf_bsub_monitor=lsf_bsub_monitor,
+                        retry_complete_event=retry_complete_event,
+                        handler_task=_handler_task,
+                    ):
+                        # A relaunch the RetryHandler owns landed while we waited;
+                        # loop to monitor the freshly launched job.
+                        continue
+                    if lsf_bsub_monitor.emitted_error_event and _handler_task is not None:
+                        # The RetryHandler finished without relaunching (gave up /
+                        # retries exhausted). Stop looping; _with_retry_handler's
+                        # __aexit__ awaits the handler task and re-raises its
+                        # WorkloadFailedException, failing the step.
+                        return
                     logger.info(
                         "LSF bsub monitoring finished for job_id %s launch_id %s",
                         job_id,
                         current_launch_id,
                     )
-                    return  # Success
+                    return  # clean terminal DONE
             finally:
                 self._lsf_retry_complete_events.pop(launch_id, None)
+
+    async def _retry_pending_after_monitor(
+        self: Self,
+        lsf_bsub_monitor: LSFBsubMonitor,
+        retry_complete_event: asyncio.Event,
+        handler_task: Optional[asyncio.Task],
+    ) -> bool:
+        """Wait for the RetryHandler to adjudicate an error the monitor emitted.
+
+        On a transient/terminal error, ``LSFBsubMonitor`` only *enqueues* an event
+        and returns; the ``RetryHandler`` consumes it on its own task and, seconds
+        later (after ``bkill`` + ``bsub``), sets ``retry_complete_event``. Reading
+        that event synchronously right after ``gather`` races the handler and can
+        return SUCCESS while a relaunch is still in flight — orphaning the new job
+        and dropping its ARTIFACT_PUSHED marker. This blocks on the outcome instead.
+
+        :param lsf_bsub_monitor: The monitor that just finished this iteration.
+        :param retry_complete_event: Event the handler sets once it has relaunched.
+        :param handler_task: The RetryHandler task, or ``None`` when retries are
+            disabled (no adjudication to wait for).
+        :returns: ``True`` if a relaunch completed (caller should loop to monitor
+            the new job); ``False`` if there is nothing to wait for or the handler
+            finished without relaunching.
+        """
+        if not lsf_bsub_monitor.emitted_error_event or handler_task is None:
+            return False
+        # Wait for whichever comes first: the relaunch completing (retry_complete_event)
+        # or the handler task finishing (it gave up and will raise on await).
+        retry_waiter = asyncio.create_task(retry_complete_event.wait())
+        try:
+            await asyncio.wait(
+                {retry_waiter, handler_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            retry_waiter.cancel()
+        return retry_complete_event.is_set()
 
     def ssh_no_verification_flags(self: Self) -> List[str]:
         """Flags to disable SSH Host key verification."""

--- a/src/gbserver/monitoring/lsf_bsub_monitor.py
+++ b/src/gbserver/monitoring/lsf_bsub_monitor.py
@@ -38,6 +38,7 @@ from gbserver.monitoring.monitor_base import MonitorBase
 from gbserver.types.buildevent import (
     BuildEvent,
     BuildEventMessagePayload,
+    BuildEventStatusPayload,
     BuildEventType,
     EntityRunMetadata,
 )
@@ -47,6 +48,7 @@ from gbserver.types.errors import (
     ErrLSFCannotOpenJobFile,
     ErrSSHConnectionError,
 )
+from gbserver.types.status import Status
 from gbserver.utils.logger import get_logger
 from gbserver.utils.ssh_tunnel import SshTunnel
 from gbserver.utils.utils import cmd_safe_join
@@ -91,6 +93,26 @@ LSF_STATE_CLASS: Dict[str, LsfStateClass] = {
     "EXIT": LsfStateClass.FAILED,
     "ZOMBI": LsfStateClass.FAILED,  # job lost with an unreachable exec host
     "POST_ERR": LsfStateClass.FAILED,  # post-exec failed
+}
+
+# Non-terminal LSF state -> the granite.build step status it should report.
+#
+# Only RUN maps to RUNNING. A job queued, held, or suspended in LSF is NOT
+# running, and reporting it as RUNNING is the false signal this mapping exists to
+# remove: the step status should never claim progress the scheduler isn't making.
+# granite.build has no SUSPENDED status, so the suspend states collapse onto
+# PENDING and the native state + reason in the event stream carries the precision
+# the enum cannot.
+LSF_ACTIVE_STATE_TO_GB_STATUS: Dict[str, Status] = {
+    "RUN": Status.RUNNING,
+    "PEND": Status.PENDING,  # queued for dispatch
+    "FWD_PEND": Status.PENDING,  # pending forward to a remote cluster
+    "WAIT": Status.PENDING,  # chunk-job member waiting to start
+    "PROV": Status.PENDING,  # execution host still provisioning
+    "PSUSP": Status.PENDING,  # suspended while pending; never dispatched
+    "SSUSP": Status.PENDING,  # suspended by LSF after dispatch
+    "USUSP": Status.PENDING,  # suspended by user/admin after dispatch
+    "UNKWN": Status.PENDING,  # exec host unreachable; progress unknown
 }
 
 # States for which PEND_REASON is meaningful and worth re-emitting when it changes.
@@ -175,6 +197,7 @@ class LSFBsubMonitor(MonitorBase):
         # is distinct from "" (a state that carries no reason).
         self._last_lsf_state: Optional[str] = None
         self._last_pend_reason_key: Optional[str] = None
+        self._last_gb_status: Optional[Status] = None
         # The record we broke the poll loop on, so the failure message can name
         # the native LSF state and exit reason.
         self._terminal_record: Optional[BJobRecord] = None
@@ -293,6 +316,44 @@ class LSFBsubMonitor(MonitorBase):
             f"and will keep monitoring rather than assume the job is over."
         )
 
+    async def _publish_gb_status(self: Self, state: str, msg: str) -> None:
+        """Report the granite.build step status implied by a non-terminal LSF state.
+
+        A job queued or suspended in LSF is not running, so the step must not sit
+        at RUNNING while it waits -- that is the false signal this mapping exists
+        to remove. Emitting a STATUS_EVENT lets BuildRunner write the mapped
+        status (and the reason, as status_msg) onto the step record, so
+        `gb build status` shows PENDING with the pend reason attached.
+
+        Only fires when the mapped status actually changes, which is far rarer
+        than an LSF state change (PEND -> PSUSP is the same gb status). Terminal
+        states are left alone: SUCCESS/FAILED are owned by the existing
+        returncode path and by Run.update_status.
+        """
+        gb_status = LSF_ACTIVE_STATE_TO_GB_STATUS.get(state)
+        if gb_status is None:
+            # Terminal, or a state we do not recognize. In the unrecognized case
+            # we genuinely do not know whether the job is progressing, so leave
+            # the step status untouched rather than assert something false.
+            return
+        if gb_status is self._last_gb_status:
+            return
+        if self.event_queue is not None:
+            await self.event_queue.put(
+                BuildEvent(
+                    run_metadata=self.entityrun_metadata,
+                    type=BuildEventType.STATUS_EVENT,
+                    payload=BuildEventStatusPayload(status=gb_status, msg=msg),
+                )
+            )
+        logger.info(
+            "[LSFBsubMonitor %s] LSF %s -> granite.build step status %s",
+            self.launch_id,
+            state,
+            gb_status,
+        )
+        self._last_gb_status = gb_status
+
     async def _publish_lsf_state_change(
         self: Self, record: BJobRecord, state_class: LsfStateClass
     ) -> None:
@@ -340,6 +401,7 @@ class LSFBsubMonitor(MonitorBase):
             logger.info("[LSFBsubMonitor %s] LSF state change: %s", self.launch_id, msg)
             self._last_lsf_state = state
             self._last_pend_reason_key = reason_key
+            await self._publish_gb_status(state, msg)
         except Exception as e:  # messaging must never block the verdict
             logger.warning(
                 "[LSFBsubMonitor %s] failed to publish LSF state change: %s",

--- a/src/gbserver/monitoring/lsf_bsub_monitor.py
+++ b/src/gbserver/monitoring/lsf_bsub_monitor.py
@@ -201,6 +201,11 @@ class LSFBsubMonitor(MonitorBase):
         # The record we broke the poll loop on, so the failure message can name
         # the native LSF state and exit reason.
         self._terminal_record: Optional[BJobRecord] = None
+        # True iff this run handed an error event (transient or terminal) to the
+        # RetryHandler for adjudication. monitor_bsub_monitor reads this to know
+        # it must wait for that out-of-band decision before deciding success,
+        # rather than racing it (which would orphan a relaunched job).
+        self.emitted_error_event = False
 
     def _classify_state(self: Self, stat: str) -> LsfStateClass:
         """Classify a native LSF STAT. Never raises.
@@ -638,6 +643,7 @@ class LSFBsubMonitor(MonitorBase):
                             ),
                         )
                     )
+                    self.emitted_error_event = True
                 return
 
             # Publish a terminal failure event so RetryHandler can detect it
@@ -662,4 +668,5 @@ class LSFBsubMonitor(MonitorBase):
                         ),
                     )
                 )
+                self.emitted_error_event = True
             return

--- a/src/gbserver/monitoring/lsf_bsub_monitor.py
+++ b/src/gbserver/monitoring/lsf_bsub_monitor.py
@@ -20,9 +20,11 @@ Monitor the job submitted via bsub.
 
 import asyncio
 import json
+import re
 import shlex
+from enum import StrEnum, auto
 from pathlib import Path
-from typing import Any, Optional, Self
+from typing import Any, Dict, Optional, Self
 
 from pydantic import BaseModel
 from tenacity import (
@@ -54,13 +56,87 @@ logger = get_logger(__name__)
 JOB_LOG_STDOUT_FILENAME = "job_log.out"
 
 
-class BJobRecord(BaseModel):
-    """A bjob record."""
+class LsfStateClass(StrEnum):
+    """How a native LSF ``STAT`` maps onto the terminal decision for a step.
 
-    JOBID: str
-    STAT: str
-    EXIT_CODE: str
-    EXIT_REASON: str
+    Deliberately not a gbserver ``Status``: monitors never set status (they emit
+    events, and the step's status follows from whether anything raised). This
+    only answers "is the job over, and did it pass".
+    """
+
+    ACTIVE = auto()  # the job is alive; keep polling
+    SUCCEEDED = auto()  # terminal -> step SUCCESS
+    FAILED = auto()  # terminal -> step FAILED
+
+
+# Native LSF STAT -> terminal decision. Source: `man bjobs` on IBM Spectrum LSF
+# Advanced 10.1.0.15. Any STAT absent from this table is treated as ACTIVE; see
+# LSFBsubMonitor._classify_state for why that direction is the safe one.
+LSF_STATE_CLASS: Dict[str, LsfStateClass] = {
+    # -- not terminal: the job has NOT finished, so keep polling ---------------
+    "PEND": LsfStateClass.ACTIVE,  # queued; PEND_REASON says why
+    "FWD_PEND": LsfStateClass.ACTIVE,  # pending forward to a remote cluster
+    "WAIT": LsfStateClass.ACTIVE,  # chunk-job member waiting to start
+    "PROV": LsfStateClass.ACTIVE,  # execution host still provisioning
+    "RUN": LsfStateClass.ACTIVE,
+    "PSUSP": LsfStateClass.ACTIVE,  # suspended while pending (bstop / bsub -H)
+    "SSUSP": LsfStateClass.ACTIVE,  # suspended by LSF (load, preemption)
+    "USUSP": LsfStateClass.ACTIVE,  # suspended by user/admin after dispatch
+    "UNKWN": LsfStateClass.ACTIVE,  # mbatchd lost contact with sbatchd; transient
+    # -- terminal, succeeded --------------------------------------------------
+    "DONE": LsfStateClass.SUCCEEDED,
+    "POST_DONE": LsfStateClass.SUCCEEDED,  # post-exec completed successfully
+    # -- terminal, failed ----------------------------------------------------
+    # EXIT_CODE/EXIT_REASON only *describe* these states; they never decide them.
+    "EXIT": LsfStateClass.FAILED,
+    "ZOMBI": LsfStateClass.FAILED,  # job lost with an unreachable exec host
+    "POST_ERR": LsfStateClass.FAILED,  # post-exec failed
+}
+
+# States for which PEND_REASON is meaningful and worth re-emitting when it changes.
+LSF_STATES_WITH_PEND_REASON = frozenset(
+    {"PEND", "FWD_PEND", "WAIT", "PROV", "PSUSP", "SSUSP", "USUSP"}
+)
+
+# A job LSF calls failed must never report success, even when EXIT_CODE is blank:
+# on a real cluster 103,256 of 315,504 EXIT jobs report EXIT_CODE="" (102,208 of
+# those TERM_OWNER, i.e. killed), and every DONE job reports "" as well -- so
+# EXIT_CODE cannot decide the verdict.
+LSF_UNSPECIFIED_FAILURE_RETURNCODE = 1
+
+_PEND_REASON_VOLATILE_NUMBERS = re.compile(r"\d+")
+
+
+def _pend_reason_key(reason: str) -> str:
+    """Collapse the live counters LSF embeds in PEND_REASON.
+
+    LSF re-renders the numbers every scheduling cycle, e.g.
+    ``"...(Resource: ngpus_physical): 340 hosts;"`` becomes ``"... 339 hosts;"``.
+    Comparing raw text would emit an event on every poll for a long PEND, so we
+    dedupe on a digit-collapsed key but always display the raw reason.
+    """
+    return _PEND_REASON_VOLATILE_NUMBERS.sub("#", (reason or "").strip())
+
+
+class BJobRecord(BaseModel):
+    """A bjob record.
+
+    Every field is defaulted on purpose. This model is validated inside the poll
+    loop's broad ``except Exception: continue``, so a ValidationError does not
+    surface as an error -- it silently costs a poll cycle, and a *persistently*
+    invalid record becomes an infinite loop. Defaults degrade to "unrecognized
+    STAT" (which warns and keeps polling) instead, and keep payloads from callers
+    that predate a new field valid.
+    """
+
+    JOBID: str = ""
+    STAT: str = ""
+    EXIT_CODE: str = ""
+    EXIT_REASON: str = ""
+    # `bjobs -o pend_reason`, LSF 10.1. NOTE: `susp_reason` does NOT exist on
+    # this LSF ("not a valid field name"); PEND_REASON already covers
+    # suspended-while-pending, e.g. "Job was suspended by the user while pending;".
+    PEND_REASON: str = ""
 
 
 class BJobOutput(BaseModel):
@@ -95,6 +171,182 @@ class LSFBsubMonitor(MonitorBase):
         self.launch_id = launch_id
         self.monitor_interval = monitor_interval
         self.monitor_command = ""
+        # On-change-only state surfacing. None means "nothing emitted yet", which
+        # is distinct from "" (a state that carries no reason).
+        self._last_lsf_state: Optional[str] = None
+        self._last_pend_reason_key: Optional[str] = None
+        # The record we broke the poll loop on, so the failure message can name
+        # the native LSF state and exit reason.
+        self._terminal_record: Optional[BJobRecord] = None
+
+    def _classify_state(self: Self, stat: str) -> LsfStateClass:
+        """Classify a native LSF STAT. Never raises.
+
+        An unrecognized STAT is treated as ACTIVE (keep polling), not terminal.
+        Assuming "anything I don't recognize means the job is over" is precisely
+        how a suspended job came to be reported as a successful build: those
+        states carry EXIT_CODE="", so the old code scored them as returncode 0.
+        Failing safe means the worst case is a visible hang rather than a silent
+        wrong SUCCESS, and it survives an LSF upgrade that adds a state.
+        """
+        state = (stat or "").strip().upper()
+        state_class = LSF_STATE_CLASS.get(state)
+        if state_class is None:
+            logger.warning(
+                "[LSFBsubMonitor %s] job %s reported unrecognized LSF STAT %r; "
+                "treating as non-terminal and continuing to poll",
+                self.launch_id,
+                self.job_id,
+                stat,
+            )
+            return LsfStateClass.ACTIVE
+        return state_class
+
+    @staticmethod
+    def _terminal_returncode(record: BJobRecord, state_class: LsfStateClass) -> int:
+        """Return a process-style returncode for a terminal LSF state. Never raises.
+
+        STAT decides pass/fail; EXIT_CODE only refines a failure's code. EXIT_CODE
+        cannot decide the verdict -- it is empty on every DONE job and on a third
+        of EXIT jobs -- so a failure with a blank or zero code still returns
+        non-zero.
+        """
+        if state_class is LsfStateClass.SUCCEEDED:
+            return 0
+        try:
+            # `bjobs -json` renders unset as ""; the -noheader table form uses "-".
+            code = int((record.EXIT_CODE or "").strip(), base=10)
+        except ValueError:
+            code = 0
+        return code if code != 0 else LSF_UNSPECIFIED_FAILURE_RETURNCODE
+
+    @staticmethod
+    def _exit_detail(record: BJobRecord) -> str:
+        """Render EXIT_CODE/EXIT_REASON as supplementary detail (may be empty)."""
+        bits = []
+        if (record.EXIT_CODE or "").strip() not in ("", "-"):
+            bits.append(f"exit_code={record.EXIT_CODE.strip()}")
+        if (record.EXIT_REASON or "").strip() not in ("", "-"):
+            bits.append(f"exit_reason={record.EXIT_REASON.strip()}")
+        return f" ({', '.join(bits)})" if bits else ""
+
+    def _format_terminal_failure_detail(self: Self) -> str:
+        """Name the native LSF state and exit reason on a failure.
+
+        EXIT_REASON has always been fetched and never read. It is the only field
+        that separates TERM_MEMLIMIT / TERM_RUNLIMIT / TERM_OWNER / TERM_ADMIN --
+        i.e. "ask for more memory" from "ask for more time" from "someone killed
+        it" from "the admin drained the host".
+        """
+        record = self._terminal_record
+        if record is None:
+            return ""
+        bits = [f"LSF state {(record.STAT or '').strip().upper()}"]
+        if (record.EXIT_REASON or "").strip() not in ("", "-"):
+            bits.append(f"exit_reason={record.EXIT_REASON.strip()}")
+        return f" ({', '.join(bits)})"
+
+    def _format_lsf_state_change(
+        self: Self, record: BJobRecord, state_class: LsfStateClass
+    ) -> str:
+        """Build the one-line message for an LSF state or reason change.
+
+        Deliberately a single plain line, NOT a fenced ```json block: the CLI
+        strips backticks and drops this string into a two-column
+        ``tabulate(tablefmt="plain")`` table (the `gb build status --show-events`
+        build history), which a multi-line blob would wreck. Carrying no json
+        fence also means ``RetryHandler._is_terminal_failure_event`` cannot match
+        an informational event, so surfacing state can never fail the build.
+        """
+        state = (record.STAT or "").strip().upper() or "UNKNOWN"
+        reason = (record.PEND_REASON or "").strip().rstrip(";")
+        detail = f" - {reason}" if reason else ""
+        previous = self._last_lsf_state
+        if previous is None or previous == state:
+            # First sighting, or the state held and only the reason moved on --
+            # rendering "PEND -> PEND" for a reason-only change reads as a bug.
+            transition = f"LSF job {self.job_id} is {state}"
+        else:
+            transition = f"LSF job {self.job_id}: {previous} -> {state}"
+
+        if state in ("PEND", "FWD_PEND", "WAIT", "PROV"):
+            return f"⏳ {transition}{detail}"
+        if state in ("PSUSP", "SSUSP", "USUSP"):
+            return (
+                f"⏸️ {transition}{detail}. The job is suspended, not finished; "
+                f"granite.build will keep monitoring until it resumes or exits "
+                f"(bresume {self.job_id} to resume, or cancel the build)."
+            )
+        if state == "UNKWN":
+            return (
+                f"❓ {transition}. LSF has lost contact with the execution host; "
+                f"this is usually transient and granite.build will keep monitoring."
+            )
+        if state == "RUN":
+            return f"⚡ {transition}"
+        if state_class is LsfStateClass.SUCCEEDED:
+            return f"✅ {transition}"
+        if state_class is LsfStateClass.FAILED:
+            return f"❌ {transition}{self._exit_detail(record)}"
+        return (
+            f"⚠️ {transition} - granite.build does not recognize this LSF state "
+            f"and will keep monitoring rather than assume the job is over."
+        )
+
+    async def _publish_lsf_state_change(
+        self: Self, record: BJobRecord, state_class: LsfStateClass
+    ) -> None:
+        """Emit a MESSAGE_EVENT when the LSF state or its reason changes.
+
+        On change only -- not once, and not on every poll: a job can sit in PEND
+        for hours at a 5s cadence.
+
+        Best effort. This runs inside the poll loop's broad ``except Exception``,
+        so it swallows its own errors rather than risk delaying or hiding the
+        terminal verdict below it.
+        """
+        try:
+            state = (record.STAT or "").strip().upper()
+            reason_key = _pend_reason_key(record.PEND_REASON)
+            state_changed = state != self._last_lsf_state
+            reason_changed = (
+                state in LSF_STATES_WITH_PEND_REASON
+                and reason_key != self._last_pend_reason_key
+            )
+            if not state_changed and not reason_changed:
+                return
+
+            msg = self._format_lsf_state_change(record, state_class)
+            if state_class is LsfStateClass.FAILED:
+                level = "ERROR"
+            elif state not in LSF_STATE_CLASS or state in (
+                "PSUSP",
+                "SSUSP",
+                "USUSP",
+                "UNKWN",
+            ):
+                level = "WARNING"
+            else:
+                level = "INFO"
+
+            if self.event_queue is not None:
+                await self.event_queue.put(
+                    BuildEvent(
+                        run_metadata=self.entityrun_metadata,
+                        type=BuildEventType.MESSAGE_EVENT,
+                        payload=BuildEventMessagePayload(level=level, msg=msg),
+                    )
+                )
+            logger.info("[LSFBsubMonitor %s] LSF state change: %s", self.launch_id, msg)
+            self._last_lsf_state = state
+            self._last_pend_reason_key = reason_key
+        except Exception as e:  # messaging must never block the verdict
+            logger.warning(
+                "[LSFBsubMonitor %s] failed to publish LSF state change: %s",
+                self.launch_id,
+                e,
+                exc_info=True,
+            )
 
     @retry(
         stop=stop_after_attempt(3),
@@ -185,8 +437,9 @@ class LSFBsubMonitor(MonitorBase):
         bare_bjobs_command = " ".join(
             [
                 "bjobs",
+                "-a",  # also return a just-finished job's record
                 "-o",
-                '"jobid stat exit_code exit_reason"',
+                '"jobid stat exit_code exit_reason pend_reason"',
                 "-json",
                 self.job_id,
             ]
@@ -234,16 +487,30 @@ class LSFBsubMonitor(MonitorBase):
                     raise ValueError(f"failed to find the bsub job '{self.job_id}'")
                 record = bjobs_output.RECORDS[0]
                 logger.info("BSubLauncher.monitor_logs record: %s", record)
-                if record.STAT not in ("PEND", "RUN"):
-                    returncode = int(record.EXIT_CODE or "0", base=10)
-                    # If stop was requested externally (e.g. retry_workload signalled us
-                    # to stop before bkilling the job), treat this as a clean exit rather
-                    # than a real failure — we may have just detected the bkill's exit code.
-                    if self.stop_event.is_set():
-                        returncode = 0
-                    break
+
+                state_class = self._classify_state(record.STAT)
+
+                # Surface the native LSF state -- and, while the job is queued or
+                # suspended, WHY -- on every change.
+                await self._publish_lsf_state_change(record, state_class)
+
+                if state_class is LsfStateClass.ACTIVE:
+                    # PEND / RUN / PSUSP / SSUSP / USUSP / UNKWN / WAIT / PROV /
+                    # FWD_PEND, plus any STAT this gbserver does not recognize.
+                    continue
+
+                self._terminal_record = record
+                returncode = self._terminal_returncode(record, state_class)
+                # If stop was requested externally (e.g. retry_workload signalled us
+                # to stop before bkilling the job), treat this as a clean exit rather
+                # than a real failure — we may have just detected the bkill's exit code.
+                if self.stop_event.is_set():
+                    returncode = 0
+                break
             except Exception as e:
-                logger.error("failed to get the status of the job. error: %s", e)
+                logger.error(
+                    "failed to get the status of the job. error: %s", e, exc_info=True
+                )
                 continue
         if self.stop_event.is_set():
             logger.warning(
@@ -267,7 +534,10 @@ class LSFBsubMonitor(MonitorBase):
         await asyncio.sleep(GBSERVER_MONITORING_GRACE_PERIOD)
         self.stop()
         if is_error:
-            error_message = f"Job {self.job_id} failed with return code {returncode}"
+            error_message = (
+                f"Job {self.job_id} failed with return code {returncode}"
+                f"{self._format_terminal_failure_detail()}"
+            )
             logger.error("[LSFBsubMonitor %s] %s", self.launch_id, error_message)
 
             # Check for transient LSF errors that should trigger a retry

--- a/src/gbserver/monitoring/streams/ssh_file_stream.py
+++ b/src/gbserver/monitoring/streams/ssh_file_stream.py
@@ -35,6 +35,26 @@ SSH_CONNECT_TIMEOUT = 10
 SSH_SERVER_ALIVE_INTERVAL = 5
 SSH_SERVER_ALIVE_COUNT_MAX = 3
 
+# Benign markers that may appear on drain stderr but do NOT indicate a real
+# connection failure. A retry relaunch recreates the job output directory, so a
+# previous iteration's drain can race against a vanished job.log: the remote
+# tail/cat then exits non-zero with "No such file or directory". That is
+# expected and must not be surfaced as a fatal ConnectionError.
+_BENIGN_DRAIN_STDERR = ("No such file or directory",)
+
+
+def _is_benign_drain_stderr(line: str) -> bool:
+    """Return True if a drain-stderr line is expected and non-fatal.
+
+    Args:
+        line: A single stderr line captured during the phase-two drain.
+
+    Returns:
+        bool: True if the line is a benign/expected message (e.g. the job.log
+            was deleted/recreated by a retry) rather than a real SSH failure.
+    """
+    return any(marker in line for marker in _BENIGN_DRAIN_STDERR)
+
 
 class SSHFileStream(LogStreamSource, RetryMixin):
     """Stream lines from a remote file via SSH."""
@@ -68,6 +88,13 @@ class SSHFileStream(LogStreamSource, RetryMixin):
             f"ServerAliveInterval={SSH_SERVER_ALIVE_INTERVAL}",
             "-o",
             f"ServerAliveCountMax={SSH_SERVER_ALIVE_COUNT_MAX}",
+            # Suppress benign SSH-client warnings (e.g. "Warning: Permanently
+            # added ... to the list of known hosts.") that otherwise land on
+            # stderr and get misclassified as a drain failure. Genuine
+            # ERROR/FATAL messages (connection refused, auth failure) are still
+            # emitted at this level.
+            "-o",
+            "LogLevel=ERROR",
             *self.ssh_opts,
             target,
             remote_cmd,
@@ -286,14 +313,30 @@ class SSHFileStream(LogStreamSource, RetryMixin):
                     self.path,
                 )
 
-            # Now check: if the process exited with an error AND stderr had output,
-            # that's a real SSH/remote failure — raise with the actual error message.
-            if final_proc.returncode and final_proc.returncode != 0 and stderr_lines:
-                stderr_output = "; ".join(stderr_lines)
-                raise ConnectionError(
-                    f"SSH drain failed for {self.path} (exit code {final_proc.returncode}): "
-                    f"{stderr_output}"
-                )
+            # If the drain process exited non-zero, decide whether it's a real
+            # failure. Benign lines — a job.log that a retry relaunch deleted or
+            # recreated, i.e. "No such file or directory" — are expected and must
+            # not raise; otherwise a transient relaunch race fails the build.
+            # Only a genuine SSH/remote error (connection refused, auth, etc.)
+            # should raise.
+            if final_proc.returncode:
+                genuine_errors = [
+                    line for line in stderr_lines if not _is_benign_drain_stderr(line)
+                ]
+                if genuine_errors:
+                    stderr_output = "; ".join(genuine_errors)
+                    raise ConnectionError(
+                        f"SSH drain failed for {self.path} (exit code {final_proc.returncode}): "
+                        f"{stderr_output}"
+                    )
+                if stderr_lines:
+                    logger.warning(
+                        "[SSHFileStream] Drain of %s exited %s with only benign "
+                        "stderr (log likely removed/recreated by a retry); "
+                        "finishing without error.",
+                        self.path,
+                        final_proc.returncode,
+                    )
 
             logger.info(
                 "[SSHFileStream] Finished draining %s: total_lines=%d, "

--- a/src/gbserver/resilience/retry_handler.py
+++ b/src/gbserver/resilience/retry_handler.py
@@ -403,7 +403,8 @@ class RetryHandler:
                         self.launch_id,
                         (
                             "Retries exhausted on retriable failure"
-                            if retries_exhausted_on_retriable and not is_terminal_failure
+                            if retries_exhausted_on_retriable
+                            and not is_terminal_failure
                             else "Terminal failure"
                         ),
                     )

--- a/src/gbserver/resilience/retry_handler.py
+++ b/src/gbserver/resilience/retry_handler.py
@@ -361,6 +361,17 @@ class RetryHandler:
                 # Check if this is a terminal failure
                 is_terminal_failure = self._is_terminal_failure_event(event)
 
+                # A retriable failure we can no longer retry (retries exhausted)
+                # is itself terminal. Without this, an event a strategy WOULD
+                # retry -- but can't, because retry_count >= max_retries -- would
+                # be neither relaunched nor raised, leaving a monitor's deferred
+                # wait (e.g. LSF's _retry_pending_after_monitor) hanging forever.
+                retries_exhausted_on_retriable = (
+                    not retry_triggered
+                    and self.retry_count >= self.max_retries
+                    and self._is_retriable_event(event)
+                )
+
                 # Always forward the event downstream, but enrich with retry metadata
                 if retry_triggered:
                     # Add retry metadata to the event payload
@@ -381,12 +392,20 @@ class RetryHandler:
                 # Forward to downstream queue
                 await self.downstream_queue.put(event)
 
-                # If terminal failure and no retry was triggered, raise exception to stop the build
-                if is_terminal_failure and not retry_triggered:
+                # If terminal failure (or a retriable failure with no retries
+                # left) and no retry was triggered, raise to stop the build.
+                if (
+                    is_terminal_failure or retries_exhausted_on_retriable
+                ) and not retry_triggered:
                     error_message = self._extract_failure_message(event)
                     logger.error(
-                        "[RetryHandler launch_id %s] Terminal failure detected with no retry possible. Raising exception.",
+                        "[RetryHandler launch_id %s] %s detected with no retry possible. Raising exception.",
                         self.launch_id,
+                        (
+                            "Retries exhausted on retriable failure"
+                            if retries_exhausted_on_retriable and not is_terminal_failure
+                            else "Terminal failure"
+                        ),
                     )
                     raise WorkloadFailedException(error_message)
 
@@ -503,6 +522,23 @@ class RetryHandler:
                     self.launch_id,
                     e,
                 )
+
+    def _is_retriable_event(self: Self, event: BuildEvent) -> bool:
+        """
+        Report whether any registered strategy recognizes this event as retriable.
+
+        Unlike _evaluate_and_retry, this ignores retry_count / max_retries; it
+        only asks whether the event matches a retry strategy. process_events uses
+        it to detect a retriable failure that can no longer be retried (retries
+        exhausted), which is itself terminal.
+
+        Args:
+            event: BuildEvent from the monitor
+
+        Returns:
+            bool: True if at least one strategy would retry this event
+        """
+        return any(strategy.should_retry(event=event) for strategy in self.strategies)
 
     async def _evaluate_and_retry(
         self: Self,

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -636,6 +636,19 @@ GBSERVER_LSF_TRANSIENT_ERROR_MAX_RETRIES = int(
 GBSERVER_LSF_TRANSIENT_ERROR_RETRY_DELAY = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_TRANSIENT_ERROR_RETRY_DELAY", "30"), base=10
 )
+# Backstop timeout (seconds) for Lsf._retry_pending_after_monitor's wait on the
+# RetryHandler to adjudicate an error the monitor emitted. The handler normally
+# relaunches or raises well within one retry (one backoff delay + bkill + bsub),
+# so this only bounds a pathological hang (a monitor error shape the handler
+# neither retries nor treats as terminal). Default is a generous multiple of the
+# backoff delay so a genuinely slow relaunch is never mistaken for a hang.
+GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT = int(
+    os.getenv(
+        ENV_VAR_PREFIX + "_LSF_RETRY_ADJUDICATION_TIMEOUT",
+        str(GBSERVER_LSF_TRANSIENT_ERROR_RETRY_DELAY * 10 + 60),
+    ),
+    base=10,
+)
 # Used by the build framework monitoring to allow the consumption of all the events
 GBSERVER_MONITORING_GRACE_PERIOD = int(
     os.getenv(ENV_VAR_PREFIX + "_MONITORING_GRACE_PERIOD", "30"), base=10

--- a/src/gbserver/types/errors.py
+++ b/src/gbserver/types/errors.py
@@ -67,6 +67,33 @@ class ErrNetworkUnreachable(Exception):
         )
 
 
+ERR_CONNECTION_CLOSED_PATTERNS = ("Connection closed", "closed by remote host")
+
+
+class ErrConnectionClosed(Exception):
+    """Remote end dropped the connection mid-transfer (e.g. scp/ssh tunnel).
+
+    This is a transient transport failure that should be retried, distinct from
+    a persistent outage. Matched narrowly (not via the broad
+    ``ERR_SSH_CONNECTION_PATTERNS``) so it only triggers on an actual dropped
+    connection rather than any message that happens to contain "connection".
+    """
+
+    @staticmethod
+    def matches_error_str(s: Union[str, bytes]) -> bool:
+        """Return True if ``s`` reports a dropped connection.
+
+        Args:
+            s: The stderr text (``str`` or ``bytes``) to classify.
+
+        Returns:
+            bool: True if any connection-closed pattern is present.
+        """
+        if isinstance(s, bytes):
+            s = s.decode("utf-8", errors="replace")
+        return any(pattern in s for pattern in ERR_CONNECTION_CLOSED_PATTERNS)
+
+
 ERR_SSH_CONNECTION_PATTERNS = ["connection", "ssh", "network", "timeout", "refused"]
 
 

--- a/src/gbserver/utils/launch.py
+++ b/src/gbserver/utils/launch.py
@@ -29,7 +29,11 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from gbserver.types.errors import ErrConnResetByPeer, ErrNetworkUnreachable
+from gbserver.types.errors import (
+    ErrConnectionClosed,
+    ErrConnResetByPeer,
+    ErrNetworkUnreachable,
+)
 from gbserver.utils.logger import get_logger
 from gbserver.utils.utils import cmd_safe_join
 
@@ -108,6 +112,8 @@ async def launch_command_and_raise_errors(
                 raise ErrConnResetByPeer(err_msg)
             if ErrNetworkUnreachable.matches_error_str(stderr):
                 raise ErrNetworkUnreachable(err_msg)
+            if ErrConnectionClosed.matches_error_str(stderr):
+                raise ErrConnectionClosed(err_msg)
             raise ValueError(err_msg)
         logger.warning("%s", err_msg)
     return process, stdout, stderr
@@ -116,7 +122,9 @@ async def launch_command_and_raise_errors(
 @retry(
     stop=stop_after_attempt(10),
     wait=wait_random_exponential(multiplier=1, max=30),
-    retry=retry_if_exception_type((ErrConnResetByPeer, ErrNetworkUnreachable)),
+    retry=retry_if_exception_type(
+        (ErrConnResetByPeer, ErrNetworkUnreachable, ErrConnectionClosed)
+    ),
 )
 async def launch_command_and_retry_or_raise_errors(
     command_list: List[str],

--- a/test/unit/buildrunner/test_step_run_timestamps.py
+++ b/test/unit/buildrunner/test_step_run_timestamps.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for BuildRunner._apply_run_timestamps.
+
+The LSF state-mapping change maps suspended/queued job states (PSUSP/SSUSP/
+USUSP/UNKWN) to granite.build PENDING, so a run can now transition
+RUNNING -> PENDING and can terminate straight from PENDING (a job killed while
+suspended). This shared helper stamps timestamps for both step runs and target
+runs; these tests pin the transition state machine:
+
+- started_at is stamped only on the FIRST entry into RUNNING (a resumed job
+  re-entering RUNNING must not push started_at later).
+- finished_at is stamped on the FIRST entry into ANY terminal status, whatever
+  the prior status -- including PENDING -> FAILED, the edge case that a
+  "was RUNNING" guard silently dropped -- and never re-stamped.
+- A RUNNING -> PENDING transition must NOT mark the run finished.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from gbserver.buildrunner.buildrunner import BuildRunner
+from gbserver.storage.stored_step_run import StoredStepRun
+from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.types.status import Status
+
+_T0 = datetime(2026, 1, 1, 0, 0, 0)
+_T1 = _T0 + timedelta(seconds=30)
+_T2 = _T0 + timedelta(seconds=60)
+
+
+def _step(status: Status, started_at=None, finished_at=None) -> StoredStepRun:
+    """Build a minimal StoredStepRun in the given pre-transition state."""
+    return StoredStepRun(
+        build_id="b1",
+        target_id="t1",
+        definition_uri="step://x",
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+
+
+def _target(status: Status, started_at=None, finished_at=None) -> StoredTargetRun:
+    """Build a minimal StoredTargetRun in the given pre-transition state."""
+    return StoredTargetRun(
+        build_id="b1",
+        environment_uri="env://x",
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+
+
+def test_first_running_stamps_started_at():
+    """PENDING -> RUNNING stamps started_at."""
+    step = _step(Status.PENDING)
+    BuildRunner._apply_run_timestamps(step, Status.RUNNING, _T0)
+    assert step.started_at == _T0
+    assert step.finished_at is None
+
+
+def test_reentry_into_running_does_not_restamp_started_at():
+    """A resumed job re-entering RUNNING keeps its original started_at.
+
+    The stored status is PENDING (the suspend-state mapping) but started_at is
+    already set, so it must be preserved rather than pushed to the later time.
+    """
+    step = _step(Status.PENDING, started_at=_T0)
+    BuildRunner._apply_run_timestamps(step, Status.RUNNING, _T1)
+    assert step.started_at == _T0
+
+
+def test_running_to_pending_does_not_finish():
+    """RUNNING -> PENDING (job queued/suspended) must NOT stamp finished_at."""
+    step = _step(Status.RUNNING, started_at=_T0)
+    BuildRunner._apply_run_timestamps(step, Status.PENDING, _T1)
+    assert step.finished_at is None
+
+
+def test_running_to_success_stamps_finished_at():
+    """The ordinary RUNNING -> SUCCESS path still stamps finished_at."""
+    step = _step(Status.RUNNING, started_at=_T0)
+    BuildRunner._apply_run_timestamps(step, Status.SUCCESS, _T2)
+    assert step.finished_at == _T2
+
+
+@pytest.mark.parametrize(
+    "terminal", [Status.FAILED, Status.SUCCESS, Status.CANCELLED, Status.INVALID]
+)
+def test_pending_to_terminal_stamps_finished_at(terminal):
+    """A step terminating straight from PENDING (e.g. killed while suspended)
+    is still stamped finished_at -- the regression the old guard dropped."""
+    step = _step(Status.PENDING, started_at=_T0)
+    BuildRunner._apply_run_timestamps(step, terminal, _T2)
+    assert step.finished_at == _T2
+
+
+def test_finished_at_not_restamped_on_redelivered_terminal():
+    """A second terminal event does not overwrite the original finished_at."""
+    step = _step(Status.FAILED, started_at=_T0, finished_at=_T1)
+    BuildRunner._apply_run_timestamps(step, Status.FAILED, _T2)
+    assert step.finished_at == _T1
+
+
+def test_target_run_pending_to_terminal_stamps_finished_at():
+    """The same guarantee holds for target runs: a target terminating from a
+    PENDING-mapped state is stamped finished_at (symmetric with the step fix)."""
+    target = _target(Status.PENDING, started_at=_T0)
+    BuildRunner._apply_run_timestamps(target, Status.FAILED, _T2)
+    assert target.finished_at == _T2
+
+
+def test_target_run_running_to_pending_does_not_finish():
+    """A target RUNNING -> PENDING transition must NOT stamp finished_at."""
+    target = _target(Status.RUNNING, started_at=_T0)
+    BuildRunner._apply_run_timestamps(target, Status.PENDING, _T1)
+    assert target.finished_at is None

--- a/test/unit/buildrunner/test_step_run_timestamps.py
+++ b/test/unit/buildrunner/test_step_run_timestamps.py
@@ -22,8 +22,9 @@ RUNNING -> PENDING and can terminate straight from PENDING (a job killed while
 suspended). This shared helper stamps timestamps for both step runs and target
 runs; these tests pin the transition state machine:
 
-- started_at is stamped only on the FIRST entry into RUNNING (a resumed job
-  re-entering RUNNING must not push started_at later).
+- started_at is stamped on the FIRST entry into RUNNING regardless of the prior
+  status (a resumed job re-entering RUNNING must not push started_at later; a run
+  entering RUNNING from a non-PENDING state such as SUBMITTED must still stamp).
 - finished_at is stamped on the FIRST entry into ANY terminal status, whatever
   the prior status -- including PENDING -> FAILED, the edge case that a
   "was RUNNING" guard silently dropped -- and never re-stamped.
@@ -73,6 +74,24 @@ def test_first_running_stamps_started_at():
     BuildRunner._apply_run_timestamps(step, Status.RUNNING, _T0)
     assert step.started_at == _T0
     assert step.finished_at is None
+
+
+def test_submitted_to_running_stamps_started_at():
+    """A non-linear first transition (SUBMITTED -> RUNNING) still stamps
+    started_at. A target run can be created SUBMITTED with started_at=None, and a
+    "was PENDING" precondition would silently drop it -- the mirror of the
+    finished_at regression."""
+    step = _step(Status.SUBMITTED)
+    BuildRunner._apply_run_timestamps(step, Status.RUNNING, _T0)
+    assert step.started_at == _T0
+
+
+def test_target_run_submitted_to_running_stamps_started_at():
+    """Same guarantee for target runs, which are the ones actually created in a
+    non-PENDING (SUBMITTED) state with started_at=None."""
+    target = _target(Status.SUBMITTED)
+    BuildRunner._apply_run_timestamps(target, Status.RUNNING, _T0)
+    assert target.started_at == _T0
 
 
 def test_reentry_into_running_does_not_restamp_started_at():

--- a/test/unit/environment/test_lsf_cleanup.py
+++ b/test/unit/environment/test_lsf_cleanup.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from typing import Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -139,3 +140,95 @@ class TestCleanupBsub:
             )
 
         assert lsf._ssh_tunnel.run_remote.call_count == 3
+
+
+class TestRetryPendingAfterMonitor:
+    """Tests for _retry_pending_after_monitor, the race guard that stops
+    monitor_bsub_monitor from declaring success while a RetryHandler-owned
+    relaunch (triggered by an emitted error event) is still in flight.
+    """
+
+    @staticmethod
+    def _monitor(emitted_error_event: bool) -> MagicMock:
+        """Build a stand-in LSFBsubMonitor exposing only emitted_error_event."""
+        monitor = MagicMock()
+        monitor.emitted_error_event = emitted_error_event
+        return monitor
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_error_emitted(self: Self) -> None:
+        """A clean DONE (no error event) must not wait — returns False at once."""
+        lsf = _make_lsf(use_ssh=True)
+        retry_complete_event = asyncio.Event()
+        handler_task = asyncio.create_task(asyncio.Event().wait())
+        try:
+            result = await lsf._retry_pending_after_monitor(
+                lsf_bsub_monitor=self._monitor(emitted_error_event=False),
+                retry_complete_event=retry_complete_event,
+                handler_task=handler_task,
+            )
+        finally:
+            handler_task.cancel()
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_handler_disabled(self: Self) -> None:
+        """With retries disabled (handler_task is None) there is nothing to wait
+        for, so the guard returns False even though an error was emitted."""
+        lsf = _make_lsf(use_ssh=True)
+
+        result = await lsf._retry_pending_after_monitor(
+            lsf_bsub_monitor=self._monitor(emitted_error_event=True),
+            retry_complete_event=asyncio.Event(),
+            handler_task=None,
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_relaunch_completes(self: Self) -> None:
+        """When the RetryHandler relaunches (sets retry_complete_event) while we
+        wait, the guard returns True so the caller monitors the new job."""
+        lsf = _make_lsf(use_ssh=True)
+        retry_complete_event = asyncio.Event()
+        # Handler task that never finishes on its own; the relaunch signal wins.
+        handler_task = asyncio.create_task(asyncio.Event().wait())
+
+        async def _signal_relaunch() -> None:
+            retry_complete_event.set()
+
+        signal_task = asyncio.create_task(_signal_relaunch())
+        try:
+            result = await lsf._retry_pending_after_monitor(
+                lsf_bsub_monitor=self._monitor(emitted_error_event=True),
+                retry_complete_event=retry_complete_event,
+                handler_task=handler_task,
+            )
+        finally:
+            handler_task.cancel()
+            await signal_task
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_handler_gives_up(self: Self) -> None:
+        """When the handler task finishes without setting retry_complete_event
+        (retries exhausted / gave up), the guard returns False so the caller
+        stops looping and the handler's exception can propagate."""
+        lsf = _make_lsf(use_ssh=True)
+        retry_complete_event = asyncio.Event()
+
+        async def _handler_gives_up() -> None:
+            return None
+
+        handler_task = asyncio.create_task(_handler_gives_up())
+
+        result = await lsf._retry_pending_after_monitor(
+            lsf_bsub_monitor=self._monitor(emitted_error_event=True),
+            retry_complete_event=retry_complete_event,
+            handler_task=handler_task,
+        )
+
+        assert result is False
+        assert retry_complete_event.is_set() is False

--- a/test/unit/environment/test_lsf_cleanup.py
+++ b/test/unit/environment/test_lsf_cleanup.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gbserver.environment.lsf import Lsf
+from gbserver.types.errors import WorkloadFailedException
 
 
 def _make_lsf(use_ssh: bool = True) -> Lsf:
@@ -232,3 +233,30 @@ class TestRetryPendingAfterMonitor:
 
         assert result is False
         assert retry_complete_event.is_set() is False
+
+    @pytest.mark.asyncio
+    async def test_raises_when_adjudication_times_out(self: Self) -> None:
+        """Backstop: if neither a relaunch nor the handler task resolves within
+        the adjudication timeout, fail the step loudly instead of hanging.
+
+        This guards the pathological case where the handler neither retries nor
+        recognizes the emitted error as terminal.
+        """
+        lsf = _make_lsf(use_ssh=True)
+        retry_complete_event = asyncio.Event()
+        # Handler task that never finishes and never signals a relaunch.
+        handler_task = asyncio.create_task(asyncio.Event().wait())
+
+        with patch(
+            "gbserver.environment.lsf.GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT",
+            0.05,
+        ):
+            try:
+                with pytest.raises(WorkloadFailedException):
+                    await lsf._retry_pending_after_monitor(
+                        lsf_bsub_monitor=self._monitor(emitted_error_event=True),
+                        retry_complete_event=retry_complete_event,
+                        handler_task=handler_task,
+                    )
+            finally:
+                handler_task.cancel()

--- a/test/unit/monitoring/test_log_draining.py
+++ b/test/unit/monitoring/test_log_draining.py
@@ -963,7 +963,14 @@ async def test_emitted_error_event_true_on_terminal_failure():
     """A non-transient EXIT failure emits a terminal failure event for the
     RetryHandler, so emitted_error_event is True."""
     monitor = await _run_bsub_monitor_over(
-        [{"JOBID": "12345", "STAT": "EXIT", "EXIT_CODE": "1", "EXIT_REASON": "TERM_OWNER"}],
+        [
+            {
+                "JOBID": "12345",
+                "STAT": "EXIT",
+                "EXIT_CODE": "1",
+                "EXIT_REASON": "TERM_OWNER",
+            }
+        ],
         transient_content=None,
     )
     assert monitor.emitted_error_event is True

--- a/test/unit/monitoring/test_log_draining.py
+++ b/test/unit/monitoring/test_log_draining.py
@@ -816,3 +816,86 @@ async def test_ssh_file_stream_phase2_clean_stderr_eof():
             collected_lines.append(line)
 
     assert collected_lines == ["line 1", "line 2", "line 3"], f"Got: {collected_lines}"
+
+
+@pytest.mark.asyncio
+async def test_ssh_file_stream_phase2_missing_file_is_benign():
+    """
+    Test 10: SSHFileStream Phase 2 tolerates a vanished job.log.
+
+    A retry relaunch recreates the job output directory, so a previous drain can
+    race against a deleted/recreated log. The remote tail/cat then exits non-zero
+    with "No such file or directory". This must NOT raise ConnectionError — the
+    drain should finish cleanly with whatever Phase 1 already captured.
+    """
+    stop_event = asyncio.Event()
+    stream = SSHFileStream(
+        host="test-host",
+        user="testuser",
+        path="/remote/job.log",
+        ssh_opts=["-o", "StrictHostKeyChecking=no"],
+    )
+
+    # Mock Phase 1 subprocess
+    mock_proc_phase1 = AsyncMock()
+    mock_proc_phase1.returncode = None
+    mock_proc_phase1.stdout = AsyncMock()
+    mock_proc_phase1.stderr = AsyncMock()
+
+    phase1_lines = [b"line 1\n"]
+
+    async def mock_readline_phase1():
+        if phase1_lines:
+            return phase1_lines.pop(0)
+        stop_event.set()
+        return b""
+
+    mock_proc_phase1.stdout.readline = mock_readline_phase1
+    mock_proc_phase1.stderr.__aiter__ = lambda self: EmptyAsyncIterator()
+
+    # Mock Phase 2 subprocess — remote tail fails because the log was recreated.
+    mock_proc_phase2 = AsyncMock()
+    mock_proc_phase2.returncode = 1  # tail/cat "No such file or directory"
+    mock_proc_phase2.pid = 12345
+    mock_proc_phase2.stdout = AsyncMock()
+    mock_proc_phase2.stderr = AsyncMock()
+
+    # stdout: nothing to read (file gone) — return EOF after a brief delay so the
+    # benign stderr line is collected first.
+    async def mock_stdout_readline():
+        await asyncio.sleep(0.1)
+        return b""
+
+    mock_proc_phase2.stdout.readline = mock_stdout_readline
+
+    # stderr: the benign missing-file message, then EOF.
+    stderr_returned = [False]
+
+    async def mock_stderr_readline():
+        if not stderr_returned[0]:
+            stderr_returned[0] = True
+            return (
+                b"tail: cannot open '/remote/job.log' for reading: "
+                b"No such file or directory\n"
+            )
+        return b""
+
+    mock_proc_phase2.stderr.readline = mock_stderr_readline
+
+    call_counter = [0]
+
+    async def mock_subprocess_exec(*args, **kwargs):
+        call_counter[0] += 1
+        if call_counter[0] == 1:
+            return mock_proc_phase1
+        else:
+            return mock_proc_phase2
+
+    collected_lines = []
+
+    with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess_exec):
+        # No ConnectionError despite non-zero exit + non-empty (benign) stderr.
+        async for line in stream.stream_lines(stop_event=stop_event):
+            collected_lines.append(line)
+
+    assert collected_lines == ["line 1"], f"Got: {collected_lines}"

--- a/test/unit/monitoring/test_log_draining.py
+++ b/test/unit/monitoring/test_log_draining.py
@@ -53,6 +53,7 @@ Test Coverage:
 """
 
 import asyncio
+import json
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -899,3 +900,81 @@ async def test_ssh_file_stream_phase2_missing_file_is_benign():
             collected_lines.append(line)
 
     assert collected_lines == ["line 1"], f"Got: {collected_lines}"
+
+
+async def _run_bsub_monitor_over(bjobs_records, transient_content=None):
+    """Run ``LSFBsubMonitor.monitor()`` over a canned bjobs record sequence.
+
+    :param bjobs_records: List of per-poll RECORDS dicts (STAT/EXIT_CODE/
+        EXIT_REASON); the last entry is repeated once the list is exhausted.
+    :param transient_content: Value ``_check_for_transient_lsf_error`` is patched
+        to return -- ``None`` drives the terminal-failure emit path; a string
+        drives the transient-retry emit path.
+    :returns: The LSFBsubMonitor after ``monitor()`` has run to completion.
+    """
+    responses = [
+        json.dumps({"COMMAND": "bjobs", "JOBS": 1, "RECORDS": [rec]})
+        for rec in bjobs_records
+    ]
+    idx = [0]
+    tunnel = AsyncMock()
+
+    async def run_remote(command, raise_on_error=True):
+        resp = responses[min(idx[0], len(responses) - 1)]
+        idx[0] += 1
+        return 0, resp, ""
+
+    tunnel.run_remote = run_remote
+    mock_lsf = MagicMock()
+    mock_lsf.use_ssh = True
+    mock_lsf.get_ssh_tunnel.return_value = tunnel
+    mock_lsf.get_log_path.return_value = ""
+
+    monitor = LSFBsubMonitor(
+        lsf=mock_lsf,
+        job_id="12345",
+        launch_id="test-launch",
+        entityrun_metadata=EntityRunMetadata(),
+        event_queue=asyncio.Queue(),
+        stop_event=asyncio.Event(),
+        monitor_interval=0.05,
+    )
+    monitor._check_for_transient_lsf_error = AsyncMock(return_value=transient_content)
+    with patch(
+        "gbserver.monitoring.lsf_bsub_monitor.GBSERVER_MONITORING_GRACE_PERIOD", 0.0
+    ):
+        await monitor.monitor()
+    return monitor
+
+
+@pytest.mark.asyncio
+async def test_emitted_error_event_false_on_clean_done():
+    """A job that reaches DONE with exit code 0 hands no error to the
+    RetryHandler, so emitted_error_event stays False (monitor_bsub_monitor may
+    resolve success immediately)."""
+    monitor = await _run_bsub_monitor_over(
+        [{"JOBID": "12345", "STAT": "DONE", "EXIT_CODE": "0", "EXIT_REASON": ""}],
+    )
+    assert monitor.emitted_error_event is False
+
+
+@pytest.mark.asyncio
+async def test_emitted_error_event_true_on_terminal_failure():
+    """A non-transient EXIT failure emits a terminal failure event for the
+    RetryHandler, so emitted_error_event is True."""
+    monitor = await _run_bsub_monitor_over(
+        [{"JOBID": "12345", "STAT": "EXIT", "EXIT_CODE": "1", "EXIT_REASON": "TERM_OWNER"}],
+        transient_content=None,
+    )
+    assert monitor.emitted_error_event is True
+
+
+@pytest.mark.asyncio
+async def test_emitted_error_event_true_on_transient_error():
+    """A transient LSF error emits a retry event for the RetryHandler, so
+    emitted_error_event is True."""
+    monitor = await _run_bsub_monitor_over(
+        [{"JOBID": "12345", "STAT": "EXIT", "EXIT_CODE": "1", "EXIT_REASON": ""}],
+        transient_content="cannot open job file",
+    )
+    assert monitor.emitted_error_event is True

--- a/test/unit/monitoring/test_lsf_bsub_monitor.py
+++ b/test/unit/monitoring/test_lsf_bsub_monitor.py
@@ -36,6 +36,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gbserver.monitoring.lsf_bsub_monitor import (
+    LSF_ACTIVE_STATE_TO_GB_STATUS,
     LSF_STATE_CLASS,
     BJobRecord,
     LSFBsubMonitor,
@@ -48,6 +49,7 @@ from gbserver.types.buildevent import (
     BuildEventType,
     EntityRunMetadata,
 )
+from gbserver.types.status import Status
 
 # Short intervals keep the suite fast; the grace period is patched per test.
 MONITOR_INTERVAL = 0.02
@@ -152,11 +154,18 @@ async def _drive(monitor: LSFBsubMonitor, *, expect_terminates: bool) -> None:
 
 
 def _msgs(queue: asyncio.Queue) -> List[str]:
-    """Drain the queue to a list of event message strings."""
+    """Drain the queue to the MESSAGE_EVENT narrative lines.
+
+    Scoped to MESSAGE_EVENT on purpose: the monitor also emits STATUS_EVENTs
+    carrying the same text to drive the step status, and counting both would
+    double every assertion about how many narrative lines a poll sequence
+    produces.
+    """
     out = []
     while not queue.empty():
         event = queue.get_nowait()
-        out.append(getattr(event.payload, "msg", "") or "")
+        if event.type is BuildEventType.MESSAGE_EVENT:
+            out.append(getattr(event.payload, "msg", "") or "")
     return out
 
 
@@ -537,6 +546,81 @@ async def test_state_change_events_can_never_fail_the_build():
         event = _as_message_event(msg)
         assert _is_build_failing(event) is False, stat
         assert bool(strategy.should_retry(event)) is False, stat
+
+
+def _status_events(queue: asyncio.Queue) -> List[Status]:
+    """Drain the queue to the sequence of STATUS_EVENT statuses."""
+    out = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        if event.type is BuildEventType.STATUS_EVENT:
+            out.append(event.payload.status)
+    return out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stat", ["PEND", "FWD_PEND", "WAIT", "PROV", "PSUSP", "SSUSP", "USUSP", "UNKWN"]
+)
+async def test_non_running_lsf_states_report_gb_pending(stat):
+    """A job queued or suspended in LSF must NOT report the step as RUNNING.
+
+    This is the point of the mapping: gb should never claim progress the
+    scheduler isn't making. Only LSF RUN means RUNNING.
+    """
+    monitor, queue, _ = _make_monitor([_bjobs_json(stat)])
+    await _drive(monitor, expect_terminates=False)
+    statuses = _status_events(queue)
+    assert Status.PENDING in statuses, f"{stat} should report PENDING, got {statuses}"
+    assert Status.RUNNING not in statuses, f"{stat} must not report RUNNING"
+
+
+@pytest.mark.asyncio
+async def test_lsf_run_reports_gb_running():
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN")])
+    await _drive(monitor, expect_terminates=False)
+    assert _status_events(queue) == [Status.RUNNING]
+
+
+@pytest.mark.asyncio
+async def test_gb_status_is_emitted_only_when_the_mapped_status_changes():
+    """PEND -> PSUSP is the same gb status, so it must not re-emit.
+
+    The LSF-level narrative still gets an event per state change; the gb status
+    only moves on PENDING <-> RUNNING.
+    """
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND"),
+            _bjobs_json("PSUSP"),
+            _bjobs_json("USUSP"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    # PENDING once across PEND/PSUSP/USUSP, then RUNNING on dispatch. DONE is
+    # terminal and owned by the returncode path, so it emits no STATUS_EVENT.
+    assert _status_events(queue) == [Status.PENDING, Status.RUNNING]
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_state_does_not_assert_a_gb_status():
+    """If we don't know the LSF state, don't claim to know the step status."""
+    monitor, queue, _ = _make_monitor([_bjobs_json("FROBNICATE")])
+    await _drive(monitor, expect_terminates=False)
+    assert _status_events(queue) == []
+
+
+def test_every_active_state_has_a_gb_status_mapping():
+    """Keep the two tables in step: every ACTIVE LSF state maps to a gb status."""
+    active = {s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.ACTIVE}
+    assert set(LSF_ACTIVE_STATE_TO_GB_STATUS) == active
+    # Only RUN is RUNNING; everything else that isn't finished is PENDING.
+    assert LSF_ACTIVE_STATE_TO_GB_STATUS["RUN"] is Status.RUNNING
+    assert {
+        s for s, v in LSF_ACTIVE_STATE_TO_GB_STATUS.items() if v is Status.PENDING
+    } == (active - {"RUN"})
 
 
 def test_lsf_state_class_table_is_locked():

--- a/test/unit/monitoring/test_lsf_bsub_monitor.py
+++ b/test/unit/monitoring/test_lsf_bsub_monitor.py
@@ -1,0 +1,591 @@
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""State-machine tests for LSFBsubMonitor.
+
+These drive a real ``LSFBsubMonitor`` against a scripted sequence of ``bjobs``
+JSON responses (the same harness idiom as
+``test/unit/monitoring/test_log_draining.py``), which lets us replay LSF states
+that are awkward or impossible to produce on demand against a real cluster.
+
+Every test goes through :func:`_drive`, which bounds the monitor with
+``asyncio.wait_for``. That is deliberate: the monitor's poll loop wraps its whole
+body in ``except Exception: continue``, so a classification bug becomes an
+*infinite loop* rather than an error. The bounded wait converts that into a
+deterministic failure -- and for the non-terminal states, "it keeps polling" is
+itself the assertion.
+"""
+
+import asyncio
+import contextlib
+import json
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gbserver.monitoring.lsf_bsub_monitor import (
+    LSF_STATE_CLASS,
+    BJobRecord,
+    LSFBsubMonitor,
+    LsfStateClass,
+)
+from gbserver.resilience.retry_handler import RetryHandler
+from gbserver.types.buildevent import (
+    BuildEvent,
+    BuildEventMessagePayload,
+    BuildEventType,
+    EntityRunMetadata,
+)
+
+# Short intervals keep the suite fast; the grace period is patched per test.
+MONITOR_INTERVAL = 0.02
+GRACE = 0.02
+# Generous enough to absorb scheduler jitter, small enough to fail fast.
+TERMINATE_BUDGET = 3.0
+NON_TERMINAL_BUDGET = 0.4
+
+
+def _bjobs_json(
+    stat: str,
+    exit_code: str = "",
+    exit_reason: str = "",
+    pend_reason: str = "",
+    jobid: str = "12345",
+) -> str:
+    """One ``bjobs -o ... -json`` response carrying a single record."""
+    return json.dumps(
+        {
+            "COMMAND": "bjobs",
+            "JOBS": 1,
+            "RECORDS": [
+                {
+                    "JOBID": jobid,
+                    "STAT": stat,
+                    "EXIT_CODE": exit_code,
+                    "EXIT_REASON": exit_reason,
+                    "PEND_REASON": pend_reason,
+                }
+            ],
+        }
+    )
+
+
+def _make_monitor(
+    responses: List[str],
+    *,
+    stop_event: Optional[asyncio.Event] = None,
+    job_id: str = "12345",
+):
+    """Build a monitor over a scripted bjobs sequence.
+
+    The last response repeats forever (same clamping idiom as
+    ``test_log_draining.py``), so a monitor that never terminates keeps seeing a
+    consistent state rather than an IndexError.
+    """
+    mock_lsf = MagicMock()
+    mock_lsf.use_ssh = True
+    # Must be a real str: on the failure path the monitor does
+    # Path(log_path).parent, and Path(MagicMock()) raises TypeError *outside*
+    # the try block, which would escape monitor() instead of being swallowed.
+    mock_lsf.get_log_path.return_value = "/tmp/gbtest-lsf/job.log"
+
+    commands: List[str] = []
+
+    async def run_remote(command, raise_on_error=True):  # noqa: ANN001
+        commands.append(command)
+        return 0, responses[min(len(commands) - 1, len(responses) - 1)], ""
+
+    tunnel = AsyncMock()
+    tunnel.run_remote = run_remote
+    mock_lsf.get_ssh_tunnel.return_value = tunnel
+
+    queue: asyncio.Queue = asyncio.Queue()
+    monitor = LSFBsubMonitor(
+        lsf=mock_lsf,
+        job_id=job_id,
+        launch_id="test-launch",
+        event_queue=queue,
+        stop_event=stop_event,
+        monitor_interval=MONITOR_INTERVAL,
+    )
+    # Never let a test reach out to a cluster for the transient-error probe.
+    monitor._check_for_transient_lsf_error = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    return monitor, queue, commands
+
+
+async def _drive(monitor: LSFBsubMonitor, *, expect_terminates: bool) -> None:
+    """Run the monitor under a bounded wait.
+
+    ``expect_terminates=False`` asserts the monitor is still polling when the
+    budget expires -- i.e. it correctly treated the state as non-terminal.
+    """
+    task = asyncio.create_task(monitor.monitor())
+    if expect_terminates:
+        try:
+            await asyncio.wait_for(task, timeout=TERMINATE_BUDGET)
+        except asyncio.TimeoutError:  # pragma: no cover - failure path
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            pytest.fail(
+                "monitor did not terminate: a terminal LSF state was treated as "
+                "non-terminal (or the poll loop is stuck swallowing an exception)"
+            )
+    else:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=NON_TERMINAL_BUDGET)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+def _msgs(queue: asyncio.Queue) -> List[str]:
+    """Drain the queue to a list of event message strings."""
+    out = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        out.append(getattr(event.payload, "msg", "") or "")
+    return out
+
+
+def _as_message_event(msg: str) -> BuildEvent:
+    """Wrap a message string in a real MESSAGE_EVENT."""
+    return BuildEvent(
+        run_metadata=EntityRunMetadata(),
+        type=BuildEventType.MESSAGE_EVENT,
+        payload=BuildEventMessagePayload(level="ERROR", msg=msg),
+    )
+
+
+def _is_build_failing(event: BuildEvent) -> bool:
+    """Ask the real RetryHandler whether this event fails the build.
+
+    Called unbound with a dummy ``self``: the method only touches ``self`` for a
+    log line. Reusing the real predicate rather than reimplementing its regex
+    keeps these tests honest if that logic changes.
+    """
+    return bool(RetryHandler._is_terminal_failure_event(MagicMock(), event))
+
+
+def _has_terminal_failure(msgs: List[str]) -> bool:
+    """True if any message would make RetryHandler fail the build."""
+    return any(_is_build_failing(_as_message_event(msg)) for msg in msgs)
+
+
+@pytest.fixture(autouse=True)
+def _fast_grace():
+    with patch(
+        "gbserver.monitoring.lsf_bsub_monitor.GBSERVER_MONITORING_GRACE_PERIOD", GRACE
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Case L -- the hang trap. Keep this first.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_bjobs_payload_without_pend_reason_still_parses():
+    """A bjobs record with no PEND_REASON key must remain valid.
+
+    These are the exact byte strings used by
+    ``test/unit/monitoring/test_log_draining.py`` (see its ``bjobs_responses``).
+    If PEND_REASON were a *required* field, validation would raise, the poll
+    loop's ``except Exception: continue`` would swallow it, and the monitor would
+    spin forever -- hanging that test (and CI) rather than failing it. Keep
+    every BJobRecord field defaulted.
+    """
+    legacy = [
+        '{"COMMAND": "bjobs", "JOBS": 1, "RECORDS": [{"JOBID": "12345", "STAT": "RUN", "EXIT_CODE": "", "EXIT_REASON": ""}]}',
+        '{"COMMAND": "bjobs", "JOBS": 1, "RECORDS": [{"JOBID": "12345", "STAT": "DONE", "EXIT_CODE": "0", "EXIT_REASON": ""}]}',
+    ]
+    monitor, queue, _ = _make_monitor(legacy)
+    await _drive(monitor, expect_terminates=True)
+    assert not _has_terminal_failure(_msgs(queue))
+
+
+# ---------------------------------------------------------------------------
+# Case C / D / E -- EXIT must fail, whatever EXIT_CODE says
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exit_with_empty_exit_code_fails_the_build():
+    """EXIT with a blank EXIT_CODE must FAIL, not succeed.
+
+    Regression guard for the measured bug: on BlueVela, 103,256 of 315,504 EXIT
+    jobs report EXIT_CODE="" (102,208 of them TERM_OWNER, i.e. killed). The old
+    ``int(record.EXIT_CODE or "0")`` scored every one of those as returncode 0,
+    so a third of genuinely failed LSF jobs were reported as successful builds.
+    """
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="")]
+    )
+    await _drive(monitor, expect_terminates=True)
+    assert _has_terminal_failure(_msgs(queue)), "EXIT with empty EXIT_CODE must fail"
+
+
+@pytest.mark.asyncio
+async def test_exit_with_dash_exit_code_fails_the_build():
+    """The ``-noheader`` table form renders unset as "-"; it must not crash int()."""
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="-")]
+    )
+    await _drive(monitor, expect_terminates=True)
+    assert _has_terminal_failure(_msgs(queue))
+
+
+@pytest.mark.asyncio
+async def test_exit_reason_is_surfaced_in_the_failure_message():
+    """EXIT_REASON has always been fetched and never read -- surface it.
+
+    It is the only field distinguishing TERM_MEMLIMIT / TERM_RUNLIMIT /
+    TERM_OWNER / TERM_ADMIN, i.e. "ask for more memory" from "ask for more time"
+    from "someone killed it".
+    """
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("RUN"),
+            _bjobs_json(
+                "EXIT",
+                exit_code="137",
+                exit_reason="TERM_MEMLIMIT: job killed after reaching LSF memory usage limit",
+            ),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert _has_terminal_failure(msgs)
+    joined = "\n".join(msgs)
+    assert "137" in joined
+    assert "TERM_MEMLIMIT" in joined
+
+
+# ---------------------------------------------------------------------------
+# Case F / G -- suspended and unknown states are NOT terminal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stat", ["PSUSP", "SSUSP", "USUSP", "UNKWN", "WAIT", "PROV", "FWD_PEND"]
+)
+async def test_non_terminal_states_keep_polling(stat):
+    """A suspended/queued/unknown job has not finished -- keep monitoring.
+
+    Regression guard for the measured bug: these states all carry EXIT_CODE="",
+    so treating them as terminal made ``int("" or "0")`` == 0 and reported a
+    live job as a SUCCESSFUL build. Verified against a real cluster: a job
+    bstop'd 8 seconds into a 180-second workload produced a green build.
+    """
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN"), _bjobs_json(stat)])
+    await _drive(monitor, expect_terminates=False)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs), f"{stat} must not fail the build"
+    assert any(stat in m for m in msgs), f"{stat} should be surfaced to the user"
+    monitor._check_for_transient_lsf_error.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_suspend_and_resume_round_trip_succeeds():
+    """RUN -> USUSP -> RUN -> DONE is a success, with one event per transition."""
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("RUN"),
+            _bjobs_json("USUSP"),
+            _bjobs_json("USUSP"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs)
+    # 4 transitions, not 5 polls: the repeated USUSP must be deduped.
+    assert len(msgs) == 4, msgs
+
+
+# ---------------------------------------------------------------------------
+# Case H / I / J -- PEND reason surfacing, on change only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pend_reason_is_emitted_once_per_distinct_reason():
+    """The user must be able to find out WHY a job is pending -- without spam."""
+    reason_a = "Job's requirements for resource reservation not satisfied (Resource: ngpus_physical): 340 hosts;"
+    reason_b = "Not enough job slot(s): ;"
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND", pend_reason=reason_a),
+            _bjobs_json("PEND", pend_reason=reason_a),
+            _bjobs_json("PEND", pend_reason=reason_a),
+            _bjobs_json("PEND", pend_reason=reason_b),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert any("ngpus_physical" in m for m in msgs), msgs
+    assert any("Not enough job slot" in m for m in msgs), msgs
+    # PEND(a), PEND(b), RUN, DONE -- reason A emitted once despite three polls.
+    assert len(msgs) == 4, msgs
+
+
+@pytest.mark.asyncio
+async def test_pend_reason_host_counter_churn_does_not_spam():
+    """LSF re-renders live counters ("340 hosts" -> "339 hosts") every cycle.
+
+    Comparing raw reason text would emit an event on every poll for a long PEND,
+    flooding the events table, the CLI history and the PR comment. Dedup must
+    compare a digit-normalized key while still displaying the raw reason.
+    """
+    tmpl = "Job's requirements for resource reservation not satisfied (Resource: ngpus_physical): {} hosts;"
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND", pend_reason=tmpl.format(340)),
+            _bjobs_json("PEND", pend_reason=tmpl.format(339)),
+            _bjobs_json("PEND", pend_reason=tmpl.format(12)),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    # PEND (once), RUN, DONE -- the counter churn must not add events.
+    assert len(msgs) == 3, msgs
+
+
+@pytest.mark.asyncio
+async def test_reason_only_change_does_not_render_a_self_transition():
+    """A reason-only change must not read as "PEND -> PEND".
+
+    Observed on a real cluster: LSF reports "New job is waiting for scheduling"
+    and then replaces it with the real blocker, e.g. "Job has a specified start
+    time". The state never moved, so an arrow would look like a bug.
+    """
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND", pend_reason="New job is waiting for scheduling;"),
+            _bjobs_json("PEND", pend_reason="Job has a specified start time;"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    pend_msgs = [m for m in msgs if "start time" in m]
+    assert pend_msgs, msgs
+    assert "PEND -> PEND" not in pend_msgs[0], pend_msgs[0]
+    assert "is PEND" in pend_msgs[0], pend_msgs[0]
+    # A genuine transition still gets an arrow.
+    assert any("PEND -> RUN" in m for m in msgs), msgs
+
+
+@pytest.mark.asyncio
+async def test_pend_reason_appearing_later_is_emitted():
+    """LSF often reports PEND with no reason first, then fills it in."""
+    reason = "Job dependency condition not satisfied;"
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND"),
+            _bjobs_json("PEND"),
+            _bjobs_json("PEND", pend_reason=reason),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert any("dependency condition" in m for m in msgs), msgs
+    assert len(msgs) == 4, msgs
+
+
+# ---------------------------------------------------------------------------
+# Case A / K -- the terminal states
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pend_run_done_succeeds_with_one_event_per_transition():
+    monitor, queue, _ = _make_monitor(
+        [
+            _bjobs_json("PEND"),
+            _bjobs_json("RUN"),
+            _bjobs_json("RUN"),
+            _bjobs_json("DONE"),
+        ]
+    )
+    await _drive(monitor, expect_terminates=True)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs)
+    assert len(msgs) == 3, msgs  # PEND, RUN, DONE -- repeated RUN deduped
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stat,should_fail",
+    [("ZOMBI", True), ("POST_ERR", True), ("POST_DONE", False), ("DONE", False)],
+)
+async def test_terminal_states_map_to_the_right_verdict(stat, should_fail):
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN"), _bjobs_json(stat)])
+    await _drive(monitor, expect_terminates=True)
+    assert _has_terminal_failure(_msgs(queue)) is should_fail
+
+
+# ---------------------------------------------------------------------------
+# Case M -- unrecognized states fail safe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_state_is_non_terminal_and_warns(caplog):
+    """An unmodelled STAT must NOT be assumed terminal.
+
+    Defaulting unknown states to "terminal" is exactly how a suspended job
+    became a green build. Failing safe means the worst case is a visible hang
+    (loud, diagnosable) instead of a silent wrong SUCCESS (trusted).
+    """
+    monitor, queue, _ = _make_monitor([_bjobs_json("RUN"), _bjobs_json("FROBNICATE")])
+    with caplog.at_level("WARNING"):
+        await _drive(monitor, expect_terminates=False)
+    msgs = _msgs(queue)
+    assert not _has_terminal_failure(msgs)
+    assert any("FROBNICATE" in m for m in msgs), msgs
+    assert "unrecognized" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Case N / O -- the bkill/retry guard must not regress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_event_set_before_start_returns_cleanly():
+    """retry_workload sets the launch-stopped event *before* bkilling.
+
+    The monitor must then return without manufacturing a failure, or every
+    transient-error retry would turn into a hard build failure.
+    """
+    stop = asyncio.Event()
+    stop.set()
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="1")], stop_event=stop
+    )
+    await _drive(monitor, expect_terminates=True)
+    assert not _has_terminal_failure(_msgs(queue))
+    monitor._check_for_transient_lsf_error.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stop_event_set_during_terminal_poll_is_not_a_failure():
+    """The other retry branch: the bkill's own EXIT is observed after stop_event."""
+    stop = asyncio.Event()
+    monitor, queue, _ = _make_monitor(
+        [_bjobs_json("RUN"), _bjobs_json("EXIT", exit_code="1")], stop_event=stop
+    )
+
+    async def set_stop_soon():
+        await asyncio.sleep(MONITOR_INTERVAL * 1.5)
+        stop.set()
+
+    asyncio.create_task(set_stop_soon())
+    await _drive(monitor, expect_terminates=True)
+    assert not _has_terminal_failure(_msgs(queue))
+
+
+# ---------------------------------------------------------------------------
+# Case P / Q / R -- invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_change_events_can_never_fail_the_build():
+    """Informational state events must not trip the resilience layer.
+
+    ``RetryHandler._is_terminal_failure_event`` scrapes ```json blocks and fails
+    the build on ``state == "Failed"``. Locking this invariant means a future
+    reword of these messages cannot silently start failing or retrying builds.
+    """
+    from gbserver.resilience.strategies.lsf_transient_error import (
+        LsfTransientErrorRetryStrategy,
+    )
+
+    strategy = LsfTransientErrorRetryStrategy()
+    for stat in list(LSF_STATE_CLASS) + ["FROBNICATE"]:
+        state_class = LSF_STATE_CLASS.get(stat, LsfStateClass.ACTIVE)
+        if state_class is not LsfStateClass.ACTIVE:
+            continue  # terminal states legitimately do fail the build
+        monitor, queue, _ = _make_monitor([_bjobs_json(stat)])
+        record = BJobRecord(JOBID="1", STAT=stat, PEND_REASON="some reason;")
+        msg = monitor._format_lsf_state_change(record, state_class)
+        assert "```json" not in msg, f"{stat}: must not emit a fenced json block"
+        event = _as_message_event(msg)
+        assert _is_build_failing(event) is False, stat
+        assert bool(strategy.should_retry(event)) is False, stat
+
+
+def test_lsf_state_class_table_is_locked():
+    """Pin the agreed partition so any future edit is deliberate."""
+    active = {
+        "PEND",
+        "FWD_PEND",
+        "WAIT",
+        "PROV",
+        "RUN",
+        "PSUSP",
+        "SSUSP",
+        "USUSP",
+        "UNKWN",
+    }
+    succeeded = {"DONE", "POST_DONE"}
+    failed = {"EXIT", "ZOMBI", "POST_ERR"}
+    assert {
+        s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.ACTIVE
+    } == active
+    assert {
+        s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.SUCCEEDED
+    } == succeeded
+    assert {
+        s for s, c in LSF_STATE_CLASS.items() if c is LsfStateClass.FAILED
+    } == failed
+
+
+@pytest.mark.parametrize(
+    "exit_code,state_class,expected",
+    [
+        ("", LsfStateClass.FAILED, 1),
+        ("0", LsfStateClass.FAILED, 1),
+        ("-", LsfStateClass.FAILED, 1),
+        ("garbage", LsfStateClass.FAILED, 1),
+        ("137", LsfStateClass.FAILED, 137),
+        ("", LsfStateClass.SUCCEEDED, 0),
+        ("0", LsfStateClass.SUCCEEDED, 0),
+        ("137", LsfStateClass.SUCCEEDED, 0),
+    ],
+)
+def test_terminal_returncode(exit_code, state_class, expected):
+    """STAT decides pass/fail; EXIT_CODE only refines a failure's code."""
+    record = BJobRecord(JOBID="1", STAT="EXIT", EXIT_CODE=exit_code)
+    assert LSFBsubMonitor._terminal_returncode(record, state_class) == expected
+
+
+def test_bjobs_record_fields_are_all_optional():
+    """Every field defaulted -- see the module docstring on the hang trap."""
+    record = BJobRecord()
+    assert record.STAT == ""
+    assert record.PEND_REASON == ""

--- a/test/unit/resilience/test_retry_handler.py
+++ b/test/unit/resilience/test_retry_handler.py
@@ -615,3 +615,55 @@ class TestWorkloadStatusTerminalFailure:
         )
         assert retry_triggered is True
         assert handler.environment.retry_called is True
+
+
+class TestExhaustedRetriableIsTerminal:
+    """A retriable failure with no retries left is itself terminal.
+
+    Without this the handler would neither relaunch nor raise on such an event,
+    leaving a monitor's deferred wait (e.g. LSF's _retry_pending_after_monitor)
+    hanging forever. The event need not carry a terminal-shaped ```json block --
+    a plain MESSAGE_EVENT that a strategy recognizes is enough.
+    """
+
+    def _handler(self, max_retries: int, strategy: RetryStrategy) -> RetryHandler:
+        return RetryHandler(
+            launch_id="test-launch-123",
+            downstream_queue=asyncio.Queue(),
+            environment=MockEnvironment(),
+            max_retries=max_retries,
+            strategies=[strategy],
+        )
+
+    def test_is_retriable_event_reflects_strategy(self: Self) -> None:
+        """_is_retriable_event ignores retry_count -- it only asks the strategies."""
+        event = create_test_event("Cannot open your job file")
+        assert self._handler(0, AlwaysRetryStrategy())._is_retriable_event(event) is True
+        assert self._handler(0, NeverRetryStrategy())._is_retriable_event(event) is False
+
+    @pytest.mark.asyncio
+    async def test_retriable_but_exhausted_raises(self: Self) -> None:
+        """max_retries reached + a strategy would retry + no terminal json block
+        -> raise WorkloadFailedException instead of silently forwarding."""
+        handler = self._handler(0, AlwaysRetryStrategy())
+        await handler.get_wrapper_queue().put(create_test_event("transient error"))
+        with pytest.raises(WorkloadFailedException):
+            await asyncio.wait_for(handler.process_events(), timeout=5.0)
+        # The event is still forwarded downstream before the exception is raised.
+        assert handler.downstream_queue.qsize() == 1
+        assert handler.environment.retry_called is False
+
+    @pytest.mark.asyncio
+    async def test_non_retriable_non_terminal_does_not_raise(self: Self) -> None:
+        """A benign event no strategy recognizes must NOT raise when exhausted --
+        it is forwarded and the loop continues (guards against over-raising)."""
+        handler = self._handler(0, NeverRetryStrategy())
+        await handler.get_wrapper_queue().put(create_test_event("just a log line"))
+        processor_task = asyncio.create_task(handler.process_events())
+        for _ in range(100):
+            if handler.downstream_queue.qsize() >= 1:
+                break
+            await asyncio.sleep(0.01)
+        handler.stop()
+        await processor_task  # completes without raising
+        assert handler.downstream_queue.qsize() == 1

--- a/test/unit/resilience/test_retry_handler.py
+++ b/test/unit/resilience/test_retry_handler.py
@@ -638,8 +638,12 @@ class TestExhaustedRetriableIsTerminal:
     def test_is_retriable_event_reflects_strategy(self: Self) -> None:
         """_is_retriable_event ignores retry_count -- it only asks the strategies."""
         event = create_test_event("Cannot open your job file")
-        assert self._handler(0, AlwaysRetryStrategy())._is_retriable_event(event) is True
-        assert self._handler(0, NeverRetryStrategy())._is_retriable_event(event) is False
+        assert (
+            self._handler(0, AlwaysRetryStrategy())._is_retriable_event(event) is True
+        )
+        assert (
+            self._handler(0, NeverRetryStrategy())._is_retriable_event(event) is False
+        )
 
     @pytest.mark.asyncio
     async def test_retriable_but_exhausted_raises(self: Self) -> None:

--- a/test/unit/utils/test_launch.py
+++ b/test/unit/utils/test_launch.py
@@ -87,8 +87,9 @@ async def test_retry_recovers_after_connection_closed():
     ok = _mock_process(returncode=0, stderr="")
 
     # Skip tenacity's exponential backoff so the test runs instantly.
-    with patch("asyncio.create_subprocess_exec", side_effect=[fail, ok]) as exec_mock, patch(
-        "asyncio.sleep", new=AsyncMock()
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=[fail, ok]) as exec_mock,
+        patch("asyncio.sleep", new=AsyncMock()),
     ):
         process, _stdout, _stderr = await launch_command_and_retry_or_raise_errors(
             command_list=["scp", "-r", "src", "host:dest"],

--- a/test/unit/utils/test_launch.py
+++ b/test/unit/utils/test_launch.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for command launching and connection-closed retry classification."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gbserver.types.errors import ErrConnectionClosed
+from gbserver.utils.launch import (
+    launch_command_and_raise_errors,
+    launch_command_and_retry_or_raise_errors,
+)
+
+# The two dropped-connection stderr shapes seen from a failing scp over the
+# LSF login-node tunnel (real bluevela log11 lines).
+SCP_CONNECTION_CLOSED = "scp: Connection closed\n"
+REMOTE_CLOSED = "Connection to localhost closed by remote host.\n"
+
+
+class TestErrConnectionClosedMatcher:
+    """The narrow matcher recognizes dropped connections but not benign text."""
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [SCP_CONNECTION_CLOSED, REMOTE_CLOSED, SCP_CONNECTION_CLOSED.encode("utf-8")],
+    )
+    def test_matches_dropped_connection(self, stderr):
+        assert ErrConnectionClosed.matches_error_str(stderr) is True
+
+    @pytest.mark.parametrize(
+        "stderr",
+        ["some unrelated failure", "Warning: Permanently added host", ""],
+    )
+    def test_ignores_unrelated_stderr(self, stderr):
+        assert ErrConnectionClosed.matches_error_str(stderr) is False
+
+
+def _mock_process(returncode: int, stderr: str) -> AsyncMock:
+    """Build a mock subprocess whose communicate() yields the given stderr/rc.
+
+    Args:
+        returncode: Exit code the mock process reports.
+        stderr: stderr text the mock process emits (stdout is empty).
+
+    Returns:
+        AsyncMock: A stand-in for an asyncio subprocess.
+    """
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(b"", stderr.encode("utf-8")))
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_raise_errors_maps_connection_closed_to_retryable():
+    """A dropped-connection scp failure raises the retryable ErrConnectionClosed
+    rather than a bare, non-retryable ValueError."""
+    proc = _mock_process(returncode=1, stderr=SCP_CONNECTION_CLOSED)
+    with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with pytest.raises(ErrConnectionClosed):
+            await launch_command_and_raise_errors(
+                command_list=["scp", "-r", "src", "host:dest"],
+                launch_id="test-launch",
+            )
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_after_connection_closed():
+    """launch_command_and_retry_or_raise_errors retries a dropped connection and
+    succeeds once the transfer goes through."""
+    fail = _mock_process(returncode=1, stderr=REMOTE_CLOSED)
+    ok = _mock_process(returncode=0, stderr="")
+
+    # Skip tenacity's exponential backoff so the test runs instantly.
+    with patch("asyncio.create_subprocess_exec", side_effect=[fail, ok]) as exec_mock, patch(
+        "asyncio.sleep", new=AsyncMock()
+    ):
+        process, _stdout, _stderr = await launch_command_and_retry_or_raise_errors(
+            command_list=["scp", "-r", "src", "host:dest"],
+            launch_id="test-launch",
+        )
+
+    assert process.returncode == 0
+    assert exec_mock.call_count == 2  # failed once, retried, then succeeded


### PR DESCRIPTION
## Description

Based on branch from PR https://github.com/ibm-granite/granite.build/pull/248 and adds multiple LSF fixes.

This branch fixes a family of LSF/bsub orchestration bugs that caused builds to
report **false SUCCESS** (suspended/unknown jobs scored as done), **false
FAILURE** (deliberate `bkill` retries scored as terminal failures), **premature
success while a retry was still in flight** (orphaned relaunch → artifact stuck
`PENDING`), and **spurious failures from benign SSH drain noise**. It also
surfaces *why* a job is pending or why it failed in the event stream.

### Changes

#### 1. Explicit LSF state classification (`lsf_bsub_monitor.py`)
- Replaced the old negative allowlist (`if STAT not in ("PEND","RUN"): returncode = int(EXIT_CODE or 0)`)
  with an explicit `LSF_STATE_CLASS` table covering all 14 documented states.
  `STAT` now drives the pass/fail verdict; `EXIT_CODE` is supplementary detail only.
  - Fixes: suspended/unknown states (`PSUSP/SSUSP/USUSP/UNKWN`) were treated as
    terminal with `EXIT_CODE=""` → `int("" or "0")==0` → **green build while the
    job was still suspended**.
  - Fixes: `EXIT_CODE` cannot decide the verdict — it's empty on all `DONE` jobs
    and ~⅓ of `EXIT` jobs (mostly `TERM_OWNER` kills).
- Unrecognized states now classify as **non-terminal + warn** — fail safe
  (visible hang) rather than silent wrong SUCCESS.
- Surfaces `PEND_REASON` / `EXIT_REASON` as `MESSAGE_EVENT`s (on change only,
  deduped on a digit-collapsed key so live LSF counters don't spam an event every
  poll). No extra SSH round trip.

#### 2. Non-terminal state → correct build status (`buildrunner.py`)
- Only stamp `started_at` on the **first** transition into `RUNNING` (a job can
  re-enter `RUNNING` after being queued/suspended).
- Stamp `finished_at` only on a genuinely terminal status
  (`payload.status.is_finished()`), not merely "no longer `RUNNING`" — a
  `RUNNING → PENDING` transition was wrongly marking a live step finished.

#### 3. LSF retry races (`lsf.py`)
- **`stop_event.clear()` race:** `retry_workload` now intentionally leaves the
  launch stop-event **set** after `bkill` (LSF reflects the kill-induced `EXIT`
  seconds later); it's cleared instead at the top of the next monitor iteration,
  once the previous monitors have wound down. Prevents a deliberate `bkill` from
  being misreported as a terminal failure.
- **Retry-adjudication race (fixes the `PENDING` artifact flake):**
  `monitor_bsub_monitor` previously read `retry_complete_event.is_set()`
  synchronously right after `gather`, racing the out-of-band `RetryHandler`. When
  the failed attempt's log drained instantly, the monitor won the race and
  returned SUCCESS *before* the relaunch happened — orphaning the relaunched job
  so its `ARTIFACT_PUSHED_EVENT` never drained. New helper
  `_retry_pending_after_monitor` waits (`asyncio.wait(FIRST_COMPLETED)`) on the
  relaunch vs. the handler task before deciding: relaunch landed → keep
  monitoring the new job; handler gave up → return so `WorkloadFailedException`
  propagates. Backed by a new `LSFBsubMonitor.emitted_error_event` flag.

#### 4. Transport hardening (`ssh_file_stream.py`, `errors.py`, `launch.py`)
- SSH drain no longer raises `ConnectionError` on **benign** stderr
  (`No such file or directory` from a `job.log` a retry relaunch removed/
  recreated); only genuine SSH/remote errors raise. Added `-o LogLevel=ERROR` to
  suppress benign client warnings (e.g. "Permanently added … to known hosts")
  that were misclassified as drain failures.
- New `ErrConnectionClosed` (narrowly matched: `Connection closed` /
  `closed by remote host`) added to the retry set in
  `launch_command_and_retry_or_raise_errors`, so a mid-transfer `scp`/tunnel drop
  is retried rather than failing the build.

#### 5. Cleanup
- Dropped the byte-identical, unreferenced `BJobRecord` / `BJobOutput` copies from
  `lsf.py`.

### Tests
- `test/unit/monitoring/test_lsf_bsub_monitor.py` (new, 675 lines) — state
  classification, verdict, reason surfacing.
- `test/unit/environment/test_lsf_cleanup.py` — `cleanup_bsub` reporting/retry +
  `_retry_pending_after_monitor` race resolution.
- `test/unit/monitoring/test_log_draining.py` — two-phase drain +
  `emitted_error_event` paths.
- `test/unit/utils/test_launch.py` — `ErrConnectionClosed` classification/retry.

### Verification
- State mapping verified end-to-end against a real BlueVela cluster
  (LSF 10.1.0.15): a `bstop`'d job now reports `PENDING` with the pend reason in
  `status_msg`, `started_at` preserved, `finished_at` left null.
- The retry-race fix resolves the intermittent `stored artifact … is not marked
  as success, status is pending` flake: **4/4 passing** on the bluevela 1-step
  buildrunner test (the prior approach failed 1/4).
- `mypy` clean on the edited modules (only pre-existing unrelated stub errors
  remain).

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
