### PR TITLE
fix(k8s): sanitize username/spacename before use as job labels

### DIFF
--- a/src/gbserver/buildrunnerjob/buildrunnerjob.py
+++ b/src/gbserver/buildrunnerjob/buildrunnerjob.py
@@ -59,6 +59,7 @@ from gbserver.types.constants import (
 from gbserver.types.status import Status
 from gbserver.utils.logger import get_logger
 from gbserver.utils.template import fill_template
+from gbserver.utils.utils import sanitize_k8s_label_value
 
 logger = get_logger(__name__)
 
@@ -242,10 +243,18 @@ class BuildRunnerJob(AbstractBuildRunner):
         stored_build = self.stored_build
         build_id = stored_build.uuid or "no_build_id"
         source_uri = stored_build.source_uri or ""
+        # username/spacename are used only for human tracking (no functional
+        # lookup matches on them), so sanitize to satisfy the k8s label-value
+        # constraints. In ibmid auth mode the username is an email address
+        # (e.g. contains '@'), which the API server would otherwise reject.
         labels = {
             "granite-dot-build/build-id": build_id,
-            "granite-dot-build/username": stored_build.username or "no_username",
-            "granite-dot-build/spacename": stored_build.space_name or "no_spacename",
+            "granite-dot-build/username": sanitize_k8s_label_value(
+                stored_build.username or "", fallback="no_username"
+            ),
+            "granite-dot-build/spacename": sanitize_k8s_label_value(
+                stored_build.space_name or "", fallback="no_spacename"
+            ),
         }
         annotations = {"granite-dot-build/pr": source_uri}
         kube_job_name = f"gb-build-runner-{build_id}"

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -287,6 +287,9 @@ class K8s(Environment):
         labels["granite-dot-build/build-step-id"] = (
             runmetadata.targetsteprun_id or "no_targetsteprun_id"
         )
+        # If re-enabled, run the value through
+        # gbserver.utils.utils.sanitize_k8s_label_value() first: usernames may
+        # be email addresses (ibmid auth) that are invalid as k8s label values.
         # labels["granite-dot-build/username"] = ""
         kwargs["labels"] = labels
         if runmetadata.targetstep_uri:

--- a/src/gbserver/utils/utils.py
+++ b/src/gbserver/utils/utils.py
@@ -107,10 +107,11 @@ def sanitize_k8s_label_value(value: str, fallback: str = "unknown") -> str:
     Values that violate these rules (e.g. an ibmid email username containing
     '@') would otherwise be rejected by the API server when creating the
     job/pod. These labels are used only for human tracking/grouping, not for
-    any functional lookup or matching, so a lossy-but-readable transformation
-    is acceptable. To keep distinct inputs from silently collapsing onto the
-    same label (which would defeat the tracking purpose), a short hash of the
-    original value is appended whenever the input had to be altered.
+    any functional lookup or matching, so a lossy transformation is fine. The
+    result is kept as close to the original as possible for readability -- the
+    goal is simply that the value not break job creation -- so illegal
+    characters are replaced in place (e.g. "ABC@foo.com" -> "ABC_foo.com")
+    rather than encoded or suffixed.
 
     Args:
         value: The raw string to sanitize.
@@ -123,33 +124,21 @@ def sanitize_k8s_label_value(value: str, fallback: str = "unknown") -> str:
         A string that satisfies the Kubernetes label value constraints,
         provided `fallback` (if used) is itself a valid label value.
     """
-    original = value or ""
     # Replace any disallowed character with '_' so the result stays readable
-    # (e.g. "user@example.com" -> "user_example.com").
-    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", original)
-    changed = sanitized != original
+    # (e.g. "ABC@foo.com" -> "ABC_foo.com").
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", value or "")
 
-    # Trim leading/trailing characters that aren't alphanumeric so the value
-    # begins and ends with an alphanumeric as k8s requires.
-    body = re.sub(r"^[^A-Za-z0-9]+", "", sanitized)
-    body = re.sub(r"[^A-Za-z0-9]+$", "", body)
+    # Truncate to the length limit, then trim leading/trailing non-alphanumeric
+    # characters so the value begins and ends with an alphanumeric as k8s
+    # requires. Trimming after truncation also cleans up any separator left
+    # dangling at the cut point.
+    sanitized = sanitized[:K8S_LABEL_VALUE_MAX_LENGTH]
+    sanitized = re.sub(r"^[^A-Za-z0-9]+", "", sanitized)
+    sanitized = re.sub(r"[^A-Za-z0-9]+$", "", sanitized)
 
-    # When the value was altered, reserve room for a "-<8charhash>" suffix so
-    # different originals that map to the same sanitized body stay distinct.
-    suffix = "-" + short_alphanumeric_lower_hash(original) if changed else ""
-    max_body = K8S_LABEL_VALUE_MAX_LENGTH - len(suffix)
-
-    # Truncate to fit, then re-trim: truncation may cut in the middle of a run
-    # of separators and leave a trailing '.', '-' or '_', which is illegal at
-    # the end of a label value. This applies whether or not a suffix follows.
-    body = re.sub(r"[^A-Za-z0-9]+$", "", body[:max_body])
-
-    if not body:
-        # Nothing usable survived (input was empty, entirely invalid chars, or
-        # truncated down to only separators).
-        return fallback
-
-    return body + suffix
+    # Nothing usable survived (input was empty or made entirely of invalid or
+    # separator characters).
+    return sanitized or fallback
 
 
 def cmd_safe_join(cmd: List[str]) -> str:

--- a/src/gbserver/utils/utils.py
+++ b/src/gbserver/utils/utils.py
@@ -93,6 +93,60 @@ def short_alphanumeric_lower_hash(input_string: str) -> str:
     return base64_encoded[:8].lower()
 
 
+K8S_LABEL_VALUE_MAX_LENGTH = 63
+
+
+def sanitize_k8s_label_value(value: str, fallback: str = "unknown") -> str:
+    """Coerce an arbitrary string into a valid Kubernetes label value.
+
+    Kubernetes label values must (per the API validation rules):
+      - be 63 characters or less,
+      - consist of alphanumerics, '-', '_' or '.',
+      - begin and end with an alphanumeric character (or be empty).
+
+    Values that violate these rules (e.g. an ibmid email username containing
+    '@') would otherwise be rejected by the API server when creating the
+    job/pod. These labels are used only for human tracking/grouping, not for
+    any functional lookup or matching, so a lossy-but-readable transformation
+    is acceptable. To keep distinct inputs from silently collapsing onto the
+    same label (which would defeat the tracking purpose), a short hash of the
+    original value is appended whenever the input had to be altered.
+
+    Args:
+        value: The raw string to sanitize.
+        fallback: Value to use when sanitization would otherwise yield an
+            empty string (e.g. input made entirely of invalid characters).
+
+    Returns:
+        A string that satisfies the Kubernetes label value constraints.
+    """
+    original = value or ""
+    # Replace any disallowed character with '_' so the result stays readable
+    # (e.g. "user@example.com" -> "user_example.com").
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", original)
+    changed = sanitized != original
+
+    # Trim leading/trailing characters that aren't alphanumeric so the value
+    # begins and ends with an alphanumeric as k8s requires.
+    body = re.sub(r"^[^A-Za-z0-9]+", "", sanitized)
+    body = re.sub(r"[^A-Za-z0-9]+$", "", body)
+
+    if not body:
+        # Nothing usable survived (e.g. input was entirely invalid chars).
+        return fallback
+
+    if changed:
+        # Reserve room for a "-<8charhash>" suffix so different originals that
+        # map to the same sanitized body remain distinguishable.
+        suffix = "-" + short_alphanumeric_lower_hash(original)
+        max_body = K8S_LABEL_VALUE_MAX_LENGTH - len(suffix)
+        # Re-trim in case truncation left a trailing non-alnum before the suffix.
+        body = re.sub(r"[^A-Za-z0-9]+$", "", body[:max_body])
+        return (body + suffix) if body else fallback
+
+    return body[:K8S_LABEL_VALUE_MAX_LENGTH]
+
+
 def cmd_safe_join(cmd: List[str]) -> str:
     """Preserves arguments with spaces in them."""
     return " ".join(f"'{x}'" if " " in x else x for x in cmd)

--- a/src/gbserver/utils/utils.py
+++ b/src/gbserver/utils/utils.py
@@ -116,9 +116,12 @@ def sanitize_k8s_label_value(value: str, fallback: str = "unknown") -> str:
         value: The raw string to sanitize.
         fallback: Value to use when sanitization would otherwise yield an
             empty string (e.g. input made entirely of invalid characters).
+            The caller is responsible for passing a valid label value here;
+            it is returned as-is (not re-sanitized).
 
     Returns:
-        A string that satisfies the Kubernetes label value constraints.
+        A string that satisfies the Kubernetes label value constraints,
+        provided `fallback` (if used) is itself a valid label value.
     """
     original = value or ""
     # Replace any disallowed character with '_' so the result stays readable
@@ -131,20 +134,22 @@ def sanitize_k8s_label_value(value: str, fallback: str = "unknown") -> str:
     body = re.sub(r"^[^A-Za-z0-9]+", "", sanitized)
     body = re.sub(r"[^A-Za-z0-9]+$", "", body)
 
+    # When the value was altered, reserve room for a "-<8charhash>" suffix so
+    # different originals that map to the same sanitized body stay distinct.
+    suffix = "-" + short_alphanumeric_lower_hash(original) if changed else ""
+    max_body = K8S_LABEL_VALUE_MAX_LENGTH - len(suffix)
+
+    # Truncate to fit, then re-trim: truncation may cut in the middle of a run
+    # of separators and leave a trailing '.', '-' or '_', which is illegal at
+    # the end of a label value. This applies whether or not a suffix follows.
+    body = re.sub(r"[^A-Za-z0-9]+$", "", body[:max_body])
+
     if not body:
-        # Nothing usable survived (e.g. input was entirely invalid chars).
+        # Nothing usable survived (input was empty, entirely invalid chars, or
+        # truncated down to only separators).
         return fallback
 
-    if changed:
-        # Reserve room for a "-<8charhash>" suffix so different originals that
-        # map to the same sanitized body remain distinguishable.
-        suffix = "-" + short_alphanumeric_lower_hash(original)
-        max_body = K8S_LABEL_VALUE_MAX_LENGTH - len(suffix)
-        # Re-trim in case truncation left a trailing non-alnum before the suffix.
-        body = re.sub(r"[^A-Za-z0-9]+$", "", body[:max_body])
-        return (body + suffix) if body else fallback
-
-    return body[:K8S_LABEL_VALUE_MAX_LENGTH]
+    return body + suffix
 
 
 def cmd_safe_join(cmd: List[str]) -> str:

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -15,11 +15,17 @@
 # limitations under the License.
 
 import asyncio
+import re
 from pathlib import Path
 
 from gbserver.types.errors import LogMonitoringFailedException
 from gbserver.utils.unwrap_errors import unwrap_errors
-from gbserver.utils.utils import get_common_ancestor, get_sha256sum
+from gbserver.utils.utils import (
+    K8S_LABEL_VALUE_MAX_LENGTH,
+    get_common_ancestor,
+    get_sha256sum,
+    sanitize_k8s_label_value,
+)
 
 
 class TestSha256sum:
@@ -271,3 +277,68 @@ assert 0 > 0
         except BaseException as e:
             readable_error = unwrap_errors(e)
             assert readable_error == expected_err
+
+
+# Kubernetes label value validation regex (from the API server rules):
+# up to 63 chars, alphanumerics/'-'/'_'/'.', beginning and ending alphanumeric.
+_K8S_LABEL_VALUE_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$")
+
+
+def _is_valid_k8s_label_value(value: str) -> bool:
+    return bool(_K8S_LABEL_VALUE_RE.fullmatch(value))
+
+
+class TestSanitizeK8sLabelValue:
+    def test_valid_value_unchanged(self):
+        # A plain github-style username is already valid and must be preserved.
+        assert sanitize_k8s_label_value("octocat") == "octocat"
+        assert sanitize_k8s_label_value("a.b-c_d") == "a.b-c_d"
+
+    def test_email_username_is_sanitized(self):
+        # ibmid auth mode: username is an email address containing '@'.
+        result = sanitize_k8s_label_value("user@example.com")
+        assert _is_valid_k8s_label_value(result)
+        assert "@" not in result
+        # Readable prefix preserved; '@' replaced with '_'.
+        assert result.startswith("user_example.com")
+
+    def test_altered_values_get_hash_suffix(self):
+        # Distinct inputs that share a sanitized prefix must not collide:
+        # "alice@corp" and "alice#corp" both sanitize to "alice_corp".
+        a = sanitize_k8s_label_value("alice@corp")
+        b = sanitize_k8s_label_value("alice#corp")
+        assert a != b
+        assert _is_valid_k8s_label_value(a)
+        assert _is_valid_k8s_label_value(b)
+
+    def test_unchanged_value_gets_no_hash_suffix(self):
+        # Already-valid values are returned verbatim (no hash noise appended).
+        assert sanitize_k8s_label_value("plainuser") == "plainuser"
+
+    def test_long_value_is_truncated_to_limit(self):
+        result = sanitize_k8s_label_value("a" * 200)
+        assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
+        assert _is_valid_k8s_label_value(result)
+
+    def test_long_altered_value_is_truncated_with_suffix(self):
+        result = sanitize_k8s_label_value("bad@" + "x" * 200)
+        assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
+        assert _is_valid_k8s_label_value(result)
+
+    def test_leading_trailing_non_alnum_trimmed(self):
+        # '@' -> '_' at both ends would be invalid; must be trimmed.
+        result = sanitize_k8s_label_value("@user@")
+        assert _is_valid_k8s_label_value(result)
+        assert result[0].isalnum() and result[-1].isalnum()
+
+    def test_empty_uses_fallback(self):
+        assert sanitize_k8s_label_value("") == "unknown"
+        assert sanitize_k8s_label_value("", fallback="no_username") == "no_username"
+
+    def test_all_invalid_chars_uses_fallback(self):
+        # Reduces to empty after trimming leading/trailing non-alnum.
+        assert sanitize_k8s_label_value("@@@", fallback="no_username") == "no_username"
+
+    def test_none_like_falsy_handled(self):
+        # buildrunnerjob passes `stored_build.username or ""`; guard "" here.
+        assert sanitize_k8s_label_value("", fallback="no_username") == "no_username"

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -325,6 +325,24 @@ class TestSanitizeK8sLabelValue:
         assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
         assert _is_valid_k8s_label_value(result)
 
+    def test_valid_charset_truncated_on_separator_is_still_valid(self):
+        # Regression: an all-valid-charset value (unchanged path) longer than
+        # 63 chars whose truncation boundary falls on a separator must not end
+        # in '.'/'-'/'_'. Space names commonly contain dots/dashes.
+        value = "a" * 62 + "." + "b" * 5
+        result = sanitize_k8s_label_value(value)
+        assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
+        assert _is_valid_k8s_label_value(result)
+        assert not result.endswith(".")
+
+    def test_all_separators_valid_charset_uses_fallback(self):
+        # All chars are in the allowed set but none are alphanumeric, so after
+        # trimming nothing usable remains -> fallback.
+        assert (
+            sanitize_k8s_label_value("." * 70, fallback="no_spacename")
+            == "no_spacename"
+        )
+
     def test_leading_trailing_non_alnum_trimmed(self):
         # '@' -> '_' at both ends would be invalid; must be trimmed.
         result = sanitize_k8s_label_value("@user@")

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -290,50 +290,37 @@ def _is_valid_k8s_label_value(value: str) -> bool:
 
 class TestSanitizeK8sLabelValue:
     def test_valid_value_unchanged(self):
-        # A plain github-style username is already valid and must be preserved.
+        # Already-valid values must be returned verbatim.
         assert sanitize_k8s_label_value("octocat") == "octocat"
         assert sanitize_k8s_label_value("a.b-c_d") == "a.b-c_d"
+        assert sanitize_k8s_label_value("my.space-name") == "my.space-name"
+        assert sanitize_k8s_label_value("a" * 63) == "a" * 63
 
-    def test_email_username_is_sanitized(self):
-        # ibmid auth mode: username is an email address containing '@'.
-        result = sanitize_k8s_label_value("user@example.com")
-        assert _is_valid_k8s_label_value(result)
-        assert "@" not in result
-        # Readable prefix preserved; '@' replaced with '_'.
-        assert result.startswith("user_example.com")
-
-    def test_altered_values_get_hash_suffix(self):
-        # Distinct inputs that share a sanitized prefix must not collide:
-        # "alice@corp" and "alice#corp" both sanitize to "alice_corp".
-        a = sanitize_k8s_label_value("alice@corp")
-        b = sanitize_k8s_label_value("alice#corp")
-        assert a != b
-        assert _is_valid_k8s_label_value(a)
-        assert _is_valid_k8s_label_value(b)
-
-    def test_unchanged_value_gets_no_hash_suffix(self):
-        # Already-valid values are returned verbatim (no hash noise appended).
-        assert sanitize_k8s_label_value("plainuser") == "plainuser"
+    def test_email_username_is_sanitized_in_place(self):
+        # ibmid auth mode: username is an email address containing '@'. The
+        # result stays as close to the original as possible -- illegal chars
+        # are replaced in place, with no encoding or hash suffix.
+        assert sanitize_k8s_label_value("ABC@foo.com") == "ABC_foo.com"
+        assert sanitize_k8s_label_value("user@example.com") == "user_example.com"
 
     def test_long_value_is_truncated_to_limit(self):
         result = sanitize_k8s_label_value("a" * 200)
-        assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
+        assert result == "a" * K8S_LABEL_VALUE_MAX_LENGTH
         assert _is_valid_k8s_label_value(result)
 
-    def test_long_altered_value_is_truncated_with_suffix(self):
+    def test_long_altered_value_is_valid(self):
         result = sanitize_k8s_label_value("bad@" + "x" * 200)
         assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
         assert _is_valid_k8s_label_value(result)
 
-    def test_valid_charset_truncated_on_separator_is_still_valid(self):
-        # Regression: an all-valid-charset value (unchanged path) longer than
-        # 63 chars whose truncation boundary falls on a separator must not end
-        # in '.'/'-'/'_'. Space names commonly contain dots/dashes.
+    def test_value_truncated_on_separator_does_not_end_in_separator(self):
+        # A value longer than 63 chars whose truncation boundary falls on a
+        # separator must not end in '.'/'-'/'_'. Space names commonly contain
+        # dots/dashes.
         value = "a" * 62 + "." + "b" * 5
         result = sanitize_k8s_label_value(value)
-        assert len(result) <= K8S_LABEL_VALUE_MAX_LENGTH
+        assert result == "a" * 62
         assert _is_valid_k8s_label_value(result)
-        assert not result.endswith(".")
 
     def test_all_separators_valid_charset_uses_fallback(self):
         # All chars are in the allowed set but none are alphanumeric, so after
@@ -345,9 +332,9 @@ class TestSanitizeK8sLabelValue:
 
     def test_leading_trailing_non_alnum_trimmed(self):
         # '@' -> '_' at both ends would be invalid; must be trimmed.
-        result = sanitize_k8s_label_value("@user@")
-        assert _is_valid_k8s_label_value(result)
-        assert result[0].isalnum() and result[-1].isalnum()
+        assert sanitize_k8s_label_value("@user@") == "user"
+        assert sanitize_k8s_label_value(".leading") == "leading"
+        assert sanitize_k8s_label_value("trailing.") == "trailing"
 
     def test_empty_uses_fallback(self):
         assert sanitize_k8s_label_value("") == "unknown"


### PR DESCRIPTION
## Summary

- In `ibmid` auth mode the user ID is an email address (e.g. `ABC@foo.com`). That value was written verbatim into the `granite-dot-build/username` k8s label on the build-runner job. `@` is not a legal character in a Kubernetes label value, so the API server rejected job creation and builds failed to launch.
- Add `sanitize_k8s_label_value()` in `gbserver/utils/utils.py` that coerces an arbitrary string into a valid k8s label value (≤63 chars, `[A-Za-z0-9._-]`, begins and ends with an alphanumeric). It replaces illegal characters in place, truncates to 63, then trims any non-alphanumeric ends (which also cleans up a separator left dangling at the truncation boundary). Falls back to a caller-supplied default when nothing usable remains.
- Apply the helper to the `username` and `spacename` labels in `buildrunnerjob.py`.
- Add a note at the commented-out `granite-dot-build/username` label in `environment/k8s.py` so any future re-enable routes through the same helper.

The transformation is intentionally minimal and kept **as close to the original as possible** for readability — the goal is simply that the value not break job creation, e.g. `ABC@foo.com` → `ABC_foo.com` (no encoding, no hash suffix). These labels are used **only for human tracking/grouping** — every functional pod/job lookup selects on `granite-dot-build/build-id` (or the appwrapper label), never on `username`/`spacename` — so a lossy sanitization is safe and requires no changes to any filter/matching code. Preserving exact uniqueness across distinct inputs is not needed and is deliberately not attempted.

`granite-dot-build/build-id` is intentionally left unsanitized: it is a server-generated UUID that is also used as a label selector (and in the job name), so it is already label-safe and must remain byte-identical to what selectors match on.

Closes ibm-granite/granite.build#262

## Test plan

- Unit tests in `test/unit/utils/test_utils.py::TestSanitizeK8sLabelValue` cover: already-valid values (including legal `.`/`-`/`_` separators and exactly-63-char values) returned verbatim; in-place email sanitization (`ABC@foo.com` → `ABC_foo.com`); truncation to 63; a truncation boundary landing on a separator (result must not end in `.`/`-`/`_`); leading/trailing non-alphanumeric trimming; all-separator and empty/all-invalid inputs falling back. Every result is validated against the k8s label-value regex.
- `python -m pytest test/unit/utils/test_utils.py` — passes.
- `python -m pytest test/unit/buildrunner/` — 61 passed.
- `black` / `isort` clean; `pylint` / `mypy` introduce no new findings over baseline.

Generated with [Claude Code](https://claude.com/claude-code)
