### PR TITLE
SkyPilot on AWS: named-profile creds + standalone tests & runbook

### DIFF
--- a/configurations/assets/environments/skypilot/aws/environment.yaml
+++ b/configurations/assets/environments/skypilot/aws/environment.yaml
@@ -14,6 +14,25 @@ config:
   retry:
     max_retries: 10
     delay_seconds: 1800
+  # AWS credentials materialized from the space secret manager into a NON-default
+  # profile in ~/.aws/credentials (avoids clobbering an existing [default]). The
+  # values are secret NAMES resolved by the space's secret_manager (local file
+  # store in standalone; server-managed in shared) — never literals.
+  aws_credentials:
+    - profile: gb-skypilot
+      aws_access_key_id: GB_AWS_ACCESS_KEY_ID
+      aws_secret_access_key: GB_AWS_SECRET_ACCESS_KEY
+  # Select that profile: deep-merged into ~/.sky/config.yaml so SkyPilot's boto3
+  # uses boto3.Session(profile_name='gb-skypilot'), which (being an explicit
+  # profile) also disables the AWS_* env-var provider. NOTE: `profile` is only a
+  # valid SkyPilot config key under workspaces.<name>.aws (not the global aws
+  # block) — the global form is rejected with "unsupported field 'profile'" and
+  # crashes the API server. 'default' is SkyPilot's default active workspace.
+  cloud_config:
+    workspaces:
+      default:
+        aws:
+          profile: gb-skypilot
 assetstores:
   - store_uri: space://assetstores/s3/
     pull:

--- a/docs/environments/skypilot-aws.md
+++ b/docs/environments/skypilot-aws.md
@@ -167,6 +167,11 @@ pytest -s -m extended --strict-markers \
   regenerated cleanly from `environment.yaml`.
 - **Collision safety.** Materialization refuses to overwrite an existing profile whose values
   differ; pick a name (e.g. `gb-skypilot`) you don't already have in `~/.aws/credentials`.
+- **Field names are exact; typos are silent.** `aws_credentials` entries are validated
+  permissively, so a misspelled key (e.g. `access_key_id` instead of `aws_access_key_id`) is
+  dropped rather than rejected and the value stays unset — surfacing later as a confusing
+  credential-resolution failure, not a config error. Use the field names exactly: `profile`,
+  `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`.
 - **Region is separate.** Placement comes from the launcher `resources.infra` (e.g. `aws/us-east-2`),
   not from this profile.
 

--- a/docs/environments/skypilot-aws.md
+++ b/docs/environments/skypilot-aws.md
@@ -50,6 +50,10 @@ config:
       # SkyPilot aws: settings, e.g. security groups, VPC, etc.
 ```
 
+> **Not here: `profile`.** Selecting a named AWS profile is *not* a valid key in this
+> global `aws:` block — SkyPilot rejects it with `Found unsupported field 'profile'` and the
+> API server fails to start. Profile selection is workspace-scoped; see the runbook below.
+
 ### Resources: instance type, spot, accelerators
 
 AWS-relevant launcher `resources` fields:
@@ -76,6 +80,95 @@ launchers:
 
 For cross-step state, point `shared_workdir` at a path backed by **EFS / FSx** mounted on every worker
 (e.g. `/mnt/efs`). See [skypilot.md](skypilot.md#shared_workdir).
+
+## Runbook: use a non-default AWS profile via the local secret store
+
+Use this when the gbserver host **already has a working `~/.aws/credentials` `[default]`** whose
+identity differs from the one you want SkyPilot to use. Materializing into `[default]` would raise
+`SkypilotConfigCollisionError`; instead materialize a **named** profile and select it. This keeps
+one `environment.yaml` usable in both standalone and shared deployments — only the secret backend
+differs (a local file here, a server-managed store in shared).
+
+### 1. Declare a named profile + select it in `environment.yaml`
+
+```yaml
+config:
+  default_cloud: aws
+  # Materialize a NON-default profile (values are secret NAMES, resolved by the
+  # space's secret_manager — never commit literals).
+  aws_credentials:
+    - profile: gb-skypilot
+      aws_access_key_id: GB_AWS_ACCESS_KEY_ID
+      aws_secret_access_key: GB_AWS_SECRET_ACCESS_KEY
+  # Select that profile. `profile` is ONLY valid under workspaces.<name>.aws —
+  # NOT the global aws: block (that form crashes the API server). `default` is
+  # SkyPilot's default active workspace.
+  cloud_config:
+    workspaces:
+      default:
+        aws:
+          profile: gb-skypilot
+```
+
+### 2. Seed the local secret store (standalone)
+
+With `secret_manager: type: local`, secrets are read from `$GB_HOME_DIR/space_secrets/` (default
+`~/.granite.build/space_secrets/`). Files may be `.json`/`.yaml`/`.env`; **values are base64-encoded**
+and looked up by exact name. Write a file whose keys match the secret names above:
+
+```bash
+mkdir -p ~/.granite.build/space_secrets
+python3 - <<'PY'
+import os, base64, json, pathlib
+d = pathlib.Path.home() / ".granite.build" / "space_secrets"; d.mkdir(parents=True, exist_ok=True)
+enc = lambda v: base64.b64encode(v.encode()).decode()
+p = d / "aws.json"
+p.write_text(json.dumps({
+    "GB_AWS_ACCESS_KEY_ID":     enc(os.environ["AWS_ACCESS_KEY_ID"]),
+    "GB_AWS_SECRET_ACCESS_KEY": enc(os.environ["AWS_SECRET_ACCESS_KEY"]),
+}, indent=2))
+p.chmod(0o600)
+PY
+```
+
+> The `env` secret manager (`type: env`) is an alternative: it reads `GBSERVER_SECRET_<NAME>`
+> env vars (prefixed, upper-cased) — note it does **not** read a bare `AWS_ACCESS_KEY_ID`.
+
+### 3. Verify cheaply (no EC2)
+
+Confirm the profile is materialized and actually used, **with the ambient AWS env vars unset** so a
+pass proves the profile — not your shell — supplied the credentials:
+
+```bash
+grep -A2 '^\[gb-skypilot\]' ~/.aws/credentials    # written by gbserver at launch
+sky api stop
+env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY sky check aws   # expect: AWS: enabled
+```
+
+### 4. Run the build standalone
+
+```bash
+export GB_ENVIRONMENT=STANDALONE GBTEST_MODE=live
+# e.g. the fixture test that provisions one t3.medium in us-east-2:
+pytest -s -m extended --strict-markers \
+  test/integration/ibm/buildrunner/skypilot/aws/test_1step_image.py
+```
+
+### How it works / gotchas
+
+- **Explicit profile wins over env vars.** `cloud_config.workspaces.default.aws.profile` makes
+  SkyPilot call `boto3.Session(profile_name=…)`, which (being an *explicit* profile) removes the env
+  provider from botocore's chain — so `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in the shell are
+  ignored while the profile is set.
+- **`profile` is workspace-scoped only.** The global `aws:` block rejects it
+  (`unsupported field 'profile'`) and the API server exits on startup.
+- **Stale `~/.sky/config.yaml`.** `cloud_config` is deep-merged, not replaced. If a bad global
+  `aws: {profile: …}` was written by an earlier attempt, delete `~/.sky/config.yaml` so it is
+  regenerated cleanly from `environment.yaml`.
+- **Collision safety.** Materialization refuses to overwrite an existing profile whose values
+  differ; pick a name (e.g. `gb-skypilot`) you don't already have in `~/.aws/credentials`.
+- **Region is separate.** Placement comes from the launcher `resources.infra` (e.g. `aws/us-east-2`),
+  not from this profile.
 
 ## Example `environment.yaml`
 

--- a/docs/secrets/local-secrets-manager.md
+++ b/docs/secrets/local-secrets-manager.md
@@ -168,3 +168,9 @@ Each secret supports the following fields:
 - Users may specify a directory or a direct file path for secrets.
 - First-time synchronization automatically populates the local secrets file when enabled.
 - Secrets are structured in a consistent, space-based hierarchy.
+
+## See also
+
+- [SkyPilot on AWS — runbook: non-default AWS profile via the local secret store](../environments/skypilot-aws.md#runbook-use-a-non-default-aws-profile-via-the-local-secret-store)
+  — a worked example that seeds this store and resolves the seeded names into a materialized
+  `~/.aws/credentials` profile.

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/1step-image/build.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/1step-image/build.yaml
@@ -1,0 +1,70 @@
+granite.build:
+  name: skypilot-aws-command-image
+  # Single command-step target on AWS EC2 (via SkyPilot) that runs the command
+  # INSIDE a container image. This is the AWS analog of the bluevela
+  # skypilot/bluevela/1step-image fixture: bluevela runs the image through LSF's
+  # enroot, whereas on AWS the skypilot command step renders image_id to
+  # "docker:<image>" and SkyPilot pulls/runs it with Docker on the EC2 instance.
+  # A public registry image (quay.io) is used so no registry auth
+  # (GBSERVER_SECRET_SKYPILOT_DOCKER_PASSWORD) is needed.
+  #
+  # env:// (env_local) I/O is a no-op: push/pull do nothing, so the artifact
+  # registration/binding works purely on the LLMB_ARTIFACT_PATH string and no
+  # real files need to exist on disk. This keeps the test free of HF/S3
+  # credentials while still driving the command step end-to-end — the simplest
+  # possible "does AWS+SkyPilot work" smoke test.
+  targets:
+    image-run:
+      environment_uri: space://environments/skypilot/aws
+      inputs:
+        # env:// input: pulled as a no-op. The path need not exist and its value
+        # isn't asserted; it just flows to the command as a binding.
+        env_input:
+          uri: "env:///tmp/gb-env-input.txt"
+      outputs:
+        # env:// output: registered inline from the LLMB_ARTIFACT marker the
+        # command emits below. `type` is required for env:// outputs.
+        env_output:
+          uri: "env://{{ binding.path }}"
+          type: fileset
+      steps:
+        - step_uri: space://steps/command
+          config:
+            # Fast completion detection for the test (base skypilot default 300s).
+            poll_interval_seconds: 5
+            command_config:
+              # Run the command INSIDE a container image (image_id: docker:<image>).
+              # On AWS this uses SkyPilot's Docker support on the EC2 instance (vs
+              # enroot on bluevela's LSF). IMPORTANT: SkyPilot runs its runtime
+              # setup INSIDE the container with apt-get, so the image MUST be
+              # Debian/Ubuntu-based. bluevela's quay.io/fedora/fedora-minimal image
+              # fails here with "apt-get: command not found" (rc 127) because
+              # enroot skips that apt setup but AWS Docker does not. ubuntu:22.04 is
+              # public and needs no auth; a fresh EC2 IP won't hit Docker Hub limits.
+              image: ubuntu:22.04
+              command: >-
+                echo "image-run target on AWS EC2 via SkyPilot (docker image)";
+                echo "env input path: {{ bindings.env_input.binding.path }}";
+                echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-aws-1step-image/{{ run_metadata.targetsteprun_id | short_hash }}/out"
+            # Unlike bluevela (whose LSF environment defines a single allowed
+            # cluster, so no resources are needed), AWS must size an EC2 instance.
+            # Pin an explicit small instance + region to keep the test cheap and
+            # deterministic — otherwise SkyPilot defaults to a large box (it chose
+            # m6i.2xlarge / 8 vCPU / 32 GiB) and the cheapest region for the type.
+            launcher_config:
+              resources:
+                # Region is parameterized: it comes from the space variable
+                # AWS_REGION and defaults to us-east-2 (the account/quota we're
+                # told to use). Override it by setting AWS_REGION in the space's
+                # `variables:` (configurations/spaces/local/space.yaml) — no need
+                # to edit this fixture. Encoded in `infra` as cloud/region because
+                # gbserver builds sky.Resources with an `infra` string, not a
+                # separate `region` kwarg.
+                infra: "aws/{{ space.variables.AWS_REGION | default('us-east-2') }}"
+                # t3.medium = 2 vCPU / 4 GiB (~$0.04/hr in us-east-2). SkyPilot
+                # installs its runtime (ray, etc.) INSIDE the ubuntu container via
+                # apt+pip, which needs more RAM than a bare echo — 2 GiB (t3.small)
+                # risks an OOM during the ray install. Smallest reliable size here.
+                instance_type: t3.medium
+                # Trim the default root volume to cut EBS cost.
+                disk_size: 40

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/1step-image/buildtest.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/1step-image/buildtest.yaml
@@ -1,0 +1,33 @@
+# YAML-driven spec for a future
+# test/integration/ibm/buildrunner/skypilot/aws/test_1step_image.py.
+# build_yaml defaults to ./build.yaml (sibling) when omitted.
+#
+# Single command-step target on AWS EC2 (via SkyPilot) that runs the command
+# inside a container image (Docker), with env:// no-op I/O. AWS analog of the
+# bluevela 1step-image fixture (which uses the enroot container path).
+targets:
+  - image-run
+target_expectations:
+  # step_count = 1: the env_local assetstore is a no-op (no pull/push steps are
+  # queued), so only the single `command` step is recorded. The env:// input and
+  # env:// output each add one artifact but launch no pull/push step; the env://
+  # output produces one jobstat.
+  - target_name: image-run
+    step_count: 1
+    input_artifact_count: 1
+    output_artifact_count: 1
+    jobstats_count: 1
+# Resolve space:// URIs (the aws environment + the shared `command` step) from
+# the repo's local space without cloning from GitHub. Relative to this YAML's
+# directory — same depth as the bluevela fixture, so the same relative path.
+space_uri: ../../../../../../../configurations/spaces/local
+# No simulated failure: the runner test exercises the happy path, and the
+# runner_cancellation test cancels a genuinely-running step (the EC2 provisioning
+# window keeps the build RUNNING long enough to catch).
+simulate_step_failure: false
+tests:
+  - runner
+  - runner_cancellation
+# AWS EC2 cold provisioning via SkyPilot (instance launch + Docker image pull) is
+# slower than bluevela's LSF path; give the single tiny command extra headroom.
+timeout_minutes: 30

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/2target/build.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/2target/build.yaml
@@ -1,0 +1,74 @@
+granite.build:
+  name: skypilot-aws-command-2target
+  # Two command-step targets on AWS EC2 (via SkyPilot), both running the generic
+  # `command` step BARE (no container image). `first` emits an output path and
+  # registers it as artifact `out1`; `second` binds `first.out1` as an input and
+  # echoes the bound path, then registers its own output `out2`. Exercises
+  # cross-target output -> input binding over the env_local (env://) assetstore.
+  #
+  # This is the AWS analog of skypilot/bluevela/2target: bluevela runs on LSF
+  # (a single `cluster: bluevela`), whereas AWS provisions a small EC2 instance
+  # per target. `second` depends on `first` (binding), so the two provision
+  # sequentially.
+  #
+  # env:// (env_local) I/O is a no-op: push/pull do nothing, so artifact
+  # registration/binding works purely on the LLMB_ARTIFACT_PATH string — no real
+  # files need to exist and no HF/S3 credentials are required.
+  targets:
+    first:
+      environment_uri: space://environments/skypilot/aws
+      outputs:
+        out1:
+          # env_local: the URI resolves to the path emitted via LLMB_ARTIFACT_PATH.
+          uri: "env://{{ binding.path }}"
+          # env_local pushes inline (no push step emits a type), so set it here.
+          type: fileset
+      steps:
+        - step_uri: space://steps/command
+          config:
+            # Fast completion detection for the test (base skypilot default 300s).
+            poll_interval_seconds: 5
+            command_config:
+              command: >-
+                echo "first target emitting out1 on AWS EC2 via SkyPilot";
+                echo "LLMB_ARTIFACT_ID:out1 LLMB_ARTIFACT_PATH:/tmp/gb-aws-2target/{{ run_metadata.targetsteprun_id | short_hash }}/out1"
+            # Unlike the sibling 1step-image fixture (which runs INSIDE an
+            # ubuntu:22.04 container and therefore needs t3.medium for the
+            # in-container ray install), this target runs the command BARE: no
+            # image_id, so SkyPilot installs its runtime on the VM directly and a
+            # small box suffices. Region is parameterized via the AWS_REGION space
+            # variable (default us-east-2), encoded in `infra` as cloud/region.
+            launcher_config:
+              resources:
+                infra: "aws/{{ space.variables.AWS_REGION | default('us-east-2') }}"
+                # t3.small = 2 vCPU / 2 GiB (~$0.02/hr in us-east-2): cheapest
+                # reliable size for a bare command; two targets each launch one.
+                instance_type: t3.small
+                # Trim the default root volume to cut EBS cost.
+                disk_size: 40
+    second:
+      environment_uri: space://environments/skypilot/aws
+      inputs:
+        from_first:
+          binding: first.out1
+      outputs:
+        out2:
+          uri: "env://{{ binding.path }}"
+          type: fileset
+      steps:
+        - step_uri: space://steps/command
+          config:
+            # Fast completion detection for the test (base skypilot default 300s).
+            poll_interval_seconds: 5
+            command_config:
+              # Echoes the path bound from first.out1 — proves the binding flows
+              # through gbserver without depending on a file existing on disk.
+              command: >-
+                echo "second target received first output path: {{ bindings.from_first.binding.path }}";
+                echo "LLMB_ARTIFACT_ID:out2 LLMB_ARTIFACT_PATH:/tmp/gb-aws-2target/{{ run_metadata.targetsteprun_id | short_hash }}/out2"
+            # Keep resources identical to target `first`.
+            launcher_config:
+              resources:
+                infra: "aws/{{ space.variables.AWS_REGION | default('us-east-2') }}"
+                instance_type: t3.small
+                disk_size: 40

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/2target/buildtest.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/2target/buildtest.yaml
@@ -1,0 +1,36 @@
+# YAML-driven spec for
+# test/integration/ibm/buildrunner/skypilot/aws/test_2target.py.
+# build_yaml defaults to ./build.yaml (sibling) when omitted.
+#
+# Two command-step targets on AWS EC2 (via SkyPilot). `second` binds `first`'s
+# output, proving cross-target output -> input binding over env_local. AWS analog
+# of the bluevela 2target fixture (which runs the same shape on LSF).
+targets:
+  - first
+  - second
+target_expectations:
+  # step_count = 1 per target: the env_local assetstore is a no-op (no pull/push
+  # steps are queued), so only the single `command` step is recorded. Each env://
+  # output adds one artifact but launches no push step and produces one jobstat;
+  # `second` also binds one input artifact.
+  - target_name: first
+    step_count: 1
+    input_artifact_count: 0
+    output_artifact_count: 1
+    jobstats_count: 1
+  - target_name: second
+    step_count: 1
+    input_artifact_count: 1
+    output_artifact_count: 1
+    jobstats_count: 1
+# Resolve space:// URIs (the aws environment + the shared `command` step) from the
+# repo's local space without cloning from GitHub. Relative to this YAML's
+# directory — same depth as the sibling 1step-image fixture, so the same path.
+space_uri: ../../../../../../../configurations/spaces/local
+# A happy-path binding test — no simulated failure, and skip the cancellation run.
+simulate_step_failure: false
+tests:
+  - runner
+# AWS EC2 cold provisioning via SkyPilot is slower than LSF, and `second` waits
+# for `first` (two sequential provisions), so give it generous headroom.
+timeout_minutes: 40

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/build.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/build.yaml
@@ -1,0 +1,63 @@
+granite.build:
+  name: skypilot-aws-filemount-test
+  # Single command-step target on AWS EC2 (via SkyPilot) that runs a custom step
+  # (space://steps/filemount-check) declaring a `file_mounts` key. The mount
+  # copies the `payload/` directory shipped next to the step's step.yaml onto the
+  # provisioned instance; the source is RELATIVE, so the SkyPilot launcher
+  # resolves it against the step.yaml's own directory (the per-run asset dir) —
+  # the behavior under test. The step's run command verifies the copy landed and
+  # fails the build if it did not. This is the AWS analog of the
+  # skypilot/bluevela/filemount fixture (which mounts through LSF's enroot).
+  #
+  # Runs BARE (empty command_config.image): file_mounts land in the VM run workdir
+  # (${GB_BUILD_WORKDIR}), which is the run command's CWD, so ./payload is
+  # reachable directly. (bluevela used an enroot container to also exercise
+  # in-container visibility; on AWS we test the core relative-source resolution on
+  # the bare VM, mirroring the aws/2target fixture.)
+  #
+  # env:// (env_local) I/O is a no-op: push/pull do nothing, so artifact
+  # registration/binding works purely on the LLMB_ARTIFACT_PATH string and no real
+  # files need to exist. Keeps the test HF/S3-credential-free and fast.
+  targets:
+    filemount:
+      environment_uri: space://environments/skypilot/aws
+      inputs:
+        # env:// input: pulled as a no-op. The path need not exist and its value
+        # isn't asserted; it just flows to the command as a binding.
+        env_input:
+          uri: "env:///tmp/gb-env-input.txt"
+      outputs:
+        # env:// output: registered inline from the LLMB_ARTIFACT marker the
+        # command emits below. `type` is required for env:// outputs; the path is
+        # arbitrary (env:// push/pull are no-ops) and just has to match the marker.
+        env_output:
+          uri: "env:///tmp/gb-aws-filemount/out.txt"
+          type: fileset
+      steps:
+        # Custom test step defined in the co-located test space (space/steps/).
+        # It declares a `file_mounts` key that copies the `payload/` directory
+        # shipped next to its step.yaml onto the instance, then (in its run)
+        # verifies the copy landed before running the command below.
+        - step_uri: space://steps/filemount-check
+          config:
+            # Fast completion detection for the test (base skypilot default 300s).
+            poll_interval_seconds: 5
+            command_config:
+              # Empty image => run BARE on the EC2 VM (no Docker). SkyPilot installs
+              # its runtime on the VM directly, so a small box suffices and there is
+              # no container indirection for the mounted payload.
+              image: ""
+              command: >-
+                echo "env input path: {{ bindings.env_input.binding.path }}";
+                echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-aws-filemount/out.txt"
+            # AWS must size an EC2 instance (unlike bluevela's single LSF cluster).
+            # Region is parameterized via the AWS_REGION space variable (default
+            # us-east-2), encoded in `infra` as cloud/region.
+            launcher_config:
+              resources:
+                infra: "aws/{{ space.variables.AWS_REGION | default('us-east-2') }}"
+                # t3.small = 2 vCPU / 2 GiB (~$0.02/hr in us-east-2): cheapest
+                # reliable size for a bare command.
+                instance_type: t3.small
+                # Trim the default root volume to cut EBS cost.
+                disk_size: 40

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/buildtest.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/buildtest.yaml
@@ -1,0 +1,30 @@
+# YAML-driven spec for
+# test/integration/ibm/buildrunner/skypilot/aws/test_filemount.py.
+# The target runs a custom step (space://steps/filemount-check) that copies a
+# directory shipped next to its step.yaml via file_mounts and verifies it is
+# present in the run command, on the AWS (SkyPilot) path. HF/S3-free (env:// in/
+# out) so it is fast and needs no credentials beyond AWS access.
+targets:
+  - filemount
+target_expectations:
+  - target_name: filemount
+    # Just the one custom step runs: the env:// input/output are no-ops (one input
+    # + one output artifact each, no extra pull/push step), and the file_mounts
+    # copy adds no step.
+    step_count: 1
+    input_artifact_count: 1
+    output_artifact_count: 1
+    jobstats_count: 1
+# Co-located test space (space/ next to this file) — carries the custom
+# filemount-check step and chains to configurations/assets for everything else.
+space_uri: space
+# Run only the basic build (skip the cancellation variant) — this test verifies
+# file_mounts, not cancel/retry behavior (covered by the aws/1step-image test).
+tests:
+  - runner
+# A single clean run with no injected synthetic failure: the step's run command
+# fails the build if the mounted dir is absent, so SUCCESS proves the mount.
+simulate_step_failure: false
+# AWS EC2 cold provisioning via SkyPilot is slower than a local cluster; give the
+# single tiny step generous headroom.
+timeout_minutes: 30

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/space.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/space.yaml
@@ -1,0 +1,19 @@
+# Test-local space for the SkyPilot-on-AWS file_mounts build test.
+#
+# Mirrors configurations/spaces/local so environments, assetstores, and builtin
+# steps resolve from the shared assets directory — but ALSO carries the
+# test-specific `steps/filemount-check` step in its own tree. The space's own
+# directory is the first base_uri (see build/space.py), so
+# `space://steps/filemount-check` resolves here; everything else falls through to
+# configurations/assets.
+name: filemount-aws-test
+secret_manager:
+  type: local
+  config: {}
+base_uris:
+  # Pull assetstores, environments, and (builtin) steps from configurations/assets/.
+  # Relative path resolves against this space.yaml's directory. Eight `..`: the
+  # aws test tree sits at the same depth as the bluevela one.
+  - file://../../../../../../../../configurations/assets
+variables:
+  DEFAULT_ENVIRONMENT: skypilot/aws

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/payload/marker.txt
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/payload/marker.txt
@@ -1,0 +1,3 @@
+gb-filemount-check payload: this directory ships next to step.yaml and is
+copied to the instance via the step's file_mounts key (relative source resolved
+against the step.yaml directory).

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/step.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/step.yaml
@@ -1,0 +1,51 @@
+name: filemount-check
+version: 1.0.0
+type: exec
+config:
+  command_config:
+    command: ""    # command to run on the launcher node
+    image: ""      # optional docker image; empty => run on the bare launcher node
+
+environment_configs:
+  Skypilot:
+    default_launcher: filemount-check
+    launchers:
+      filemount-check:
+        type: skypilot
+        monitors:
+          - skypilot_monitor
+        config:
+          # image_id follows command_config.image, mirroring the builtin `command`
+          # step: a non-empty image would run via Docker on the EC2 instance, an
+          # empty one runs on the bare VM. This AWS fixture uses an EMPTY image, so
+          # file_mounts land in the VM run workdir and are reachable directly by the
+          # run command's CWD (no container indirection).
+          image_id: '{{ ("docker:" ~ config.command_config.image) if config.command_config.image else "" }}'
+          resources: {}
+          # Copy the `payload/` directory that ships next to THIS step.yaml onto the
+          # instance. The source is relative, so the SkyPilot launcher resolves it
+          # against the step.yaml's own directory (the per-run asset dir) — this is
+          # the behavior under test. The DESTINATION is also relative, which gbserver
+          # remaps under the per-run build workdir (${GB_BUILD_WORKDIR}). The run
+          # script's CWD is that same workdir, so the payload is reachable at exactly
+          # ./payload — the same step-relative path the source occupies on disk
+          # (relative in, relative out).
+          file_mounts:
+            payload: payload
+          run: |
+            set -euo pipefail
+            # Verify file_mounts copied the step-relative payload dir to the matching
+            # relative path in the run CWD (${GB_BUILD_WORKDIR}). `set -e` + `test`
+            # fail the step (=> build FAILED) if it is absent.
+            echo "verifying file_mounts copied the step-relative payload dir..."
+            test -d ./payload
+            test -f ./payload/marker.txt
+            echo "payload marker: $(cat ./payload/marker.txt)"
+            # Build-supplied command (emits the artifact markers, mirroring the
+            # builtin command step).
+            {{ config.command_config.command }}
+    monitors:
+      # Shipped monitor library (builtins/monitors/skypilot); inherits the
+      # LLMB_ARTIFACT convention and honors build.yaml's poll_interval_seconds.
+      skypilot_monitor:
+        ref: space://monitors/skypilot

--- a/test/integration/ibm/buildrunner/skypilot/aws/test_1step_image.py
+++ b/test/integration/ibm/buildrunner/skypilot/aws/test_1step_image.py
@@ -1,0 +1,78 @@
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Containerized command-step target on AWS EC2 (via SkyPilot).
+
+Runs a single ``command`` step whose ``command_config.image`` is set, so the
+command executes INSIDE a Docker container on the provisioned EC2 instance. This
+is the AWS analog of the sibling
+``test/integration/ibm/buildrunner/skypilot/bluevela/test_1step_image.py``:
+bluevela runs the image through LSF's enroot, whereas SkyPilot on AWS renders
+``image_id`` to ``docker:<image>`` and runs it with Docker on the VM.
+
+``env://`` (env_local) I/O is a no-op, so the test drives the command step
+end-to-end without HF/S3 credentials — the simplest "does AWS + SkyPilot work"
+smoke test.
+
+Unlike the bluevela sibling, this test is intentionally NOT marked ``ibm``: it
+needs AWS credentials + SkyPilot, not the IBM cloud secret bundle that the
+``ibm`` marker's ``check_cloud_config()`` gate enforces (Lakehouse token, IBM
+Cloud API key, GitHub token, image tags). It is gated instead on AWS credentials
+being present, so it auto-skips in CI and on machines without AWS access.
+
+Prerequisites to actually run (locally, in the extended suite):
+  1. AWS credentials configured (env vars or ``~/.aws/credentials``).
+  2. SkyPilot installed and ``sky check aws`` passing.
+  3. quay.io reachable from the launched instance (public image, no auth).
+
+The fixture's build.yaml and buildtest.yaml live in the directory returned by
+``_get_yaml_spec_dir`` below.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractYamlBuildRunnerTest,
+    get_test_data_dir_for,
+)
+from libgbtest.constants import extended_testing_only
+
+
+def _aws_credentials_available() -> bool:
+    """True if AWS credentials look configured (env vars or ~/.aws/credentials)."""
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    return (Path.home() / ".aws" / "credentials").is_file()
+
+
+# Real-infra build test (SkyPilot provisions an EC2 instance) — only run in the
+# extended suite (make extended-tests), not the fast quick-tests suite. Its own
+# xdist group serializes concurrent AWS provisions so they don't race on
+# SkyPilot's local state.
+@extended_testing_only
+@pytest.mark.xdist_group(name="buildtest_aws")
+@pytest.mark.skipif(
+    not _aws_credentials_available(),
+    reason="AWS credentials not configured (set AWS_ACCESS_KEY_ID/"
+    "AWS_SECRET_ACCESS_KEY or provide ~/.aws/credentials); SkyPilot cannot "
+    "provision an EC2 instance. Also requires `sky check aws` to pass.",
+)
+class TestSkypilotAws1StepImage(AbstractYamlBuildRunnerTest):
+    """Single command step running inside a Docker image on AWS EC2 via SkyPilot."""
+
+    def _get_yaml_spec_dir(self) -> Path:
+        """Return the fixture dir holding this test's build.yaml and buildtest.yaml."""
+        return get_test_data_dir_for(__file__) / "1step-image"

--- a/test/integration/ibm/buildrunner/skypilot/aws/test_2target.py
+++ b/test/integration/ibm/buildrunner/skypilot/aws/test_2target.py
@@ -1,0 +1,77 @@
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two command-step targets on AWS EC2 (via SkyPilot), with cross-target binding.
+
+`first` runs the generic `command` step to emit an output path and register it as
+artifact `out1`; `second` binds `first.out1` as an input, echoes the bound path,
+and registers its own output `out2`. This exercises cross-target output -> input
+binding over the env_local (env://) assetstore. It is the AWS analog of the
+sibling ``test/integration/ibm/buildrunner/skypilot/bluevela/test_2target.py``:
+bluevela runs on LSF, whereas SkyPilot on AWS provisions a small EC2 instance per
+target (bare command, no container).
+
+``env://`` (env_local) I/O is a no-op, so the test drives both command steps
+end-to-end without HF/S3 credentials.
+
+Like the sibling aws/1step-image test, this is intentionally NOT marked ``ibm``:
+it needs AWS credentials + SkyPilot, not the IBM cloud secret bundle that the
+``ibm`` marker's ``check_cloud_config()`` gate enforces. It is gated instead on
+AWS credentials being present, so it auto-skips in CI and on machines without AWS
+access.
+
+Prerequisites to actually run (locally, in the extended suite):
+  1. AWS credentials configured (env vars or ``~/.aws/credentials``).
+  2. SkyPilot installed and ``sky check aws`` passing.
+
+The fixture's build.yaml and buildtest.yaml live in the directory returned by
+``_get_yaml_spec_dir`` below.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractYamlBuildRunnerTest,
+    get_test_data_dir_for,
+)
+from libgbtest.constants import extended_testing_only
+
+
+def _aws_credentials_available() -> bool:
+    """True if AWS credentials look configured (env vars or ~/.aws/credentials)."""
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    return (Path.home() / ".aws" / "credentials").is_file()
+
+
+# Real-infra build test (SkyPilot provisions EC2 instances) — only run in the
+# extended suite (make extended-tests), not the fast quick-tests suite. Shares the
+# same xdist group as the sibling AWS test so concurrent AWS provisions don't race
+# on SkyPilot's local state.
+@extended_testing_only
+@pytest.mark.xdist_group(name="buildtest_aws")
+@pytest.mark.skipif(
+    not _aws_credentials_available(),
+    reason="AWS credentials not configured (set AWS_ACCESS_KEY_ID/"
+    "AWS_SECRET_ACCESS_KEY or provide ~/.aws/credentials); SkyPilot cannot "
+    "provision an EC2 instance. Also requires `sky check aws` to pass.",
+)
+class TestSkypilotAws2Target(AbstractYamlBuildRunnerTest):
+    """Two command-step targets on AWS EC2 via SkyPilot; target 2 binds target 1's output."""
+
+    def _get_yaml_spec_dir(self) -> Path:
+        """Return the fixture dir holding this test's build.yaml and buildtest.yaml."""
+        return get_test_data_dir_for(__file__) / "2target"

--- a/test/integration/ibm/buildrunner/skypilot/aws/test_filemount.py
+++ b/test/integration/ibm/buildrunner/skypilot/aws/test_filemount.py
@@ -1,0 +1,82 @@
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test: SkyPilot-on-AWS file_mounts copies a step-relative dir.
+
+The AWS analog of the sibling
+``test/integration/ibm/buildrunner/skypilot/bluevela/test_filemount.py``. The
+target runs a custom step (defined in a co-located test space) that declares a
+``file_mounts`` key copying the ``payload/`` directory shipped next to its
+``step.yaml`` onto the provisioned EC2 instance. The step's ``run`` command
+asserts the directory is present (failing the step, and thus the build, if it is
+missing), exercising the SkyPilot launcher's relative-source resolution against
+the step.yaml dir on the AWS path.
+
+Runs BARE (empty ``command_config.image``): file_mounts land in the VM run
+workdir (``${GB_BUILD_WORKDIR}``), which is the run command's CWD, so
+``./payload`` is reachable directly — no container indirection (bluevela used
+enroot to also exercise in-container visibility).
+
+``env://`` (env_local) I/O is a no-op, so the test drives the step end-to-end
+without HF/S3 credentials.
+
+Like the sibling aws build tests, this is intentionally NOT marked ``ibm``: it
+needs AWS credentials + SkyPilot, not the IBM cloud secret bundle that the
+``ibm`` marker's ``check_cloud_config()`` gate enforces. It is gated instead on
+AWS credentials being present, so it auto-skips in CI and on machines without AWS
+access.
+
+Prerequisites to actually run (locally, in the extended suite):
+  1. AWS credentials configured (env vars or ``~/.aws/credentials``).
+  2. SkyPilot installed and ``sky check aws`` passing.
+
+The fixture's build.yaml, buildtest.yaml, and test space live in the directory
+returned by ``_get_yaml_spec_dir`` below.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractYamlBuildRunnerTest,
+    get_test_data_dir_for,
+)
+from libgbtest.constants import extended_testing_only
+
+
+def _aws_credentials_available() -> bool:
+    """True if AWS credentials look configured (env vars or ~/.aws/credentials)."""
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    return (Path.home() / ".aws" / "credentials").is_file()
+
+
+# Real-infra build test (SkyPilot provisions an EC2 instance) — only run in the
+# extended suite (make extended-tests). Shares the same xdist group as the other
+# AWS tests so concurrent AWS provisions don't race on SkyPilot's local state.
+@extended_testing_only
+@pytest.mark.xdist_group(name="buildtest_aws")
+@pytest.mark.skipif(
+    not _aws_credentials_available(),
+    reason="AWS credentials not configured (set AWS_ACCESS_KEY_ID/"
+    "AWS_SECRET_ACCESS_KEY or provide ~/.aws/credentials); SkyPilot cannot "
+    "provision an EC2 instance. Also requires `sky check aws` to pass.",
+)
+class TestSkypilotAwsFileMount(AbstractYamlBuildRunnerTest):
+    """Custom step copies a step-relative dir via file_mounts on AWS EC2."""
+
+    def _get_yaml_spec_dir(self) -> Path:
+        """Return the fixture dir holding this test's build.yaml and buildtest.yaml."""
+        return get_test_data_dir_for(__file__) / "filemount"


### PR DESCRIPTION
## Summary

Unifies a single `skypilot/aws` `environment.yaml` for both **standalone** and **shared** deployments, and adds standalone SkyPilot-on-AWS build tests that exercise it.

**Problem.** The `skypilot/aws` environment relied on SkyPilot's ambient boto3 credential chain (env vars / `~/.aws/credentials`). That works from a developer's terminal but isn't portable to a shared gbserver, and on a host that already has a *different* `~/.aws/credentials` `[default]`, materializing into `[default]` would raise `SkypilotConfigCollisionError`.

**Approach.** Source credentials from the space's `secret_manager` instead of the shell, using a **non-default** profile that both avoids the collision and is explicitly selected:
- `aws_credentials` materializes a `gb-skypilot` profile into `~/.aws/credentials` (values are secret *names*, resolved by the space secret manager — never literals).
- `cloud_config.workspaces.default.aws.profile: gb-skypilot` selects it, so SkyPilot uses `boto3.Session(profile_name=…)`.

The YAML is byte-identical across environments; only the secret *backend* differs — a local base64 file store (`type: local`) in standalone, a server-managed store in shared. Because an explicit profile removes the env-var provider from botocore's chain, credential resolution is deterministic and no longer depends on the launching shell.

**Key finding.** The profile selector must be **workspace-scoped**. A global `aws: {profile: …}` block is rejected by SkyPilot's config schema (`Found unsupported field 'profile'`) and crashes the API server on startup; `profile` is only valid under `workspaces.<name>.aws`.

**Changes.**
- `configurations/assets/environments/skypilot/aws/environment.yaml` — `aws_credentials` (`gb-skypilot`) + workspace-scoped `cloud_config` selector.
- `docs/environments/skypilot-aws.md` — runbook (env.yaml blocks, seeding the local secret store, `sky check aws` verification, credential-precedence/schema gotchas) + caveat on the invalid global `aws.profile`.
- `docs/secrets/local-secrets-manager.md` — cross-link to the runbook.
- `test/integration/ibm/buildrunner/skypilot/aws/test_1step_image.py` + fixtures — 1step-image build test (single containerized command step).
- `test/integration/ibm/buildrunner/skypilot/aws/test_2target.py` + fixtures — 2target build test (cross-target output→input binding; bare command on `t3.small`).
- `test/integration/ibm/buildrunner/skypilot/aws/test_filemount.py` + fixtures — filemount build test (custom step with step-relative `file_mounts`; bare command on `t3.small`).

All three tests are AWS analogs of the corresponding `skypilot/bluevela/*` fixtures — extended, credential-gated, and **not** `ibm`.

## Test plan

- [x] Seeded the local secret store; gbserver materialized the `[gb-skypilot]` profile into `~/.aws/credentials`.
- [x] `sky check aws` passed with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` **unset** — creds resolved via the profile, not the shell.
- [x] `1step-image` `test_runner` provisioned a `t3.medium` in `us-east-2` and tore it down cleanly (`1 passed`).
- [x] `1step-image` `test_runner_cancellation` cancelled mid-provision → build/target/step `CANCELLED` and the SkyPilot cluster was torn down (`1 passed`).
- [x] `2target` `test_runner` provisioned two `t3.small` sequentially; cross-target binding (`first.out1` → `second` input) verified; both clusters torn down (`1 passed, 1 skipped`).
- [x] `filemount` `test_runner` provisioned a `t3.small`; the custom step's `set -e` assertions confirmed the step-relative `file_mounts` payload landed in the run workdir; cluster torn down (`1 passed, 1 skipped`).
- [x] `sky status` shows no lingering clusters after every run.
- [x] Reviewer: `GB_ENVIRONMENT=STANDALONE GBTEST_MODE=live pytest -m extended test/integration/ibm/buildrunner/skypilot/aws/` with AWS creds configured.

Generated with [Claude Code](https://claude.com/claude-code)

