### PR TITLE
SkyPilot on AWS: compute-floor minimums + Debian eval image

### DIFF
--- a/configurations/assets/environments/skypilot/steps/byoc/README.md
+++ b/configurations/assets/environments/skypilot/steps/byoc/README.md
@@ -5,6 +5,11 @@ Bring-Your-Own-Code step for SkyPilot clusters. It clones a **public git repo** 
 and runs a user-defined command during `run`, inside a **public container image** or on
 the bare launcher node — no custom image is built for this step.
 
+> **Developing or testing this step?** See `steps/byoc/skypilot/README.md` in the
+> granite.build repository for how the step is generated, tested, and published —
+> including the environment variables the SkyPilot **aws** integration test requires
+> (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`).
+
 ## Referencing the step
 
 Point your build's Space at one that provides the step, then reference it by the stable

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -943,6 +943,14 @@ class Skypilot(Environment):
                 **self._resources_from_compute_config(
                     compute_config, cloud=cloud_group
                 ),
+                # override_res is passed VERBATIM to sky.Resources. On cloud
+                # catalogs (aws/gcp/azure/k8s) an explicit resources.cpus/memory
+                # must therefore use the "N+" minimum form (e.g. cpus: "3+"); a
+                # bare int is an EXACT request no catalog satisfies ("Catalog does
+                # not contain any instances satisfying ..."). The compute_config
+                # floor above converts for you, but this free-form passthrough of
+                # SkyPilot's own resources spec does not. (slurm/lsf match CPUs
+                # directly, so a bare int is fine there.)
                 **override_res,
             }
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -766,20 +766,37 @@ class Skypilot(Environment):
         Reads the raw dict (NOT the :class:`ComputeConfig` model, whose defaults
         of 8 GPUs / 512G memory would over-size a bare command). Only emits keys
         that are explicitly and validly set, so the caller can layer this as the
-        lowest-precedence floor. Values are numeric — never the ``"1+"`` form
-        that crashes SkyPilot's LSF cloud.
+        lowest-precedence floor. Both ``cpus`` and ``memory`` are emitted as
+        SkyPilot minimums (``"{n}+"``) so catalog matching selects the smallest
+        instance with *at least* that much CPU/RAM — a bare number is an EXACT
+        match no cloud catalog satisfies for odd sizes ("Catalog does not contain
+        any instances satisfying the request: 1x AWS(mem=1.0)" / ``cpus=3``). The
+        ``"+"`` form crashes SkyPilot's LSF cloud, so on slurm/lsf ``cpus`` stays
+        a bare int (those schedulers match CPUs directly, not via a cloud
+        catalog) and ``memory`` is skipped entirely (below).
 
         :param compute_config: the step's ``config.compute_config`` dict.
         :param cloud: the normalized target cloud (lowercased first infra
             segment, e.g. ``"slurm"``, ``"lsf"``, ``"k8s"``).
-        :returns: a dict optionally containing ``cpus`` (int, when
-            ``num_cpus_per_node`` > 0) and ``memory`` (float GiB, when
-            ``total_memory_per_node`` parses).
+        :returns: a dict optionally containing ``cpus`` (a ``"{n}+"`` minimum on
+            cloud catalogs, or a bare int on slurm/lsf, when ``num_cpus_per_node``
+            > 0) and ``memory`` (a ``"{n}+"`` GiB-minimum string, when
+            ``total_memory_per_node`` parses and the cloud is not slurm/lsf).
         """
         resources: Dict = {}
         num_cpus = compute_config.get("num_cpus_per_node", 0)
         if isinstance(num_cpus, int) and num_cpus > 0:
-            resources["cpus"] = num_cpus
+            # Same exact-match trap as memory (below): a bare number is an EXACT
+            # request and no cloud catalog has an instance with, e.g., exactly 3
+            # vCPUs, so SkyPilot dies with "Catalog does not contain any
+            # instances satisfying the request". Emit a minimum ("{n}+") so it
+            # picks the smallest instance with at least that many vCPUs. slurm/lsf
+            # keep the bare int: the "+" form crashes the fork's LSF cloud, and
+            # those schedulers match CPUs directly, so an exact request is fine.
+            if cloud in _SSH_HPC_CLOUDS:
+                resources["cpus"] = num_cpus
+            else:
+                resources["cpus"] = f"{num_cpus}+"
         # SLURM/LSF (bare HPC schedulers) commonly don't track memory as a
         # consumable resource (RealMemory unset in slurm.conf), so a --memory
         # request fails at resource matching ("Catalog does not contain any
@@ -791,7 +808,15 @@ class Skypilot(Environment):
                 compute_config.get("total_memory_per_node", "")
             )
             if memory is not None:
-                resources["memory"] = memory
+                # Emit as a minimum ("{n}+"), not an exact float: an exact
+                # memory=1.0 matches no cloud instance type (SkyPilot dies with
+                # "Catalog does not contain any instances satisfying ...
+                # AWS(mem=1.0)"). Format without an exponent and strip the
+                # trailing ".0"/zeros (1.0 -> "1+", 0.5 -> "0.5+"); ":g" would
+                # switch large values to scientific notation (e.g. "1e+06+")
+                # which SkyPilot cannot parse. Safe here: slurm/lsf excluded.
+                mem_str = f"{memory:f}".rstrip("0").rstrip(".")
+                resources["memory"] = f"{mem_str}+"
         return resources
 
     async def launch_skypilot(

--- a/steps/byoc/skypilot/README.md
+++ b/steps/byoc/skypilot/README.md
@@ -34,3 +34,48 @@ step ships user-facing docs. See
 [Two test modes](../../README.md#two-test-modes) for how the same test runs both
 against the locally rendered `space/` (Mode 1, `make test`) and against the
 published step (Mode 2, under `test/steps/`).
+
+## Running the tests
+
+`make test` runs the whole `test/` tree — both the `slurm/` and `aws/` build
+tests — against the locally rendered `space/`. Both are **extended-suite only**
+(`@extended_testing_only`) and carry the `skypilot_integration` marker, and each
+self-skips unless its backend is reachable, so neither runs by accident:
+
+```
+make -C steps/byoc/skypilot test   # uses the repo-root .venv; runs `make space` first
+```
+
+- **slurm test** — needs the local Docker SLURM cluster + MinIO endpoint. Bring
+  them up once with `make test-setup` (delegates to the repo-root `slurm-setup` /
+  `minio-setup`).
+- **aws test** — needs AWS credentials in the environment (below).
+
+### Environment variables for the aws test
+
+`test/aws/test_skypilot_aws_byoc.py` provisions a **real EC2 instance** via
+SkyPilot, so it is gated on AWS credentials being present in the environment. The
+gate is the shared `gbserver.environment.skypilot.aws_credentials_present()`
+predicate (the same one gbserver uses to decide boto3 has something to try),
+which requires **either**:
+
+| Variable(s) | Meaning |
+|---|---|
+| `AWS_ACCESS_KEY_ID` **and** `AWS_SECRET_ACCESS_KEY` | An explicit access-key pair. |
+| `AWS_PROFILE` | A named profile in `~/.aws/credentials` (e.g. `gb-skypilot`). |
+
+If neither is set the test **skips cleanly** — no EC2 instance is ever
+provisioned without credentials explicitly exported. Note this gate reads the
+**environment only**: a bare `~/.aws/credentials` `[default]` is picked up only
+because boto3/SkyPilot read it at launch, but it does *not* satisfy the skip gate
+unless `AWS_PROFILE` (or the key pair) is exported.
+
+Also required for the launch itself to succeed (not part of the skip gate):
+
+- **`sky check aws` must report `AWS: enabled`** — SkyPilot uses boto3 to
+  provision the instance.
+- **A region** must be configured — via the AWS profile / `~/.aws/config`, or
+  `AWS_DEFAULT_REGION`.
+
+No `HF_TOKEN` is needed: the fixture is HF-free (`env://` I/O) and runs on the
+bare node (`image: ""`).

--- a/steps/byoc/skypilot/USAGE.md
+++ b/steps/byoc/skypilot/USAGE.md
@@ -5,6 +5,11 @@ Bring-Your-Own-Code step for SkyPilot clusters. It clones a **public git repo** 
 and runs a user-defined command during `run`, inside a **public container image** or on
 the bare launcher node — no custom image is built for this step.
 
+> **Developing or testing this step?** See `steps/byoc/skypilot/README.md` in the
+> granite.build repository for how the step is generated, tested, and published —
+> including the environment variables the SkyPilot **aws** integration test requires
+> (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`).
+
 ## Referencing the step
 
 Point your build's Space at one that provides the step, then reference it by the stable

--- a/steps/eval/skypilot/Dockerfile
+++ b/steps/eval/skypilot/Dockerfile
@@ -3,13 +3,18 @@
 # (contrast byoc, a public-image step that brings its code at runtime).
 #
 # The exemplar payload is a small placeholder SHELL script (src/eval.sh), so the
-# image needs no Python/pip — a minimal Fedora base is enough. It lives on quay.io
-# to match the rest of this repo (the byoc default and the buildrunner test-data)
-# and to avoid Docker Hub's unauthenticated pull-rate limit. When eval is
-# implemented for real, base the image on a suitable runtime (e.g. a Python image)
+# image needs no Python/pip — a minimal base is enough. It MUST be Debian/Ubuntu
+# based: SkyPilot's docker runtime runs `apt-get` inside the container to install
+# its own dependencies, so a non-apt base (e.g. Fedora) fails cloud provisioning
+# with "apt-get: command not found" (return code 127). debian:*-slim ships bash,
+# which is all eval.sh needs. It is pulled from AWS's public Docker Hub mirror
+# (public.ecr.aws/docker/library) rather than docker.io directly, to avoid Docker
+# Hub's unauthenticated pull-rate limit on a hot path (CI). Swappable for another
+# mirror, e.g. mirror.gcr.io/library/debian. When eval is implemented for real,
+# base the image on a suitable Debian/Ubuntu runtime (e.g. a python:*-slim image)
 # and install the evaluation dependencies here.
-ARG FEDORA_VERSION=42
-FROM quay.io/fedora/fedora-minimal:${FEDORA_VERSION}
+ARG DEBIAN_VERSION=12
+FROM public.ecr.aws/docker/library/debian:${DEBIAN_VERSION}-slim
 
 # Bake the eval script into the image and make it executable. The generated
 # step.yaml run/command block invokes `bash /opt/eval/eval.sh`.

--- a/steps/eval/skypilot/README.md
+++ b/steps/eval/skypilot/README.md
@@ -93,3 +93,46 @@ make -C steps/eval/skypilot test
   publish-image` (after `podman login`) before submitting such a build. The
   `Docker` launcher is the exception: it uses the **local** image, so `make
   image` (done for you by `make test`) is enough — no publish.
+
+## Running the AWS test (real EC2)
+
+`make -C steps/eval/skypilot test` runs the whole `test/` tree — the local
+`docker/` test (above) **and** `test/aws/test_skypilot_aws_eval.py`, which runs
+the eval step on a real EC2 node via SkyPilot. Like the [byoc AWS
+test](../../byoc/skypilot/README.md#environment-variables-for-the-aws-test) it is
+**extended-suite only** (`@extended_testing_only` + the `skypilot_integration`
+marker) and **self-skips** unless AWS credentials are in the environment, so it
+never provisions an instance by accident.
+
+### Environment variables
+
+The skip gate is the shared
+`gbserver.environment.skypilot.aws_credentials_present()` predicate, which
+requires **either**:
+
+| Variable(s) | Meaning |
+|---|---|
+| `AWS_ACCESS_KEY_ID` **and** `AWS_SECRET_ACCESS_KEY` | An explicit access-key pair. |
+| `AWS_PROFILE` | A named profile in `~/.aws/credentials` (e.g. `gb-skypilot`). |
+
+If neither is set the test skips cleanly. Also required for the launch itself
+(not part of the skip gate): `sky check aws` must report `AWS: enabled`, and a
+region must be configured — via the AWS profile / `~/.aws/config`, or
+`AWS_DEFAULT_REGION`. No `HF_TOKEN` is needed: the exemplar fixture uses `env://`
+I/O and downloads nothing.
+
+### The image must be published first (unlike byoc)
+
+eval bakes its evaluator into a **custom image**, and the EC2 node *pulls* that
+image by the `image_id` (`docker:${IMAGE_REF}`) frozen into the step at `make
+space` time. The `if-not-present` shortcut the `Docker` launcher uses does **not**
+apply on a remote node, so the aws test only passes once the image is pushed to a
+**public/pullable** registry — the committed default `quay.io/your-org` is a
+placeholder that fails auth. Build + publish at a real registry, then run the
+tests with that same `REGISTRY` so the rendered `image_id` points at the image you
+pushed:
+
+```sh
+make -C steps/eval/skypilot image publish-image REGISTRY=quay.io/<you>   # build + push (after `podman login`)
+make -C steps/eval/skypilot test REGISTRY=quay.io/<you>                  # renders image_id -> your ref, runs docker + aws tests
+```

--- a/test/unit/environment/test_skypilot.py
+++ b/test/unit/environment/test_skypilot.py
@@ -414,8 +414,9 @@ class TestLaunchSkypilot:
                 }
             },
         )
-        assert kwargs.get("cpus") == 2
-        assert kwargs.get("memory") == 1.0
+        # k8s (fixture default_cloud) is a cloud catalog, so cpus is a minimum.
+        assert kwargs.get("cpus") == "2+"
+        assert kwargs.get("memory") == "1+"
 
     @pytest.mark.asyncio
     async def test_launcher_resources_override_compute_config(self, skypilot_env):
@@ -432,8 +433,8 @@ class TestLaunchSkypilot:
             },
         )
         assert kwargs.get("cpus") == "4+"
-        # memory floor still applies (not overridden)
-        assert kwargs.get("memory") == 1.0
+        # memory floor still applies (not overridden), as a minimum
+        assert kwargs.get("memory") == "1+"
 
     @pytest.mark.asyncio
     async def test_no_compute_config_leaves_resources_unset(self, skypilot_env):
@@ -463,7 +464,7 @@ class TestLaunchSkypilot:
             },
         )
         assert kwargs.get("cpus") is None
-        assert kwargs.get("memory") == 1.0
+        assert kwargs.get("memory") == "1+"
 
     @pytest.mark.asyncio
     async def test_slurm_infra_drops_memory_floor(self, skypilot_env):
@@ -526,10 +527,12 @@ class TestSkypilotComputeConfigResources:
         from gbserver.environment.skypilot import Skypilot
 
         env = Skypilot(event_q=asyncio.Queue())
-        # cpus emitted only when > 0; memory parsed from the string.
+        # cpus emitted only when > 0; on a cloud catalog both cpus and memory are
+        # emitted as a SkyPilot minimum ("{n}+"), never an exact number (see
+        # test_cpus_floor_is_minimum_not_exact / test_memory_floor_is_minimum_not_exact).
         assert env._resources_from_compute_config(
             {"num_cpus_per_node": 3, "total_memory_per_node": "2Gi"}
-        ) == {"cpus": 3, "memory": 2.0}
+        ) == {"cpus": "3+", "memory": "2+"}
         # num_cpus_per_node <= 0 is skipped (cloud default); empty memory skipped.
         assert (
             env._resources_from_compute_config(
@@ -540,16 +543,59 @@ class TestSkypilotComputeConfigResources:
         # empty compute_config yields no floor.
         assert env._resources_from_compute_config({}) == {}
         # On slurm/lsf the memory floor is dropped (bare HPC schedulers often
-        # don't track memory as a consumable resource), but cpus is still emitted.
+        # don't track memory as a consumable resource), and cpus stays a bare
+        # int (the "+" form crashes the fork's LSF cloud).
         for hpc_cloud in ("slurm", "lsf"):
             assert env._resources_from_compute_config(
                 {"num_cpus_per_node": 3, "total_memory_per_node": "2Gi"},
                 cloud=hpc_cloud,
             ) == {"cpus": 3}
-        # Non-HPC clouds keep the memory floor.
+        # Non-HPC clouds keep both floors, each as a minimum.
         assert env._resources_from_compute_config(
-            {"total_memory_per_node": "2Gi"}, cloud="k8s"
-        ) == {"memory": 2.0}
+            {"num_cpus_per_node": 3, "total_memory_per_node": "2Gi"}, cloud="k8s"
+        ) == {"cpus": "3+", "memory": "2+"}
+
+    def test_cpus_floor_is_minimum_not_exact(self):
+        """The cloud cpus floor must be a SkyPilot minimum ("{n}+"), not an
+        exact number.
+
+        Regression: an exact ``cpus=3`` matches no cloud instance type (no AWS
+        type has exactly 3 vCPUs), so provisioning dies with the same "Catalog
+        does not contain any instances satisfying the request" failure the
+        memory floor hit. Emitting ``"3+"`` lets SkyPilot pick the smallest
+        instance with at least that many vCPUs. slurm/lsf keep the bare int (the
+        ``"+"`` form crashes the fork's LSF cloud).
+        """
+        from gbserver.environment.skypilot import Skypilot
+
+        env = Skypilot(event_q=asyncio.Queue())
+        assert env._resources_from_compute_config(
+            {"num_cpus_per_node": 3}, cloud="aws"
+        ) == {"cpus": "3+"}
+        assert env._resources_from_compute_config(
+            {"num_cpus_per_node": 3}, cloud="lsf"
+        ) == {"cpus": 3}
+
+    def test_memory_floor_is_minimum_not_exact(self):
+        """The cloud memory floor must be a SkyPilot minimum ("{n}+"), not an
+        exact number.
+
+        Regression: an exact ``memory=1.0`` matches no cloud instance type, so
+        provisioning dies with "Catalog does not contain any instances
+        satisfying the request: 1x AWS(mem=1.0)." Emitting ``"1+"`` lets
+        SkyPilot pick the smallest instance with at least that much RAM.
+        Fractional sizes format without a trailing ``.0`` (e.g. ``512Mi`` ->
+        ``"0.5+"``).
+        """
+        from gbserver.environment.skypilot import Skypilot
+
+        env = Skypilot(event_q=asyncio.Queue())
+        assert env._resources_from_compute_config(
+            {"total_memory_per_node": "1Gi"}, cloud="aws"
+        ) == {"memory": "1+"}
+        assert env._resources_from_compute_config(
+            {"total_memory_per_node": "512Mi"}, cloud="aws"
+        ) == {"memory": "0.5+"}
 
 
 class TestMonitorSkypilotMonitor:


### PR DESCRIPTION
## Summary

Two independent SkyPilot-on-AWS fixes surfaced while enabling the byoc/eval step tests on a bare EC2 node. Rebuilt on top of #282 (which now owns the step cwd / `GB_BUILD_WORKDIR` contract), so this PR is scoped to just the resource-floor and eval-image fixes.

## Changes

- **`fix(skypilot)`: emit cpus/memory floors as SkyPilot minimums (`"{n}+"`).** Mapping `compute_config` to an exact `sky.Resources(cpus=N, memory=F)` is an EXACT catalog request no cloud instance type satisfies for odd sizes — provisioning died with `Catalog does not contain any instances satisfying the request: 1x AWS(mem=1.0)` (and likewise `cpus=3`). Emit both as SkyPilot minimums (`"{n}+"`) so it picks the smallest instance with at least that much CPU/RAM. `slurm`/`lsf` are excluded: the `+` form crashes the fork's LSF cloud and those schedulers match CPUs directly, so `cpus` stays a bare int and the memory floor is dropped as before. Memory is formatted without an exponent (`f`-format + `rstrip`) so large values don't become unparseable scientific notation.
- **`fix(eval/skypilot)`: Debian-based image via AWS Docker Hub mirror.** SkyPilot's docker runtime runs `apt-get` inside the container, so the Fedora base failed cloud provisioning with `apt-get: command not found` (rc 127). Rebased the eval exemplar image on `debian:*-slim` (ships `bash`, all `eval.sh` needs), pulled from AWS's Docker Hub mirror (`public.ecr.aws/docker/library/debian`, swappable for `mirror.gcr.io/library/debian`) to keep the pull-rate-limit protection.

## Scope notes

Rebased onto `main` after #282 merged. The `GB_BUILD_WORKDIR` binding, `byoc` cd-into-repo, jobstats_count fixture tweaks, and mount-docs from earlier revisions of this branch were **dropped** — #282 supersedes them (the launcher now prepends `set -eu` and `cd`s into `$GB_BUILD_WORKDIR` only when a `shared_workdir` is provisioned; steps stay cwd-agnostic).

## Test plan

- [x] `test/unit/environment/test_skypilot.py` updated for the `"{n}+"` floor behavior; unit tests pass (140 passed across `test_skypilot.py` + `test_skypilot_slurm.py`).
- [x] eval Dockerfile builds from the mirror base with no auth; ships `apt` + `bash`.
- [ ] Reviewer: `make -C steps/eval/skypilot test` with AWS creds exported (credential-gated EC2 test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)