### PR TITLE
feat(api): derive files-env URI from public space by default

### DIFF
--- a/src/gbserver/api/environment_files_paths.py
+++ b/src/gbserver/api/environment_files_paths.py
@@ -102,9 +102,10 @@ class EnvironmentNotConfigured(HTTPException):
     """503 for a *known* environment that is unconfigured on this deployment.
 
     Distinct from ``AccessDenied``: reaching this means the ``{environment}`` is
-    supported (in the registry) but its ``environment_uri`` is unset, which is a
-    deployment-config problem — not something a caller can probe for, so it does
-    not need to hide behind the uniform 404.
+    supported (in the registry) but its ``environment_uri`` could not be derived
+    from the public space config on this deployment, which is a deployment-config
+    problem — not something a caller can probe for, so it does not need to hide
+    behind the uniform 404.
     """
 
     def __init__(self, environment: str) -> None:
@@ -120,16 +121,16 @@ def resolve_environment(environment: str) -> EnvironmentFilesConfig:
     Raises ``AccessDenied`` (the uniform 404) for any unsupported environment —
     identical to a missing folder, so the supported set can't be enumerated.
     Raises ``EnvironmentNotConfigured`` (503) for a supported environment whose
-    environment URI can be neither read (explicit override) nor derived (from the
-    public space config repo) on this deployment. Otherwise returns the
-    ``EnvironmentFilesConfig`` the handlers thread into tunnel + path resolution,
-    with ``environment_uri`` set to the resolved (override-or-derived) value.
+    environment URI can't be derived from the public space config repo on this
+    deployment. Otherwise returns the ``EnvironmentFilesConfig`` the handlers
+    thread into tunnel + path resolution, with ``environment_uri`` set to the
+    derived value.
     """
     config = ENVIRONMENT_FILES_REGISTRY.get(environment)
     if config is None:
         raise AccessDenied()
-    # There is one supported environment today, so its resolver is called
-    # directly. A second environment would generalize this to a per-entry
+    # bluevela is the only supported environment today, so its derivation is
+    # called directly. A second environment would generalize this to a per-entry
     # resolver; not abstracted prematurely.
     environment_uri = (
         get_supported_env_for_files_uri()

--- a/src/gbserver/api/environment_files_paths.py
+++ b/src/gbserver/api/environment_files_paths.py
@@ -52,6 +52,7 @@ SECURITY — this file is the access-control core of the environment-files API:
 
 import re
 import shlex
+from dataclasses import replace
 from pathlib import PurePosixPath
 from typing import List, Optional, Set
 
@@ -65,7 +66,9 @@ from gbserver.api.build_files_paths import (  # noqa: F401
 from gbserver.types.constants import (
     ENV_FILES_GETENT_BATCH_MAX,
     ENVIRONMENT_FILES_REGISTRY,
+    SUPPORTED_ENV_FOR_FILES,
     EnvironmentFilesConfig,
+    get_supported_env_for_files_uri,
 )
 from gbserver.utils.logger import get_logger
 
@@ -117,15 +120,25 @@ def resolve_environment(environment: str) -> EnvironmentFilesConfig:
     Raises ``AccessDenied`` (the uniform 404) for any unsupported environment —
     identical to a missing folder, so the supported set can't be enumerated.
     Raises ``EnvironmentNotConfigured`` (503) for a supported environment whose
-    ``environment_uri`` is unset on this deployment. Otherwise returns the
-    ``EnvironmentFilesConfig`` the handlers thread into tunnel + path resolution.
+    environment URI can be neither read (explicit override) nor derived (from the
+    public space config repo) on this deployment. Otherwise returns the
+    ``EnvironmentFilesConfig`` the handlers thread into tunnel + path resolution,
+    with ``environment_uri`` set to the resolved (override-or-derived) value.
     """
     config = ENVIRONMENT_FILES_REGISTRY.get(environment)
     if config is None:
         raise AccessDenied()
-    if not config.environment_uri:
+    # There is one supported environment today, so its resolver is called
+    # directly. A second environment would generalize this to a per-entry
+    # resolver; not abstracted prematurely.
+    environment_uri = (
+        get_supported_env_for_files_uri()
+        if environment == SUPPORTED_ENV_FOR_FILES
+        else config.environment_uri
+    )
+    if not environment_uri:
         raise EnvironmentNotConfigured(environment)
-    return config
+    return replace(config, environment_uri=environment_uri)
 
 
 def validate_folder_name(folder: str) -> str:

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -452,12 +452,17 @@ class EnvironmentFilesConfig:
         caller-supplied.
       * ``space_name`` — space whose IBM Cloud Secret Manager holds the service
         SSH key used to open the tunnel (server-resolved, never the requester).
-      * ``environment_uri`` — a ``space://…`` asset URI pointing at the LSF
-        ``environment.yaml`` whose login nodes mount ``gpfs_base``. This is the
-        one value that differs per deployment (dev/staging/prod) and cannot be
-        inferred from code; it MUST be set for the environment to function. An
-        empty value means "known environment, not configured for this
-        deployment" → the endpoints return 503 rather than guess.
+      * ``environment_uri`` — an OPTIONAL explicit override for the asset URI
+        pointing at the LSF ``environment.yaml`` whose login nodes mount
+        ``gpfs_base``. When empty (the default) the effective URI is derived from
+        the public space's config repo at request time (see
+        ``get_supported_env_for_files_uri``), yielding a
+        ``git+ssh://…@<config-branch>#subdirectory=environments/<env>`` asset URI
+        — so per-deployment (dev/staging/prod) differences come "for free" from
+        the public space config rather than a separately-set value. This field is
+        the override slot only; the endpoints resolve the effective URI via the
+        helper and return 503 only when neither an override nor a derivable
+        public space URI exists (rather than guess).
     """
 
     gpfs_base: str
@@ -475,21 +480,72 @@ class EnvironmentFilesConfig:
 # NOT a bare GB_ prefix.
 # GBSERVER_BLUEVELA_FILES_SPACE_NAME: defaults to the public space (literal
 #   "public"; the PUBLIC_SPACE_NAME constant is defined further down this file).
-# GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI: empty default → bluevela is a known
-#   environment but "not configured" on this deployment (503, not a guess).
+# GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI: an OPTIONAL explicit override for the
+#   supported environment's environment.yaml asset URI. Empty default → the URI
+#   is derived from the public space config repo at request time (see
+#   get_supported_env_for_files_uri below). 503 only when neither the override
+#   nor a derivable public space URI is available (e.g. STANDALONE), never a
+#   guess.
 ENV_VAR_GBSERVER_BLUEVELA_FILES_SPACE_NAME = (
     ENV_VAR_PREFIX + "_BLUEVELA_FILES_SPACE_NAME"
 )
 ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI = (
     ENV_VAR_PREFIX + "_BLUEVELA_FILES_ENVIRONMENT_URI"
 )
+
+# The single supported environment name for the files API. Used both as the
+# registry key and by the environment-URI derivation (the `environments/<name>`
+# subdirectory in the public space config repo). Only the value is "bluevela"
+# specific; the symbol is generic so a future supported env is a data change.
+SUPPORTED_ENV_FOR_FILES = "bluevela"
+
 ENVIRONMENT_FILES_REGISTRY: Dict[str, EnvironmentFilesConfig] = {
-    "bluevela": EnvironmentFilesConfig(
+    SUPPORTED_ENV_FOR_FILES: EnvironmentFilesConfig(
         gpfs_base="/proj",
         space_name=os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_SPACE_NAME, "public"),
+        # Holds only the explicit override (empty default). The effective URI is
+        # resolved lazily via get_supported_env_for_files_uri() so the derived
+        # value picks up the GitHub token / public-space config at request time.
         environment_uri=os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, ""),
     ),
 }
+
+
+def get_supported_env_for_files_uri() -> str:
+    """Resolve the supported environment's environment.yaml asset URI.
+
+    Returns the explicit ``GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI`` override
+    when set; otherwise derives it from the public space's config repo
+    (``PUBLIC_SPACE_GIT_URI``) by converting that ``https://…`` repo URL into the
+    ``git+ssh://…@<config-branch>#subdirectory=environments/<env>`` asset URI
+    the environment loader expects — the same conversion the build path uses
+    (``GitURI.get_gb_space_config_uri``). Returns ``""`` when there is nothing to
+    derive from (no override and no public space URI, e.g. STANDALONE), which the
+    caller turns into a 503.
+
+    Evaluated lazily (not at import): the ``GitURI`` import would otherwise cycle
+    (git.py imports GBSERVER_GITHUB_TOKEN from this module), and the ``@<branch>``
+    suffix is only appended when a GitHub token is present in the process env —
+    which may be set after import.
+    """
+    override = os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, "")
+    if override:
+        return override
+    if not PUBLIC_SPACE_GIT_URI:
+        return ""
+    # Function-local import: git.py imports from this module, so a top-level
+    # import here would be a cycle.
+    from gbcommon.uri.git import GitURI
+    from gbcommon.uri.uri import URI
+
+    base = GitURI.get_gb_space_config_uri(PUBLIC_SPACE_GIT_URI)
+    if not base:
+        return ""
+    # base ends with an empty "#subdirectory="; append_path fills it with the
+    # env's subdirectory (merging into the existing fragment, not adding a second).
+    uri = URI.get_uri(base)
+    uri.append_path(f"environments/{SUPPORTED_ENV_FOR_FILES}")
+    return str(uri)
 
 ENV_VAR_GBSERVER_DEFAULT_GH_REQUEST_TIMEOUT = (
     ENV_VAR_PREFIX + "_DEFAULT_GH_REQUEST_TIMEOUT"

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -452,22 +452,20 @@ class EnvironmentFilesConfig:
         caller-supplied.
       * ``space_name`` — space whose IBM Cloud Secret Manager holds the service
         SSH key used to open the tunnel (server-resolved, never the requester).
-      * ``environment_uri`` — an OPTIONAL explicit override for the asset URI
-        pointing at the LSF ``environment.yaml`` whose login nodes mount
-        ``gpfs_base``. When empty (the default) the effective URI is derived from
-        the public space's config repo at request time (see
-        ``get_supported_env_for_files_uri``), yielding a
-        ``git+ssh://…@<config-branch>#subdirectory=environments/<env>`` asset URI
-        — so per-deployment (dev/staging/prod) differences come "for free" from
-        the public space config rather than a separately-set value. This field is
-        the override slot only; the endpoints resolve the effective URI via the
-        helper and return 503 only when neither an override nor a derivable
-        public space URI exists (rather than guess).
+      * ``environment_uri`` — the asset URI pointing at the LSF
+        ``environment.yaml`` whose login nodes mount ``gpfs_base``. Registry
+        entries leave this empty: it is filled per request by
+        ``resolve_environment``, which derives it from the public space's config
+        repo (see ``get_supported_env_for_files_uri``), yielding a
+        ``git+ssh://…@<config-branch>#subdirectory=environments/<env>`` asset URI.
+        Per-deployment (dev/staging/prod) differences come "for free" from the
+        public space config, so there is no separately-set value; the endpoints
+        return 503 when the URI can't be derived (rather than guess).
     """
 
     gpfs_base: str
     space_name: str
-    environment_uri: str
+    environment_uri: str = ""
 
 
 # Registry of supported environments for the files API. Adding a new supported
@@ -475,22 +473,15 @@ class EnvironmentFilesConfig:
 # environment is `bluevela` (LSF login nodes mounting /proj), preserving the
 # behavior the API shipped with.
 #
-# The env vars carry the module-wide GBSERVER_ prefix (ENV_VAR_PREFIX), i.e.
-# GBSERVER_BLUEVELA_FILES_SPACE_NAME / GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI —
-# NOT a bare GB_ prefix.
-# GBSERVER_BLUEVELA_FILES_SPACE_NAME: defaults to the public space (literal
-#   "public"; the PUBLIC_SPACE_NAME constant is defined further down this file).
-# GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI: an OPTIONAL explicit override for the
-#   supported environment's environment.yaml asset URI. Empty default → the URI
-#   is derived from the public space config repo at request time (see
-#   get_supported_env_for_files_uri below). 503 when the URI can't be produced —
-#   no override and no derivable public space URI (e.g. STANDALONE), or the
-#   derivation's GitHub probe failing — never a guess.
+# GBSERVER_BLUEVELA_FILES_SPACE_NAME carries the module-wide GBSERVER_ prefix
+# (ENV_VAR_PREFIX) — NOT a bare GB_ prefix — and defaults to the public space
+# (literal "public"; the PUBLIC_SPACE_NAME constant is defined further down this
+# file). There is no environment-URI env var: the asset URI is always derived
+# from the public space config repo at request time (see
+# get_supported_env_for_files_uri below), so per-deployment differences come from
+# the public space config, not a separately-set value.
 ENV_VAR_GBSERVER_BLUEVELA_FILES_SPACE_NAME = (
     ENV_VAR_PREFIX + "_BLUEVELA_FILES_SPACE_NAME"
-)
-ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI = (
-    ENV_VAR_PREFIX + "_BLUEVELA_FILES_ENVIRONMENT_URI"
 )
 
 # The single supported environment name for the files API. Used both as the
@@ -503,10 +494,8 @@ ENVIRONMENT_FILES_REGISTRY: Dict[str, EnvironmentFilesConfig] = {
     SUPPORTED_ENV_FOR_FILES: EnvironmentFilesConfig(
         gpfs_base="/proj",
         space_name=os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_SPACE_NAME, "public"),
-        # Holds only the explicit override (empty default). The effective URI is
-        # resolved lazily via get_supported_env_for_files_uri() so the derived
-        # value picks up the GitHub token / public-space config at request time.
-        environment_uri=os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, ""),
+        # environment_uri is left empty here and filled per request by
+        # resolve_environment via get_supported_env_for_files_uri().
     ),
 }
 
@@ -516,27 +505,26 @@ ENVIRONMENT_FILES_REGISTRY: Dict[str, EnvironmentFilesConfig] = {
 # GitURI.get_gb_space_config_uri, which makes an uncached live GitHub call
 # (is_branch_present) when a token is set; resolve_environment is on the files-API
 # per-request access-control path, so we memoize to run that probe at most once
-# per (process, public-space URI) on success. The explicit override is never
-# cached (read live, short-circuits above), and failed/empty derivations are not
-# cached either — so a transient GitHub error doesn't stick.
+# per (process, public-space URI) on success. Failed/empty derivations are not
+# cached — so a transient GitHub error doesn't stick.
 _DERIVED_ENV_FOR_FILES_URI_CACHE: Dict[str, str] = {}
 
 
 def get_supported_env_for_files_uri() -> str:
-    """Resolve the supported environment's environment.yaml asset URI.
+    """Derive the supported environment's environment.yaml asset URI.
 
-    Returns the explicit ``GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI`` override
-    when set; otherwise derives it from the public space's config repo
-    (``PUBLIC_SPACE_GIT_URI``) by converting that ``https://…`` repo URL into a
+    Derives it from the public space's config repo (``PUBLIC_SPACE_GIT_URI``) by
+    converting that ``https://…`` repo URL into a
     ``git+ssh://…[@<config-branch>]#subdirectory=environments/<env>`` asset URI
     the environment loader expects — the same conversion the build path uses
-    (``GitURI.get_gb_space_config_uri``).
+    (``GitURI.get_gb_space_config_uri``). There is no override; the URI is always
+    derived, so per-deployment differences come from the public space config.
 
     Returns ``""`` (→ 503 in the caller) in every "can't produce a URI right now"
-    case: no override and no ``PUBLIC_SPACE_GIT_URI`` (e.g. STANDALONE), or the
-    derivation's GitHub config-branch probe failing (expired/invalid token,
-    GitHub unreachable). Callers therefore never see the raw exception — a
-    transient GitHub problem reads as "not configured", not a 500.
+    case: no ``PUBLIC_SPACE_GIT_URI`` (e.g. STANDALONE), or the derivation's
+    GitHub config-branch probe failing (expired/invalid token, GitHub
+    unreachable). Callers therefore never see the raw exception — a transient
+    GitHub problem reads as "not configured", not a 500.
 
     Evaluated lazily (not at import): the ``GitURI`` import would otherwise cycle
     (git.py imports GBSERVER_GITHUB_TOKEN from this module). A *successful*
@@ -545,9 +533,6 @@ def get_supported_env_for_files_uri() -> str:
     probe runs at most once per process; failures and empties are not cached, so
     a later request retries once the token/config is healthy.
     """
-    override = os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, "")
-    if override:
-        return override
     if not PUBLIC_SPACE_GIT_URI:
         return ""
     cached = _DERIVED_ENV_FOR_FILES_URI_CACHE.get(PUBLIC_SPACE_GIT_URI)

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -500,58 +500,50 @@ ENVIRONMENT_FILES_REGISTRY: Dict[str, EnvironmentFilesConfig] = {
 }
 
 
-# Process-level cache of the successfully-DERIVED environment URI, keyed by the
-# public-space repo URL it was derived from. The derivation calls
-# GitURI.get_gb_space_config_uri, which makes an uncached live GitHub call
-# (is_branch_present) when a token is set; resolve_environment is on the files-API
-# per-request access-control path, so we memoize to run that probe at most once
-# per (process, public-space URI) on success. Failed/empty derivations are not
-# cached — so a transient GitHub error doesn't stick.
+# Process-level cache of the derived environment URI, keyed by public-space repo
+# URL. Only a *stable* derivation is cached (a git result with a config branch, or
+# a file:// path); a branchless git result / failures / empties are not, so a later
+# request retries once the gbspace-config branch / token is healthy. Lock-free
+# write is fine: dict assignment is atomic, worst case is a redundant re-probe.
 _DERIVED_ENV_FOR_FILES_URI_CACHE: Dict[str, str] = {}
 
 
 def get_supported_env_for_files_uri() -> str:
     """Derive the supported environment's environment.yaml asset URI.
 
-    Derives it from the public space's config repo (``PUBLIC_SPACE_GIT_URI``) by
-    converting that ``https://…`` repo URL into a
+    Converts ``PUBLIC_SPACE_GIT_URI`` (the public space config repo) into a
     ``git+ssh://…[@<config-branch>]#subdirectory=environments/<env>`` asset URI
-    the environment loader expects — the same conversion the build path uses
-    (``GitURI.get_gb_space_config_uri``). There is no override; the URI is always
-    derived, so per-deployment differences come from the public space config.
+    via ``GitURI.get_gb_space_config_uri`` (the same conversion the build path
+    uses) and appends the env subdirectory. There is no override; the URI is
+    always derived, so per-deployment differences come from the public space.
 
-    Returns ``""`` (→ 503 in the caller) in every "can't produce a URI right now"
-    case: no ``PUBLIC_SPACE_GIT_URI`` (e.g. STANDALONE), or the derivation's
-    GitHub config-branch probe failing (expired/invalid token, GitHub
-    unreachable). Callers therefore never see the raw exception — a transient
-    GitHub problem reads as "not configured", not a 500.
+    Returns ``""`` (→ 503 in the caller) whenever a URI can't be produced: no
+    ``PUBLIC_SPACE_GIT_URI`` (e.g. STANDALONE), or the GitHub config-branch probe
+    failing — the exception is caught so a transient GitHub problem reads as "not
+    configured", not a 500.
 
-    Evaluated lazily (not at import): the ``GitURI`` import would otherwise cycle
-    (git.py imports GBSERVER_GITHUB_TOKEN from this module). A *successful*
-    derivation is memoized per public-space URI (see
-    ``_DERIVED_ENV_FOR_FILES_URI_CACHE``) so the underlying live GitHub branch
-    probe runs at most once per process; failures and empties are not cached, so
-    a later request retries once the token/config is healthy.
+    Lazy (not evaluated at import) to avoid a cycle: git.py imports
+    ``GBSERVER_GITHUB_TOKEN`` from this module. See the cache note above for what
+    is / isn't memoized.
     """
     if not PUBLIC_SPACE_GIT_URI:
         return ""
     cached = _DERIVED_ENV_FOR_FILES_URI_CACHE.get(PUBLIC_SPACE_GIT_URI)
     if cached is not None:
         return cached
-    # Function-local import: git.py imports from this module, so a top-level
-    # import here would be a cycle.
+    # Function-local import: git.py imports from this module (cycle otherwise).
+    from requests import RequestException
+
     from gbcommon.uri.git import GitURI
     from gbcommon.uri.uri import URI
     from gbserver.utils.logger import get_logger
 
     try:
         base = GitURI.get_gb_space_config_uri(PUBLIC_SPACE_GIT_URI)
-    except Exception as e:  # pylint: disable=broad-except
-        # get_gb_space_config_uri probes GitHub for the config branch when a
-        # token is set; is_branch_present raises on 401 / network / non-404 HTTP.
-        # This is on the files-API access-control path, so degrade to "not
-        # derivable" (→ 503) rather than let it surface as a 500. Not cached:
-        # a later request retries once GitHub/the token recovers.
+    except (ValueError, RuntimeError, RequestException) as e:
+        # is_branch_present raises ValueError (401) / RuntimeError (non-404) /
+        # requests error (network); degrade those to 503, not 500. Anything else
+        # is an unexpected bug and propagates. Not cached — retry on recovery.
         get_logger(__name__).warning(
             "failed to derive files-env URI from public space %r: %s",
             PUBLIC_SPACE_GIT_URI,
@@ -559,19 +551,16 @@ def get_supported_env_for_files_uri() -> str:
         )
         return ""
     if not base:
-        # Don't cache a transient empty — a later call (token/config now present)
-        # should get another chance to derive a real URI.
         return ""
-    # append_path points the URI at environments/<env>. When a config branch was
-    # found, get_gb_space_config_uri produced an empty "#subdirectory=" fragment
-    # that parse_qs treats as absent, so append_path creates the fragment; when no
-    # branch was found there is no fragment at all and it likewise creates one —
-    # so both the "branch, empty subdirectory" and "no branch, no fragment" cases
-    # resolve to the same environments/<env> target.
+    # get_gb_space_config_uri never adds a fragment (only `@<branch>` on a match),
+    # so append_path always creates the `#subdirectory=` fragment here.
     uri = URI.get_uri(base)
     uri.append_path(f"environments/{SUPPORTED_ENV_FOR_FILES}")
     resolved = str(uri)
-    _DERIVED_ENV_FOR_FILES_URI_CACHE[PUBLIC_SPACE_GIT_URI] = resolved
+    # Cache only a stable result (file:// path, or git with a config branch); a
+    # branchless git URI points at the default branch and is left uncached.
+    if base.startswith("file://") or "@" in base.split("#", 1)[0]:
+        _DERIVED_ENV_FOR_FILES_URI_CACHE[PUBLIC_SPACE_GIT_URI] = resolved
     return resolved
 
 

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -511,13 +511,22 @@ ENVIRONMENT_FILES_REGISTRY: Dict[str, EnvironmentFilesConfig] = {
 }
 
 
+# Process-level cache of the DERIVED environment URI, keyed by the public-space
+# repo URL it was derived from. The derivation calls GitURI.get_gb_space_config_uri,
+# which makes an uncached live GitHub call (is_branch_present) when a token is set;
+# resolve_environment is on the files-API per-request access-control path, so we
+# memoize to run that probe at most once per (process, public-space URI). The
+# explicit override is never cached — it is read live and short-circuits above.
+_DERIVED_ENV_FOR_FILES_URI_CACHE: Dict[str, str] = {}
+
+
 def get_supported_env_for_files_uri() -> str:
     """Resolve the supported environment's environment.yaml asset URI.
 
     Returns the explicit ``GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI`` override
     when set; otherwise derives it from the public space's config repo
-    (``PUBLIC_SPACE_GIT_URI``) by converting that ``https://…`` repo URL into the
-    ``git+ssh://…@<config-branch>#subdirectory=environments/<env>`` asset URI
+    (``PUBLIC_SPACE_GIT_URI``) by converting that ``https://…`` repo URL into a
+    ``git+ssh://…[@<config-branch>]#subdirectory=environments/<env>`` asset URI
     the environment loader expects — the same conversion the build path uses
     (``GitURI.get_gb_space_config_uri``). Returns ``""`` when there is nothing to
     derive from (no override and no public space URI, e.g. STANDALONE), which the
@@ -526,13 +535,18 @@ def get_supported_env_for_files_uri() -> str:
     Evaluated lazily (not at import): the ``GitURI`` import would otherwise cycle
     (git.py imports GBSERVER_GITHUB_TOKEN from this module), and the ``@<branch>``
     suffix is only appended when a GitHub token is present in the process env —
-    which may be set after import.
+    which may be set after import. The derived value is memoized per public-space
+    URI (see ``_DERIVED_ENV_FOR_FILES_URI_CACHE``) so the underlying live GitHub
+    branch probe runs at most once per process.
     """
     override = os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, "")
     if override:
         return override
     if not PUBLIC_SPACE_GIT_URI:
         return ""
+    cached = _DERIVED_ENV_FOR_FILES_URI_CACHE.get(PUBLIC_SPACE_GIT_URI)
+    if cached is not None:
+        return cached
     # Function-local import: git.py imports from this module, so a top-level
     # import here would be a cycle.
     from gbcommon.uri.git import GitURI
@@ -540,12 +554,18 @@ def get_supported_env_for_files_uri() -> str:
 
     base = GitURI.get_gb_space_config_uri(PUBLIC_SPACE_GIT_URI)
     if not base:
+        # Don't cache a transient empty — a later call (token/config now present)
+        # should get another chance to derive a real URI.
         return ""
-    # base ends with an empty "#subdirectory="; append_path fills it with the
-    # env's subdirectory (merging into the existing fragment, not adding a second).
+    # append_path points the URI at environments/<env>: it extends an existing
+    # "#subdirectory=" fragment when get_gb_space_config_uri added one (a config
+    # branch was found) and creates the fragment when it didn't — so the "no
+    # branch, no fragment" and "branch, empty subdirectory" cases both resolve.
     uri = URI.get_uri(base)
     uri.append_path(f"environments/{SUPPORTED_ENV_FOR_FILES}")
-    return str(uri)
+    resolved = str(uri)
+    _DERIVED_ENV_FOR_FILES_URI_CACHE[PUBLIC_SPACE_GIT_URI] = resolved
+    return resolved
 
 
 ENV_VAR_GBSERVER_DEFAULT_GH_REQUEST_TIMEOUT = (

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -547,6 +547,7 @@ def get_supported_env_for_files_uri() -> str:
     uri.append_path(f"environments/{SUPPORTED_ENV_FOR_FILES}")
     return str(uri)
 
+
 ENV_VAR_GBSERVER_DEFAULT_GH_REQUEST_TIMEOUT = (
     ENV_VAR_PREFIX + "_DEFAULT_GH_REQUEST_TIMEOUT"
 )

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -483,9 +483,9 @@ class EnvironmentFilesConfig:
 # GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI: an OPTIONAL explicit override for the
 #   supported environment's environment.yaml asset URI. Empty default → the URI
 #   is derived from the public space config repo at request time (see
-#   get_supported_env_for_files_uri below). 503 only when neither the override
-#   nor a derivable public space URI is available (e.g. STANDALONE), never a
-#   guess.
+#   get_supported_env_for_files_uri below). 503 when the URI can't be produced —
+#   no override and no derivable public space URI (e.g. STANDALONE), or the
+#   derivation's GitHub probe failing — never a guess.
 ENV_VAR_GBSERVER_BLUEVELA_FILES_SPACE_NAME = (
     ENV_VAR_PREFIX + "_BLUEVELA_FILES_SPACE_NAME"
 )
@@ -511,12 +511,14 @@ ENVIRONMENT_FILES_REGISTRY: Dict[str, EnvironmentFilesConfig] = {
 }
 
 
-# Process-level cache of the DERIVED environment URI, keyed by the public-space
-# repo URL it was derived from. The derivation calls GitURI.get_gb_space_config_uri,
-# which makes an uncached live GitHub call (is_branch_present) when a token is set;
-# resolve_environment is on the files-API per-request access-control path, so we
-# memoize to run that probe at most once per (process, public-space URI). The
-# explicit override is never cached — it is read live and short-circuits above.
+# Process-level cache of the successfully-DERIVED environment URI, keyed by the
+# public-space repo URL it was derived from. The derivation calls
+# GitURI.get_gb_space_config_uri, which makes an uncached live GitHub call
+# (is_branch_present) when a token is set; resolve_environment is on the files-API
+# per-request access-control path, so we memoize to run that probe at most once
+# per (process, public-space URI) on success. The explicit override is never
+# cached (read live, short-circuits above), and failed/empty derivations are not
+# cached either — so a transient GitHub error doesn't stick.
 _DERIVED_ENV_FOR_FILES_URI_CACHE: Dict[str, str] = {}
 
 
@@ -528,16 +530,20 @@ def get_supported_env_for_files_uri() -> str:
     (``PUBLIC_SPACE_GIT_URI``) by converting that ``https://…`` repo URL into a
     ``git+ssh://…[@<config-branch>]#subdirectory=environments/<env>`` asset URI
     the environment loader expects — the same conversion the build path uses
-    (``GitURI.get_gb_space_config_uri``). Returns ``""`` when there is nothing to
-    derive from (no override and no public space URI, e.g. STANDALONE), which the
-    caller turns into a 503.
+    (``GitURI.get_gb_space_config_uri``).
+
+    Returns ``""`` (→ 503 in the caller) in every "can't produce a URI right now"
+    case: no override and no ``PUBLIC_SPACE_GIT_URI`` (e.g. STANDALONE), or the
+    derivation's GitHub config-branch probe failing (expired/invalid token,
+    GitHub unreachable). Callers therefore never see the raw exception — a
+    transient GitHub problem reads as "not configured", not a 500.
 
     Evaluated lazily (not at import): the ``GitURI`` import would otherwise cycle
-    (git.py imports GBSERVER_GITHUB_TOKEN from this module), and the ``@<branch>``
-    suffix is only appended when a GitHub token is present in the process env —
-    which may be set after import. The derived value is memoized per public-space
-    URI (see ``_DERIVED_ENV_FOR_FILES_URI_CACHE``) so the underlying live GitHub
-    branch probe runs at most once per process.
+    (git.py imports GBSERVER_GITHUB_TOKEN from this module). A *successful*
+    derivation is memoized per public-space URI (see
+    ``_DERIVED_ENV_FOR_FILES_URI_CACHE``) so the underlying live GitHub branch
+    probe runs at most once per process; failures and empties are not cached, so
+    a later request retries once the token/config is healthy.
     """
     override = os.getenv(ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, "")
     if override:
@@ -551,16 +557,32 @@ def get_supported_env_for_files_uri() -> str:
     # import here would be a cycle.
     from gbcommon.uri.git import GitURI
     from gbcommon.uri.uri import URI
+    from gbserver.utils.logger import get_logger
 
-    base = GitURI.get_gb_space_config_uri(PUBLIC_SPACE_GIT_URI)
+    try:
+        base = GitURI.get_gb_space_config_uri(PUBLIC_SPACE_GIT_URI)
+    except Exception as e:  # pylint: disable=broad-except
+        # get_gb_space_config_uri probes GitHub for the config branch when a
+        # token is set; is_branch_present raises on 401 / network / non-404 HTTP.
+        # This is on the files-API access-control path, so degrade to "not
+        # derivable" (→ 503) rather than let it surface as a 500. Not cached:
+        # a later request retries once GitHub/the token recovers.
+        get_logger(__name__).warning(
+            "failed to derive files-env URI from public space %r: %s",
+            PUBLIC_SPACE_GIT_URI,
+            e,
+        )
+        return ""
     if not base:
         # Don't cache a transient empty — a later call (token/config now present)
         # should get another chance to derive a real URI.
         return ""
-    # append_path points the URI at environments/<env>: it extends an existing
-    # "#subdirectory=" fragment when get_gb_space_config_uri added one (a config
-    # branch was found) and creates the fragment when it didn't — so the "no
-    # branch, no fragment" and "branch, empty subdirectory" cases both resolve.
+    # append_path points the URI at environments/<env>. When a config branch was
+    # found, get_gb_space_config_uri produced an empty "#subdirectory=" fragment
+    # that parse_qs treats as absent, so append_path creates the fragment; when no
+    # branch was found there is no fragment at all and it likewise creates one —
+    # so both the "branch, empty subdirectory" and "no branch, no fragment" cases
+    # resolve to the same environments/<env> target.
     uri = URI.get_uri(base)
     uri.append_path(f"environments/{SUPPORTED_ENV_FOR_FILES}")
     resolved = str(uri)

--- a/test/unit/api/test_environment_files.py
+++ b/test/unit/api/test_environment_files.py
@@ -659,25 +659,63 @@ class TestDownloadAndPeek:
 
 class TestNotConfigured:
     def test_missing_environment_uri_returns_503(self):
-        # With bluevela's environment_uri unset (the real default), the endpoint
-        # 503s instead of guessing. Patch only the tunnel; leave the registry
-        # real with the empty-URI default.
+        # 503 requires that the environment URI can neither be read (explicit
+        # override) nor derived (public space config repo). We simulate that by
+        # pinning the resolver to "" — the single decision point resolve_environment
+        # consults. Patch only the tunnel besides that; leave the registry real.
         from gbserver.api import environment_files_paths as epaths
 
         tunnel = _RecordingTunnel()
-        unconfigured = EnvironmentFilesConfig(
-            gpfs_base="/proj", space_name="public", environment_uri=""
-        )
         with (
             patch.object(
                 environment_files_mod, "open_lsf_tunnel", _fake_tunnel_cm(tunnel)
             ),
-            patch.dict(
-                epaths.ENVIRONMENT_FILES_REGISTRY,
-                {ENVIRONMENT: unconfigured},
-                clear=True,
-            ),
+            patch.object(epaths, "get_supported_env_for_files_uri", return_value=""),
         ):
             r = _client().get(_url("demo"))
         assert r.status_code == 503
         assert tunnel.commands == []
+
+
+class TestEnvironmentUriResolution:
+    """get_supported_env_for_files_uri: explicit override, else derive, else empty."""
+
+    def test_explicit_override_returned_verbatim(self, monkeypatch):
+        from gbserver.types import constants as c
+
+        monkeypatch.setenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI,
+            "space://environments/bluevela",
+        )
+        # Override wins even when a public space URI is available to derive from.
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        assert c.get_supported_env_for_files_uri() == "space://environments/bluevela"
+
+    def test_derived_from_public_space_when_override_unset(self, monkeypatch):
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        # Empty GitHub token → get_gb_space_config_uri skips the @<branch> suffix
+        # (and any repo probe), so this stays offline. The shape we assert on: a
+        # git+ssh asset URI into environments/bluevela of the public space repo.
+        monkeypatch.setattr(c, "GBSERVER_GITHUB_TOKEN", "", raising=False)
+        uri = c.get_supported_env_for_files_uri()
+        assert uri.startswith("git+ssh://example.com/org/gbspace-public.git")
+        # subdirectory fragment points at environments/bluevela (URL-encoded '/').
+        assert "subdirectory=environments%2Fbluevela" in uri
+
+    def test_empty_when_no_override_and_no_public_space(self, monkeypatch):
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        monkeypatch.setattr(c, "PUBLIC_SPACE_GIT_URI", "")
+        assert c.get_supported_env_for_files_uri() == ""

--- a/test/unit/api/test_environment_files.py
+++ b/test/unit/api/test_environment_files.py
@@ -676,6 +676,35 @@ class TestNotConfigured:
         assert r.status_code == 503
         assert tunnel.commands == []
 
+    def test_github_error_during_derivation_returns_503_not_500(self, monkeypatch):
+        # End-to-end: a GitHub failure in the derivation must surface as the
+        # documented 503, not an unhandled 500. Exercise the real resolve_environment
+        # + get_supported_env_for_files_uri (no override, public space set), and make
+        # the config-branch probe seam raise. No folder data is touched.
+        from gbcommon.uri.git import GitURI
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        c._DERIVED_ENV_FOR_FILES_URI_CACHE.clear()
+
+        def _raising(*_a, **_k):
+            raise RuntimeError("github down")
+
+        monkeypatch.setattr(GitURI, "get_gb_space_config_uri", staticmethod(_raising))
+        tunnel = _RecordingTunnel()
+        with patch.object(
+            environment_files_mod, "open_lsf_tunnel", _fake_tunnel_cm(tunnel)
+        ):
+            r = _client().get(_url("demo"))
+        assert r.status_code == 503
+        assert tunnel.commands == []
+        c._DERIVED_ENV_FOR_FILES_URI_CACHE.clear()
+
 
 class TestEnvironmentUriResolution:
     """get_supported_env_for_files_uri: explicit override, else derive, else empty."""
@@ -802,3 +831,27 @@ class TestEnvironmentUriResolution:
         assert first == second
         # The live-GitHub-probing conversion ran once despite two resolutions.
         assert calls["n"] == 1
+
+    def test_github_error_during_derivation_yields_empty_uncached(self, monkeypatch):
+        from gbcommon.uri.git import GitURI
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        # The config-branch probe raising (expired token → ValueError, GitHub
+        # down → RuntimeError) must degrade to "" (→ 503), not propagate as a 500.
+        calls = {"n": 0}
+
+        def _raising(uri, *a, **k):
+            calls["n"] += 1
+            raise RuntimeError("github unreachable")
+
+        monkeypatch.setattr(GitURI, "get_gb_space_config_uri", staticmethod(_raising))
+        assert c.get_supported_env_for_files_uri() == ""
+        # Not cached: a later request retries rather than serving a stuck failure.
+        assert c.get_supported_env_for_files_uri() == ""
+        assert calls["n"] == 2

--- a/test/unit/api/test_environment_files.py
+++ b/test/unit/api/test_environment_files.py
@@ -748,16 +748,15 @@ class TestEnvironmentUriResolution:
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )
-        # When a config branch WAS found, get_gb_space_config_uri returns a URI
-        # with @<branch> and an empty "#subdirectory="; append_path must extend
-        # that fragment, not add a second one, and keep the @<branch> ref.
+        # When a config branch WAS found, get_gb_space_config_uri returns the repo
+        # with @<branch> appended and NO fragment; append_path then creates the
+        # single #subdirectory= fragment while preserving the @<branch> ref.
         monkeypatch.setattr(
             GitURI,
             "get_gb_space_config_uri",
             staticmethod(
                 lambda uri, *a, **k: (
-                    "git+ssh://example.com/org/gbspace-public.git"
-                    "@gbspace-config#subdirectory="
+                    "git+ssh://example.com/org/gbspace-public.git@gbspace-config"
                 )
             ),
         )
@@ -792,7 +791,8 @@ class TestEnvironmentUriResolution:
 
         def _counting(uri, *a, **k):
             calls["n"] += 1
-            return "git+ssh://example.com/org/gbspace-public.git"
+            # Branch-bearing result → stable → cacheable.
+            return "git+ssh://example.com/org/gbspace-public.git@gbspace-config"
 
         monkeypatch.setattr(GitURI, "get_gb_space_config_uri", staticmethod(_counting))
         first = c.get_supported_env_for_files_uri()
@@ -800,6 +800,32 @@ class TestEnvironmentUriResolution:
         assert first == second
         # The live-GitHub-probing conversion ran once despite two resolutions.
         assert calls["n"] == 1
+
+    def test_branchless_derivation_not_cached(self, monkeypatch):
+        from gbcommon.uri.git import GitURI
+        from gbserver.types import constants as c
+
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        # No config branch found → branchless URI (points at the default branch).
+        # It's returned, but not cached, so a later request re-probes for the
+        # branch rather than serving the branchless URI for the process lifetime.
+        calls = {"n": 0}
+
+        def _branchless(uri, *a, **k):
+            calls["n"] += 1
+            return "git+ssh://example.com/org/gbspace-public.git"
+
+        monkeypatch.setattr(
+            GitURI, "get_gb_space_config_uri", staticmethod(_branchless)
+        )
+        first = c.get_supported_env_for_files_uri()
+        second = c.get_supported_env_for_files_uri()
+        assert first == second
+        assert "subdirectory=environments%2Fbluevela" in first
+        assert calls["n"] == 2  # re-derived, not memoized
+        assert c.PUBLIC_SPACE_GIT_URI not in c._DERIVED_ENV_FOR_FILES_URI_CACHE
 
     def test_github_error_during_derivation_yields_empty_uncached(self, monkeypatch):
         from gbcommon.uri.git import GitURI

--- a/test/unit/api/test_environment_files.py
+++ b/test/unit/api/test_environment_files.py
@@ -659,10 +659,10 @@ class TestDownloadAndPeek:
 
 class TestNotConfigured:
     def test_missing_environment_uri_returns_503(self):
-        # 503 requires that the environment URI can neither be read (explicit
-        # override) nor derived (public space config repo). We simulate that by
-        # pinning the resolver to "" — the single decision point resolve_environment
-        # consults. Patch only the tunnel besides that; leave the registry real.
+        # 503 requires that the environment URI can't be derived (from the public
+        # space config repo). We simulate that by pinning the resolver to "" — the
+        # single decision point resolve_environment consults. Patch only the tunnel
+        # besides that; leave the registry real.
         from gbserver.api import environment_files_paths as epaths
 
         tunnel = _RecordingTunnel()
@@ -679,14 +679,11 @@ class TestNotConfigured:
     def test_github_error_during_derivation_returns_503_not_500(self, monkeypatch):
         # End-to-end: a GitHub failure in the derivation must surface as the
         # documented 503, not an unhandled 500. Exercise the real resolve_environment
-        # + get_supported_env_for_files_uri (no override, public space set), and make
-        # the config-branch probe seam raise. No folder data is touched.
+        # + get_supported_env_for_files_uri (public space set), and make the
+        # config-branch probe seam raise. No folder data is touched.
         from gbcommon.uri.git import GitURI
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )
@@ -707,7 +704,7 @@ class TestNotConfigured:
 
 
 class TestEnvironmentUriResolution:
-    """get_supported_env_for_files_uri: explicit override, else derive, else empty."""
+    """get_supported_env_for_files_uri: derive from the public space, else empty."""
 
     @pytest.fixture(autouse=True)
     def _clear_derive_cache(self):
@@ -720,26 +717,10 @@ class TestEnvironmentUriResolution:
         yield
         c._DERIVED_ENV_FOR_FILES_URI_CACHE.clear()
 
-    def test_explicit_override_returned_verbatim(self, monkeypatch):
-        from gbserver.types import constants as c
-
-        monkeypatch.setenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI,
-            "space://environments/bluevela",
-        )
-        # Override wins even when a public space URI is available to derive from.
-        monkeypatch.setattr(
-            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
-        )
-        assert c.get_supported_env_for_files_uri() == "space://environments/bluevela"
-
-    def test_derived_from_public_space_when_override_unset(self, monkeypatch):
+    def test_derived_from_public_space(self, monkeypatch):
         from gbcommon.uri.git import GitURI
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )
@@ -764,9 +745,6 @@ class TestEnvironmentUriResolution:
         from gbcommon.uri.git import GitURI
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )
@@ -791,21 +769,15 @@ class TestEnvironmentUriResolution:
     def test_derived_from_file_public_space(self, monkeypatch):
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         # A file:// public space (standalone / local dev): get_gb_space_config_uri
         # returns it unmodified, and append_path extends the path. No network.
         monkeypatch.setattr(c, "PUBLIC_SPACE_GIT_URI", "file:///tmp/gbspace-public")
         uri = c.get_supported_env_for_files_uri()
         assert uri == "file:///tmp/gbspace-public/environments/bluevela"
 
-    def test_empty_when_no_override_and_no_public_space(self, monkeypatch):
+    def test_empty_when_no_public_space(self, monkeypatch):
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         monkeypatch.setattr(c, "PUBLIC_SPACE_GIT_URI", "")
         assert c.get_supported_env_for_files_uri() == ""
 
@@ -813,9 +785,6 @@ class TestEnvironmentUriResolution:
         from gbcommon.uri.git import GitURI
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )
@@ -836,9 +805,6 @@ class TestEnvironmentUriResolution:
         from gbcommon.uri.git import GitURI
         from gbserver.types import constants as c
 
-        monkeypatch.delenv(
-            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
-        )
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )

--- a/test/unit/api/test_environment_files.py
+++ b/test/unit/api/test_environment_files.py
@@ -680,6 +680,17 @@ class TestNotConfigured:
 class TestEnvironmentUriResolution:
     """get_supported_env_for_files_uri: explicit override, else derive, else empty."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_derive_cache(self):
+        # The derived URI is memoized per public-space URI at module scope; clear
+        # it around each test so a monkeypatched PUBLIC_SPACE_GIT_URI never reads
+        # or leaves a stale entry.
+        from gbserver.types import constants as c
+
+        c._DERIVED_ENV_FOR_FILES_URI_CACHE.clear()
+        yield
+        c._DERIVED_ENV_FOR_FILES_URI_CACHE.clear()
+
     def test_explicit_override_returned_verbatim(self, monkeypatch):
         from gbserver.types import constants as c
 
@@ -694,6 +705,7 @@ class TestEnvironmentUriResolution:
         assert c.get_supported_env_for_files_uri() == "space://environments/bluevela"
 
     def test_derived_from_public_space_when_override_unset(self, monkeypatch):
+        from gbcommon.uri.git import GitURI
         from gbserver.types import constants as c
 
         monkeypatch.delenv(
@@ -702,14 +714,62 @@ class TestEnvironmentUriResolution:
         monkeypatch.setattr(
             c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
         )
-        # Empty GitHub token → get_gb_space_config_uri skips the @<branch> suffix
-        # (and any repo probe), so this stays offline. The shape we assert on: a
-        # git+ssh asset URI into environments/bluevela of the public space repo.
-        monkeypatch.setattr(c, "GBSERVER_GITHUB_TOKEN", "", raising=False)
+        # Patch the actual seam (the space-config-URI conversion) rather than the
+        # token: get_gb_space_config_uri binds its token default at import time, so
+        # patching the module attribute would be a no-op and the real call could
+        # hit the network. Here we return the branchless base (no config branch
+        # found) to confirm append_path still targets environments/bluevela.
+        monkeypatch.setattr(
+            GitURI,
+            "get_gb_space_config_uri",
+            staticmethod(
+                lambda uri, *a, **k: "git+ssh://example.com/org/gbspace-public.git"
+            ),
+        )
         uri = c.get_supported_env_for_files_uri()
         assert uri.startswith("git+ssh://example.com/org/gbspace-public.git")
         # subdirectory fragment points at environments/bluevela (URL-encoded '/').
         assert "subdirectory=environments%2Fbluevela" in uri
+
+    def test_derived_preserves_config_branch_suffix(self, monkeypatch):
+        from gbcommon.uri.git import GitURI
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        # When a config branch WAS found, get_gb_space_config_uri returns a URI
+        # with @<branch> and an empty "#subdirectory="; append_path must extend
+        # that fragment, not add a second one, and keep the @<branch> ref.
+        monkeypatch.setattr(
+            GitURI,
+            "get_gb_space_config_uri",
+            staticmethod(
+                lambda uri, *a, **k: (
+                    "git+ssh://example.com/org/gbspace-public.git"
+                    "@gbspace-config#subdirectory="
+                )
+            ),
+        )
+        uri = c.get_supported_env_for_files_uri()
+        assert "@gbspace-config" in uri
+        assert uri.count("#") == 1  # single fragment, not two
+        assert "subdirectory=environments%2Fbluevela" in uri
+
+    def test_derived_from_file_public_space(self, monkeypatch):
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        # A file:// public space (standalone / local dev): get_gb_space_config_uri
+        # returns it unmodified, and append_path extends the path. No network.
+        monkeypatch.setattr(c, "PUBLIC_SPACE_GIT_URI", "file:///tmp/gbspace-public")
+        uri = c.get_supported_env_for_files_uri()
+        assert uri == "file:///tmp/gbspace-public/environments/bluevela"
 
     def test_empty_when_no_override_and_no_public_space(self, monkeypatch):
         from gbserver.types import constants as c
@@ -719,3 +779,26 @@ class TestEnvironmentUriResolution:
         )
         monkeypatch.setattr(c, "PUBLIC_SPACE_GIT_URI", "")
         assert c.get_supported_env_for_files_uri() == ""
+
+    def test_derived_uri_is_memoized(self, monkeypatch):
+        from gbcommon.uri.git import GitURI
+        from gbserver.types import constants as c
+
+        monkeypatch.delenv(
+            c.ENV_VAR_GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI, raising=False
+        )
+        monkeypatch.setattr(
+            c, "PUBLIC_SPACE_GIT_URI", "https://example.com/org/gbspace-public"
+        )
+        calls = {"n": 0}
+
+        def _counting(uri, *a, **k):
+            calls["n"] += 1
+            return "git+ssh://example.com/org/gbspace-public.git"
+
+        monkeypatch.setattr(GitURI, "get_gb_space_config_uri", staticmethod(_counting))
+        first = c.get_supported_env_for_files_uri()
+        second = c.get_supported_env_for_files_uri()
+        assert first == second
+        # The live-GitHub-probing conversion ran once despite two resolutions.
+        assert calls["n"] == 1


### PR DESCRIPTION
## Summary

The project-folder files API (`/api/v1/files/{environment}/{folder}`, added in
#252) needs an LSF `environment.yaml` asset URI to open the SSH tunnel to the
login nodes. #252 introduced `GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI` as the
**only** source for that URI — an empty value returned 503 ("not configured").

That URI does not need to be a separate per-deployment secret: the public space
config repo already carries the `environment.yaml`, and its repo URL is already
known per-environment as `GBEnvConfig.public_space_git_uri`. This PR **removes
the env var entirely** and always derives the URI from the public space.

- **`GBSERVER_BLUEVELA_FILES_ENVIRONMENT_URI` is removed.** There is no override;
  the URI is always derived from `PUBLIC_SPACE_GIT_URI`, so per-deployment
  (dev/staging/prod) differences come "for free" from the public space config.
  (An earlier revision of this PR kept it as an optional override; that was
  dropped after reviewer feedback confirmed the derivation works.)
- **Derivation reuses the existing build-path transform.**
  `GitURI.get_gb_space_config_uri` converts the `https://…` public-space repo URL
  into `git+ssh://…[@<config-branch>]#subdirectory=environments/<env>` — the same
  asset-URI form the environment loader (`Environment.load_environment_config`)
  already consumes, and the identical conversion used at build-creation time
  (`buildrunner/validation.py`).
- **Lazy + memoized.** The URI is derived at request time in a new helper
  `get_supported_env_for_files_uri()` rather than at import — `git.py` imports
  from `constants.py`, so a top-level `GitURI` import would cycle. That conversion
  makes a live GitHub branch probe when a token is set, and `resolve_environment`
  sits on the per-request access-control path, so a **stable** derivation is
  memoized per public-space URL (probe runs at most once per process). A
  branchless git result, failures, and empties are **not** cached, so a later
  request retries once the `gbspace-config` branch / token is healthy.
- **GitHub errors → 503, not 500.** The branch probe can raise (`401`, network,
  non-404 HTTP). Those specific types are caught and mapped to the documented 503
  on the access-control path; anything else propagates (a real bug shouldn't
  masquerade as "not configured").
- **503 only when nothing is derivable** (e.g. `STANDALONE`, empty
  `PUBLIC_SPACE_GIT_URI`) or the probe fails — never a guess.
- **Generic naming.** The single supported-environment name is a generic constant
  `SUPPORTED_ENV_FOR_FILES` (value `"bluevela"`), used as the registry key and by
  the derivation. The pre-existing `GBSERVER_BLUEVELA_FILES_SPACE_NAME` env-var
  name (external contract from #252) is unchanged.

### Not changed (deferred)

The `GBSERVER_BLUEVELA_FILES_SPACE_NAME` env var is arguably redundant with the
public/default space concept (it already defaults to `"public"`), but that is
left for a follow-up — this PR is scoped to the environment-URI derivation. The
trust model is unchanged: the SSH key still comes from `space_name` via the
secret manager, and folder access is still gated by POSIX group membership.

## Test plan

- `pytest test/unit/api/test_environment_files.py` → 54 passed (verified under
  `GB_ENVIRONMENT` = STANDALONE / STAGING / DEV — the resolution tests are
  environment-independent).
  - `TestEnvironmentUriResolution`: derivation (branchless + config-branch),
    `file://` public space, empty → 503, memoization (one underlying conversion
    across two resolutions), **branchless-not-cached** (re-derived, verified to
    fail without the caching guard), and GitHub-error → empty/uncached (retries).
  - `TestNotConfigured`: end-to-end 503 (missing URI) and 503-not-500 on a GitHub
    error — the latter verified to fail against the pre-fix code.
  - Tests patch the real conversion seam (`GitURI.get_gb_space_config_uri`), so
    they never touch the network.
- Import-cycle sanity: `python -c "import gbserver.types.constants; import gbserver.api.environment_files_paths"`.
- `black` / `isort --profile black` clean; `pylint` no errors; `mypy` no new
  errors in the changed files.

Generated with [Claude Code](https://claude.com/claude-code)
