### PR TITLE
feat(plugins): discover subsystem implementations via entry points

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,115 @@
+# Plugins
+
+> **Audience:** developers packaging functionality that ships *outside* the `granite.build` repo — for
+> example an organization-specific asset store, secret manager, or compute environment — and want the
+> core to discover it at runtime without any code living in the public repo.
+
+A **plugin** is an ordinary pip-installable Python package that contributes implementations to
+`granite.build`'s pluggable subsystems. When the plugin is installed alongside `granite.build`, the core
+discovers its classes automatically; when it is absent, the core runs exactly as before. There is no code
+in the public repo that names the plugin, and no configuration to switch it on beyond installing it.
+
+## How discovery works
+
+Each pluggable subsystem keeps a registry that it populates in two passes:
+
+1. **In-tree scan** — the subsystem imports the implementations that live in its own package directory
+   (this is how the built-in environments, URI handlers, etc. register).
+2. **Entry-point scan** — the subsystem then enumerates a well-known
+   [Python packaging *entry-point group*](https://packaging.python.org/en/latest/specifications/entry-points/)
+   and folds any classes it finds into the same registry.
+
+The entry-point table in your plugin's `pyproject.toml` **is** the plugin manifest — there is no separate
+manifest file to author. You declare, per subsystem, which of your classes to expose:
+
+```toml
+# pyproject.toml of your plugin package (e.g. granite_build_ibm)
+[project.entry-points."gbserver.uri_handlers"]
+lh = "granite_build_ibm.uri_handlers.lh:LhURI"
+
+[project.entry-points."gbserver.asset_stores"]
+lakehouse = "granite_build_ibm.asset_stores.lhstore:Lhstore"
+
+[project.entry-points."gbserver.secret_managers"]
+ibmcloud = "granite_build_ibm.secret_managers.ibmcloud:IbmcloudSpaceSecretManager"
+
+[project.entry-points."gbserver.environments"]
+myenv = "granite_build_ibm.environments.myenv:Myenv"
+```
+
+The shared discovery helper lives in [`src/gbcommon/plugins.py`](../../src/gbcommon/plugins.py). It wraps
+`importlib.metadata.entry_points(group=...)`, loads each entry point, and is **defensive by
+construction**: if the entry-point table cannot be read, or a single entry point fails to import, the
+failure is logged and skipped so that one broken plugin never prevents the core (or its other plugins)
+from starting.
+
+## Precedence: core wins
+
+The in-tree scan runs first; the entry-point scan only ever **adds** to the registry. If a plugin
+declares an implementation whose key (URI scheme, environment type name, secret-manager key, or the URI
+class an asset store handles) is already registered by the core, the **core implementation is kept** and
+the plugin's is skipped with a `WARNING` in the logs. Plugins extend the core; in this release they do not
+override it.
+
+Both passes — the in-tree scan and the entry-point scan — file their classes through the same
+`PluginRegistrar` (in [`src/gbcommon/plugins.py`](../../src/gbcommon/plugins.py)), so this collision rule
+lives in exactly one place. A subsystem constructs a registrar with its own registry dict and a
+`keys_of(cls, name)` callback that says which key(s) a class maps to; the registrar owns the rest.
+
+## Supported subsystems
+
+These subsystems discover plugins today. Declare a class in the listed group; the class must subclass the
+listed base class and provide the listed key.
+
+| Group | Base class | Key derivation |
+|---|---|---|
+| `gbserver.uri_handlers` | `gbcommon.uri.uri.URI` | the scheme(s) returned by `get_supported_schemes()` |
+| `gbserver.asset_stores` | `gbserver.asset.assetstore.Assetstore` | the URI class(es) returned by `get_supported_uri_classes()` |
+| `gbserver.environments` | `gbserver.environment.environment.Environment` | the **entry-point name** (registered under both `name.lower()` and `name.capitalize()`) |
+| `gbserver.secret_managers` | `SpaceSecretManager` **or** `UserSecretManager` | the **entry-point name** (lowercased). One group feeds both families; each class is routed to the family whose base class it subclasses |
+
+For the URI and asset-store groups the entry-point *name* is cosmetic — the registration key comes from
+the class's own method, so name your entry point whatever reads well. For the environment and
+secret-manager groups the entry-point *name* is the registration key.
+
+> **Name-keyed groups are case-normalized.** Environments register under both `name.lower()` and
+> `name.capitalize()`, and secret managers under `name.lower()`. `str.capitalize()` lowercases every
+> character after the first, so an entry-point name with intended internal capitals (e.g. `AWSBatch`)
+> is only reachable as `awsbatch` / `Awsbatch` — a build that references `type: AWSBatch` will not
+> resolve. Use a lowercase entry-point name to avoid surprises.
+
+## Reserved groups (wired in later releases)
+
+The same mechanism will be extended to the following subsystems in subsequent releases. The group names
+are reserved now so plugin authors can target stable names; wiring them into the core is tracked
+separately.
+
+| Group | Purpose |
+|---|---|
+| `gbserver.auth_providers` | Additional authentication providers (`AuthProvider` subclasses) |
+| `gbserver.resilience_strategies` | Additional retry / resilience strategies (`RetryStrategy` subclasses) |
+| `gbserver.builtin_steps` | Additional built-in step directories contributed as step search roots |
+| `gbcli.plugins` | Additional `gbcli` subcommands (a module exposing a `cli` click command) |
+
+The canonical list of group-name constants is
+[`src/gbcommon/plugins.py`](../../src/gbcommon/plugins.py) — import the constants from there rather than
+hardcoding the strings.
+
+## Writing a plugin class
+
+A plugin class is just a normal subclass — the same class you would write in-tree. For example, a URI
+handler:
+
+```python
+# granite_build_ibm/uri_handlers/lh.py
+from gbcommon.uri.uri import URI
+
+class LhURI(URI):
+    @staticmethod
+    def get_supported_schemes():
+        return ["lh"]
+    # ... the rest of the URI contract
+```
+
+Once your package is installed (`pip install granite_build_ibm`), starting `gbserver` will resolve
+`lh://` URIs through `LhURI` with no further configuration.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -37,6 +37,14 @@ ibmcloud = "granite_build_ibm.secret_managers.ibmcloud:IbmcloudSpaceSecretManage
 myenv = "granite_build_ibm.environments.myenv:Myenv"
 ```
 
+> **The double-quotes around the group name are required.** These groups contain a dot, and in TOML an
+> unquoted dot is a table-nesting separator — `[project.entry-points.gbserver.uri_handlers]` declares two
+> nested tables (`gbserver` → `uri_handlers`), *not* an entry-point group named `gbserver.uri_handlers`.
+> Quoting the whole dotted name keeps it a single key. (The [entry-points
+> spec](https://packaging.python.org/en/latest/specifications/entry-points/) shows dotted group names
+> unquoted only because its examples are in the `entry_points.txt` INI format, where section headers like
+> `[pygments.styles]` are never quoted; the TOML `pyproject.toml` surface has the opposite requirement.)
+
 The shared discovery helper lives in [`src/gbcommon/plugins.py`](../../src/gbcommon/plugins.py). It wraps
 `importlib.metadata.entry_points(group=...)`, loads each entry point, and is **defensive by
 construction**: if the entry-point table cannot be read, or a single entry point fails to import, the
@@ -65,18 +73,17 @@ listed base class and provide the listed key.
 |---|---|---|
 | `gbserver.uri_handlers` | `gbcommon.uri.uri.URI` | the scheme(s) returned by `get_supported_schemes()` |
 | `gbserver.asset_stores` | `gbserver.asset.assetstore.Assetstore` | the URI class(es) returned by `get_supported_uri_classes()` |
-| `gbserver.environments` | `gbserver.environment.environment.Environment` | the **entry-point name** (registered under both `name.lower()` and `name.capitalize()`) |
+| `gbserver.environments` | `gbserver.environment.environment.Environment` | the **entry-point name** (registered under both `name.lower()` and the name exactly as declared) |
 | `gbserver.secret_managers` | `SpaceSecretManager` **or** `UserSecretManager` | the **entry-point name** (lowercased). One group feeds both families; each class is routed to the family whose base class it subclasses |
 
 For the URI and asset-store groups the entry-point *name* is cosmetic — the registration key comes from
 the class's own method, so name your entry point whatever reads well. For the environment and
 secret-manager groups the entry-point *name* is the registration key.
 
-> **Name-keyed groups are case-normalized.** Environments register under both `name.lower()` and
-> `name.capitalize()`, and secret managers under `name.lower()`. `str.capitalize()` lowercases every
-> character after the first, so an entry-point name with intended internal capitals (e.g. `AWSBatch`)
-> is only reachable as `awsbatch` / `Awsbatch` — a build that references `type: AWSBatch` will not
-> resolve. Use a lowercase entry-point name to avoid surprises.
+> **Name-keyed groups are case-normalized.** Environments register under both `name.lower()` and the
+> entry-point name exactly as you declared it; secret managers under `name.lower()`. Because the declared
+> name is preserved verbatim, an entry-point name with internal capitals (e.g. `AWSBatch`) is reachable
+> both as `awsbatch` and as `AWSBatch`, so a build referencing `type: AWSBatch` resolves as written.
 
 ## Reserved groups (wired in later releases)
 
@@ -110,6 +117,18 @@ class LhURI(URI):
         return ["lh"]
     # ... the rest of the URI contract
 ```
+
+Register it by adding the class to the `gbserver.uri_handlers` group in your `pyproject.toml`:
+
+```toml
+# pyproject.toml of granite_build_ibm
+[project.entry-points."gbserver.uri_handlers"]
+lh = "granite_build_ibm.uri_handlers.lh:LhURI"
+```
+
+The entry-point *name* on the left (`lh`) is cosmetic for this group — the registration key comes from
+`get_supported_schemes()`, so name it whatever reads well. The value on the right is
+`<import.path>:<ClassName>`.
 
 Once your package is installed (`pip install granite_build_ibm`), starting `gbserver` will resolve
 `lh://` URIs through `LhURI` with no further configuration.

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -36,7 +36,7 @@ loaders already use.
 
 from collections.abc import Hashable
 from importlib.metadata import EntryPoint, entry_points
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 from gbserver.utils.logger import get_logger
 
@@ -64,23 +64,34 @@ GROUP_BUILTIN_STEPS = "gbserver.builtin_steps"
 GROUP_CLI_PLUGINS = "gbcli.plugins"
 
 
-def iter_entry_point_objects(group: str) -> Iterable[Tuple[str, Any]]:
-    """Yield ``(name, loaded_object)`` for every entry point in *group*.
+# Loaded entry points, cached per group. A group's entry-point table is fixed
+# for the life of the process (installed packages don't change under a running
+# server), and a single group can be consumed by more than one registry pass —
+# the secret-manager group, for instance, feeds both the Space and the User
+# family. Loading once and caching means each entry point is imported (and any
+# load failure logged) exactly once per group, not once per consuming pass.
+_loaded_groups: Dict[str, Tuple[Tuple[str, Any], ...]] = {}
 
-    ``loaded_object`` is whatever the entry point points at — a class, a
-    module, a function. Callers that require a class should use
-    :func:`iter_entry_point_classes` instead.
 
-    Never raises: a failure to enumerate the group, or to ``load()`` an
-    individual entry point, is logged at ERROR and that entry point is skipped.
-    A group with no entry points yields nothing (the no-plugin-installed case).
+def _clear_entry_point_cache() -> None:
+    """Drop the per-group load cache. For tests that swap ``entry_points``."""
+    _loaded_groups.clear()
+
+
+def _load_group(group: str) -> Tuple[Tuple[str, Any], ...]:
+    """Enumerate and ``load()`` *group* once, returning ``(name, obj)`` pairs.
+
+    Enumeration failure -> ``()``; a single entry point that fails to load is
+    logged (once) and dropped. The result is memoized in ``_loaded_groups``.
     """
     try:
         eps: Iterable[EntryPoint] = entry_points(group=group)
     except Exception as e:  # pragma: no cover - defensive; enumerate rarely fails
         logger.error("Error enumerating plugin entry points for group %s: %s", group, e)
-        return
+        _loaded_groups[group] = ()
+        return ()
 
+    loaded: List[Tuple[str, Any]] = []
     for ep in eps:
         try:
             obj = ep.load()
@@ -94,7 +105,30 @@ def iter_entry_point_objects(group: str) -> Iterable[Tuple[str, Any]]:
                 e,
             )
             continue
-        yield ep.name, obj
+        loaded.append((ep.name, obj))
+
+    result = tuple(loaded)
+    _loaded_groups[group] = result
+    return result
+
+
+def iter_entry_point_objects(group: str) -> Iterable[Tuple[str, Any]]:
+    """Yield ``(name, loaded_object)`` for every entry point in *group*.
+
+    ``loaded_object`` is whatever the entry point points at — a class, a
+    module, a function. Callers that require a class should use
+    :func:`iter_entry_point_classes` instead.
+
+    Never raises: a failure to enumerate the group, or to ``load()`` an
+    individual entry point, is logged at ERROR and that entry point is skipped.
+    A group with no entry points yields nothing (the no-plugin-installed case).
+    The group is loaded at most once (see :data:`_loaded_groups`); repeat calls
+    for the same group replay the cached objects without re-importing.
+    """
+    cached = _loaded_groups.get(group)
+    if cached is None:
+        cached = _load_group(group)
+    yield from cached
 
 
 def iter_entry_point_classes(
@@ -176,8 +210,16 @@ class PluginRegistrar:
         self.keys_of = keys_of
 
     def add(self, cls: Type, name: Optional[str] = None) -> None:
-        """Register ``cls`` under each of its keys, honoring core-wins."""
+        """Register ``cls`` under each of its keys, honoring core-wins.
+
+        A class that yields *no* keys (e.g. a discovered handler that forgot to
+        override its key method and inherits the base ``[]``) is filed nowhere
+        and would silently never resolve; warn so its author gets a diagnostic
+        rather than a handler that is quietly ignored at runtime.
+        """
+        produced_key = False
         for key in self.keys_of(cls, name):
+            produced_key = True
             existing = self.registry.get(key)
             if existing is not None and existing is not cls:
                 logger.warning(
@@ -189,6 +231,13 @@ class PluginRegistrar:
                 )
                 continue
             self.registry[key] = cls
+        if not produced_key:
+            logger.warning(
+                "%s: %s produced no keys and was not registered; "
+                "check that its key derivation is implemented",
+                self.label,
+                getattr(cls, "__name__", cls),
+            )
 
     def discover(self, group: str, base_class: Type) -> None:
         """Run the entry-point plugin pass for ``group`` into this registry.
@@ -246,9 +295,20 @@ def keys_by_name_lower(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
 
 
 def keys_by_name_cased(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
-    """Keys = the name lowercased *and* capitalized. (environments)"""
+    """Keys = the name lowercased *and* the name exactly as declared. (environments)
+
+    The declared name is preserved verbatim so a plugin's own casing stays
+    reachable: an entry point ``AWSBatch`` registers under both ``awsbatch`` and
+    ``AWSBatch``, so a build referencing ``type: AWSBatch`` resolves. (An earlier
+    version used ``str.capitalize()``, which lowercases every character after the
+    first and left internal capitals unreachable.) In-tree names are already a
+    single ``str.capitalize()`` (module ``k8s`` -> ``K8s``), so this keeps the
+    historical ``{k8s, K8s}`` keys unchanged while no longer mangling plugins.
+    """
     resolved = _require_name(name)
-    return (resolved.lower(), resolved.capitalize())
+    lowered = resolved.lower()
+    # Dedup so an already-lowercase name doesn't file the same key twice.
+    return (lowered,) if resolved == lowered else (lowered, resolved)
 
 
 def keys_from_method(method_name: str) -> KeysOf:

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Out-of-tree plugin discovery via Python packaging entry points.
+
+granite.build's subsystems (environments, secret managers, asset stores, URI
+handlers, ...) each keep a registry populated by scanning their own package
+directory. This module adds the *second* discovery source: implementations
+shipped by a separately-installed package that declares
+`[project.entry-points."<group>"]` in its ``pyproject.toml``.
+
+The entry-point table **is** the plugin manifest — no bespoke manifest file is
+needed. Each subsystem defines a well-known group name (see the constants
+below) and, after its in-tree directory scan, calls one of the iterators here
+and folds the results into its own registry using its own key-derivation rule.
+
+Discovery is defensive by construction: a plugin group that cannot be
+enumerated, or a single entry point that fails to import/load, is logged and
+skipped so that one broken plugin never prevents the core (or its other
+plugins) from starting. This mirrors the try/except-and-log style the in-tree
+loaders already use.
+"""
+
+from collections.abc import Hashable
+from importlib.metadata import EntryPoint, entry_points
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type
+
+from gbserver.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Entry-point group names — the plugin API surface.
+#
+# Centralized here so a typo becomes an import error rather than a silently
+# empty discovery pass. Keep in sync with docs/plugins/README.md.
+# ---------------------------------------------------------------------------
+
+# Groups wired to a discovery pass today (see the four registry loaders).
+GROUP_ENVIRONMENTS = "gbserver.environments"
+GROUP_SECRET_MANAGERS = "gbserver.secret_managers"
+GROUP_ASSET_STORES = "gbserver.asset_stores"
+GROUP_URI_HANDLERS = "gbserver.uri_handlers"
+
+# Groups reserved for subsystems that will adopt this same mechanism in
+# follow-up PRs. Declared now so the plugin package and its docs can be written
+# against stable names.
+GROUP_AUTH_PROVIDERS = "gbserver.auth_providers"
+GROUP_RESILIENCE_STRATEGIES = "gbserver.resilience_strategies"
+GROUP_BUILTIN_STEPS = "gbserver.builtin_steps"
+GROUP_CLI_PLUGINS = "gbcli.plugins"
+
+
+def iter_entry_point_objects(group: str) -> Iterable[Tuple[str, Any]]:
+    """Yield ``(name, loaded_object)`` for every entry point in *group*.
+
+    ``loaded_object`` is whatever the entry point points at — a class, a
+    module, a function. Callers that require a class should use
+    :func:`iter_entry_point_classes` instead.
+
+    Never raises: a failure to enumerate the group, or to ``load()`` an
+    individual entry point, is logged at ERROR and that entry point is skipped.
+    A group with no entry points yields nothing (the no-plugin-installed case).
+    """
+    try:
+        eps: Iterable[EntryPoint] = entry_points(group=group)
+    except Exception as e:  # pragma: no cover - defensive; enumerate rarely fails
+        logger.error("Error enumerating plugin entry points for group %s: %s", group, e)
+        return
+
+    for ep in eps:
+        try:
+            obj = ep.load()
+        except Exception as e:
+            # One broken plugin must not take down the core or its siblings.
+            logger.error(
+                "Error loading plugin entry point %s=%s (group %s): %s",
+                ep.name,
+                ep.value,
+                group,
+                e,
+            )
+            continue
+        yield ep.name, obj
+
+
+def iter_entry_point_classes(
+    group: str, base_class: Type
+) -> Iterable[Tuple[str, Type]]:
+    """Yield ``(name, cls)`` for entry points in *group* that are subclasses of *base_class*.
+
+    Two kinds of mismatch are handled differently:
+
+    - A loaded object that is **not a class** is a genuine misconfiguration (the
+      entry point points at a function or module where a class is required) and
+      is logged at ERROR.
+    - A loaded object that **is a class but not a subclass** of *base_class* is
+      skipped quietly (DEBUG). A single group may legitimately be consumed by
+      more than one registry that filter by base class — the secret-manager
+      group, for instance, feeds both the space and user families, so each pass
+      sees (and must ignore without complaint) the other family's classes.
+    """
+    for name, obj in iter_entry_point_objects(group):
+        if not isinstance(obj, type):
+            logger.error(
+                "Ignoring plugin entry point %s (group %s): %r is not a class",
+                name,
+                group,
+                obj,
+            )
+            continue
+        if issubclass(obj, base_class):
+            yield name, obj
+        else:
+            logger.debug(
+                "Skipping plugin entry point %s (group %s): %s is not a subclass of %s",
+                name,
+                group,
+                obj.__name__,
+                base_class.__name__,
+            )
+
+
+# ---------------------------------------------------------------------------
+# PluginRegistrar — one place that owns the register/collision rule.
+# ---------------------------------------------------------------------------
+
+# Given a class and its (optional) entry-point name, return the registry keys
+# the class should be filed under. The name is None for the in-tree pass (keys
+# derived from the class itself) and the entry-point name for the plugin pass.
+KeysOf = Callable[[Type, Optional[str]], Iterable[Hashable]]
+
+
+class PluginRegistrar:
+    """Files subsystem implementations into a registry with a uniform rule.
+
+    Every pluggable subsystem keeps a ``dict`` mapping some key (URI scheme,
+    environment type name, URI class, ...) to an implementation class. Both the
+    in-tree directory scan and the entry-point plugin scan register through this
+    one object, so the collision policy lives in a single place:
+
+    **Core wins.** A key already bound to a *different* class is left untouched
+    and the newcomer is skipped with a WARNING — so a plugin can only *add* to
+    the registry, never silently shadow a built-in (or an earlier plugin).
+
+    The only thing that varies per subsystem is how a class maps to its key(s);
+    the caller supplies that as ``keys_of(cls, name)``.
+    """
+
+    def __init__(
+        self,
+        registry: Dict[Hashable, Type],
+        label: str,
+        keys_of: KeysOf,
+    ) -> None:
+        """``registry`` is the subsystem's own dict; mutated in place.
+
+        ``label`` names the key in log messages (e.g. ``"URI scheme"``).
+        ``keys_of(cls, name)`` yields the registry keys ``cls`` belongs under.
+        """
+        self.registry = registry
+        self.label = label
+        self.keys_of = keys_of
+
+    def add(self, cls: Type, name: Optional[str] = None) -> None:
+        """Register ``cls`` under each of its keys, honoring core-wins."""
+        for key in self.keys_of(cls, name):
+            existing = self.registry.get(key)
+            if existing is not None and existing is not cls:
+                logger.warning(
+                    "%s %r already registered to %s; ignoring %s",
+                    self.label,
+                    _key_label(key),
+                    existing.__name__,
+                    cls.__name__,
+                )
+                continue
+            self.registry[key] = cls
+
+    def discover(self, group: str, base_class: Type) -> None:
+        """Run the entry-point plugin pass for ``group`` into this registry.
+
+        Call this *after* the in-tree scan so the core-wins rule protects the
+        built-in implementations. **Never raises** — the entry point loader
+        guards ``load()``, and each ``add()`` is guarded here so that a plugin
+        with a broken key derivation (``keys_of`` raising, or returning a
+        non-iterable — e.g. a single class where a list is expected) is logged
+        and skipped rather than aborting discovery. These loaders run at package
+        import time, so an unguarded failure would prevent startup entirely.
+        """
+        for name, cls in iter_entry_point_classes(group, base_class):
+            try:
+                self.add(cls, name)
+            except Exception as e:
+                logger.error(
+                    "Error registering plugin %s=%s (group %s): %s",
+                    name,
+                    getattr(cls, "__name__", cls),
+                    group,
+                    e,
+                )
+
+
+def _key_label(key: Hashable) -> Any:
+    """Human-readable form of a registry key for log messages.
+
+    Registry keys are usually strings, but the asset-store registry is keyed by
+    URI *class*; show its name rather than its ``repr``.
+    """
+    return getattr(key, "__name__", key)
+
+
+# ---------------------------------------------------------------------------
+# Ready-made ``keys_of`` callbacks for the common key-derivation shapes.
+#
+# A subsystem picks one of these when constructing its PluginRegistrar instead
+# of re-spelling the same lambda. They cover the two ways a key is derived:
+# from the discovered *name* (module name in-tree / entry-point name), or by
+# asking the class itself via one of its methods.
+# ---------------------------------------------------------------------------
+
+
+def _require_name(name: Optional[str]) -> str:
+    """A name-derived ``keys_of`` requires a name; misuse is a bug, not a warning."""
+    if not name:
+        raise ValueError("this keys_of derives the key from a name, but none was given")
+    return name
+
+
+def keys_by_name_lower(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
+    """Key = the name, lowercased. (secret managers)"""
+    return (_require_name(name).lower(),)
+
+
+def keys_by_name_cased(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
+    """Keys = the name lowercased *and* capitalized. (environments)"""
+    resolved = _require_name(name)
+    return (resolved.lower(), resolved.capitalize())
+
+
+def keys_from_method(method_name: str) -> KeysOf:
+    """Build a ``keys_of`` that asks the class for its keys via ``method_name``.
+
+    Used when the registration keys come from the class rather than its name —
+    e.g. ``get_supported_schemes`` (URI) or ``get_supported_uri_classes``
+    (asset stores). The discovered ``name`` is unused.
+    """
+
+    def keys_of(cls: Type, _name: Optional[str]) -> Iterable[Hashable]:
+        return getattr(cls, method_name)()
+
+    return keys_of

--- a/src/gbcommon/uri/uri.py
+++ b/src/gbcommon/uri/uri.py
@@ -86,6 +86,19 @@ class URI(ABC):
 
     @staticmethod
     def _load_urihandlers() -> None:
+        from gbcommon.plugins import (
+            GROUP_URI_HANDLERS,
+            PluginRegistrar,
+            keys_from_method,
+        )
+
+        # Files each URI handler under the scheme(s) it advertises. Both the
+        # in-tree scan and the plugin pass register through this one registrar.
+        registrar = PluginRegistrar(
+            URI.uri_handler_classes,
+            "URI scheme",
+            keys_from_method("get_supported_schemes"),
+        )
         package_dir = os.path.dirname(__file__)
 
         for filename in os.listdir(package_dir):
@@ -106,11 +119,7 @@ class URI(ABC):
                         if isinstance(handler_class, type) and issubclass(
                             handler_class, URI
                         ):
-                            supported_schemes = handler_class.get_supported_schemes()
-                            for supported_scheme in supported_schemes:
-                                URI.uri_handler_classes[supported_scheme] = (
-                                    handler_class
-                                )
+                            registrar.add(handler_class)
                         else:
                             logger.error(
                                 f"Ignoring {urihandler_name} since it is not a subclass or URI class"
@@ -125,6 +134,10 @@ class URI(ABC):
                     logger.error(
                         f"Error loading uri handler from {urihandler_name}: {e}"
                     )
+
+        # Discover URI handlers shipped by separately-installed plugin packages.
+        # Runs after the in-tree scan so the core-wins rule protects built-ins.
+        registrar.discover(GROUP_URI_HANDLERS, URI)
 
     @classmethod
     def get_uri_class(

--- a/src/gbserver/asset/assetstore.py
+++ b/src/gbserver/asset/assetstore.py
@@ -135,6 +135,19 @@ class Assetstore(ABC):
     def _load_assetstore_types(cls):
         if len(cls.assetstore_types) != 0:
             return
+        from gbcommon.plugins import (
+            GROUP_ASSET_STORES,
+            PluginRegistrar,
+            keys_from_method,
+        )
+
+        # Files each asset store under the URI class(es) it supports. Both the
+        # in-tree scan and the plugin pass register through this one registrar.
+        registrar = PluginRegistrar(
+            cls.assetstore_types,
+            "Asset store for URI class",
+            keys_from_method("get_supported_uri_classes"),
+        )
         package_dir = os.path.dirname(__file__)
 
         for filename in os.listdir(package_dir):
@@ -155,8 +168,7 @@ class Assetstore(ABC):
                         if isinstance(handler_class, type) and issubclass(
                             handler_class, cls
                         ):
-                            for uriclass in handler_class.get_supported_uri_classes():
-                                cls.assetstore_types[uriclass] = handler_class
+                            registrar.add(handler_class)
                         else:
                             logger.error(
                                 f"Ignoring {assetstore_classname} since it is not a subclass of AssetStore class"
@@ -173,6 +185,10 @@ class Assetstore(ABC):
                     logger.error(
                         f"Error loading AssetStore type from {assetstore_classname}: {e}"
                     )
+
+        # Discover asset stores shipped by separately-installed plugin packages.
+        # Runs after the in-tree scan so the core-wins rule protects built-ins.
+        registrar.discover(GROUP_ASSET_STORES, cls)
 
     @classmethod
     @abstractmethod

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -1353,6 +1353,18 @@ class Environment(ABC):
 
     @classmethod
     def _load_environment_types(cls: Type[Self]) -> None:
+        from gbcommon.plugins import (
+            GROUP_ENVIRONMENTS,
+            PluginRegistrar,
+            keys_by_name_cased,
+        )
+
+        # Files each environment under both cased forms of its name (module name
+        # in-tree, entry-point name for plugins), mirroring the historical
+        # behavior. Both passes register through this one registrar.
+        registrar = PluginRegistrar(
+            cls.environment_types, "Environment type", keys_by_name_cased
+        )
         package_dir = os.path.dirname(__file__)
 
         for filename in os.listdir(package_dir):
@@ -1374,10 +1386,7 @@ class Environment(ABC):
                         if isinstance(handler_class, type) and issubclass(
                             handler_class, cls
                         ):
-                            cls.environment_types[environment_type_name.lower()] = (
-                                handler_class
-                            )
-                            cls.environment_types[environment_type_name] = handler_class
+                            registrar.add(handler_class, environment_type_name)
                         else:
                             logger.warning(
                                 "Ignoring %s since it is not a subclass of Environment class",
@@ -1401,6 +1410,11 @@ class Environment(ABC):
                         environment_type_name,
                         e,
                     )
+
+        # Discover environments shipped by separately-installed plugin packages.
+        # Runs after the in-tree scan so the core-wins rule protects built-ins.
+        # The entry-point *name* is the type key (e.g. ``k8s``).
+        registrar.discover(GROUP_ENVIRONMENTS, cls)
 
     async def _read_stream_and_create_event_all(
         self: Self,

--- a/src/gbserver/utils/secretmanager_discovery.py
+++ b/src/gbserver/utils/secretmanager_discovery.py
@@ -49,10 +49,22 @@ def discover_secret_managers(
     """
     if len(registry) != 0:
         return
+    # Import locally to avoid a hard import-time dependency and keep parity with
+    # the other subsystems, which import the registrar lazily too.
+    from gbcommon.plugins import (
+        GROUP_SECRET_MANAGERS,
+        PluginRegistrar,
+        keys_by_name_lower,
+    )
+
     package_dir = os.path.dirname(package_file)
     base_name = base_class.__name__  # e.g. "UserSecretManager"
     suffix = base_name.lower()  # e.g. "usersecretmanager"
     self_module = os.path.basename(package_file)
+
+    # Key = the discovered name lowercased (module <key> prefix in-tree,
+    # entry-point name for plugins). Both passes register through this registrar.
+    registrar = PluginRegistrar(registry, f"{base_name} key", keys_by_name_lower)
 
     for filename in os.listdir(package_dir):
         if not filename.endswith(".py"):
@@ -78,7 +90,7 @@ def discover_secret_managers(
             if isinstance(handler_class, type) and issubclass(
                 handler_class, base_class
             ):
-                registry[key_name] = handler_class
+                registrar.add(handler_class, key_name)
             else:
                 logger.error(
                     "Ignoring %s since it is not a subclass of %s",
@@ -89,3 +101,9 @@ def discover_secret_managers(
             logger.error("Error importing module %s: %s", type_name, e)
         except Exception as e:
             logger.error("Error loading secret manager type from %s: %s", type_name, e)
+
+    # Discover secret managers shipped by separately-installed plugin packages.
+    # Runs after the in-tree scan so the core-wins rule protects built-ins. The
+    # one group feeds both the Space and User families — the ``issubclass``
+    # filter in ``discover`` routes each class to the family it belongs to.
+    registrar.discover(GROUP_SECRET_MANAGERS, base_class)

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -72,6 +72,19 @@ def _patch_entry_points(monkeypatch, group_to_eps):
         return group_to_eps.get(group, [])
 
     monkeypatch.setattr(plugins, "entry_points", fake_entry_points)
+    # The group load-cache may already hold results read from the *real*
+    # entry_points at package-import time (some subsystems discover on import);
+    # swapping the source invalidates it.
+    plugins._clear_entry_point_cache()
+
+
+@pytest.fixture(autouse=True)
+def _clear_plugin_group_cache():
+    """Isolate the per-group load cache so one test's fake entry points don't
+    leak into the next (the cache is keyed by group and lives for the process)."""
+    plugins._clear_entry_point_cache()
+    yield
+    plugins._clear_entry_point_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +199,14 @@ def test_registrar_reregister_same_class_is_quiet(caplog):
 
 def test_keys_of_helpers():
     assert list(plugins.keys_by_name_lower(_Good, "Foo")) == ["foo"]
-    assert list(plugins.keys_by_name_cased(_Good, "foo")) == ["foo", "Foo"]
+    # An in-tree name is already capitalized (module k8s -> "K8s"), giving the
+    # historical {lower, cased} pair.
+    assert list(plugins.keys_by_name_cased(_Good, "K8s")) == ["k8s", "K8s"]
+    # An already-lowercase name files exactly one key, not a duplicate pair.
+    assert list(plugins.keys_by_name_cased(_Good, "foo")) == ["foo"]
+    # A plugin's internal capitals survive verbatim so `type: AWSBatch` resolves
+    # (the old str.capitalize() would have mangled this to "Awsbatch").
+    assert list(plugins.keys_by_name_cased(_Good, "AWSBatch")) == ["awsbatch", "AWSBatch"]
 
     class HasKeys:
         @classmethod
@@ -195,6 +215,47 @@ def test_keys_of_helpers():
 
     keys_of = plugins.keys_from_method("get_supported_schemes")
     assert list(keys_of(HasKeys, None)) == ["a", "b"]
+
+
+def test_registrar_warns_when_class_produces_no_keys(caplog):
+    """A discovered class whose key derivation yields nothing is filed nowhere;
+    warn so its author isn't left with a handler that silently never resolves."""
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "URI scheme", keys_of=lambda cls, name: [])
+    registrar.add(_Good, "forgot_to_override")
+    assert reg == {}
+    assert "produced no keys" in caplog.text
+    assert "_Good" in caplog.text
+
+
+def test_group_loaded_once_and_cached(monkeypatch):
+    """Two passes over the same group import each entry point once, not twice
+    (the secret-manager group feeds both the Space and User families)."""
+    load_calls = {"n": 0}
+
+    class _CountingEP(EntryPoint):
+        def load(self):  # type: ignore[override]
+            load_calls["n"] += 1
+            return _Good
+
+    ep = _CountingEP(name="good", value="_x:_Good", group="ignored")
+    _patch_entry_points(monkeypatch, {"shared": [ep]})
+
+    first = list(plugins.iter_entry_point_objects("shared"))
+    second = list(plugins.iter_entry_point_objects("shared"))
+    assert first == second == [("good", _Good)]
+    assert load_calls["n"] == 1  # loaded once, replayed from cache the second time
+
+
+def test_broken_entry_point_logged_once_across_passes(monkeypatch, caplog):
+    """A failing load() is logged a single time even when the group is consumed
+    by multiple passes — no double error per broken plugin."""
+    eps = _make_entry_points(monkeypatch, {"boom": ("Boom", RAISE)})
+    _patch_entry_points(monkeypatch, {"shared": eps})
+
+    list(plugins.iter_entry_point_objects("shared"))
+    list(plugins.iter_entry_point_objects("shared"))
+    assert caplog.text.count("Error loading plugin entry point boom") == 1
 
 
 def test_registrar_discover_routes_through_add(monkeypatch):
@@ -313,18 +374,39 @@ def env_registry_snapshot():
     Environment.environment_types.update(saved)
 
 
-def test_environment_plugin_adds_type_both_cases(monkeypatch, env_registry_snapshot):
+def test_environment_plugin_registers_declared_name_verbatim(
+    monkeypatch, env_registry_snapshot
+):
+    """The declared entry-point name is preserved as-is (plus a lowercase alias),
+    so a plugin's own casing stays reachable — `type: DummyEnv` resolves. The old
+    str.capitalize() would have filed this only under 'Dummyenv' and lost it."""
     from gbserver.environment.environment import Environment
 
     # A bare subclass; the loader only touches the registry, not instantiation.
     DummyEnv = type("DummyEnv", (Environment,), {})
 
-    eps = _make_entry_points(monkeypatch, {"dummyenv": ("DummyEnv", DummyEnv)})
+    eps = _make_entry_points(monkeypatch, {"DummyEnv": ("DummyEnv", DummyEnv)})
     _patch_entry_points(monkeypatch, {plugins.GROUP_ENVIRONMENTS: eps})
 
     Environment._load_environment_types()
     assert Environment.environment_types["dummyenv"] is DummyEnv
-    assert Environment.environment_types["Dummyenv"] is DummyEnv
+    assert Environment.environment_types["DummyEnv"] is DummyEnv
+    # The mangled middle-cased form is no longer produced.
+    assert "Dummyenv" not in Environment.environment_types
+
+
+def test_environment_plugin_lowercase_name_single_key(
+    monkeypatch, env_registry_snapshot
+):
+    """An already-lowercase entry-point name files exactly one key (no dup pair)."""
+    from gbserver.environment.environment import Environment
+
+    LowerEnv = type("LowerEnv", (Environment,), {})
+    eps = _make_entry_points(monkeypatch, {"lowerenv": ("LowerEnv", LowerEnv)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_ENVIRONMENTS: eps})
+
+    Environment._load_environment_types()
+    assert Environment.environment_types["lowerenv"] is LowerEnv
 
 
 def test_environment_plugin_collision_core_wins(

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -206,7 +206,10 @@ def test_keys_of_helpers():
     assert list(plugins.keys_by_name_cased(_Good, "foo")) == ["foo"]
     # A plugin's internal capitals survive verbatim so `type: AWSBatch` resolves
     # (the old str.capitalize() would have mangled this to "Awsbatch").
-    assert list(plugins.keys_by_name_cased(_Good, "AWSBatch")) == ["awsbatch", "AWSBatch"]
+    assert list(plugins.keys_by_name_cased(_Good, "AWSBatch")) == [
+        "awsbatch",
+        "AWSBatch",
+    ]
 
     class HasKeys:
         @classmethod

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the entry-point plugin discovery mechanism.
+
+Exercises the shared helper in ``gbcommon.plugins`` and the four loaders wired
+to it, without installing a real plugin package: ``entry_points`` is
+monkeypatched to return hand-built ``EntryPoint`` objects. The four loaders'
+in-tree registries are snapshotted and restored so a test never leaks a fake
+class into another test (or the rest of the suite).
+"""
+
+from importlib.metadata import EntryPoint
+
+import pytest
+
+import gbcommon.plugins as plugins
+
+# ---------------------------------------------------------------------------
+# Helpers: build fake EntryPoint objects that resolve to arbitrary objects.
+# EntryPoint.load() imports `module` and getattrs `attr`; we bypass that by
+# registering the targets in a fake module we inject into sys.modules.
+# ---------------------------------------------------------------------------
+
+
+def _make_entry_points(monkeypatch, mapping):
+    """Install a fake module exposing ``mapping`` values and return EntryPoints.
+
+    ``mapping`` is ``{ep_name: (attr_name, object_or_RAISE)}``. A value of the
+    sentinel ``RAISE`` makes that entry point's ``load()`` raise, to test
+    per-entry-point failure isolation.
+    """
+    import sys
+    import types
+
+    mod = types.ModuleType("_gbtest_fake_plugin")
+    eps = []
+    for ep_name, (attr, obj) in mapping.items():
+        if obj is not RAISE:
+            setattr(mod, attr, obj)
+        eps.append(
+            EntryPoint(
+                name=ep_name,
+                value=f"_gbtest_fake_plugin:{attr}",
+                group="ignored",
+            )
+        )
+    monkeypatch.setitem(sys.modules, "_gbtest_fake_plugin", mod)
+    return eps
+
+
+RAISE = object()  # sentinel: entry point whose load() should raise
+
+
+def _patch_entry_points(monkeypatch, group_to_eps):
+    """Patch gbcommon.plugins.entry_points to serve the given per-group lists."""
+
+    def fake_entry_points(*, group):
+        return group_to_eps.get(group, [])
+
+    monkeypatch.setattr(plugins, "entry_points", fake_entry_points)
+
+
+# ---------------------------------------------------------------------------
+# Shared helper: gbcommon.plugins
+# ---------------------------------------------------------------------------
+
+
+class _Base:
+    pass
+
+
+class _Good(_Base):
+    pass
+
+
+class _NotSubclass:
+    pass
+
+
+def test_iter_objects_yields_loaded_objects(monkeypatch):
+    eps = _make_entry_points(monkeypatch, {"good": ("Good", _Good)})
+    _patch_entry_points(monkeypatch, {"g": eps})
+    assert list(plugins.iter_entry_point_objects("g")) == [("good", _Good)]
+
+
+def test_iter_objects_empty_group_is_noop(monkeypatch):
+    _patch_entry_points(monkeypatch, {})
+    assert list(plugins.iter_entry_point_objects("nonexistent")) == []
+
+
+def test_iter_classes_filters_non_subclass_quietly(monkeypatch, caplog):
+    """A valid class that isn't a subclass is filtered without an ERROR.
+
+    A shared group (e.g. secret managers) is consumed by more than one registry,
+    so each pass legitimately sees the other's classes and must ignore them
+    without crying wolf.
+    """
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    eps = _make_entry_points(
+        monkeypatch,
+        {"good": ("Good", _Good), "other": ("Other", _NotSubclass)},
+    )
+    _patch_entry_points(monkeypatch, {"g": eps})
+    result = list(plugins.iter_entry_point_classes("g", _Base))
+    assert result == [("good", _Good)]
+    # Skipped quietly: DEBUG, never ERROR.
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def test_iter_classes_non_class_is_error(monkeypatch, caplog):
+    """An entry point pointing at a non-class is a real misconfig → ERROR."""
+    eps = _make_entry_points(monkeypatch, {"fn": ("a_function", lambda: None)})
+    _patch_entry_points(monkeypatch, {"g": eps})
+    result = list(plugins.iter_entry_point_classes("g", _Base))
+    assert result == []
+    assert "is not a class" in caplog.text
+
+
+def test_iter_objects_isolates_load_failure(monkeypatch, caplog):
+    """A single failing load() is logged and skipped; siblings still yield."""
+    eps = _make_entry_points(
+        monkeypatch,
+        {"boom": ("Boom", RAISE), "good": ("Good", _Good)},
+    )
+    _patch_entry_points(monkeypatch, {"g": eps})
+    result = list(plugins.iter_entry_point_objects("g"))
+    assert result == [("good", _Good)]
+    assert "Error loading plugin entry point boom" in caplog.text
+
+
+def test_enumerate_failure_is_contained(monkeypatch, caplog):
+    def boom(*, group):
+        raise RuntimeError("registry unreadable")
+
+    monkeypatch.setattr(plugins, "entry_points", boom)
+    assert list(plugins.iter_entry_point_objects("g")) == []
+    assert "Error enumerating plugin entry points" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# PluginRegistrar
+# ---------------------------------------------------------------------------
+
+
+def test_registrar_add_files_under_all_keys():
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(
+        reg, "thing", keys_of=lambda cls, name: [name, name.upper()]
+    )
+    registrar.add(_Good, "x")
+    assert reg == {"x": _Good, "X": _Good}
+
+
+def test_registrar_core_wins_on_collision(caplog):
+    reg = {"x": _Good}
+    registrar = plugins.PluginRegistrar(reg, "thing", keys_of=lambda cls, name: [name])
+    registrar.add(_NotSubclass, "x")  # different class, same key
+    assert reg["x"] is _Good  # core kept
+    assert "already registered" in caplog.text
+
+
+def test_registrar_reregister_same_class_is_quiet(caplog):
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "thing", keys_of=lambda cls, name: [name])
+    registrar.add(_Good, "x")
+    registrar.add(_Good, "x")  # idempotent: same class, no warning
+    assert reg["x"] is _Good
+    assert "already registered" not in caplog.text
+
+
+def test_keys_of_helpers():
+    assert list(plugins.keys_by_name_lower(_Good, "Foo")) == ["foo"]
+    assert list(plugins.keys_by_name_cased(_Good, "foo")) == ["foo", "Foo"]
+
+    class HasKeys:
+        @classmethod
+        def get_supported_schemes(cls):
+            return ["a", "b"]
+
+    keys_of = plugins.keys_from_method("get_supported_schemes")
+    assert list(keys_of(HasKeys, None)) == ["a", "b"]
+
+
+def test_registrar_discover_routes_through_add(monkeypatch):
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "thing", keys_of=lambda cls, name: [name])
+    eps = _make_entry_points(monkeypatch, {"good": ("Good", _Good)})
+    _patch_entry_points(monkeypatch, {"g": eps})
+    registrar.discover("g", _Base)
+    assert reg == {"good": _Good}
+
+
+def test_registrar_discover_isolates_keys_of_raising(monkeypatch, caplog):
+    """A plugin whose key derivation raises is skipped; siblings still register.
+
+    Guards the startup guarantee: these loaders run at import time, so an
+    unguarded keys_of failure would abort subsystem import.
+    """
+
+    def keys_of(cls, name):
+        if name == "boom":
+            raise RuntimeError("bad key derivation")
+        return [name]
+
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "thing", keys_of=keys_of)
+    eps = _make_entry_points(
+        monkeypatch, {"boom": ("Boom", _Good), "good": ("Good2", _Good)}
+    )
+    _patch_entry_points(monkeypatch, {"g": eps})
+    registrar.discover("g", _Base)
+    assert reg == {"good": _Good}  # boom skipped, good survives
+    assert "Error registering plugin boom" in caplog.text
+
+
+def test_registrar_discover_isolates_non_iterable_keys(monkeypatch, caplog):
+    """keys_of returning a non-iterable (e.g. a single class) is skipped, not fatal."""
+    reg: dict = {}
+    # Simulates the common get_supported_uri_classes() -> SingleClass mistake.
+    registrar = plugins.PluginRegistrar(reg, "thing", keys_of=lambda cls, name: cls)
+    eps = _make_entry_points(monkeypatch, {"bad": ("Bad", _Good)})
+    _patch_entry_points(monkeypatch, {"g": eps})
+    registrar.discover("g", _Base)  # must not raise
+    assert reg == {}
+    assert "Error registering plugin bad" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# URI loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def uri_registry_snapshot():
+    from gbcommon.uri.uri import URI
+
+    saved = dict(URI.uri_handler_classes)
+    yield URI
+    URI.uri_handler_classes.clear()
+    URI.uri_handler_classes.update(saved)
+
+
+def test_uri_plugin_adds_new_scheme(monkeypatch, uri_registry_snapshot):
+    from gbcommon.uri.uri import URI
+
+    class DummyURI(URI):
+        @staticmethod
+        def get_supported_schemes():
+            return ["dummy"]
+
+    eps = _make_entry_points(monkeypatch, {"dummy": ("DummyURI", DummyURI)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_URI_HANDLERS: eps})
+
+    URI._load_urihandlers()
+    assert URI.uri_handler_classes["dummy"] is DummyURI
+
+
+def test_uri_plugin_collision_core_wins(monkeypatch, caplog, uri_registry_snapshot):
+    from gbcommon.uri.uri import URI
+
+    core_for_hf = URI.uri_handler_classes["hf"]
+
+    class ShadowHfURI(URI):
+        @staticmethod
+        def get_supported_schemes():
+            return ["hf"]
+
+    eps = _make_entry_points(monkeypatch, {"hf": ("ShadowHfURI", ShadowHfURI)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_URI_HANDLERS: eps})
+
+    URI._load_urihandlers()
+    assert URI.uri_handler_classes["hf"] is core_for_hf
+    assert "already registered" in caplog.text
+
+
+def test_uri_noop_when_no_plugins(monkeypatch, uri_registry_snapshot):
+    from gbcommon.uri.uri import URI
+
+    baseline = dict(URI.uri_handler_classes)
+    _patch_entry_points(monkeypatch, {})
+    URI._load_urihandlers()
+    assert URI.uri_handler_classes == baseline
+
+
+# ---------------------------------------------------------------------------
+# Environment loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_registry_snapshot():
+    from gbserver.environment.environment import Environment
+
+    saved = dict(Environment.environment_types)
+    yield Environment
+    Environment.environment_types.clear()
+    Environment.environment_types.update(saved)
+
+
+def test_environment_plugin_adds_type_both_cases(monkeypatch, env_registry_snapshot):
+    from gbserver.environment.environment import Environment
+
+    # A bare subclass; the loader only touches the registry, not instantiation.
+    DummyEnv = type("DummyEnv", (Environment,), {})
+
+    eps = _make_entry_points(monkeypatch, {"dummyenv": ("DummyEnv", DummyEnv)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_ENVIRONMENTS: eps})
+
+    Environment._load_environment_types()
+    assert Environment.environment_types["dummyenv"] is DummyEnv
+    assert Environment.environment_types["Dummyenv"] is DummyEnv
+
+
+def test_environment_plugin_collision_core_wins(
+    monkeypatch, caplog, env_registry_snapshot
+):
+    from gbserver.environment.environment import Environment
+
+    # Seed a known core type ourselves rather than depending on a specific
+    # built-in (e.g. "k8s" is only registered when its optional dependency is
+    # installed, which is not the case in the standalone CI env). This keeps the
+    # test hermetic under any dependency set and under parallel execution.
+    CoreEnv = type("CoreEnv", (Environment,), {})
+    Environment.environment_types["seeded"] = CoreEnv
+    Environment.environment_types["Seeded"] = CoreEnv
+
+    ShadowEnv = type("ShadowEnv", (Environment,), {})
+    eps = _make_entry_points(monkeypatch, {"seeded": ("ShadowEnv", ShadowEnv)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_ENVIRONMENTS: eps})
+
+    Environment._load_environment_types()
+    assert Environment.environment_types["seeded"] is CoreEnv  # core kept
+    assert "already registered" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Assetstore loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def assetstore_registry_snapshot():
+    from gbserver.asset.assetstore import Assetstore
+
+    saved = dict(Assetstore.assetstore_types)
+    yield Assetstore
+    Assetstore.assetstore_types.clear()
+    Assetstore.assetstore_types.update(saved)
+
+
+def test_assetstore_plugin_collision_core_wins(
+    monkeypatch, caplog, assetstore_registry_snapshot
+):
+    from gbcommon.uri.hf import HfURI
+    from gbserver.asset.assetstore import Assetstore
+
+    core_hf_store = Assetstore.assetstore_types[HfURI]
+
+    class ShadowStore(Assetstore):
+        @classmethod
+        def get_supported_uri_classes(cls):
+            return [HfURI]
+
+    eps = _make_entry_points(monkeypatch, {"shadow": ("ShadowStore", ShadowStore)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_ASSET_STORES: eps})
+
+    # Force the loader past its len-guard by clearing, then re-populating via
+    # the in-tree pass + the plugin pass in a single call.
+    Assetstore.assetstore_types.clear()
+    Assetstore._load_assetstore_types()
+    assert Assetstore.assetstore_types[HfURI] is core_hf_store
+    assert "already registered" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Secret manager loader (shared helper, both families)
+# ---------------------------------------------------------------------------
+
+
+def test_secret_manager_plugin_discovered_alongside_intree(monkeypatch):
+    """The plugin pass runs after (and adds to) the in-tree directory scan."""
+    from gbserver.spacesecretmanager import spacesecretmanager as sm_module
+    from gbserver.spacesecretmanager.spacesecretmanager import SpaceSecretManager
+    from gbserver.utils import secretmanager_discovery
+
+    class DummySpaceSM(SpaceSecretManager):
+        pass
+
+    eps = _make_entry_points(monkeypatch, {"dummy": ("DummySpaceSM", DummySpaceSM)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_SECRET_MANAGERS: eps})
+
+    registry: dict = {}
+    secretmanager_discovery.discover_secret_managers(
+        package_file=sm_module.__file__,
+        package_name="gbserver.spacesecretmanager",
+        base_class=SpaceSecretManager,
+        registry=registry,
+    )
+    # In-tree backends are present AND the plugin's dummy was added on top.
+    assert "local" in registry
+    assert registry.get("dummy") is DummySpaceSM
+
+
+def test_secret_manager_plugin_routed_by_base_class(monkeypatch):
+    """One group feeds both families; issubclass routing keeps them separate.
+
+    A ``SpaceSecretManager`` subclass declared in the group must NOT land in a
+    ``UserSecretManager`` registry.
+    """
+    from gbserver.spacesecretmanager.spacesecretmanager import SpaceSecretManager
+    from gbserver.usersecretmanager import usersecretmanager as usm_module
+    from gbserver.usersecretmanager.usersecretmanager import UserSecretManager
+    from gbserver.utils import secretmanager_discovery
+
+    class DummySpaceSM(SpaceSecretManager):
+        pass
+
+    eps = _make_entry_points(monkeypatch, {"dummy": ("DummySpaceSM", DummySpaceSM)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_SECRET_MANAGERS: eps})
+
+    registry: dict = {}
+    secretmanager_discovery.discover_secret_managers(
+        package_file=usm_module.__file__,
+        package_name="gbserver.usersecretmanager",
+        base_class=UserSecretManager,
+        registry=registry,
+    )
+    # The Space-family dummy is filtered out of the User-family registry.
+    assert "dummy" not in registry


### PR DESCRIPTION
## Summary

`granite.build` bundles a number of pluggable subsystems — compute environments, asset stores, URI handlers, secret managers, and more — each of which discovers its implementations by scanning its own package directory. This works well for implementations that live in this repo, but there is no way for an implementation to live **outside** the repo and still be picked up at runtime.

The high-level goal is to let implementations of these subsystems ship in a separately-installed package and be discovered by the core automatically, so that deployment- or organization-specific integrations can be maintained out of tree while the core stays clean and self-contained. This is useful both for keeping internal/proprietary integrations out of the public codebase and for anyone who wants to extend `granite.build` for their own infrastructure without forking it.

**This is the first phase: it lays the plugin foundation.** It wires up discovery for the four subsystems that already have a directory-scan registry. Discovery for the remaining subsystems (auth providers, resilience strategies, built-in steps, CLI commands) will build on this same mechanism in subsequent PRs — their entry-point group names are already reserved and documented.

The change is **purely additive**: with no plugin installed, every registry is populated exactly as before.

## How it works

- A plugin is an ordinary pip-installable package that declares
  [entry points](https://packaging.python.org/en/latest/specifications/entry-points/) into well-known groups (e.g. `gbserver.uri_handlers`). That entry-point table *is* the plugin manifest — no bespoke manifest format.
- Each subsystem keeps its existing in-tree directory scan, then runs a second pass that enumerates its entry-point group and folds any classes it finds into the same registry.
- A single `PluginRegistrar` (`gbcommon/plugins.py`) owns the register step and the collision policy for all subsystems, so both the in-tree scan and the plugin pass register through one code path. Each subsystem supplies only how a class maps to its key(s).

## Precedence and safety

- **Core wins.** A key already bound to a different class is kept; a colliding plugin class is skipped with a warning. Plugins can only *add*, never silently shadow a built-in.
- **Defensive discovery.** These loaders run at import time, so discovery must never take down startup. An unreadable entry-point table, an entry point that fails to import, or a plugin with a broken key derivation is logged and skipped — the core and its other plugins still load.

## Subsystems covered in this phase

| Group | Base class |
|---|---|
| `gbserver.uri_handlers` | `URI` |
| `gbserver.asset_stores` | `Assetstore` |
| `gbserver.environments` | `Environment` |
| `gbserver.secret_managers` | `SpaceSecretManager` / `UserSecretManager` |

## Test plan

- New `test/unit/plugins/` suite (20 tests): registrar behavior (multi-key filing, core-wins collision, idempotent re-register, key-derivation helpers), per-loader discovery + collision + no-op-when-absent, and defensive-discovery cases (entry-point load failure, key-derivation raising, non-iterable keys) — all isolated so a bad plugin never aborts the pass.
- Regression: existing URI / asset-store / secret-manager unit suites pass unchanged, confirming the added pass is a no-op when no plugin is installed (registries identical to before).

## A note on scope

Each subsystem currently supplies its key-derivation via a different helper (`keys_by_name_lower`, `keys_by_name_cased`, or `keys_from_method`). This inconsistency is deliberate for this phase: it lets the change preserve each subsystem's existing key naming and registration mechanism, keeping the diff small and low-risk. As more subsystems adopt this foundation, a follow-up may unify key derivation into a single consistent approach across all of them.

## Docs

`docs/plugins/README.md` documents the entry-point contract, the supported and reserved groups, the core-wins rule, and plugin-authoring notes.

Generated with [Claude Code](https://claude.com/claude-code)

