### PR TITLE
Capture step config and new metadata in lineage

### DIFF
--- a/configurations/assets/environments/skypilot/steps/byoc/README.md
+++ b/configurations/assets/environments/skypilot/steps/byoc/README.md
@@ -1,0 +1,147 @@
+# byoc (SkyPilot)
+
+Bring-Your-Own-Code step for SkyPilot clusters. It clones a **public git repo** during
+`setup` (optionally running a `setup_command` afterwards, e.g. to install dependencies)
+and runs a user-defined command during `run`, inside a **public container image** or on
+the bare launcher node — no custom image is built for this step.
+
+## Referencing the step
+
+Point your build's Space at one that provides the step, then reference it by the stable
+`space://steps/byoc` URI:
+
+```yaml
+steps:
+  - step_uri: space://steps/byoc
+```
+
+## Config contract (`byoc_config`)
+
+All fields live under the step's `config.byoc_config`.
+
+### Required
+
+| Field | Type | Purpose |
+|---|---|---|
+| `repo` | string | Public git repository URL cloned during `setup`. An empty value fails the step. |
+| `command` | string | Bash command executed during `run`, from inside the cloned repo directory. |
+
+### Optional
+
+| Field | Type | Purpose |
+|---|---|---|
+| `image` | string | Public container image the step runs in, e.g. `python:3.12-slim`. Rendered at runtime as SkyPilot `docker:<image>`. Defaults to `quay.io/fedora/fedora-minimal:42`; set to `""` to run on the bare launcher node instead (e.g. a cluster without Pyxis, which cannot run container images). |
+| `ref` | string | Branch, tag, or commit checked out after cloning. Default: the repo's default branch. |
+| `workdir` | string | Subdirectory (under `$GB_BUILD_WORKDIR`) the repo is cloned into. Default: `code`. |
+| `setup_command` | string | Bash command run during `setup`, **after** the clone, from `$GB_BUILD_WORKDIR` (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
+
+> **`image` is a runtime choice, not a built image.** Unlike custom-image steps (which
+> build a Dockerfile), `byoc` builds no image; `image` selects an existing public image
+> and the code arrives at run time via `git clone`.
+
+## Inputs and outputs
+
+`byoc` declares no step-level I/O schema of its own, but the **target** can declare
+**any number** of keyed `inputs:` and `outputs:` — there is nothing to change on the
+step to consume more of either.
+
+### Inputs (any number)
+
+Declare each input on the target (a direct `uri:`, or a `binding:` to an upstream
+target's output). The byoc `command` references each one by name via Jinja, which is
+rendered into `config.byoc_config.command` **before** `run` (inputs are resolved by the
+environment first, so they are concrete paths/values at launch time):
+
+- filesystem-backed inputs (`env://`, `hf://`, `file://`, `lh://`, …):
+  `{{ bindings.<name>.binding.path }}`
+- `mem://` state inputs: `{{ bindings.<name>.binding.state }}`
+
+Reference each input by the scheme it actually uses (`.path` for filesystem, `.state`
+for `mem://`) — byoc accesses bindings explicitly, so there is no auto-exported
+`GB_BYOC_INPUT_*` env var.
+
+**File mounts** — the optional `src/` directory beside the template is mounted to
+`$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
+demonstrating the SkyPilot `file_mounts` input.
+
+### Outputs (any number)
+
+Declare each output on the target, then have your `command` register an artifact by
+printing one marker line per artifact (captured by `skypilot_monitor`):
+
+```
+LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>
+```
+
+- `<output-id>` must match an `outputs.<id>` declared on the target.
+- Emit one line per artifact; **repeat** the same `<output-id>` on additional lines to
+  register multiple artifacts under a single output.
+- For `mem://` outputs, use `LLMB_ARTIFACT_STATE:<value>` instead of `LLMB_ARTIFACT_PATH`.
+
+For the full target I/O schema and the `bindings.*` Jinja variables, see
+`docs/builds/build-yaml-reference.md`; for the marker convention (PATH vs STATE,
+anchoring, the shipped monitors), see `docs/steps/monitoring-and-artifact-events.md` in
+the granite.build repository.
+
+## Env vars the step provides to your commands
+
+The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into both `setup` and `run`: the
+per-run workdir and the run script's initial CWD. `repo` is cloned to
+`$GB_BUILD_WORKDIR/<workdir>` and `src/` is mounted at `$GB_BUILD_WORKDIR/src`.
+
+## Example build.yaml
+
+This example wires **two inputs** (one direct `uri:`, one `binding:` to an upstream
+target's output) and **two outputs** (one of which receives two artifacts via repeated
+markers). The `command` reads each input via `{{ bindings.<name>.binding.path }}` and
+registers each artifact via a marker line:
+
+```yaml
+granite.build:
+  name: byoc-example
+  version: 0.0.1
+  targets:
+    run:
+      environment_uri: space://environments/skypilot/aws
+      inputs:
+        dataset:
+          uri: hf:///datasets/org/my-dataset
+        upstream_model:
+          binding: pretrain.model   # <upstream-target>.<output-id>
+      outputs:
+        checkpoints:
+          uri: lh://prod/myspace/models/shared/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}/1
+        report:
+          uri: lh://prod/myspace/reports/shared/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}/1
+      steps:
+        - step_uri: space://steps/byoc
+          config:
+            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
+            byoc_config:
+              image: "python:3.12-slim"
+              repo: "https://github.com/org/repo"
+              ref: "main"
+              workdir: "code"
+              setup_command: "cd code && pip install -r requirements.txt"
+              command: >-
+                python main.py
+                --dataset "{{ bindings.dataset.binding.path }}"
+                --init-model "{{ bindings.upstream_model.binding.path }}"
+                --out-dir "$GB_BUILD_WORKDIR/out";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-1.ckpt";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-2.ckpt";
+                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/report.json"
+```
+
+A single direct input and output are just the one-entry case of the above.
+
+## Notes and limitations
+
+- **Public repos only.** `setup` runs an unauthenticated `git clone`; private
+  repositories (and the credential/secret wiring the LSF `custom_code_lsf` step
+  provides) are out of scope for this exemplar.
+- **No dependency caching.** Dependencies are whatever the chosen public `image`
+  provides plus anything your `command`/repo installs at run time.
+- **Variable inputs/outputs are a target-level feature, not a step limitation.** Declare
+  any number of `inputs:`/`outputs:` on the target and wire them from the `command` as
+  shown in [Inputs and outputs](#inputs-and-outputs) — no change to the step is required.

--- a/configurations/assets/environments/skypilot/steps/byoc/step.yaml
+++ b/configurations/assets/environments/skypilot/steps/byoc/step.yaml
@@ -78,10 +78,20 @@ environment_configs:
             set -eu
             CODE_DIR="${GB_BUILD_WORKDIR:-$HOME}/{{ config.byoc_config.workdir }}"
             cd "$CODE_DIR"
+            # Record the resolved commit as step metadata so build lineage captures
+            # exactly which commit was built (build.yaml may pin only a branch/tag,
+            # or nothing). Defensive: never fail the build for lineage metadata,
+            # even though set -eu is in effect.
+            COMMIT_SHA="$(git -C "$CODE_DIR" rev-parse HEAD 2>/dev/null || true)"
+            [ -n "$COMMIT_SHA" ] && echo "LLMB_STEP_METADATA_KEY:commit_hash LLMB_STEP_METADATA_VALUE:$COMMIT_SHA"
             echo "byoc: running command in $(pwd)"
             {{ config.byoc_config.command }}
-            # To register an output artifact, print (at the start of a line):
-            #   echo "LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>"
+            # Markers the skypilot monitor captures (print at the start of a line):
+            #   register an output artifact:
+            #     echo "LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>"
+            #   record step metadata (merged into StoredStepRun.metadata, surfaced
+            #   in lineage):
+            #     echo "LLMB_STEP_METADATA_KEY:<key> LLMB_STEP_METADATA_VALUE:<value>"
     monitors:
       # Standard artifact/status convention from the shipped monitor library.
       skypilot_monitor:

--- a/docs/environments/step-resolution.md
+++ b/docs/environments/step-resolution.md
@@ -1,6 +1,18 @@
 # Step resolution: routing steps to environments
 
-When a target runs, every `space://steps/<name>` URI is resolved against the active environment.  Two mechanisms are available — pick whichever fits the step:
+When a target runs, every `space://steps/<name>` URI is resolved against the active environment.  Several mechanisms are available — pick whichever fits the step:
+
+## Space-root steps (highest priority)
+
+The **space's own directory** — the first entry in `base_uris`, i.e. the space's own `uristr` — is the most authoritative step source.  A step the space ships at `<space>/steps/<name>/step.yaml` **overrides** any env-co-located step (the ancestor-walk below) or any step inherited through the rest of the `base_uris` chain (e.g. a published `configurations/assets` tree).
+
+This is what lets a step be **developed and tested inside its own space before it is published** into an inherited assets tree.  A step's `space/` dir is re-rendered on every `make test`, so the co-located test exercises that freshly-rendered local copy — not the already-published copy reachable via `base_uris` — and publishing (`make publish-step`) is only needed once the test passes.
+
+The override honors the same `subtypes` restriction (below) as every other tier: a space-root step whose `subtypes` exclude the active env is skipped, and resolution falls through to the ancestor-walk and the remaining tiers.
+
+> Practically this only changes resolution when the space itself ships a `steps/<name>`.  A consuming space (e.g. `configurations/spaces/local`) that ships no steps is unaffected — its steps still resolve through the ancestor-walk / env-class-match against the inherited assets tree.
+
+> **Environments and asset stores get this priority for free.**  `space://environments/<name>` and `space://assetstores/<name>` have no env-co-located ancestor-walk — they resolve directly against the `base_uris` chain in order, and the space's own directory is `base_uris[0]`.  So a space's own `environments/<name>` / `assetstores/<name>` already overrides any inherited copy without a special case; only steps needed the explicit space-root check above, because their ancestor-walk would otherwise reach into the inherited tree first.  See [Spaces and `space.yaml`](../spaces/README.md#base_uris-and-space-resolution).
 
 ## Co-located steps and the ancestor-walk
 
@@ -60,19 +72,21 @@ When the active env class is `K8s`, the resolver picks `steps/k8s/s3push/step.ya
 
 For `space://steps/<name>` and an env of class `K8s` loaded from `<env-dir>`:
 
-1. Walk `<env-dir>` → parents up to the enclosing `base_uri`, first `steps/<name>/step.yaml` hit wins (nearest overrides); a candidate whose `subtypes` restriction excludes the active env is skipped and the walk continues.
-2. Recursive glob `<base>/**/<name>/step.yaml` across `base_uris` — first candidate (by specificity, then lex) whose `environment_configs` contains `K8s` (case-insensitively) **and** whose `subtypes` restriction admits the active env's sub-type.
-3. `<base>/steps/<name>/step.yaml` — env-agnostic fallback.  Existence is checked via the resolved URI's own scheme-aware `exists()`, and the resolved (git or file) URI is returned as-is; the `subtypes` restriction and `<rest>` containment are still enforced against the base's local materialization, so a candidate the active env's sub-type excludes is skipped.
-4. unresolvable → `ValueError`.
+1. **Space-root** — `base_uris[0]/steps/<name>/step.yaml` (the space's own dir); if present and its `subtypes` restriction admits the active env, it wins outright.  This step runs at the head of the ancestor-walk, so it applies whenever an env is active; when no env is active, step 4's base_uris-order scan already checks `base_uris[0]` first, so the space still wins.
+2. Walk `<env-dir>` → parents up to the enclosing `base_uri`, first `steps/<name>/step.yaml` hit wins (nearest overrides); a candidate whose `subtypes` restriction excludes the active env is skipped and the walk continues.
+3. Recursive glob `<base>/**/<name>/step.yaml` across `base_uris` — first candidate (by specificity, then lex) whose `environment_configs` contains `K8s` (case-insensitively) **and** whose `subtypes` restriction admits the active env's sub-type.
+4. `<base>/steps/<name>/step.yaml` — env-agnostic fallback.  Existence is checked via the resolved URI's own scheme-aware `exists()`, and the resolved (git or file) URI is returned as-is; the `subtypes` restriction and `<rest>` containment are still enforced against the base's local materialization, so a candidate the active env's sub-type excludes is skipped.
+5. unresolvable → `ValueError`.
 
 The `subtypes` restriction is honored by **all** step tiers, so it is never bypassed by falling through from one tier to the next.
 
 ### Git-backed spaces
 
-`base_uris` may be git URIs (`git+ssh://…`), not just local `file://` dirs.  All three tiers operate off a repo's **already-cloned** local copy (the thread-local git clone cache, reused — no re-clone), via a git-aware local-path resolver:
+`base_uris` may be git URIs (`git+ssh://…`), not just local `file://` dirs.  All step lookups operate off a repo's **already-cloned** local copy (the thread-local git clone cache, reused — no re-clone), via a git-aware local-path resolver:
 
-- Tier 2 (glob) and Tier 3 (fallback) scan/inspect any git base's clone.
-- Tier 1 (ancestor-walk) resolves the env dir to its clone and walks within it, so co-located steps in the **same repo** (base_uri) as the environment resolve.  Steps in a *different* repo from the env live in a separate clone and are not reachable by the walk — use env-class-match or the fallback for those.
+- The env-class-match glob and the env-agnostic fallback scan/inspect any git base's clone.
+- The ancestor-walk resolves the env dir to its clone and walks within it, so co-located steps in the **same repo** (base_uri) as the environment resolve.  Steps in a *different* repo from the env live in a separate clone and are not reachable by the walk — use env-class-match or the fallback for those.
+- The space-root check resolves `base_uris[0]` to its clone as well, so a git-backed space's own `steps/<name>` still takes priority.
 
 A base that can't be materialized locally (unsupported scheme, or a clone failure) is treated as "can't inspect": Tier 1/2 skip it and Tier 3 admits by path existence only, matching pre-`subtypes` behavior.
 
@@ -95,5 +109,5 @@ Auto-discovery of the active env's dir still happens on top of this — listing 
 
 - [Spaces and `space.yaml`](../spaces/README.md) — the `base_uris` chain these lookups walk.
 - [Environments overview](README.md) — `environment.yaml` / `step.yaml` reference and the per-type pages.
-- [`src/gbcommon/uri/space.py`](../../src/gbcommon/uri/space.py) — the `SpaceURI` resolver implementing the three-tier lookup.
+- [`src/gbcommon/uri/space.py`](../../src/gbcommon/uri/space.py) — the `SpaceURI` resolver implementing the space-root check and the three-tier lookup.
 - [`src/gbserver/build/targetstep.py`](../../src/gbserver/build/targetstep.py) — scopes the active env on the resolver thread-local during step assimilation.

--- a/docs/spaces/README.md
+++ b/docs/spaces/README.md
@@ -47,8 +47,8 @@ variables:                        # Optional. Template values exposed to build.y
 `base_uris` is the search path for `space://` URIs. When a target uses
 `environment_uri: space://environments/skypilot/kubernetes` or a step is `space://steps/hfpull`, the
 resolver walks the `base_uris` chain (plus the active environment's own directory) to find the matching
-asset. The full three-tier resolution algorithm — env-co-located lookup, env-class matching, and
-env-agnostic fallback — is documented in
+asset. The full resolution algorithm — space-root priority (a step the space itself ships wins),
+env-co-located lookup, env-class matching, and env-agnostic fallback — is documented in
 [step-resolution.md](../environments/step-resolution.md).
 
 #### Worked example: how a space references environments and asset stores
@@ -72,9 +72,20 @@ So a build running in this space resolves, for example:
 - `environment_uri: space://environments/skypilot/kubernetes` → `configurations/assets/environments/skypilot/kubernetes/` (the space's `DEFAULT_ENVIRONMENT` variable);
 - an [asset store](../asset-stores/README.md) reference like `space://assetstores/hf` → [`configurations/assets/assetstores/hf/`](../../configurations/assets/assetstores/).
 
-**`base_uris` is optional.** The space's own directory (the one containing `space.yaml`) is always
-searched first, ahead of any `base_uris`. So a **self-contained** space can drop the `environments/`,
-`assetstores/`, and `steps/` directories right next to its `space.yaml` and omit `base_uris` entirely:
+**The space's own directory wins.** The directory containing `space.yaml` is always searched first,
+ahead of any `base_uris` — it is `base_uris[0]` in the resolver. This holds for **all three** asset
+kinds: an `environments/<name>`, `assetstores/<name>`, or `steps/<name>` the space itself ships
+**overrides** any copy inherited through the rest of the `base_uris` chain (e.g. a shared
+`configurations/assets` tree). So a space can develop and test its own environment, asset store, or
+step locally and have it take effect before — or instead of — the published/inherited version. (Steps
+need an extra rule to guarantee this because their env-co-located lookup would otherwise reach into the
+inherited tree first; see [step-resolution.md](../environments/step-resolution.md#space-root-steps-highest-priority).
+Environments and asset stores have no such lookup, so the space-first `base_uris` order already decides
+them.)
+
+**`base_uris` is optional.** Because the space's own directory is always searched, a **self-contained**
+space can drop the `environments/`, `assetstores/`, and `steps/` directories right next to its
+`space.yaml` and omit `base_uris` entirely:
 
 ```
 my-space/

--- a/docs/steps/README.md
+++ b/docs/steps/README.md
@@ -22,7 +22,7 @@ steps:
 
 | Scheme | Example | Description |
 |--------|---------|-------------|
-| `space://steps/<name>` | `space://steps/hfpull` | Resolves to a step registered in the active space. |
+| `space://steps/<name>` | `space://steps/command` | Resolves to a step registered in the active space. |
 | `file://<path>` | `file://./my-step` | Local directory containing a `step.yaml`. |
 | `git+ssh://<repo>#subdirectory=<path>` | `git+ssh://github.com/org/repo.git#subdirectory=steps/custom` | Step from a Git repository. |
 
@@ -30,17 +30,18 @@ If `step_uri` is omitted, the built-in `gbstep` step is used.
 
 ## Built-in steps
 
-These steps ship with gbserver in `src/gbserver/builtins/steps/`:
+These steps ship with gbserver in `src/gbserver/builtins/steps/`. Steps intended for
+direct reference from a `build.yaml` have a focused reference page (linked below).
 
-| Step | Description |
-|------|-------------|
-| `gbstep` | Base step runner. Default when `step_uri` is omitted. Supports `setup_command`, `start_command`, and `cleanup_command`. |
-| `hfpull` | Pull a model or dataset from HuggingFace Hub. |
-| `hfpush` | Push artifacts to HuggingFace Hub. |
-| `s3pull` | Pull files from an S3-compatible object store. |
-| `s3push` | Push files to an S3-compatible object store. |
-| `cosrclone` | Transfer files using rclone (supports COS, S3, and many backends). |
-| `command` | Run a shell command (available on the Bash, Docker, and Skypilot environments). On Docker/Skypilot set `command_config.image` to run it inside a container image (BYOI); leave the image empty to run on the bare node. |
+| Step | Description | Environments | Reference |
+|------|-------------|--------------|-----------|
+| `gbstep` | Base step runner. Default when `step_uri` is omitted. Supports `setup_command`, `start_command`, and `cleanup_command`. | All (Bash, Docker, K8s, LSF, RunPod, Skypilot, Skypilot-managed) | — |
+| `command` | Run a shell command; its exit status is the step's status. Docker/Skypilot can run it inside a container image via `command_config.image` (BYOI); Bash always runs on the bare node. | Bash, Docker, Skypilot | [`command`](command.md) |
+
+> The data-staging utility steps `hfpull`/`hfpush` (HuggingFace), `s3pull`/`s3push`
+> (S3-compatible stores), and `cosrclone` (rclone-based transfers) are wired in
+> automatically to move a target's declared inputs/outputs and are **not** intended
+> to be referenced directly from a `build.yaml`, so they are not documented here.
 
 ## Bash example steps
 

--- a/docs/steps/README.md
+++ b/docs/steps/README.md
@@ -133,6 +133,7 @@ Three approaches for running custom code:
 
 ## See also
 
+- [Step Implementation Framework](../../steps/README.md) — how step implementations are authored, rendered, and published from the `steps/` source tree (for step *developers*, complementing this user-facing guide)
 - [Monitoring and artifact events](monitoring-and-artifact-events.md) — how a step captures its outputs by parsing workload logs
 - [bash environment](../environments/bash.md) — how bash steps execute (inputs, config, outputs)
 - [Templates](../templates/README.md) — reusable build.yaml patterns

--- a/docs/steps/command.md
+++ b/docs/steps/command.md
@@ -1,0 +1,125 @@
+# `command` (built-in step)
+
+Runs an arbitrary shell command as a step. It is the simplest built-in workload:
+give it a command line and it executes it on the launcher node (or inside a
+container image, where supported). The command's **exit status becomes the step's
+status**, so `command: "exit 1"` hard-fails the target — which makes it useful for
+tests and quick experiments as well as real one-shot workloads.
+
+> **Audience:** users authoring builds who want the exact config contract and
+> environment support of the `command` step. For step concepts (referencing steps,
+> the `step.yaml` structure, custom steps) see the [steps overview](README.md); for
+> how a step reports outputs see
+> [Monitoring and artifact events](monitoring-and-artifact-events.md).
+
+## Referencing the step
+
+```yaml
+steps:
+  - step_uri: space://steps/command
+    config:
+      command_config:
+        command: "python train.py --epochs 3"
+```
+
+## Config contract (`command_config`)
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `command` | string | **required** | Shell command executed on the launcher node. The step exits with this command's status. |
+| `image` | string | optional (**Docker / Skypilot only**) | Container image to run the command inside. Empty (default) ⇒ run on the **bare launcher node**. Not supported on the Bash environment. |
+
+`compute_config` is also honored where the environment uses it (see the matrix
+below); on Skypilot, resource requests are otherwise supplied via
+`config.launcher_config.resources`.
+
+## Environment support
+
+The `command` step is implemented for three environments, with small but important
+differences:
+
+| Environment | `image` supported? | Launcher | Monitor | Notes |
+|---|---|---|---|---|
+| **Bash** | no | `nohup` | [`space://monitors/bash`](../../src/gbserver/builtins/monitors/bash/monitor.yaml) | Always runs on the bare node; the command is exec'd so its exit status is the step's status. |
+| **Docker** | yes | `docker` | [`space://monitors/docker`](../../src/gbserver/builtins/monitors/docker/monitor.yaml) | Runs `bash -c '<command>'` inside `image`. Defaults: `num_gpus_per_node: 0`, `total_memory_per_node: 4Gi`. |
+| **Skypilot** | yes | `skypilot` | [`space://monitors/skypilot`](../../src/gbserver/builtins/monitors/skypilot/monitor.yaml) | Empty `image` runs on the bare launcher node (no Pyxis SPANK plugin required, e.g. the local Docker SLURM cluster); a non-empty value renders to `docker:<image>`. Resources are left cloud-agnostic. |
+
+## Running inside a container image (the BYOI pattern)
+
+On **Docker** and **Skypilot**, setting `command_config.image` runs the command
+inside a pre-built, pullable container image — the "bring your own image" pattern.
+Point `image` at any accessible public or private image and invoke its tooling from
+`command`:
+
+```yaml
+steps:
+  - step_uri: space://steps/command
+    config:
+      command_config:
+        image: "nvcr.io/nvidia/pytorch:24.01-py3"
+        command: "torchrun --nproc_per_node=4 /workspace/train.py"
+```
+
+> If instead you want to **clone code from a git repo into a public image at run
+> time**, use the [`byoc` step](../../configurations/assets/environments/skypilot/steps/byoc/README.md),
+> which is the maintained exemplar for that workflow on Skypilot.
+
+## Reporting outputs
+
+`command` has no I/O schema of its own; declare `inputs:`/`outputs:` on the
+**target** and register produced artifacts from your command by printing marker
+lines that the environment's monitor captures:
+
+```
+LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>
+```
+
+See [Monitoring and artifact events](monitoring-and-artifact-events.md) for the full
+marker convention (path vs. `mem://` state, anchoring, and the shipped monitors).
+
+## Examples
+
+**Bash — a controllable local workload (no image):**
+
+```yaml
+steps:
+  - step_uri: space://steps/command
+    config:
+      command_config:
+        command: "python -m my_smoke_test && echo done"
+```
+
+**Docker — run inside an image with a GPU:**
+
+```yaml
+steps:
+  - step_uri: space://steps/command
+    config:
+      command_config:
+        image: "python:3.12-slim"
+        command: "pip install -e . && python run.py"
+      compute_config:
+        num_gpus_per_node: 1
+```
+
+**Skypilot — run on a cloud cluster inside an image:**
+
+```yaml
+steps:
+  - step_uri: space://steps/command
+    config:
+      command_config:
+        image: "python:3.12-slim"
+        command: "python main.py --out $GB_BUILD_WORKDIR/out"
+      launcher_config:
+        resources: { cpus: "4+", accelerators: "A100:1" }
+```
+
+## Notes and limitations
+
+- **Exit status is the contract.** The step succeeds or fails with the command's
+  own exit code; there is no separate success marker to print.
+- **`image` is Docker/Skypilot only.** On Bash the command always runs on the bare
+  launcher node.
+- **No dependency management.** Whatever the chosen `image` (or bare node) provides,
+  plus anything the command installs at run time, is all that is available.

--- a/docs/steps/monitoring-and-artifact-events.md
+++ b/docs/steps/monitoring-and-artifact-events.md
@@ -268,6 +268,24 @@ Anchoring `space://monitors/skypilot` "for consistency" once caused a real regre
 markers stopped matching and the job registered **zero** artifacts. If you author a new monitor,
 anchor only when the environment injects a line you must avoid matching.
 
+> **Exception — the step-metadata marker is anchored on every monitor.** Unlike the artifact
+> rules above, `LLMB_STEP_METADATA_KEY/VALUE` surfaces in lineage as *authoritative build
+> provenance* (e.g. a byoc step's resolved `commit_hash`), so it must not be injectable by
+> arbitrary mid-stream output from cloned-repo code. Bash and Docker anchor it with a plain
+> `^`; SkyPilot anchors it too but permits only its own `(name, pid=N) ` log prefix before the
+> marker (`^(\([^)]*\)\s+)?LLMB_STEP_METADATA_KEY:...`), so a marker embedded after other text
+> on the line is ignored. Do **not** un-anchor these to match the artifact rules — the trade-off
+> is deliberate. (Caveat: because SkyPilot prefixes every line, a *deliberate* clean-line echo of
+> just the marker is still indistinguishable from the scaffold's own emission; anchoring closes
+> the incidental/embedded case, which is the realistic one.)
+>
+> **ANSI is handled once, centrally — not per monitor.** SkyPilot colourises its line prefix
+> (`\x1b[36m(name, pid=N)\x1b[0m`) in retrieved logs. Rather than teach each monitor's regex to
+> skip escape codes (which would also be needed for the `^` anchor to match), `get_events_from_log_line`
+> strips all ANSI escape sequences from every log line before any rule runs. So monitor regexes —
+> in **all** environments — only ever see clean text, and captured values never absorb a stray
+> escape (e.g. a reset folded onto a commit hash). Keep ANSI handling there, not in `line_regex`.
+
 ### Gotcha: one line, one rule
 
 The engine's `get_events_from_log_line`

--- a/src/gbcommon/uri/space.py
+++ b/src/gbcommon/uri/space.py
@@ -179,14 +179,40 @@ class SpaceURI(URI):
         return boundary
 
     @staticmethod
-    def _env_config_entry(data: dict, env_class: str):
-        """Look up ``environment_configs[<env_class>]`` case-insensitively.
+    def _matching_env_key(configs, env_class: str) -> Optional[str]:
+        """Return the ``environment_configs`` key that matches ``env_class``.
 
         Env class names (``K8s``, ``Skypilot``, ...) and the ``environment_configs``
         keys authored in ``step.yaml`` don't always agree on case (e.g. a step
         keyed ``k8s`` for the ``K8s`` env class), so the match is by
         case-insensitive string equality.  An exact match is preferred; a
-        case-insensitive match is the fallback.
+        case-insensitive match is the fallback.  The lookup is on the **key**
+        only and ignores the entry's value, so a present-but-null entry
+        (``{Skypilot:}``) still reports its key.
+
+        Args:
+            configs: The ``environment_configs`` mapping (any non-dict value,
+                including ``None``, yields ``None``).
+            env_class: Active env class name.
+
+        Returns:
+            The matching key, or ``None`` when no key matches.
+        """
+        if not isinstance(configs, dict):
+            return None
+        if env_class in configs:
+            return env_class
+        lowered = env_class.lower()
+        for key in configs:
+            if isinstance(key, str) and key.lower() == lowered:
+                return key
+        return None
+
+    @staticmethod
+    def _env_config_entry(data: dict, env_class: str):
+        """Look up the value of ``environment_configs[<env_class>]``.
+
+        Uses :meth:`_matching_env_key` for the case-insensitive key match.
 
         Args:
             data: Parsed ``step.yaml`` mapping.
@@ -194,18 +220,37 @@ class SpaceURI(URI):
 
         Returns:
             The matching ``environment_configs`` value, or ``None`` when no key
-            matches.
+            matches **or the matched key's value is null**.  Because a null value
+            is indistinguishable from an absent key here, callers testing whether
+            the class is *declared* must use :meth:`_env_class_present`, not an
+            ``is None`` check on this result.
         """
-        configs = data.get("environment_configs") or {}
+        configs = data.get("environment_configs")
         if not isinstance(configs, dict):
             return None
-        if env_class in configs:
-            return configs[env_class]
-        lowered = env_class.lower()
-        for key, value in configs.items():
-            if isinstance(key, str) and key.lower() == lowered:
-                return value
-        return None
+        key = SpaceURI._matching_env_key(configs, env_class)
+        return configs[key] if key is not None else None
+
+    @staticmethod
+    def _env_class_present(data: dict, env_class: str) -> bool:
+        """Return whether ``environment_configs`` *declares* ``env_class`` by key.
+
+        Presence is decided by the key alone, so a class that is present but null
+        (``environment_configs: {Skypilot:}`` — declared, hence admissible under
+        the active ``Skypilot`` env) is distinguished from one that is genuinely
+        absent (the step is scoped to other classes only).
+
+        Args:
+            data: Parsed ``step.yaml`` mapping.
+            env_class: Active env class name.
+
+        Returns:
+            ``True`` when a key matches ``env_class`` (case-insensitively).
+        """
+        return (
+            SpaceURI._matching_env_key(data.get("environment_configs"), env_class)
+            is not None
+        )
 
     @staticmethod
     def _subtype_ok(
@@ -263,14 +308,21 @@ class SpaceURI(URI):
 
         * ``env_class`` unknown → ``True`` (no class context to filter on, as in
           :meth:`_subtype_ok`).
-        * a **non-empty** ``environment_configs`` block that does **not** list the
-          active class → ``False``: the step is scoped to other env classes and
-          cannot run here, so it is not a match.  This is the class-presence
-          requirement the sub-type-only predicate deliberately left to callers.
-        * otherwise (the class is present, **or** the step declares no
+        * a **non-empty** ``environment_configs`` block whose keys do **not**
+          include the active class → ``False``: the step is scoped to other env
+          classes and cannot run here, so it is not a match.  This is the
+          class-presence requirement the sub-type-only predicate deliberately left
+          to callers.
+        * otherwise (the class **key** is present, **or** the step declares no
           ``environment_configs`` at all) → delegate to :meth:`_subtype_ok`.  A
           step with no ``environment_configs`` stays env-agnostic/universal,
           preserving the directory-placed ancestor-walk behavior.
+
+        Presence is decided by the class **key**, not its value: a present-but-null
+        entry (``environment_configs: {Skypilot:}``) declares the class and so is
+        admitted (:meth:`_subtype_ok` then treats the null entry as unrestricted).
+        A value-based ``is None`` check would wrongly skip such a step, which is
+        scoped to exactly the active class.
 
         Args:
             data: Parsed ``step.yaml`` mapping.
@@ -283,7 +335,7 @@ class SpaceURI(URI):
         if (
             isinstance(configs, dict)
             and configs
-            and SpaceURI._env_config_entry(data, env_class) is None
+            and not SpaceURI._env_class_present(data, env_class)
         ):
             # Declared for other env classes only → not a match for this env.
             return False

--- a/src/gbcommon/uri/space.py
+++ b/src/gbcommon/uri/space.py
@@ -57,7 +57,10 @@ class SpaceURI(URI):
         # Tier 1: for `space://steps/<name>` with an active env, first honor the
         # space's own root step (`base_uris[0]/steps/<name>`, highest priority),
         # then the env-co-located ancestor-walk (nearest-wins), bounded by the
-        # enclosing base_uri.  Honors any per-step ``subtypes`` restriction.
+        # enclosing base_uri.  Each candidate must be admissible for the active
+        # env: a step declaring ``environment_configs`` must list the active env
+        # class and satisfy its ``subtypes`` restriction, else it is skipped and
+        # resolution continues (a step scoped to other classes never wins here).
         if uri_suffix.startswith(STEPS_PREFIX):
             walked = SpaceURI._walk_colocated_steps(uri_suffix)
             if walked is not None:
@@ -245,18 +248,59 @@ class SpaceURI(URI):
         if not isinstance(subtypes, list) or not subtypes:
             # Empty, or a non-list we can't interpret as sub-types → universal,
             # matching the module's "can't read the restriction → admit"
-            # convention (see :meth:`_step_subtype_ok`).
+            # convention (see :meth:`_step_env_ok`).
             return True
         return env_subtype in subtypes
 
     @staticmethod
-    def _step_subtype_ok(
+    def _env_ok(
+        data: dict, env_class: Optional[str], env_subtype: Optional[str]
+    ) -> bool:
+        """Return whether a step's ``environment_configs`` admit the active env.
+
+        This is the full directory-tier gate: a two-stage check that first
+        matches the env **class**, then (via :meth:`_subtype_ok`) the sub-type.
+
+        * ``env_class`` unknown → ``True`` (no class context to filter on, as in
+          :meth:`_subtype_ok`).
+        * a **non-empty** ``environment_configs`` block that does **not** list the
+          active class → ``False``: the step is scoped to other env classes and
+          cannot run here, so it is not a match.  This is the class-presence
+          requirement the sub-type-only predicate deliberately left to callers.
+        * otherwise (the class is present, **or** the step declares no
+          ``environment_configs`` at all) → delegate to :meth:`_subtype_ok`.  A
+          step with no ``environment_configs`` stays env-agnostic/universal,
+          preserving the directory-placed ancestor-walk behavior.
+
+        Args:
+            data: Parsed ``step.yaml`` mapping.
+            env_class: Active env class name (e.g. ``"Skypilot"``), or ``None``.
+            env_subtype: Active env sub-type (e.g. ``"kubernetes"``), or ``None``.
+        """
+        if not env_class:
+            return True
+        configs = data.get("environment_configs")
+        if (
+            isinstance(configs, dict)
+            and configs
+            and SpaceURI._env_config_entry(data, env_class) is None
+        ):
+            # Declared for other env classes only → not a match for this env.
+            return False
+        return SpaceURI._subtype_ok(data, env_class, env_subtype)
+
+    @staticmethod
+    def _step_env_ok(
         step_yaml: Path, env_class: Optional[str], env_subtype: Optional[str]
     ) -> bool:
-        """Parse ``step_yaml`` and apply :meth:`_subtype_ok`.
+        """Parse ``step_yaml`` and apply :meth:`_env_ok`.
 
-        A file that can't be read/parsed carries no sub-type restriction we can
-        evaluate, so it is admitted (directory-only match, as before sub-types).
+        Applies the class-presence + sub-type gate: a step declaring an
+        ``environment_configs`` block must list the active env class (and satisfy
+        its sub-type restriction) to be admitted; a step with no
+        ``environment_configs`` is env-agnostic and admitted.  A file that can't
+        be read/parsed carries no restriction we can evaluate, so it is admitted
+        (directory-only match, as before env/sub-type filtering).
 
         Args:
             step_yaml: Path to the candidate ``step.yaml``.
@@ -270,7 +314,7 @@ class SpaceURI(URI):
             return True
         if not isinstance(data, dict):
             return True
-        return SpaceURI._subtype_ok(data, env_class, env_subtype)
+        return SpaceURI._env_ok(data, env_class, env_subtype)
 
     @staticmethod
     def _fallback_steps_ok(base_uri: str, parsed: Tuple[str, str]) -> bool:
@@ -282,8 +326,11 @@ class SpaceURI(URI):
 
         * **containment** — a ``<rest>`` that escapes ``<base>/steps/<name>``
           (e.g. ``../../secret``) is rejected, matching Tiers 1 & 2;
-        * **sub-type** — the step's own ``step.yaml`` is read and its
-          ``subtypes`` restriction (if any) must admit the active env.
+        * **env** — the step's own ``step.yaml`` is read and its
+          ``environment_configs`` must admit the active env: a step that
+          declares that block must list the active env class (and satisfy its
+          ``subtypes`` restriction, if any); a step with no
+          ``environment_configs`` is env-agnostic and admitted.
 
         Reading the step's *own* ``step.yaml`` (resolved from ``<name>``, not
         from the possibly ``..``-displaced ``<rest>``) keeps the restriction
@@ -298,7 +345,8 @@ class SpaceURI(URI):
 
         Returns:
             ``True`` when the hit is admitted; ``False`` when ``rest`` escapes
-            the step dir or the ``subtypes`` restriction excludes the env.
+            the step dir or the ``environment_configs`` restriction (class or
+            sub-type) excludes the env.
         """
         name, rest = parsed
         root = SpaceURI._uri_to_local_path(base_uri)
@@ -312,7 +360,7 @@ class SpaceURI(URI):
                 return False
         env_class = getattr(SpaceURI._thread_local, "current_env_class_name", None)
         env_subtype = getattr(SpaceURI._thread_local, "current_env_subtype", None)
-        return SpaceURI._step_subtype_ok(
+        return SpaceURI._step_env_ok(
             step_dir / STEP_FILE_NAME, env_class, env_subtype
         )
 
@@ -327,9 +375,12 @@ class SpaceURI(URI):
         ``<space>/steps/<name>`` overrides an env-co-located step or one inherited
         via ``base_uris[1:]`` (e.g. a published assets tree).  This lets a step
         being developed in its own space be exercised (by ``make test``) before it
-        is published into an inherited tree.  The same ``subtypes`` restriction as
-        the ancestor-walk is applied, so a space step that excludes the active
-        env's sub-type is skipped and resolution falls through.
+        is published into an inherited tree.  The same env gate as the
+        ancestor-walk is applied (:meth:`_step_env_ok`), so a space step that
+        declares ``environment_configs`` without the active env class — or whose
+        ``subtypes`` exclude the active env — is skipped and resolution falls
+        through (it must never override a valid step with one that cannot run
+        under the active environment).
 
         Args:
             name: Step name.
@@ -348,7 +399,7 @@ class SpaceURI(URI):
         if space_root is None:
             return None
         step_yaml = space_root.resolve() / "steps" / name / STEP_FILE_NAME
-        if not step_yaml.is_file() or not SpaceURI._step_subtype_ok(
+        if not step_yaml.is_file() or not SpaceURI._step_env_ok(
             step_yaml, env_class, env_subtype
         ):
             return None
@@ -367,8 +418,10 @@ class SpaceURI(URI):
         at (and including) the deepest ``base_uri`` that encloses the env dir.
         This lets sibling environments under a common family directory share one
         step implementation while an env's own dir still overrides it.  A
-        candidate that declares a ``subtypes`` restriction not satisfied by the
-        active env is skipped and the walk continues upward.
+        candidate whose ``environment_configs`` don't admit the active env — it
+        declares that block without the active env class, or its ``subtypes``
+        exclude the active env — is skipped and the walk continues upward
+        (see :meth:`_step_env_ok`).
 
         The env dir URI is materialized to a local path via
         :meth:`_uri_to_local_path`, so a git-backed env resolves against its
@@ -407,7 +460,7 @@ class SpaceURI(URI):
         cur = env_path
         while True:
             step_yaml = cur / "steps" / name / STEP_FILE_NAME
-            if step_yaml.is_file() and SpaceURI._step_subtype_ok(
+            if step_yaml.is_file() and SpaceURI._step_env_ok(
                 step_yaml, env_class, env_subtype
             ):
                 found = SpaceURI._step_uri_from_dir(step_yaml.parent, rest)

--- a/src/gbcommon/uri/space.py
+++ b/src/gbcommon/uri/space.py
@@ -54,9 +54,10 @@ class SpaceURI(URI):
             uri_suffix = uristr.removeprefix(GBSPACE_SCHEME + "://")
         elif uristr.startswith(SPACE_SCHEME):
             uri_suffix = uristr.removeprefix(SPACE_SCHEME + "://")
-        # Tier 1: env-co-located step lookup with ancestor-walk (nearest-wins),
-        # bounded by the enclosing base_uri.  Applies only to `space://steps/<name>`
-        # and honors any per-step ``subtypes`` restriction.
+        # Tier 1: for `space://steps/<name>` with an active env, first honor the
+        # space's own root step (`base_uris[0]/steps/<name>`, highest priority),
+        # then the env-co-located ancestor-walk (nearest-wins), bounded by the
+        # enclosing base_uri.  Honors any per-step ``subtypes`` restriction.
         if uri_suffix.startswith(STEPS_PREFIX):
             walked = SpaceURI._walk_colocated_steps(uri_suffix)
             if walked is not None:
@@ -316,8 +317,50 @@ class SpaceURI(URI):
         )
 
     @staticmethod
+    def _space_root_step(
+        name: str, rest: str, env_class: Optional[str], env_subtype: Optional[str]
+    ) -> Optional[URI]:
+        """Resolve ``steps/<name>`` against the space's own root (``base_uris[0]``).
+
+        The space directory (the first base_uri — the space's own ``uristr``) is
+        the most authoritative step source: a step it ships at
+        ``<space>/steps/<name>`` overrides an env-co-located step or one inherited
+        via ``base_uris[1:]`` (e.g. a published assets tree).  This lets a step
+        being developed in its own space be exercised (by ``make test``) before it
+        is published into an inherited tree.  The same ``subtypes`` restriction as
+        the ancestor-walk is applied, so a space step that excludes the active
+        env's sub-type is skipped and resolution falls through.
+
+        Args:
+            name: Step name.
+            rest: Sub-asset suffix appended to the step dir (empty for a bare URI).
+            env_class: Active env class name (for the sub-type gate), or ``None``.
+            env_subtype: Active env sub-type (for the sub-type gate), or ``None``.
+
+        Returns:
+            The resolved step ``URI`` when the space ships an admitting
+            ``steps/<name>``, else ``None``.
+        """
+        base_uris = getattr(SpaceURI._thread_local, "base_uris", None)
+        if not base_uris:
+            return None
+        space_root = SpaceURI._uri_to_local_path(base_uris[0])
+        if space_root is None:
+            return None
+        step_yaml = space_root.resolve() / "steps" / name / STEP_FILE_NAME
+        if not step_yaml.is_file() or not SpaceURI._step_subtype_ok(
+            step_yaml, env_class, env_subtype
+        ):
+            return None
+        return SpaceURI._step_uri_from_dir(step_yaml.parent, rest)
+
+    @staticmethod
     def _walk_colocated_steps(uri_suffix: str) -> Optional[URI]:
         """Resolve ``space://steps/<name>`` by walking up from the active env dir.
+
+        Before the walk, the space's own root step (``base_uris[0]/steps/<name>``,
+        see :meth:`_space_root_step`) takes priority, so a step the space ships
+        overrides an env-co-located or inherited copy of the same name.
 
         Starting at ``current_env_dir_uri`` the resolver checks
         ``<dir>/steps/<name>/step.yaml`` at each ancestor, nearest-wins, stopping
@@ -354,6 +397,12 @@ class SpaceURI(URI):
         env_path = env_path.resolve()
         env_class = getattr(SpaceURI._thread_local, "current_env_class_name", None)
         env_subtype = getattr(SpaceURI._thread_local, "current_env_subtype", None)
+        # Space-root priority: a step the space itself ships at
+        # ``<space>/steps/<name>`` overrides any env-co-located or inherited copy,
+        # so a locally-developed step is exercised before it is published.
+        space_hit = SpaceURI._space_root_step(name, rest, env_class, env_subtype)
+        if space_hit is not None:
+            return space_hit
         boundary = SpaceURI._enclosing_base_boundary(env_path)
         cur = env_path
         while True:

--- a/src/gbcommon/uri/space.py
+++ b/src/gbcommon/uri/space.py
@@ -575,9 +575,14 @@ class SpaceURI(URI):
                 if not isinstance(data, dict):
                     continue
                 env_keys = list((data.get("environment_configs") or {}).keys())
-                if SpaceURI._env_config_entry(
+                # Class-presence by key (not value): a present-but-null entry
+                # (``{Skypilot:}``) is still declared for the active class and must
+                # match here, matching the _env_ok tier.  Testing
+                # ``_env_config_entry(...) is not None`` would silently drop it (its
+                # value is null), leaving the two tiers disagreeing on such steps.
+                if SpaceURI._env_class_present(
                     data, env_class
-                ) is not None and SpaceURI._subtype_ok(data, env_class, env_subtype):
+                ) and SpaceURI._subtype_ok(data, env_class, env_subtype):
                     matches.append((len(env_keys), str(cand), cand))
         if not matches:
             return None

--- a/src/gbcommon/uri/space.py
+++ b/src/gbcommon/uri/space.py
@@ -360,9 +360,7 @@ class SpaceURI(URI):
                 return False
         env_class = getattr(SpaceURI._thread_local, "current_env_class_name", None)
         env_subtype = getattr(SpaceURI._thread_local, "current_env_subtype", None)
-        return SpaceURI._step_env_ok(
-            step_dir / STEP_FILE_NAME, env_class, env_subtype
-        )
+        return SpaceURI._step_env_ok(step_dir / STEP_FILE_NAME, env_class, env_subtype)
 
     @staticmethod
     def _space_root_step(

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -225,11 +225,14 @@ def search_lineage_events(request: Request, body: TagSearchRequest):
             )
             if not has_access:
                 continue
-            # job_input_params carries step config/metadata that can embed
-            # credentials. The write-side builder (wandb_jobstats._build_events_for_target)
-            # already masks secret-named keys; redact again here as defense-in-depth on
-            # this persisted-read path so the surfaced metadata (e.g. commit_hash) stays
-            # visible while secret-named keys remain masked.
+            # job_input_params carries per-step config/metadata that can embed
+            # credentials. Always redact it here on the read path, unconditionally:
+            # the write-side builder (wandb_jobstats._build_events_for_target) already
+            # masks secret-named keys, so for freshly-persisted rows this runs twice —
+            # an accepted redundancy that also protects any row persisted before the
+            # write-side masking landed. redact_sensitive is idempotent, so the double
+            # pass is harmless; secret-named keys stay masked while step metadata
+            # (e.g. commit_hash) and config surface with their non-secret values intact.
             run_facets["job_input_params"] = redact_sensitive(
                 run_facets.get("job_input_params") or {}
             )

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -41,6 +41,7 @@ from gbserver.storage.singleton_storage import get_admin_storage
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.utils.logger import get_logger
+from gbserver.utils.redaction import redact_sensitive
 
 logger = get_logger(__name__)
 
@@ -224,10 +225,14 @@ def search_lineage_events(request: Request, body: TagSearchRequest):
             )
             if not has_access:
                 continue
-            # job_input_params carries raw build.yaml step config and can embed
-            # credentials — redact it here too, same as get_build_jobstats, rather
-            # than widening who can read pipeline secrets via search.
-            run_facets.pop("job_input_params", None)
+            # job_input_params carries step config/metadata that can embed
+            # credentials. The write-side builder (wandb_jobstats._build_events_for_target)
+            # already masks secret-named keys; redact again here as defense-in-depth on
+            # this persisted-read path so the surfaced metadata (e.g. commit_hash) stays
+            # visible while secret-named keys remain masked.
+            run_facets["job_input_params"] = redact_sensitive(
+                run_facets.get("job_input_params") or {}
+            )
             accessible.append(result)
         backend_offset += len(page_results)
 

--- a/src/gbserver/api/lineage.py
+++ b/src/gbserver/api/lineage.py
@@ -67,6 +67,24 @@ def _uri_from_url(url: Optional[str]) -> Optional[str]:
         return url
 
 
+def get_redacted_job_input_params(source: dict) -> dict:
+    """Read ``job_input_params`` from a run mapping, redacted for the read path.
+
+    Both member-readable lineage read endpoints (``search_lineage_events`` and
+    ``get_artifact_graph``) must mask this facet unconditionally: the write-side
+    builder (``wandb_jobstats._build_events_for_target``) already masks secret-named
+    keys, but going through this single accessor guarantees the two paths stay
+    consistent and also protects any row persisted before that write-side masking
+    landed. Non-secret step data (e.g. a ``commit_hash``) surfaces intact;
+    ``redact_sensitive`` is idempotent, so re-masking an already-masked row is safe.
+
+    :param source: a run's facets (search path) or metadata (graph path) mapping.
+    :returns: the ``job_input_params`` mapping with secret-named values redacted,
+        or an empty dict when the key is absent/empty.
+    """
+    return redact_sensitive(source.get("job_input_params") or {})
+
+
 lineage_api = FastAPI()
 
 
@@ -225,17 +243,10 @@ def search_lineage_events(request: Request, body: TagSearchRequest):
             )
             if not has_access:
                 continue
-            # job_input_params carries per-step config/metadata that can embed
-            # credentials. Always redact it here on the read path, unconditionally:
-            # the write-side builder (wandb_jobstats._build_events_for_target) already
-            # masks secret-named keys, so for freshly-persisted rows this runs twice —
-            # an accepted redundancy that also protects any row persisted before the
-            # write-side masking landed. redact_sensitive is idempotent, so the double
-            # pass is harmless; secret-named keys stay masked while step metadata
-            # (e.g. commit_hash) and config surface with their non-secret values intact.
-            run_facets["job_input_params"] = redact_sensitive(
-                run_facets.get("job_input_params") or {}
-            )
+            # Redact on the read path via the shared accessor (see
+            # get_redacted_job_input_params) so this and the artifact-graph path
+            # stay consistent.
+            run_facets["job_input_params"] = get_redacted_job_input_params(run_facets)
             accessible.append(result)
         backend_offset += len(page_results)
 
@@ -378,7 +389,9 @@ def get_artifact_graph(request: Request, body: ArtifactGraphRequest):
             category=metadata.get("category") or "",
             owner=metadata.get("owner") or "",
             source_code_details=metadata.get("source_code_details") or {},
-            job_input_params=metadata.get("job_input_params") or {},
+            # Redact on the read path via the shared accessor, matching
+            # search_lineage_events above (both endpoints are member-readable).
+            job_input_params=get_redacted_job_input_params(metadata),
             execution_stats=metadata.get("execution_stats") or {},
             job_output_stats=metadata.get("job_output_stats") or {},
         )

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -173,6 +173,14 @@ class BuildRunner(AbstractBuildRunner):
         # is written unconditionally, but entity finalization only touches
         # unfinished entities).
         self._finalize_lock = threading.Lock()
+        # Buffers step metadata (targetsteprun_id -> {key: value}) pushed by a
+        # STEP_METADATA_UPDATE_EVENT that is processed before the status event which
+        # creates the StoredStepRun row. These come from different producers (log
+        # parsing vs. step lifecycle) with no ordering guarantee, so the value is held
+        # here and flushed onto the row once it exists (see _apply_pending_step_metadata),
+        # rather than dropped. The single serial worker loop is the only accessor, so
+        # no lock is needed.
+        self._pending_step_metadata: dict[str, dict[str, str]] = {}
 
     def stop(self: Self) -> None:
         """Stop the building thread if it was started."""
@@ -1756,14 +1764,19 @@ Download : {download_msg}
         ), f"expected {targetsteprun_id} actual {stored_step_run.uuid}"
         logger.info("creating/updating the step: %s", stored_step_run)
         self.storage.step_storage.update(stored_step_run)
+        # Flush any step metadata that was processed before this row existed (a
+        # log-parsed STEP_METADATA_UPDATE_EVENT can race ahead of this status event).
+        self._apply_pending_step_metadata(targetsteprun_id)
 
     def __process_step_metadata_update_event(self: Self, event: BuildEvent) -> None:
-        """Merge a runtime key/value into the step's StoredStepRun.metadata.
+        """Buffer a runtime key/value and merge it into the step's metadata.
 
-        Correlates via event.run_metadata.targetsteprun_id and preserves all existing
-        metadata keys. Logs and no-ops if the step row is not present yet (a later
-        status event will create it; metadata for an unknown step is dropped rather
-        than crashing the single serial worker loop).
+        Correlates via event.run_metadata.targetsteprun_id. The value is recorded in
+        _pending_step_metadata first, then flushed onto StoredStepRun.metadata by
+        _apply_pending_step_metadata. If the row does not exist yet (this log-parsed
+        event was processed before the status event that creates it), the value stays
+        buffered and is flushed when the step status handler creates the row, so
+        metadata is never lost to event-ordering.
 
         :param event: a STEP_METADATA_UPDATE_EVENT carrying a
             StepMetadataUpdateEventPayload.
@@ -1771,14 +1784,29 @@ Download : {download_msg}
         payload = event.payload
         assert isinstance(payload, StepMetadataUpdateEventPayload)
         targetsteprun_id = event.run_metadata.targetsteprun_id
+        assert isinstance(targetsteprun_id, str)
+        self._pending_step_metadata.setdefault(targetsteprun_id, {})[
+            payload.metadata_key
+        ] = payload.metadata_value
+        self._apply_pending_step_metadata(targetsteprun_id)
+
+    def _apply_pending_step_metadata(self: Self, targetsteprun_id: str) -> None:
+        """Flush buffered step metadata onto its StoredStepRun row once it exists.
+
+        No-op while the row is absent (a metadata event arrived before the status
+        event that creates the row); the buffer is retried from here and from the step
+        status handler after row creation. On success the buffered keys are merged into
+        the row (existing keys preserved) and the buffer entry is cleared.
+
+        :param targetsteprun_id: uuid of the step run whose buffered metadata to flush.
+        """
+        pending = self._pending_step_metadata.get(targetsteprun_id)
+        if not pending:
+            return
         stored = self.storage.step_storage.get_by_uuid(targetsteprun_id)
         if stored is None:
-            logger.warning(
-                "step metadata update for unknown step %s (key=%s); dropping",
-                targetsteprun_id,
-                payload.metadata_key,
-            )
-            return
+            return  # row not created yet; keep buffered for a later flush
         assert isinstance(stored, StoredStepRun)
-        stored.metadata[payload.metadata_key] = payload.metadata_value
+        stored.metadata.update(pending)
         self.storage.step_storage.update(stored)
+        del self._pending_step_metadata[targetsteprun_id]

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -1763,10 +1763,17 @@ Download : {download_msg}
             stored_step_run.uuid == targetsteprun_id
         ), f"expected {targetsteprun_id} actual {stored_step_run.uuid}"
         logger.info("creating/updating the step: %s", stored_step_run)
+        # Merge any step metadata buffered before this row existed (a log-parsed
+        # STEP_METADATA_UPDATE_EVENT can race ahead of this status event) so the
+        # single update below persists status and metadata together, rather than
+        # re-fetching and writing a second time. The buffer is cleared only after
+        # the write succeeds.
+        pending_metadata = self._pending_step_metadata.get(targetsteprun_id)
+        if pending_metadata:
+            stored_step_run.metadata.update(pending_metadata)
         self.storage.step_storage.update(stored_step_run)
-        # Flush any step metadata that was processed before this row existed (a
-        # log-parsed STEP_METADATA_UPDATE_EVENT can race ahead of this status event).
-        self._apply_pending_step_metadata(targetsteprun_id)
+        if pending_metadata:
+            del self._pending_step_metadata[targetsteprun_id]
 
     def __process_step_metadata_update_event(self: Self, event: BuildEvent) -> None:
         """Buffer a runtime key/value and merge it into the step's metadata.

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -1785,13 +1785,25 @@ Download : {download_msg}
         buffered and is flushed when the step status handler creates the row, so
         metadata is never lost to event-ordering.
 
+        An event with no targetsteprun_id to correlate against — e.g. a stray marker
+        in non-step output, or an uncorrelated monitor context — is dropped with a
+        warning rather than raising, matching the buffering path's "no-op if the row
+        isn't present" posture. A raise here would fail the whole build under
+        GBSERVER_RAISE_BUILD_EXCEPTIONS over a benign lineage marker.
+
         :param event: a STEP_METADATA_UPDATE_EVENT carrying a
             StepMetadataUpdateEventPayload.
         """
         payload = event.payload
         assert isinstance(payload, StepMetadataUpdateEventPayload)
         targetsteprun_id = event.run_metadata.targetsteprun_id
-        assert isinstance(targetsteprun_id, str)
+        if not targetsteprun_id:
+            logger.warning(
+                "Ignoring STEP_METADATA_UPDATE_EVENT with no targetsteprun_id "
+                "(key=%s); nothing to correlate it to.",
+                payload.metadata_key,
+            )
+            return
         self._pending_step_metadata.setdefault(targetsteprun_id, {})[
             payload.metadata_key
         ] = payload.metadata_value

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -73,6 +73,7 @@ from gbserver.types.buildevent import (
     BuildEventType,
     BuildEventWorkloadStatusPayload,
     CreatedArtifactEventPayload,
+    StepMetadataUpdateEventPayload,
 )
 from gbserver.types.constants import (
     DEFAULT_DIR_PERMS,
@@ -920,6 +921,8 @@ class BuildRunner(AbstractBuildRunner):
             self.__process_workload_status_event(event=event)
         elif event.type is BuildEventType.METRICS_EVENT:
             self.__process_metrics_event(event=event)
+        elif event.type is BuildEventType.STEP_METADATA_UPDATE_EVENT:
+            self.__process_step_metadata_update_event(event=event)
         else:
             logger.error("unsupported event type: %s", event)
         logger.debug("BuildRunner.process_event end")
@@ -1753,3 +1756,29 @@ Download : {download_msg}
         ), f"expected {targetsteprun_id} actual {stored_step_run.uuid}"
         logger.info("creating/updating the step: %s", stored_step_run)
         self.storage.step_storage.update(stored_step_run)
+
+    def __process_step_metadata_update_event(self: Self, event: BuildEvent) -> None:
+        """Merge a runtime key/value into the step's StoredStepRun.metadata.
+
+        Correlates via event.run_metadata.targetsteprun_id and preserves all existing
+        metadata keys. Logs and no-ops if the step row is not present yet (a later
+        status event will create it; metadata for an unknown step is dropped rather
+        than crashing the single serial worker loop).
+
+        :param event: a STEP_METADATA_UPDATE_EVENT carrying a
+            StepMetadataUpdateEventPayload.
+        """
+        payload = event.payload
+        assert isinstance(payload, StepMetadataUpdateEventPayload)
+        targetsteprun_id = event.run_metadata.targetsteprun_id
+        stored = self.storage.step_storage.get_by_uuid(targetsteprun_id)
+        if stored is None:
+            logger.warning(
+                "step metadata update for unknown step %s (key=%s); dropping",
+                targetsteprun_id,
+                payload.metadata_key,
+            )
+            return
+        assert isinstance(stored, StoredStepRun)
+        stored.metadata[payload.metadata_key] = payload.metadata_value
+        self.storage.step_storage.update(stored)

--- a/src/gbserver/builtins/monitors/bash/monitor.yaml
+++ b/src/gbserver/builtins/monitors/bash/monitor.yaml
@@ -61,4 +61,6 @@ config:
         - field_name: metadata_key
           field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"
         - field_name: metadata_value
-          field_regex: "(?<=LLMB_STEP_METADATA_VALUE:).*"
+          # Trim trailing whitespace/carriage-return (CRLF logs) so it is not folded
+          # into the value; internal spaces are preserved.
+          field_regex: '(?<=LLMB_STEP_METADATA_VALUE:).*?(?=\s*$)'

--- a/src/gbserver/builtins/monitors/bash/monitor.yaml
+++ b/src/gbserver/builtins/monitors/bash/monitor.yaml
@@ -1,8 +1,8 @@
 # Shared monitor for the `log_monitor` type (Bash environment). Referenced by
 # bash steps via `ref: space://monitors/bash`. Streams every log line as a
 # MESSAGE_EVENT and detects the standard LLMB artifact markers (env:// PATH and
-# mem:// STATE forms). Steps that emit no artifact markers simply never fire
-# those events.
+# mem:// STATE forms) plus the LLMB_STEP_METADATA_KEY/VALUE step-metadata marker.
+# Steps that emit no markers simply never fire those events.
 type: log_monitor
 config:
   event_configs:
@@ -48,3 +48,17 @@ config:
         - field_name: binding
           field_value_template: '{ "state": "{{ fields.data.state }}" }'
           is_json: true
+    # step metadata: a line that BEGINS with
+    #   LLMB_STEP_METADATA_KEY:<key> LLMB_STEP_METADATA_VALUE:<value>
+    # merges <value> into the step's StoredStepRun.metadata under <key> (e.g. a
+    # git commit_hash resolved at runtime). Both fields are top-level, so they are
+    # splatted into StepMetadataUpdateEventPayload. `^`-anchored for the same
+    # reason as the artifact markers (the command step echoes the command back).
+    - event_type: STEP_METADATA_UPDATE_EVENT
+      line_regex: "^LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*"
+      is_json: false
+      event_fields:
+        - field_name: metadata_key
+          field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"
+        - field_name: metadata_value
+          field_regex: "(?<=LLMB_STEP_METADATA_VALUE:).*"

--- a/src/gbserver/builtins/monitors/docker/monitor.yaml
+++ b/src/gbserver/builtins/monitors/docker/monitor.yaml
@@ -1,6 +1,7 @@
 # Shared monitor for the `docker_log` type (Docker environment). Referenced by
 # docker steps via `ref: space://monitors/docker`. Detects the standard
-# LLMB env:// artifact marker (with a binding payload) and streams every other
+# LLMB env:// artifact marker (with a binding payload) and the
+# LLMB_STEP_METADATA_KEY/VALUE step-metadata marker, and streams every other
 # line as a MESSAGE_EVENT.
 type: docker_log
 config:
@@ -36,6 +37,18 @@ config:
         - field_name: binding
           field_value_template: '{ "state": "{{ fields.data.state }}" }'
           is_json: true
+    # step metadata: merges <value> into the step's StoredStepRun.metadata under
+    # <key> (e.g. a git commit_hash resolved at runtime). Both fields are
+    # top-level, so they are splatted into StepMetadataUpdateEventPayload.
+    # Unanchored, matching the artifact markers above.
+    - event_type: STEP_METADATA_UPDATE_EVENT
+      line_regex: "LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*"
+      is_json: false
+      event_fields:
+        - field_name: metadata_key
+          field_regex: (?<=LLMB_STEP_METADATA_KEY:)[^ ]+
+        - field_name: metadata_value
+          field_regex: (?<=LLMB_STEP_METADATA_VALUE:).*
     - event_type: MESSAGE_EVENT
       line_regex: .*
       is_json: false

--- a/src/gbserver/builtins/monitors/docker/monitor.yaml
+++ b/src/gbserver/builtins/monitors/docker/monitor.yaml
@@ -40,9 +40,15 @@ config:
     # step metadata: merges <value> into the step's StoredStepRun.metadata under
     # <key> (e.g. a git commit_hash resolved at runtime). Both fields are
     # top-level, so they are splatted into StepMetadataUpdateEventPayload.
-    # Unanchored, matching the artifact markers above.
+    #
+    # Unlike the artifact markers above, this one is `^`-anchored: step metadata
+    # surfaces in lineage as authoritative build provenance, so it must not be
+    # injectable by arbitrary mid-stream output from cloned-repo code (e.g. a byoc
+    # command echoing a config that happens to contain the marker substring).
+    # Docker streams raw stdout (no platform prefix), so a plain `^` anchor is
+    # enough here — same posture as the bash monitor.
     - event_type: STEP_METADATA_UPDATE_EVENT
-      line_regex: "LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*"
+      line_regex: "^LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*"
       is_json: false
       event_fields:
         - field_name: metadata_key

--- a/src/gbserver/builtins/monitors/docker/monitor.yaml
+++ b/src/gbserver/builtins/monitors/docker/monitor.yaml
@@ -48,7 +48,9 @@ config:
         - field_name: metadata_key
           field_regex: (?<=LLMB_STEP_METADATA_KEY:)[^ ]+
         - field_name: metadata_value
-          field_regex: (?<=LLMB_STEP_METADATA_VALUE:).*
+          # Trim trailing whitespace/carriage-return (CRLF logs) so it is not folded
+          # into the value; internal spaces are preserved.
+          field_regex: '(?<=LLMB_STEP_METADATA_VALUE:).*?(?=\s*$)'
     - event_type: MESSAGE_EVENT
       line_regex: .*
       is_json: false

--- a/src/gbserver/builtins/monitors/skypilot/monitor.yaml
+++ b/src/gbserver/builtins/monitors/skypilot/monitor.yaml
@@ -68,4 +68,6 @@ config:
         - field_name: metadata_key
           field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"
         - field_name: metadata_value
-          field_regex: "(?<=LLMB_STEP_METADATA_VALUE:).*"
+          # Trim trailing whitespace/carriage-return (CRLF logs) so it is not folded
+          # into the value; internal spaces are preserved.
+          field_regex: '(?<=LLMB_STEP_METADATA_VALUE:).*?(?=\s*$)'

--- a/src/gbserver/builtins/monitors/skypilot/monitor.yaml
+++ b/src/gbserver/builtins/monitors/skypilot/monitor.yaml
@@ -59,11 +59,25 @@ config:
           is_json: true
     # step metadata: merges <value> into the step's StoredStepRun.metadata under
     # <key> (e.g. a git commit_hash resolved at runtime). Both fields are
-    # top-level, so they are splatted into StepMetadataUpdateEventPayload. NOT
-    # anchored and event-level is_json omitted, matching the artifact blocks above
-    # (retrieved log lines are prefixed, so `^` would not match).
+    # top-level, so they are splatted into StepMetadataUpdateEventPayload.
+    #
+    # Unlike the artifact blocks above, this marker is anchored: step metadata
+    # surfaces in lineage as authoritative build provenance, so it must not be
+    # injectable by arbitrary mid-stream output from cloned-repo code (e.g. a byoc
+    # command echoing a config that happens to contain the marker substring). The
+    # anchor permits ONLY SkyPilot's own log prefix — a leading `(name, pid=N) `
+    # group — before the marker, then requires the marker immediately; a marker
+    # sitting mid-line after other text no longer matches.
+    #
+    # ANSI note: SkyPilot colourises that prefix (`\x1b[36m(...)\x1b[0m`) in its
+    # retrieved logs, but escape sequences are stripped centrally in
+    # get_events_from_log_line before this regex runs, so it only ever sees the
+    # plain `(name, pid=N) ` text — no ANSI handling belongs here. (Limitation:
+    # SkyPilot prefixes every line including user output, so a deliberate clean-line
+    # echo of just the marker is still indistinguishable from the scaffold's own
+    # emission; anchoring closes the incidental/embedded case, not that residual one.)
     - event_type: STEP_METADATA_UPDATE_EVENT
-      line_regex: "LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*"
+      line_regex: '^(\([^)]*\)\s+)?LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*'
       event_fields:
         - field_name: metadata_key
           field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"

--- a/src/gbserver/builtins/monitors/skypilot/monitor.yaml
+++ b/src/gbserver/builtins/monitors/skypilot/monitor.yaml
@@ -4,6 +4,9 @@
 # `ref: space://monitors/skypilot` and overrides only what differs (poll
 # interval, log_retrieval mode, extra event_configs).
 #
+# It also detects the LLMB_STEP_METADATA_KEY/VALUE marker, merged into the step's
+# StoredStepRun.metadata (e.g. a git commit_hash resolved at runtime).
+#
 # The artifact event emits a `binding` payload ({"path": <artifact path>}) — this
 # is what downstream targets dereference as `{{ bindings.<x>.binding.path }}`, and
 # it enables retry-transparent NEWARTIFACT deduplication. Every {{ config.* }}
@@ -54,3 +57,15 @@ config:
         - field_name: binding
           field_value_template: '{ "state": "{{ fields.data.state }}" }'
           is_json: true
+    # step metadata: merges <value> into the step's StoredStepRun.metadata under
+    # <key> (e.g. a git commit_hash resolved at runtime). Both fields are
+    # top-level, so they are splatted into StepMetadataUpdateEventPayload. NOT
+    # anchored and event-level is_json omitted, matching the artifact blocks above
+    # (retrieved log lines are prefixed, so `^` would not match).
+    - event_type: STEP_METADATA_UPDATE_EVENT
+      line_regex: "LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*"
+      event_fields:
+        - field_name: metadata_key
+          field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"
+        - field_name: metadata_value
+          field_regex: "(?<=LLMB_STEP_METADATA_VALUE:).*"

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -94,6 +94,26 @@ logger = get_logger(__name__)
 
 BINDING_KEY = "binding"
 
+# ANSI escape sequences (colour codes, cursor moves, etc.). Some environments'
+# retrieved logs colourise their line prefixes — SkyPilot, for example, wraps its
+# `(name, pid=N)` worker prefix in a cyan SGR sequence (`\x1b[36m(...)\x1b[0m`).
+# Left in place these would (a) defeat a `^`-anchored line_regex, since the line no
+# longer starts with the marker, and (b) leak into a captured field value (e.g. a
+# trailing reset folded onto a commit hash). We strip them once, centrally, in
+# get_events_from_log_line so every monitor sees clean text and no per-environment
+# regex has to account for ANSI — the handling is uniform across all environments.
+# Pattern covers both CSI sequences (`\x1b[...<final>`) and two-char escapes.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences (colour codes, cursor moves) from a log line.
+
+    :param text: a raw log line that may carry terminal escape sequences.
+    :returns: the line with all ANSI escape sequences removed.
+    """
+    return _ANSI_ESCAPE_RE.sub("", text)
+
 
 class EventFieldRegexLogParserConfig(Config):
     """Details of a single field in the event payload."""

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -1471,6 +1471,12 @@ class Environment(ABC):
         the events will be plain dicts instead of BuildEvent
         to allow sending over the network.
         """
+        # Normalise away terminal colour codes before any rule runs, so anchored
+        # markers still match and captured values never absorb a stray escape. Done
+        # once here rather than per-monitor, keeping ANSI handling uniform across all
+        # environments (SkyPilot's retrieved logs colourise their line prefix; bash
+        # and docker stream raw stdout and are unaffected).
+        log_line = _strip_ansi(log_line)
         logger.debug("Running get_events_from_log_line for line: %s", log_line)
         if event_q is None:
             event_q = asyncio.Queue()

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -32,6 +32,7 @@ from gbserver.types.constants import (
     GB_JOB_STATS_DETAIL_TYPE,
 )
 from gbserver.types.status import Status
+from gbserver.utils.redaction import redact_sensitive
 
 _LINEAGE_REPO_ORG = "ibm-granite" if is_public_github() else "granite-dot-build"
 LINEAGE_PRODUCER_URL = f"https://{DEFAULT_GH_DOMAIN}/{_LINEAGE_REPO_ORG}/granite.build"
@@ -202,13 +203,17 @@ class WandBLineageStore(ILineageStore):
         step_configs = []
         steps = storage.step_storage.get_by_where({"target_id": targetrun.uuid})
         for step in steps:
-            # step.config/config_dir are copied verbatim from the build's own
-            # build.yaml and can embed credentials — jobstats is readable by any
-            # space member (not just the build owner/admin, unlike get_build_archive),
-            # so omit them here rather than widening who can read pipeline secrets.
+            # step.config is the rendered build.yaml input and step.metadata is
+            # runtime data the step pushed (e.g. commit_hash). jobstats is readable
+            # by any space member (not just the build owner/admin), so both are
+            # emitted with secret-*named* keys masked via redact_sensitive rather
+            # than omitted — a secret stored under a non-secret-looking key would
+            # not be masked (accepted tradeoff; see utils/redaction.py).
             step_configs.append(
                 {
                     "uri": step.definition_uri,
+                    "config": redact_sensitive(step.config),
+                    "metadata": redact_sensitive(step.metadata),
                 }
             )
 

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -32,7 +32,7 @@ from gbserver.types.constants import (
     GB_JOB_STATS_DETAIL_TYPE,
 )
 from gbserver.types.status import Status
-from gbserver.utils.redaction import redact_sensitive
+from gbserver.utils.redaction import redact_sensitive, scrub_url_credentials
 
 _LINEAGE_REPO_ORG = "ibm-granite" if is_public_github() else "granite-dot-build"
 LINEAGE_PRODUCER_URL = f"https://{DEFAULT_GH_DOMAIN}/{_LINEAGE_REPO_ORG}/granite.build"
@@ -206,12 +206,13 @@ class WandBLineageStore(ILineageStore):
             # step.config is the rendered build.yaml input and step.metadata is
             # runtime data the step pushed (e.g. commit_hash). jobstats is readable
             # by any space member (not just the build owner/admin), so both are
-            # emitted with secret-*named* keys masked via redact_sensitive rather
-            # than omitted — a secret stored under a non-secret-looking key would
-            # not be masked (accepted tradeoff; see utils/redaction.py).
+            # emitted with secret-*named* keys masked via redact_sensitive, which
+            # also scrubs userinfo@ credentials out of any URL-shaped value. The
+            # definition_uri is scrubbed the same way so a credentialed BYOS clone
+            # URL (git+ssh://token@... / https://token@...) cannot leak here.
             step_configs.append(
                 {
-                    "uri": step.definition_uri,
+                    "uri": scrub_url_credentials(step.definition_uri),
                     "config": redact_sensitive(step.config),
                     "metadata": redact_sensitive(step.metadata),
                 }

--- a/src/gbserver/storage/stored_step_run.py
+++ b/src/gbserver/storage/stored_step_run.py
@@ -15,6 +15,13 @@ class StoredStepRun(BaseStoredItem):
     status: Status = Status.PENDING
     status_msg: str = ""
     config: dict = {}
+    # Runtime key/values produced by the step itself (e.g. a resolved git commit
+    # SHA), pushed via the LLMB_STEP_METADATA_KEY/VALUE stdout hook and merged by
+    # the buildrunner. Kept separate from `config` (the rendered build.yaml input)
+    # so step-generated data never mutates the declared configuration. Serialized
+    # into the row's JSON blob like `config`, so it needs no column/migration and
+    # old rows deserialize to {}.
+    metadata: dict = {}
     config_dir: str = ""
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None

--- a/src/gbserver/types/buildevent.py
+++ b/src/gbserver/types/buildevent.py
@@ -61,6 +61,9 @@ class BuildEventType(StrEnum):
     TARGET_ARTIFACTS_DONE_EVENT = auto()
     """Internal sentinel: a target has emitted all its output-artifact events.
     Used by TargetRun/BuildRun to barrier on output-push enqueuing. """
+    STEP_METADATA_UPDATE_EVENT = auto()
+    """A step pushed a runtime key/value (via the LLMB_STEP_METADATA_KEY/VALUE stdout
+    hook) to be merged into its StoredStepRun.metadata. """
     # LOG_EVENT = auto()
     # """Log events are typically internal log messages produced by the internals of gbserver, but which may still be useful to both developers and end users. """
 
@@ -114,6 +117,8 @@ class EventPayload:
                 return BuildEventMetricsPayload(**metrics_data)
             case BuildEventType.VALIDATION_DATA_EVENT:
                 return BuildEventValidationDataPayload(**data)
+            case BuildEventType.STEP_METADATA_UPDATE_EVENT:
+                return StepMetadataUpdateEventPayload(**data)
         self = cls(data=data)
         return self
 
@@ -257,6 +262,18 @@ class ArtifactPushedEventPayload(EventPayload):
     uri: Optional[str] = None
     binding_id: str = ""
     type: Optional[ArtifactType] = ArtifactType.UNDEFINED
+
+
+@dataclass
+class StepMetadataUpdateEventPayload(EventPayload):
+    """Runtime key/value merged into a step's StoredStepRun.metadata.
+
+    metadata_key: metadata field name to set/overwrite.
+    metadata_value: its runtime-resolved string value.
+    """
+
+    metadata_key: str = ""
+    metadata_value: str = ""
 
 
 @dataclass

--- a/src/gbserver/utils/redaction.py
+++ b/src/gbserver/utils/redaction.py
@@ -45,7 +45,10 @@ SENSITIVE_KEY_RE = re.compile(
     | private[_-]?key
     | ssh[_-]?key
     | authorization
-    | auth(?!(?-i:[a-z]))    # 'auth', 'auth_token', 'authToken' — but NOT 'author(ization)'
+    | auth(?!or|en)          # 'auth', 'auth_token', 'authToken' — but NOT 'author'/'authentic…'
+                             # Exclusion is on the word stem (case-insensitive via re.IGNORECASE),
+                             # so all-caps keys like AUTHOR / AUTHORED_DATE / GIT_AUTHOR are also
+                             # left unmasked (the old (?-i:[a-z]) guard only skipped lowercase).
     """,
     re.IGNORECASE | re.VERBOSE,
 )

--- a/src/gbserver/utils/redaction.py
+++ b/src/gbserver/utils/redaction.py
@@ -14,18 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Key-name based redaction of secret-looking values before they leave the server.
+"""Redaction of secret-looking values before they leave the server.
 
 Used when emitting step ``config``/``metadata`` into build lineage, which is readable
-by any space member. Redaction is by *key name* (not value inspection), so a secret
-stored under a non-secret-looking key is not masked — an accepted defense-in-depth
-tradeoff, since step metadata is operational data (e.g. a git commit SHA).
+by any space member. Two complementary passes run:
+
+* **Key-name masking** (:data:`SENSITIVE_KEY_RE`) — replaces the value of any key whose
+  *name* looks secret (``password``, ``token``, ...). A secret under a non-secret-looking
+  key is not caught by this pass alone — an accepted defense-in-depth tradeoff, since step
+  metadata is largely operational data (e.g. a git commit SHA).
+* **Value scrubbing** (:func:`scrub_url_credentials`) — masks ``userinfo@`` credentials
+  embedded in URL-shaped strings regardless of their key name. This closes the specific
+  leak of a credentialed clone URL (e.g. ``https://x-access-token:ghp_x@github.com/org/repo``)
+  riding in a byoc/BYOS step config or ``step_uri`` under an innocuous key like ``repo``.
 """
 
 import re
 from typing import Any
 
-__all__ = ["SENSITIVE_KEY_RE", "REDACTED", "redact_sensitive"]
+__all__ = [
+    "SENSITIVE_KEY_RE",
+    "URL_USERINFO_RE",
+    "REDACTED",
+    "redact_sensitive",
+    "scrub_url_credentials",
+]
 
 # Case-insensitive, ``-``/``_`` tolerant match on common secret-bearing key names.
 # Verbose form (whitespace/comments ignored) for readability; each alternative is a
@@ -56,6 +69,38 @@ SENSITIVE_KEY_RE = re.compile(
 # Placeholder substituted for the value of any secret-looking key.
 REDACTED = "<redacted>"
 
+# Matches the ``userinfo`` (credential) component of a URL: a scheme, ``://``, then a
+# ``user:secret`` pair up to the first ``@``. The embedded ``:`` is required, so only a
+# credential *pair* is masked — a bare ``user@``/``git@`` (a username with no password)
+# is left intact. Neither side may contain ``/`` or whitespace, so the match stays within
+# the authority component and never crosses into the path (``https://github.com/a@b`` is
+# left alone). Captures the ``scheme://`` prefix so it can be preserved while the
+# credentials are replaced. Works standalone or embedded in a larger command string.
+# Note: this does NOT catch a token-as-username with no ``:`` (``https://TOKEN@host``);
+# such secrets should be stored under a secret-*named* key so key-name masking covers them.
+URL_USERINFO_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]*:[^/@\s]*@")
+
+
+def scrub_url_credentials(text: str) -> str:
+    """Mask ``userinfo@`` credentials embedded in any URL-shaped substrings.
+
+    Value-level companion to the key-name redaction: catches a secret that rides
+    inside a URL *value* (e.g. a credentialed git clone URL) under a key whose name
+    does not look sensitive. The scheme, host, and path are preserved so the entry
+    stays useful in lineage; only the credential portion is replaced.
+
+    Only a ``user:secret`` pair is masked; a bare ``user@``/``git@`` (username with
+    no password) is preserved. A token-as-username with no ``:`` is therefore not
+    caught here — rely on a secret-named key for that case.
+
+    :param text: an arbitrary string, possibly containing one or more URLs
+        (standalone or embedded in a larger command line).
+    :returns: the string with each URL's ``user:secret`` credential pair replaced by
+        ``REDACTED`` (``scheme://<redacted>@host/...``); a string with no
+        credential-pair URL is returned unchanged.
+    """
+    return URL_USERINFO_RE.sub(rf"\1{REDACTED}@", text)
+
 
 def redact_sensitive(value: Any) -> Any:
     """Recursively copy a mapping/list, masking values under secret-looking keys.
@@ -63,8 +108,9 @@ def redact_sensitive(value: Any) -> Any:
     :param value: any value; dicts and lists are copied and recursed into, other
         types are returned unchanged (no mutation of the input).
     :returns: a redacted deep-ish copy where any dict key matching
-        ``SENSITIVE_KEY_RE`` has its value replaced with ``REDACTED``; nested dicts
-        and lists are redacted in turn.
+        ``SENSITIVE_KEY_RE`` has its value replaced with ``REDACTED``; every surviving
+        string value has its URL credentials scrubbed via
+        :func:`scrub_url_credentials`; nested dicts and lists are redacted in turn.
     """
     if isinstance(value, dict):
         return {
@@ -77,4 +123,6 @@ def redact_sensitive(value: Any) -> Any:
         }
     if isinstance(value, list):
         return [redact_sensitive(item) for item in value]
+    if isinstance(value, str):
+        return scrub_url_credentials(value)
     return value

--- a/src/gbserver/utils/redaction.py
+++ b/src/gbserver/utils/redaction.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Key-name based redaction of secret-looking values before they leave the server.
+
+Used when emitting step ``config``/``metadata`` into build lineage, which is readable
+by any space member. Redaction is by *key name* (not value inspection), so a secret
+stored under a non-secret-looking key is not masked — an accepted defense-in-depth
+tradeoff, since step metadata is operational data (e.g. a git commit SHA).
+"""
+
+import re
+from typing import Any
+
+__all__ = ["SENSITIVE_KEY_RE", "REDACTED", "redact_sensitive"]
+
+# Case-insensitive, ``-``/``_`` tolerant match on common secret-bearing key names.
+SENSITIVE_KEY_RE = re.compile(
+    r"(password|passwd|pwd|secret|token|api[_-]?key|credential|access[_-]?key|private[_-]?key)",
+    re.IGNORECASE,
+)
+
+# Placeholder substituted for the value of any secret-looking key.
+REDACTED = "<redacted>"
+
+
+def redact_sensitive(value: Any) -> Any:
+    """Recursively copy a mapping/list, masking values under secret-looking keys.
+
+    :param value: any value; dicts and lists are copied and recursed into, other
+        types are returned unchanged (no mutation of the input).
+    :returns: a redacted deep-ish copy where any dict key matching
+        ``SENSITIVE_KEY_RE`` has its value replaced with ``REDACTED``; nested dicts
+        and lists are redacted in turn.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                REDACTED
+                if isinstance(key, str) and SENSITIVE_KEY_RE.search(key)
+                else redact_sensitive(val)
+            )
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_sensitive(item) for item in value]
+    return value

--- a/src/gbserver/utils/redaction.py
+++ b/src/gbserver/utils/redaction.py
@@ -28,9 +28,26 @@ from typing import Any
 __all__ = ["SENSITIVE_KEY_RE", "REDACTED", "redact_sensitive"]
 
 # Case-insensitive, ``-``/``_`` tolerant match on common secret-bearing key names.
+# Verbose form (whitespace/comments ignored) for readability; each alternative is a
+# substring test against the key name. ``[_-]?`` also tolerates camelCase because the
+# separator is optional and the following letter is matched case-insensitively (so
+# ``apiKey``/``sshKey`` match too).
 SENSITIVE_KEY_RE = re.compile(
-    r"(password|passwd|pwd|secret|token|api[_-]?key|credential|access[_-]?key|private[_-]?key)",
-    re.IGNORECASE,
+    r"""
+      password | passwd | pwd
+    | secret
+    | token
+    | credential
+    | cookie
+    | bearer
+    | api[_-]?key
+    | access[_-]?key
+    | private[_-]?key
+    | ssh[_-]?key
+    | authorization
+    | auth(?!(?-i:[a-z]))    # 'auth', 'auth_token', 'authToken' — but NOT 'author(ization)'
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
 
 # Placeholder substituted for the value of any secret-looking key.

--- a/steps/README.md
+++ b/steps/README.md
@@ -53,17 +53,20 @@ editing the released asset in place.
 ### What promotion does — and what the framework is *for*
 
 Promotion is deliberately narrow. `make publish-step` (and the `make space` render it
-builds on) does four things and no more:
+builds on) does five things and no more:
 
 1. **Renders one token.** `step-template.yaml` → `step.yaml` substituting only the
    literal `${IMAGE_REF}` (empty for public-image steps); all runtime Jinja `{{ … }}`
    and shell `${VAR}` pass through verbatim.
 2. **Copies `src/`** into the released step.
-3. **Copies the per-cluster build tests** into `test/steps/<name>/<env>/<cluster>/`
+3. **Publishes `USAGE.md` as `README.md`** beside the released `step.yaml`, so the
+   step ships user docs (the authoring `README.md` is dev-oriented and is *not*
+   published).
+4. **Copies the per-cluster build tests** into `test/steps/<name>/<env>/<cluster>/`
    and their fixtures into `test-data/steps/…`, **rewriting each `buildtest.yaml`'s
    `space_uri`** so the *same* test file resolves in both modes (see
    [Two test modes](#two-test-modes)).
-4. **Freezes the image tag** for custom-image steps — the per-commit `IMAGE_REF`
+5. **Freezes the image tag** for custom-image steps — the per-commit `IMAGE_REF`
    (default tag = git short SHA) that you can't reasonably hand-maintain.
 
 It is **not** a one-to-many generator and **not** parameterized templating: one source
@@ -107,6 +110,15 @@ The minimum a step/environment directory needs for `make` to render it:
 * **`Makefile`** — a thin file that sets a couple of variables (notably `STEP_NAME`)
   and includes the shared [`common.mk`](common.mk). It exposes the conventional
   targets below.
+* **`USAGE.md`** — the **user-facing** doc: how to reference, configure (the
+  `config` contract), and wire the step's inputs/outputs in a `build.yaml`, with a
+  worked example. `make publish-step` copies it to `README.md` **beside the published
+  `step.yaml`** (see the publish sections below), so the released step in
+  `configurations/` ships user docs. Because that copy lands several levels deep in a
+  different subtree, `USAGE.md` must be **self-contained**: only co-located links that
+  survive the copy (e.g. `src/<file>`, which is published next to `step.yaml`) and
+  in-file `#anchors`; reference framework/repo docs by plain-text path, not a relative
+  link that would rot at the published depth.
 
 ### Optional
 
@@ -131,10 +143,13 @@ Present or absent depending on what the step needs:
   `build.yaml`/`buildtest.yaml` in `test-data/slurm/` or `test-data/docker/`).
   Kept beside the step rather than in the repo's parallel `test/` ↔ `test-data/`
   tree, so the step is self-contained.
-* **`README.md`** — documents that step's function, its `config` contract, and its
-  inputs/outputs (see [`byoc/skypilot`](byoc/skypilot/README.md) and
-  [`eval/skypilot`](eval/skypilot/README.md) for the two step-type examples).
-  Conventional for every step, though not needed to build or render one.
+* **`README.md`** — the **development-oriented** doc: how the step is
+  generated/built/published, its test modes, drift, and framework framing, plus a
+  prominent pointer to `USAGE.md` (see [`byoc/skypilot`](byoc/skypilot/README.md) and
+  [`eval/skypilot`](eval/skypilot/README.md) for the two step-type examples). Unlike
+  `USAGE.md`, this authoring README is **not** published — `publish-step` ships
+  `USAGE.md` as the released step's `README.md` instead. Conventional for every step,
+  though not needed to build or render one.
 
 ### Generated
 
@@ -176,7 +191,8 @@ Defined once in [`common.mk`](common.mk) and shared by every step:
   bundled `src/`. Cheap and offline; it does *not* rebuild/push.
 * **`publish-step`** — promote the step into the repo's committed assets tree
   (`configurations/assets/environments/<env>/steps/<step-name>/`, rendered exactly as
-  `space` renders `step.yaml` + bundled `src/`) **and** copy the step's per-cluster
+  `space` renders `step.yaml` + bundled `src/`, plus `USAGE.md` copied there as
+  `README.md`) **and** copy the step's per-cluster
   build tests into the top-level `test/steps/<step-name>/<env>/<cluster>/` tree, with
   their fixtures in the parallel `test-data/steps/<step-name>/<env>/<cluster>/` tree
   (mirroring the repo's `test/` ↔ `test-data/` convention) and each copied
@@ -430,11 +446,11 @@ only.
 ## Generated artifacts and drift
 
 `make publish-step` writes **three committed trees derived from the step's source** under
-`steps/<step>/<env>/` (its `step-template.yaml`, `src/`, and per-cluster
+`steps/<step>/<env>/` (its `step-template.yaml`, `src/`, `USAGE.md`, and per-cluster
 `test/`+`test-data/`):
 
 1. the assets step — `configurations/assets/environments/<env>/steps/<name>/`
-   (`step.yaml` + bundled `src/`);
+   (`step.yaml` + bundled `src/` + `README.md` copied from `USAGE.md`);
 2. the Mode-2 tests — `test/steps/<name>/<env>/<cluster>/`;
 3. their fixtures — `test-data/steps/<name>/<env>/<cluster>/`.
 

--- a/steps/README.md
+++ b/steps/README.md
@@ -387,6 +387,31 @@ step's `run:` block:
   build test can assert the persisted values via `expected_steps` in its
   `buildtest.yaml` (see [Two test modes](#two-test-modes)).
 
+### Metadata coverage and rollout
+
+The *parse* side (the monitor markers above) is universal — every step under a
+builtin monitor can emit either marker. The *emit* side, however, is **opt-in per
+step**: a step records metadata only if its own `run:` block prints the marker.
+
+- **Where it is authored.** The emit line lives in the step's **authored source**
+  (`steps/<step>/<env>/step-template.yaml`). `make publish-step` renders that source
+  into the released `configurations/assets/.../steps/<step>/step.yaml`, so the *same*
+  line appears in both files. That pair is [source vs. release](#source-of-truth-steps-vs-configurations),
+  **not** a duplicate hand-edit — only the `step-template.yaml` copy is edited; the
+  asset copy is regenerated. Never hand-edit the emitted marker in the asset tree.
+- **Current coverage.** Only [`byoc/skypilot`](byoc/skypilot/step-template.yaml)
+  emits metadata today (a `commit_hash` recording the resolved git commit). Every
+  other step emits nothing — the absence is expected, not a bug.
+- **Asset-only steps cannot inherit it.** The ~30+ steps that exist *only* under
+  `configurations/assets/.../steps/*` (no `steps/` source, so no `step-template.yaml`)
+  have no template to carry the line. Adding metadata to one means either authoring
+  its own emit line, or first migrating the step into `steps/` so it gains a source of
+  truth. There is no central switch that turns metadata on for all steps at once.
+- **Intended rollout.** Extend emission step-by-step as each step gains a value worth
+  recording in lineage, preferring migration into `steps/` first. This mostly becomes
+  moot once every step is sourced under `steps/`; until then, treat each step's emit
+  line as its own small change.
+
 ## Two test modes
 
 A step's build tests run in **two modes** against the **same test files** — the

--- a/steps/README.md
+++ b/steps/README.md
@@ -378,7 +378,8 @@ step's `run:` block:
 
 * **Record step metadata** — push a runtime-generated key/value that is merged into
   the step's `StoredStepRun.metadata` and surfaced in build lineage (secret-*named*
-  keys are redacted before emission). Use it for values only known on the remote node
+  keys are redacted, and `userinfo@` credentials in any URL-shaped value are scrubbed,
+  before emission). Use it for values only known on the remote node
   at runtime — the byoc step records the resolved git commit with it:
 
   ```sh

--- a/steps/README.md
+++ b/steps/README.md
@@ -341,6 +341,36 @@ Both submit their `build.yaml` through the buildtest framework; for ad-hoc runs,
 submit a `build.yaml` via the `gbserver` MCP tools (see the `run-gbserver` and
 `create-step` skills).
 
+## Emitting data from a step (stdout markers)
+
+A step's only channel back to the server is its **stdout**, which the builtin
+monitors (`bash`, `docker`, `skypilot`) parse into build events. Two general
+step-framework hooks are recognised — print either at the start of a line from the
+step's `run:` block:
+
+* **Register an output artifact** — bind a produced path (or `mem://` state) to a
+  named build output:
+
+  ```sh
+  echo "LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>"
+  ```
+
+* **Record step metadata** — push a runtime-generated key/value that is merged into
+  the step's `StoredStepRun.metadata` and surfaced in build lineage (secret-*named*
+  keys are redacted before emission). Use it for values only known on the remote node
+  at runtime — the byoc step records the resolved git commit with it:
+
+  ```sh
+  COMMIT_SHA="$(git -C "$CODE_DIR" rev-parse HEAD 2>/dev/null || true)"
+  [ -n "$COMMIT_SHA" ] && echo "LLMB_STEP_METADATA_KEY:commit_hash LLMB_STEP_METADATA_VALUE:$COMMIT_SHA"
+  ```
+
+  Metadata is kept separate from the step's declared `config` (the rendered
+  `build.yaml` input) so step-produced data never mutates the configuration. The hook
+  is monitor-level, so any step running under a builtin monitor gets it for free; a
+  build test can assert the persisted values via `expected_steps` in its
+  `buildtest.yaml` (see [Two test modes](#two-test-modes)).
+
 ## Two test modes
 
 A step's build tests run in **two modes** against the **same test files** — the

--- a/steps/README.md
+++ b/steps/README.md
@@ -8,6 +8,11 @@ Subdirectories contain step implementations (`eval`, `byoc`, etc.), each with
 per-compute-environment subdirectories (`skypilot`, `lsf`, `k8s`, ...). For
 example, `steps/eval/skypilot` holds the eval step's SkyPilot implementation.
 
+> **Audience:** step *developers* authoring and publishing step implementations.
+> If you are instead *using* steps in a `build.yaml` (referencing, configuring, or
+> picking a built-in step), see the user-facing guide:
+> [docs/steps/README.md](../docs/steps/README.md).
+
 ## Source of truth: `steps/` vs. `configurations/`
 
 Think of the two trees as **source vs. release**: `steps/` is a source-like

--- a/steps/byoc/skypilot/README.md
+++ b/steps/byoc/skypilot/README.md
@@ -49,20 +49,47 @@ All fields live under the step's `config.byoc_config`.
 
 ## Inputs and outputs
 
-- **Inputs** — this step declares no target `inputs:` of its own; it brings its
-  code by cloning `repo`. Bind target inputs in your `build.yaml` as usual if the
-  cloned command needs them (they are resolved by the environment before `run`).
-- **File mounts** — the optional `src/` directory beside the template is mounted
-  to `$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
-  demonstrating the SkyPilot `file_mounts` input.
-- **Outputs** — to register an artifact, have your `command` print a line that
-  begins with the Granite.build marker (captured by `skypilot_monitor`):
+`byoc` declares no step-level I/O schema of its own, but the **target** can declare
+**any number** of keyed `inputs:` and `outputs:` — there is nothing to change on the
+step to consume more of either.
 
-  ```
-  LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>
-  ```
+### Inputs (any number)
 
-  `<output-id>` must match an `outputs.<id>` declared on the target.
+Declare each input on the target (a direct `uri:`, or a `binding:` to an upstream
+target's output). The byoc `command` references each one by name via Jinja, which is
+rendered into `config.byoc_config.command` **before** `run` (inputs are resolved by the
+environment first, so they are concrete paths/values at launch time):
+
+- filesystem-backed inputs (`env://`, `hf://`, `file://`, `lh://`, …):
+  `{{ bindings.<name>.binding.path }}`
+- `mem://` state inputs: `{{ bindings.<name>.binding.state }}`
+
+Reference each input by the scheme it actually uses (`.path` for filesystem, `.state`
+for `mem://`) — byoc accesses bindings explicitly, so there is no auto-exported
+`GB_BYOC_INPUT_*` env var.
+
+**File mounts** — the optional `src/` directory beside the template is mounted to
+`$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
+demonstrating the SkyPilot `file_mounts` input.
+
+### Outputs (any number)
+
+Declare each output on the target, then have your `command` register an artifact by
+printing one marker line per artifact (captured by `skypilot_monitor`):
+
+```
+LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>
+```
+
+- `<output-id>` must match an `outputs.<id>` declared on the target.
+- Emit one line per artifact; **repeat** the same `<output-id>` on additional lines to
+  register multiple artifacts under a single output.
+- For `mem://` outputs, use `LLMB_ARTIFACT_STATE:<value>` instead of `LLMB_ARTIFACT_PATH`.
+
+For the full target I/O schema and the `bindings.*` Jinja variables, see
+[docs/builds/build-yaml-reference.md](../../../docs/builds/build-yaml-reference.md); for
+the marker convention (PATH vs STATE, anchoring, the shipped monitors), see
+[docs/steps/monitoring-and-artifact-events.md](../../../docs/steps/monitoring-and-artifact-events.md).
 
 ## Env vars the step provides to your commands
 
@@ -90,6 +117,11 @@ published step (Mode 2, under `test/steps/`).
 
 ## Example build.yaml
 
+This example wires **two inputs** (one direct `uri:`, one `binding:` to an upstream
+target's output) and **two outputs** (one of which receives two artifacts via repeated
+markers). The `command` reads each input via `{{ bindings.<name>.binding.path }}` and
+registers each artifact via a marker line:
+
 ```yaml
 granite.build:
   name: byoc-example
@@ -97,9 +129,16 @@ granite.build:
   targets:
     run:
       environment_uri: space://environments/skypilot/aws
+      inputs:
+        dataset:
+          uri: hf:///datasets/org/my-dataset
+        upstream_model:
+          binding: pretrain.model   # <upstream-target>.<output-id>
       outputs:
-        result:
+        checkpoints:
           uri: lh://prod/myspace/models/shared/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}/1
+        report:
+          uri: lh://prod/myspace/reports/shared/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}/1
       steps:
         - step_uri: space://steps/byoc
           config:
@@ -110,8 +149,18 @@ granite.build:
               ref: "main"
               workdir: "code"
               setup_command: "cd code && pip install -r requirements.txt"
-              command: "python main.py --out $GB_BUILD_WORKDIR/result"
+              command: >-
+                python main.py
+                --dataset "{{ bindings.dataset.binding.path }}"
+                --init-model "{{ bindings.upstream_model.binding.path }}"
+                --out-dir "$GB_BUILD_WORKDIR/out";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-1.ckpt";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-2.ckpt";
+                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/report.json"
 ```
+
+A single direct input and output are just the one-entry case of the above — see the
+runnable fixtures at [`test-data/slurm/build.yaml`](test-data/slurm/build.yaml).
 
 ## Notes and limitations
 
@@ -121,5 +170,7 @@ granite.build:
 - **No dependency caching.** Unlike `custom_code_lsf`'s hash-keyed conda cache,
   dependencies are whatever the chosen public `image` provides plus anything your
   `command`/repo installs at run time.
-- **Single output artifact** in the exemplar; emit additional `LLMB_ARTIFACT_ID`
-  lines and declare matching `outputs` to register more.
+- **Variable inputs/outputs are a target-level feature, not a step limitation.**
+  Declare any number of `inputs:`/`outputs:` on the target and wire them from the
+  `command` as shown in [Inputs and outputs](#inputs-and-outputs) — no change to the
+  step is required.

--- a/steps/byoc/skypilot/README.md
+++ b/steps/byoc/skypilot/README.md
@@ -1,101 +1,18 @@
-# byoc (SkyPilot)
+# byoc (SkyPilot) — development
 
-Bring-Your-Own-Code step for SkyPilot clusters. Runs in a **public container
-image** (or on the bare launcher node), clones a public git repo during `setup`
-(optionally running a `setup_command` afterwards, e.g. to install dependencies),
-and runs a user-defined command during `run` — no custom image is built or
-published for this step.
+> **Using this step?** See [USAGE.md](USAGE.md) for how to reference and configure
+> `byoc` in a `build.yaml` (config contract, inputs/outputs, examples). This file
+> covers how the step is *generated, tested, and published*.
+
+Bring-Your-Own-Code step for SkyPilot clusters. Runs in a **public container image**
+(or on the bare launcher node), clones a public git repo during `setup`, and runs a
+user-defined command during `run` — no custom image is built or published for this step.
 
 This is the SkyPilot counterpart of the LSF `custom_code_lsf` and Kubernetes
-`custom_code` steps. It is *generated* from the sources in this directory by the
-shared Makefile conventions — see the framework overview:
+`custom_code` steps, and the public-image counterpart of the custom-image
+[eval](../../eval/skypilot/README.md) step. It is *generated* from the sources in this
+directory by the shared Makefile conventions — see the framework overview:
 [steps/README.md](../../README.md).
-
-## Referencing the step
-
-`make space` renders a self-contained Space into `space/` (see `SPACE_DIR` in the
-[framework overview](../../README.md)). Point the build's Space at that directory
-and reference the step by the stable `space://steps/byoc` URI:
-
-```yaml
-steps:
-  - step_uri: space://steps/byoc
-```
-
-## Config contract (`byoc_config`)
-
-All fields live under the step's `config.byoc_config`.
-
-### Required
-
-| Field | Type | Purpose |
-|---|---|---|
-| `repo` | string | Public git repository URL cloned during `setup`. An empty value fails the step. |
-| `command` | string | Bash command executed during `run`, from inside the cloned repo directory. |
-
-### Optional
-
-| Field | Type | Purpose |
-|---|---|---|
-| `image` | string | Public container image the step runs in, e.g. `python:3.12-slim`. Rendered at runtime as SkyPilot `docker:<image>`. Defaults to `quay.io/fedora/fedora-minimal:42`; set to `""` to run on the bare launcher node instead (e.g. a cluster without Pyxis, which cannot run container images). |
-| `ref` | string | Branch, tag, or commit checked out after cloning. Default: the repo's default branch. |
-| `workdir` | string | Subdirectory (under `$GB_BUILD_WORKDIR`) the repo is cloned into. Default: `code`. |
-| `setup_command` | string | Bash command run during `setup`, **after** the clone, from `$GB_BUILD_WORKDIR` (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
-
-> **`image` is a runtime choice, not a built image.** Unlike custom-image steps
-> (e.g. [eval](../../eval/skypilot/README.md)), `byoc` builds no Dockerfile;
-> `image` selects an existing public image and the code arrives at run time via
-> `git clone`.
-
-## Inputs and outputs
-
-`byoc` declares no step-level I/O schema of its own, but the **target** can declare
-**any number** of keyed `inputs:` and `outputs:` — there is nothing to change on the
-step to consume more of either.
-
-### Inputs (any number)
-
-Declare each input on the target (a direct `uri:`, or a `binding:` to an upstream
-target's output). The byoc `command` references each one by name via Jinja, which is
-rendered into `config.byoc_config.command` **before** `run` (inputs are resolved by the
-environment first, so they are concrete paths/values at launch time):
-
-- filesystem-backed inputs (`env://`, `hf://`, `file://`, `lh://`, …):
-  `{{ bindings.<name>.binding.path }}`
-- `mem://` state inputs: `{{ bindings.<name>.binding.state }}`
-
-Reference each input by the scheme it actually uses (`.path` for filesystem, `.state`
-for `mem://`) — byoc accesses bindings explicitly, so there is no auto-exported
-`GB_BYOC_INPUT_*` env var.
-
-**File mounts** — the optional `src/` directory beside the template is mounted to
-`$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
-demonstrating the SkyPilot `file_mounts` input.
-
-### Outputs (any number)
-
-Declare each output on the target, then have your `command` register an artifact by
-printing one marker line per artifact (captured by `skypilot_monitor`):
-
-```
-LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>
-```
-
-- `<output-id>` must match an `outputs.<id>` declared on the target.
-- Emit one line per artifact; **repeat** the same `<output-id>` on additional lines to
-  register multiple artifacts under a single output.
-- For `mem://` outputs, use `LLMB_ARTIFACT_STATE:<value>` instead of `LLMB_ARTIFACT_PATH`.
-
-For the full target I/O schema and the `bindings.*` Jinja variables, see
-[docs/builds/build-yaml-reference.md](../../../docs/builds/build-yaml-reference.md); for
-the marker convention (PATH vs STATE, anchoring, the shipped monitors), see
-[docs/steps/monitoring-and-artifact-events.md](../../../docs/steps/monitoring-and-artifact-events.md).
-
-## Env vars the step provides to your commands
-
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into both `setup` and `run`: the
-per-run workdir and the run script's initial CWD. `repo` is cloned to
-`$GB_BUILD_WORKDIR/<workdir>` and `src/` is mounted at `$GB_BUILD_WORKDIR/src`.
 
 ## Generating and deploying the step
 
@@ -104,73 +21,16 @@ only `make space` (render the Space + bundle `src/`), `make clean`, and
 `make help` do anything here. For the full target list and variables, see the
 shared [Makefile target conventions](../../README.md#makefile-target-conventions).
 
-Then point the build's Space at the generated `space/` directory and reference
-the step by `space://steps/byoc` (see above).
+`make space` renders a self-contained Space into `space/` (see `SPACE_DIR` in the
+framework overview). Point the build's Space at that directory to reference the step by
+`space://steps/byoc`.
 
 To promote the step into the repo's committed assets tree
 (`configurations/assets/environments/skypilot/steps/byoc/`) and copy its slurm
 build test into `test/steps/byoc/skypilot/` so it is runnable from VSCode against
-the published step, run `make publish-step`. See
+the published step, run `make publish-step`. Publishing also copies
+[USAGE.md](USAGE.md) to `README.md` beside the published `step.yaml`, so the released
+step ships user-facing docs. See
 [Two test modes](../../README.md#two-test-modes) for how the same test runs both
 against the locally rendered `space/` (Mode 1, `make test`) and against the
 published step (Mode 2, under `test/steps/`).
-
-## Example build.yaml
-
-This example wires **two inputs** (one direct `uri:`, one `binding:` to an upstream
-target's output) and **two outputs** (one of which receives two artifacts via repeated
-markers). The `command` reads each input via `{{ bindings.<name>.binding.path }}` and
-registers each artifact via a marker line:
-
-```yaml
-granite.build:
-  name: byoc-example
-  version: 0.0.1
-  targets:
-    run:
-      environment_uri: space://environments/skypilot/aws
-      inputs:
-        dataset:
-          uri: hf:///datasets/org/my-dataset
-        upstream_model:
-          binding: pretrain.model   # <upstream-target>.<output-id>
-      outputs:
-        checkpoints:
-          uri: lh://prod/myspace/models/shared/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}/1
-        report:
-          uri: lh://prod/myspace/reports/shared/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}/1
-      steps:
-        - step_uri: space://steps/byoc
-          config:
-            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
-            byoc_config:
-              image: "python:3.12-slim"
-              repo: "https://github.com/org/repo"
-              ref: "main"
-              workdir: "code"
-              setup_command: "cd code && pip install -r requirements.txt"
-              command: >-
-                python main.py
-                --dataset "{{ bindings.dataset.binding.path }}"
-                --init-model "{{ bindings.upstream_model.binding.path }}"
-                --out-dir "$GB_BUILD_WORKDIR/out";
-                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-1.ckpt";
-                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-2.ckpt";
-                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/report.json"
-```
-
-A single direct input and output are just the one-entry case of the above — see the
-runnable fixtures at [`test-data/slurm/build.yaml`](test-data/slurm/build.yaml).
-
-## Notes and limitations
-
-- **Public repos only.** `setup` runs an unauthenticated `git clone`; private
-  repositories (and the credential/secret wiring the LSF `custom_code_lsf` step
-  provides) are out of scope for this exemplar.
-- **No dependency caching.** Unlike `custom_code_lsf`'s hash-keyed conda cache,
-  dependencies are whatever the chosen public `image` provides plus anything your
-  `command`/repo installs at run time.
-- **Variable inputs/outputs are a target-level feature, not a step limitation.**
-  Declare any number of `inputs:`/`outputs:` on the target and wire them from the
-  `command` as shown in [Inputs and outputs](#inputs-and-outputs) — no change to the
-  step is required.

--- a/steps/byoc/skypilot/USAGE.md
+++ b/steps/byoc/skypilot/USAGE.md
@@ -1,0 +1,147 @@
+# byoc (SkyPilot)
+
+Bring-Your-Own-Code step for SkyPilot clusters. It clones a **public git repo** during
+`setup` (optionally running a `setup_command` afterwards, e.g. to install dependencies)
+and runs a user-defined command during `run`, inside a **public container image** or on
+the bare launcher node — no custom image is built for this step.
+
+## Referencing the step
+
+Point your build's Space at one that provides the step, then reference it by the stable
+`space://steps/byoc` URI:
+
+```yaml
+steps:
+  - step_uri: space://steps/byoc
+```
+
+## Config contract (`byoc_config`)
+
+All fields live under the step's `config.byoc_config`.
+
+### Required
+
+| Field | Type | Purpose |
+|---|---|---|
+| `repo` | string | Public git repository URL cloned during `setup`. An empty value fails the step. |
+| `command` | string | Bash command executed during `run`, from inside the cloned repo directory. |
+
+### Optional
+
+| Field | Type | Purpose |
+|---|---|---|
+| `image` | string | Public container image the step runs in, e.g. `python:3.12-slim`. Rendered at runtime as SkyPilot `docker:<image>`. Defaults to `quay.io/fedora/fedora-minimal:42`; set to `""` to run on the bare launcher node instead (e.g. a cluster without Pyxis, which cannot run container images). |
+| `ref` | string | Branch, tag, or commit checked out after cloning. Default: the repo's default branch. |
+| `workdir` | string | Subdirectory (under `$GB_BUILD_WORKDIR`) the repo is cloned into. Default: `code`. |
+| `setup_command` | string | Bash command run during `setup`, **after** the clone, from `$GB_BUILD_WORKDIR` (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
+
+> **`image` is a runtime choice, not a built image.** Unlike custom-image steps (which
+> build a Dockerfile), `byoc` builds no image; `image` selects an existing public image
+> and the code arrives at run time via `git clone`.
+
+## Inputs and outputs
+
+`byoc` declares no step-level I/O schema of its own, but the **target** can declare
+**any number** of keyed `inputs:` and `outputs:` — there is nothing to change on the
+step to consume more of either.
+
+### Inputs (any number)
+
+Declare each input on the target (a direct `uri:`, or a `binding:` to an upstream
+target's output). The byoc `command` references each one by name via Jinja, which is
+rendered into `config.byoc_config.command` **before** `run` (inputs are resolved by the
+environment first, so they are concrete paths/values at launch time):
+
+- filesystem-backed inputs (`env://`, `hf://`, `file://`, `lh://`, …):
+  `{{ bindings.<name>.binding.path }}`
+- `mem://` state inputs: `{{ bindings.<name>.binding.state }}`
+
+Reference each input by the scheme it actually uses (`.path` for filesystem, `.state`
+for `mem://`) — byoc accesses bindings explicitly, so there is no auto-exported
+`GB_BYOC_INPUT_*` env var.
+
+**File mounts** — the optional `src/` directory beside the template is mounted to
+`$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
+demonstrating the SkyPilot `file_mounts` input.
+
+### Outputs (any number)
+
+Declare each output on the target, then have your `command` register an artifact by
+printing one marker line per artifact (captured by `skypilot_monitor`):
+
+```
+LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>
+```
+
+- `<output-id>` must match an `outputs.<id>` declared on the target.
+- Emit one line per artifact; **repeat** the same `<output-id>` on additional lines to
+  register multiple artifacts under a single output.
+- For `mem://` outputs, use `LLMB_ARTIFACT_STATE:<value>` instead of `LLMB_ARTIFACT_PATH`.
+
+For the full target I/O schema and the `bindings.*` Jinja variables, see
+`docs/builds/build-yaml-reference.md`; for the marker convention (PATH vs STATE,
+anchoring, the shipped monitors), see `docs/steps/monitoring-and-artifact-events.md` in
+the granite.build repository.
+
+## Env vars the step provides to your commands
+
+The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into both `setup` and `run`: the
+per-run workdir and the run script's initial CWD. `repo` is cloned to
+`$GB_BUILD_WORKDIR/<workdir>` and `src/` is mounted at `$GB_BUILD_WORKDIR/src`.
+
+## Example build.yaml
+
+This example wires **two inputs** (one direct `uri:`, one `binding:` to an upstream
+target's output) and **two outputs** (one of which receives two artifacts via repeated
+markers). The `command` reads each input via `{{ bindings.<name>.binding.path }}` and
+registers each artifact via a marker line:
+
+```yaml
+granite.build:
+  name: byoc-example
+  version: 0.0.1
+  targets:
+    run:
+      environment_uri: space://environments/skypilot/aws
+      inputs:
+        dataset:
+          uri: hf:///datasets/org/my-dataset
+        upstream_model:
+          binding: pretrain.model   # <upstream-target>.<output-id>
+      outputs:
+        checkpoints:
+          uri: lh://prod/myspace/models/shared/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}/1
+        report:
+          uri: lh://prod/myspace/reports/shared/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}/1
+      steps:
+        - step_uri: space://steps/byoc
+          config:
+            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
+            byoc_config:
+              image: "python:3.12-slim"
+              repo: "https://github.com/org/repo"
+              ref: "main"
+              workdir: "code"
+              setup_command: "cd code && pip install -r requirements.txt"
+              command: >-
+                python main.py
+                --dataset "{{ bindings.dataset.binding.path }}"
+                --init-model "{{ bindings.upstream_model.binding.path }}"
+                --out-dir "$GB_BUILD_WORKDIR/out";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-1.ckpt";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-2.ckpt";
+                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/report.json"
+```
+
+A single direct input and output are just the one-entry case of the above.
+
+## Notes and limitations
+
+- **Public repos only.** `setup` runs an unauthenticated `git clone`; private
+  repositories (and the credential/secret wiring the LSF `custom_code_lsf` step
+  provides) are out of scope for this exemplar.
+- **No dependency caching.** Dependencies are whatever the chosen public `image`
+  provides plus anything your `command`/repo installs at run time.
+- **Variable inputs/outputs are a target-level feature, not a step limitation.** Declare
+  any number of `inputs:`/`outputs:` on the target and wire them from the `command` as
+  shown in [Inputs and outputs](#inputs-and-outputs) — no change to the step is required.

--- a/steps/byoc/skypilot/step-template.yaml
+++ b/steps/byoc/skypilot/step-template.yaml
@@ -78,10 +78,20 @@ environment_configs:
             set -eu
             CODE_DIR="${GB_BUILD_WORKDIR:-$HOME}/{{ config.byoc_config.workdir }}"
             cd "$CODE_DIR"
+            # Record the resolved commit as step metadata so build lineage captures
+            # exactly which commit was built (build.yaml may pin only a branch/tag,
+            # or nothing). Defensive: never fail the build for lineage metadata,
+            # even though set -eu is in effect.
+            COMMIT_SHA="$(git -C "$CODE_DIR" rev-parse HEAD 2>/dev/null || true)"
+            [ -n "$COMMIT_SHA" ] && echo "LLMB_STEP_METADATA_KEY:commit_hash LLMB_STEP_METADATA_VALUE:$COMMIT_SHA"
             echo "byoc: running command in $(pwd)"
             {{ config.byoc_config.command }}
-            # To register an output artifact, print (at the start of a line):
-            #   echo "LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>"
+            # Markers the skypilot monitor captures (print at the start of a line):
+            #   register an output artifact:
+            #     echo "LLMB_ARTIFACT_ID:<output-id> LLMB_ARTIFACT_PATH:<abs-path>"
+            #   record step metadata (merged into StoredStepRun.metadata, surfaced
+            #   in lineage):
+            #     echo "LLMB_STEP_METADATA_KEY:<key> LLMB_STEP_METADATA_VALUE:<value>"
     monitors:
       # Standard artifact/status convention from the shipped monitor library.
       skypilot_monitor:

--- a/steps/byoc/skypilot/test-data/aws/buildtest.yaml
+++ b/steps/byoc/skypilot/test-data/aws/buildtest.yaml
@@ -16,6 +16,16 @@ target_expectations:
     input_artifact_count: 1
     output_artifact_count: 1
     jobstats_count: 1
+    # Verify the byoc step captured its runtime commit SHA as step metadata (via
+    # the LLMB_STEP_METADATA_KEY/VALUE hook) and that the rendered config persisted.
+    # Single step, so step_uri is omitted. Read from step_storage directly, so this
+    # holds even under standalone's NoopLineageStore.
+    expected_steps:
+      - metadata_matches:
+          commit_hash: "^[0-9a-f]{40}$"
+        config:
+          byoc_config:
+            repo: "https://github.com/octocat/Hello-World.git"
 # The Space this test resolves the step (and the environment, monitors, and any
 # other assets) through. In the step dir (Mode 1) it is the local Space rendered
 # by `make space` two levels up (steps/byoc/skypilot/space/), which carries

--- a/steps/byoc/skypilot/test-data/slurm/buildtest.yaml
+++ b/steps/byoc/skypilot/test-data/slurm/buildtest.yaml
@@ -15,6 +15,16 @@ target_expectations:
     input_artifact_count: 1
     output_artifact_count: 1
     jobstats_count: 1
+    # Verify the byoc step captured its runtime commit SHA as step metadata (via
+    # the LLMB_STEP_METADATA_KEY/VALUE hook) and that the rendered config persisted.
+    # Single step, so step_uri is omitted. Read from step_storage directly, so this
+    # holds even under standalone's NoopLineageStore.
+    expected_steps:
+      - metadata_matches:
+          commit_hash: "^[0-9a-f]{40}$"
+        config:
+          byoc_config:
+            repo: "https://github.com/octocat/Hello-World.git"
 # The Space this test resolves the step (and the environment, monitors, and any
 # other assets) through. In the step dir (Mode 1) it is the local Space rendered
 # by `make space` two levels up (steps/byoc/skypilot/space/), which carries

--- a/steps/common.mk
+++ b/steps/common.mk
@@ -229,7 +229,7 @@ help:
 	@echo
 	@echo "Targets:"
 	@echo "  space          render step.yaml + a space.yaml into the Space $(SPACE_DIR)/ (offline)"
-	@echo "  publish-step   render the step into the assets tree + copy build tests into test/steps/ (not in all; image steps: image must be published first, override with PUBLISH_REQUIRE_IMAGE=false)"
+	@echo "  publish-step   render the step into the assets tree (+ USAGE.md as README.md) + copy build tests into test/steps/ (not in all; image steps: image must be published first, override with PUBLISH_REQUIRE_IMAGE=false)"
 	@echo "  check-published  re-render to a temp dir and diff against the committed artifacts; exit 1 on drift"
 	@echo "  image          build the image from $(DOCKERFILE) for $(PLATFORM)  (no-op when no Dockerfile is present)"
 	@echo "  publish-image  push the image to the registry                 (no-op when no Dockerfile is present)"
@@ -353,8 +353,12 @@ space:
 # Promote the step into the committed assets tree and copy its build tests into
 # the repo's parallel top-level test/ <-> test-data/ trees:
 #   $(PUBLISH_STEP_DIR)/step.yaml               (+ bundled src/)   — the published step
+#   $(PUBLISH_STEP_DIR)/README.md               (from USAGE.md)    — user-facing usage doc
 #   $(PUBLISH_TEST_DIR)/<cluster>/              — per-cluster build tests (copied)
 #   $(PUBLISH_TESTDATA_DIR)/<cluster>/          — their fixtures, with space_uri rewritten
+#
+# The step's own README.md (development-oriented) is NOT published; only USAGE.md is,
+# renamed to README.md so a user browsing the released assets tree finds usage docs.
 #
 # The step's own `test/<cluster>/` nesting is flattened on copy (the inner `test`
 # segment is dropped) so the published test lands at test/steps/<name>/<env>/<cluster>/
@@ -380,6 +384,12 @@ publish-step:
 	@if [ -d "$(SRC_DIR)" ] && [ -n "$$(ls -A $(SRC_DIR) 2>/dev/null)" ]; then \
 		rm -rf "$(PUBLISH_STEP_DIR)/$(SRC_DIR)"; \
 		cp -R "$(SRC_DIR)" "$(PUBLISH_STEP_DIR)/$(SRC_DIR)"; \
+	fi
+	@if [ -f USAGE.md ]; then \
+		cp USAGE.md "$(PUBLISH_STEP_DIR)/README.md"; \
+		echo "[$(STEP_NAME)] published USAGE.md -> $(PUBLISH_STEP_DIR)/README.md"; \
+	else \
+		echo "[$(STEP_NAME)] WARNING: no USAGE.md to publish as README.md"; \
 	fi
 	@rm -rf "$(PUBLISH_TEST_DIR)" "$(PUBLISH_TESTDATA_DIR)"
 	@mkdir -p "$(PUBLISH_TEST_DIR)" "$(PUBLISH_TESTDATA_DIR)"

--- a/steps/eval/skypilot/README.md
+++ b/steps/eval/skypilot/README.md
@@ -1,4 +1,8 @@
-# eval (SkyPilot)
+# eval (SkyPilot) — development
+
+> **Using this step?** See [USAGE.md](USAGE.md) for how to reference and configure
+> `eval` in a `build.yaml` (config contract, inputs/outputs, examples). This file
+> covers how the step is *built, tested, and published*.
 
 Evaluation step for SkyPilot clusters. Its evaluation code is baked into a
 **custom image** built from [`Dockerfile`](Dockerfile), published to a registry,
@@ -16,73 +20,8 @@ this directory by the shared Makefile conventions — see the framework overview
 > `results.json` recording its parameters but performs no real evaluation, so the
 > image needs no Python or dependencies (just a minimal Fedora base). When you
 > implement eval for real, replace the script body with a real harness and give
-> the image a suitable runtime + dependencies (see
-> [the base image](#building-publishing-and-deploying-the-step) below); the flag
-> contract and the fixed `results.json` output path are what the step depends on.
-
-## Who emits the artifact line?
-
-This step demonstrates the **preferred** pattern for a workload with a single,
-fixed output: **the step registers the output, not the workload.**
-
-- `eval.sh` always writes its results to `<output-dir>/results.json` — a path the
-  step already knows. It prints no Granite.build marker and has no dependency on
-  the artifact convention.
-- The `run:` block in `step.yaml`, after the eval command, emits the registration
-  line for that known path:
-
-  ```sh
-  RESULT_FILE="$(cd "$OUTPUT_DIR" && pwd)/results.json"
-  echo "LLMB_ARTIFACT_ID:results LLMB_ARTIFACT_PATH:${RESULT_FILE}"
-  ```
-
-Contrast this with a **training** workload, whose output path (a checkpoint dir)
-is decided by the code at run time — there the *script* must print the line,
-because only it knows the path. Prefer registering from `step.yaml` whenever the
-output location is fixed and known ahead of time.
-
-## Referencing the step
-
-`make space` renders a self-contained Space into `space/` (see `SPACE_DIR` in the
-[framework overview](../../README.md)). Point the build's Space at that directory
-and reference the step by the stable `space://steps/eval` URI:
-
-```yaml
-steps:
-  - step_uri: space://steps/eval
-```
-
-## Config contract (`eval_config`)
-
-All fields live under the step's `config.eval_config` and are templated into the
-`run` block as CLI arguments to `eval.sh`.
-
-| Field | Type | Required | Purpose |
-|---|---|---|---|
-| `model_path` | string | **required** | Model to evaluate (path or hub id). Passed as `--model-path`. |
-| `tasks` | string | optional (default empty ⇒ a `placeholder` task) | Comma-separated benchmark/task names. Passed as `--tasks`. |
-| `output_dir` | string | optional (default `output`) | Directory the results file is written into; `results.json` is created here. Passed as `--output-dir`. |
-| `per_device_eval_batch_size` | int | optional (default `8`) | Per-device eval batch size. Passed as `--batch-size`. |
-
-## Inputs and outputs
-
-- **Inputs** — the exemplar takes the model to evaluate as the `model_path`
-  *config* string rather than a bound artifact input, so it declares no target
-  `inputs:`. (To consume a resolved artifact instead, add a target input and
-  reference its path in the `run` block.)
-- **Outputs** — declared on the step as `outputs.optional.results` (`type:
-  dataset`), a single file at `<output_dir>/results.json`. It is registered by the
-  `run:` block (see [Who emits the artifact line?](#who-emits-the-artifact-line)),
-  not by `eval.sh`. Bind a matching `outputs.results` on the target to persist it.
-
-## Env vars the step provides to your commands
-
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into `run`: the per-run workdir
-and the run script's initial CWD. Relative `output_dir` values resolve here, giving
-per-run isolation.
-
-The eval script runs inside the **image** (built from `Dockerfile`); the exemplar
-is a shell script, so the image needs no Python interpreter or runtime venv.
+> the image a suitable runtime + dependencies; the flag contract and the fixed
+> `results.json` output path are what the step depends on.
 
 ## Building, publishing, and deploying the step
 
@@ -94,7 +33,9 @@ Because a `Dockerfile` is present, this is an image step: `make all` runs
 To promote the step into the repo's committed assets tree
 (`configurations/assets/environments/skypilot/steps/eval/`) and copy its Docker
 build test into `test/steps/eval/skypilot/` so it is runnable from VSCode against
-the published step, run `make publish-step`. See
+the published step, run `make publish-step`. Publishing also copies
+[USAGE.md](USAGE.md) to `README.md` beside the published `step.yaml`, so the released
+step ships user-facing docs. See
 [Two test modes](../../README.md#two-test-modes) for how the same test runs both
 against the locally rendered `space/` (Mode 1, `make test`) and against the
 published step (Mode 2, under `test/steps/`).
@@ -116,8 +57,9 @@ Eval-specific notes:
 The step's `step-template.yaml` also carries a **`Docker`** environment config
 (a `docker` launcher running the same image and `eval.sh`). This lets the image
 be **built and exercised locally with no registry publish**: `make test` renders
-the Space and builds the image locally (`make image`), then the docker build test
-in [`test/docker/`](test/docker/) runs it against the local Docker daemon. The
+the Space and builds the image locally (`make image`), then a docker build test
+under `test/docker/` (the per-cluster test dir the `Docker` launcher expects) runs
+it against the local Docker daemon. The
 `docker` environment's `pull_policy` is `if-not-present`, so the just-built local
 image is used as-is — no push, no pull, no container-capable cluster needed. Run
 it (with the repo-root `.venv` active) via:
@@ -129,8 +71,8 @@ make -C steps/eval/skypilot test
 > **Running the *committed* Mode-2 docker test — tag coupling.** The Mode-1 flow
 > above always works because `make test` builds the image and renders the Space at
 > the same commit, so their tags agree. The **committed** Mode-2 test
-> ([`test/steps/eval/skypilot/docker/`](../../../test/steps/eval/skypilot/docker/))
-> instead runs against the **published** `step.yaml` under
+> (`test/steps/eval/skypilot/docker/`, created by `make publish-step`) instead runs
+> against the **published** `step.yaml` under
 > `configurations/assets/…/steps/eval/`, whose `image`/`image_id` bake in
 > `IMAGE_TAG` (the git short SHA by default) **as of the commit `make publish-step` was
 > last run at**. Because `pull_policy` is `if-not-present`, that test only resolves
@@ -146,38 +88,6 @@ make -C steps/eval/skypilot test
 > … image publish-step IMAGE_TAG=local` on both sides — if you would rather the
 > committed assets not drift per commit.
 
-## Example build.yaml
-
-```yaml
-granite.build:
-  name: eval-example
-  version: 0.0.1
-  targets:
-    evaluate:
-      environment_uri: space://environments/skypilot/aws
-      outputs:
-        results:
-          uri: lh://prod/myspace/datasets/shared/eval-{{ run_metadata.targetsteprun_id | short_hash }}/1
-      steps:
-        - step_uri: space://steps/eval
-          config:
-            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
-            eval_config:
-              model_path: "ibm-granite/granite-4.0-h-350m"
-              tasks: "hellaswag,arc_easy"
-              output_dir: "output"
-              per_device_eval_batch_size: 8
-```
-
-## Notes and limitations
-
-- **Placeholder evaluation.** The shipped `eval.sh` records its parameters into
-  `results.json` but runs no harness. Implementing eval for real means a real
-  evaluation loop plus a base image that carries its runtime and dependencies
-  (the current placeholder needs neither), then choosing the proper image.
-- **Single, fixed output.** `results.json` is the one artifact, registered by the
-  step. A workload whose output path varies at run time should instead print the
-  `LLMB_ARTIFACT_ID` line itself.
 - **Image is required at run time.** On a real remote cluster (the Skypilot
   launcher) the image must be **published and reachable** — run `make
   publish-image` (after `podman login`) before submitting such a build. The

--- a/steps/eval/skypilot/USAGE.md
+++ b/steps/eval/skypilot/USAGE.md
@@ -1,0 +1,106 @@
+# eval (SkyPilot)
+
+Evaluation step for SkyPilot clusters. Its evaluation code is baked into a container
+image; the `run` block invokes that entrypoint with parameters from `config.eval_config`
+and registers the single results file as the step's output.
+
+> **This is an exemplar, not a working evaluator.** The shipped evaluation script
+> ([`src/eval.sh`](src/eval.sh)) is a **placeholder** — it writes a `results.json`
+> recording its parameters but performs no real evaluation. When you implement eval for
+> real, replace the script body with a real harness (and give the image a suitable
+> runtime + dependencies); the flag contract and the fixed `results.json` output path
+> are what the step depends on.
+
+## Who emits the artifact line?
+
+This step demonstrates the **preferred** pattern for a workload with a single,
+fixed output: **the step registers the output, not the workload.**
+
+- `eval.sh` always writes its results to `<output-dir>/results.json` — a path the
+  step already knows. It prints no Granite.build marker and has no dependency on
+  the artifact convention.
+- The `run:` block in `step.yaml`, after the eval command, emits the registration
+  line for that known path:
+
+  ```sh
+  RESULT_FILE="$(cd "$OUTPUT_DIR" && pwd)/results.json"
+  echo "LLMB_ARTIFACT_ID:results LLMB_ARTIFACT_PATH:${RESULT_FILE}"
+  ```
+
+Contrast this with a **training** workload, whose output path (a checkpoint dir)
+is decided by the code at run time — there the *script* must print the line,
+because only it knows the path. Prefer registering from `step.yaml` whenever the
+output location is fixed and known ahead of time.
+
+## Referencing the step
+
+Point your build's Space at one that provides the step, then reference it by the stable
+`space://steps/eval` URI:
+
+```yaml
+steps:
+  - step_uri: space://steps/eval
+```
+
+## Config contract (`eval_config`)
+
+All fields live under the step's `config.eval_config` and are templated into the
+`run` block as CLI arguments to `eval.sh`.
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `model_path` | string | **required** | Model to evaluate (path or hub id). Passed as `--model-path`. |
+| `tasks` | string | optional (default empty ⇒ a `placeholder` task) | Comma-separated benchmark/task names. Passed as `--tasks`. |
+| `output_dir` | string | optional (default `output`) | Directory the results file is written into; `results.json` is created here. Passed as `--output-dir`. |
+| `per_device_eval_batch_size` | int | optional (default `8`) | Per-device eval batch size. Passed as `--batch-size`. |
+
+## Inputs and outputs
+
+- **Inputs** — the exemplar takes the model to evaluate as the `model_path`
+  *config* string rather than a bound artifact input, so it declares no target
+  `inputs:`. (To consume a resolved artifact instead, add a target input and
+  reference its path in the `run` block.)
+- **Outputs** — declared on the step as `outputs.optional.results` (`type:
+  dataset`), a single file at `<output_dir>/results.json`. It is registered by the
+  `run:` block (see [Who emits the artifact line?](#who-emits-the-artifact-line)),
+  not by `eval.sh`. Bind a matching `outputs.results` on the target to persist it.
+
+## Env vars the step provides to your commands
+
+The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into `run`: the per-run workdir
+and the run script's initial CWD. Relative `output_dir` values resolve here, giving
+per-run isolation.
+
+## Example build.yaml
+
+```yaml
+granite.build:
+  name: eval-example
+  version: 0.0.1
+  targets:
+    evaluate:
+      environment_uri: space://environments/skypilot/aws
+      outputs:
+        results:
+          uri: lh://prod/myspace/datasets/shared/eval-{{ run_metadata.targetsteprun_id | short_hash }}/1
+      steps:
+        - step_uri: space://steps/eval
+          config:
+            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
+            eval_config:
+              model_path: "ibm-granite/granite-4.0-h-350m"
+              tasks: "hellaswag,arc_easy"
+              output_dir: "output"
+              per_device_eval_batch_size: 8
+```
+
+## Notes and limitations
+
+- **Placeholder evaluation.** The shipped `eval.sh` records its parameters into
+  `results.json` but runs no harness. Implementing eval for real means a real
+  evaluation loop plus a base image that carries its runtime and dependencies.
+- **Single, fixed output.** `results.json` is the one artifact, registered by the
+  step. A workload whose output path varies at run time should instead print the
+  `LLMB_ARTIFACT_ID` line itself.
+- **Image is required at run time.** On a real remote cluster the evaluation image must
+  be published and reachable before submitting a build.

--- a/test-data/integration/standalone/buildrunner/docker/1step/build.yaml
+++ b/test-data/integration/standalone/buildrunner/docker/1step/build.yaml
@@ -19,8 +19,10 @@ granite.build:
               # Docker Hub).  The docker `command` step runs `bash -c <command>`,
               # so the image must contain bash — which rules out the busybox
               # images used elsewhere in the tests (sh only).
+              # We include a sleep 5 to allow the cancellation test to pass
               image: quay.io/fedora/fedora-minimal:42
               command: >-
+                sleep 5;
                 mkdir /gb-workspace/outputs;
                 file=/gb-workspace/outputs/foo1a.json; echo '{"artifact": "output_model1", "file": "foo1a"}' > $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";
                 file=/gb-workspace/outputs/foo1b.json; echo '{"artifact": "output_model1", "file": "foo1b"}' > $file; echo "LLMB_ARTIFACT_ID:output_model1 LLMB_ARTIFACT_PATH:$file";

--- a/test-data/steps/byoc/skypilot/aws/buildtest.yaml
+++ b/test-data/steps/byoc/skypilot/aws/buildtest.yaml
@@ -16,6 +16,16 @@ target_expectations:
     input_artifact_count: 1
     output_artifact_count: 1
     jobstats_count: 1
+    # Verify the byoc step captured its runtime commit SHA as step metadata (via
+    # the LLMB_STEP_METADATA_KEY/VALUE hook) and that the rendered config persisted.
+    # Single step, so step_uri is omitted. Read from step_storage directly, so this
+    # holds even under standalone's NoopLineageStore.
+    expected_steps:
+      - metadata_matches:
+          commit_hash: "^[0-9a-f]{40}$"
+        config:
+          byoc_config:
+            repo: "https://github.com/octocat/Hello-World.git"
 # The Space this test resolves the step (and the environment, monitors, and any
 # other assets) through. In the step dir (Mode 1) it is the local Space rendered
 # by `make space` two levels up (steps/byoc/skypilot/space/), which carries

--- a/test-data/steps/byoc/skypilot/slurm/buildtest.yaml
+++ b/test-data/steps/byoc/skypilot/slurm/buildtest.yaml
@@ -15,6 +15,16 @@ target_expectations:
     input_artifact_count: 1
     output_artifact_count: 1
     jobstats_count: 1
+    # Verify the byoc step captured its runtime commit SHA as step metadata (via
+    # the LLMB_STEP_METADATA_KEY/VALUE hook) and that the rendered config persisted.
+    # Single step, so step_uri is omitted. Read from step_storage directly, so this
+    # holds even under standalone's NoopLineageStore.
+    expected_steps:
+      - metadata_matches:
+          commit_hash: "^[0-9a-f]{40}$"
+        config:
+          byoc_config:
+            repo: "https://github.com/octocat/Hello-World.git"
 # The Space this test resolves the step (and the environment, monitors, and any
 # other assets) through. In the step dir (Mode 1) it is the local Space rendered
 # by `make space` two levels up (steps/byoc/skypilot/space/), which carries

--- a/test-data/steps/eval/skypilot/aws/build.yaml
+++ b/test-data/steps/eval/skypilot/aws/build.yaml
@@ -1,0 +1,43 @@
+# Build spec for the sibling ../../test/aws/test_skypilot_aws_eval.py.
+# Runs the eval step (space://steps/eval) on the SkyPilot aws environment (a real
+# EC2 backend). The eval step is a CUSTOM-IMAGE step: the EC2 node PULLS the eval
+# image from its registry by the reference frozen into the step's image_id
+# (docker:${IMAGE_REF}), so the image must be PUBLISHED to a pullable registry
+# first (`make image publish-image REGISTRY=...`) — the committed quay.io/your-org
+# default will not pull. (Contrast the local Docker environment, whose
+# pull_policy=if-not-present used a locally built image with no publish.)
+#
+# HF-free: the placeholder eval.sh writes results.json without downloading a
+# model, and the single output is an env:// artifact (a no-op push that just
+# registers the path — available on every environment), so no HF_TOKEN or
+# network access is needed — only AWS credentials.
+granite.build:
+  name: skypilot-aws-eval-test
+  targets:
+    eval-run:
+      environment_uri: space://environments/skypilot/aws
+      outputs:
+        # env:// output: the step writes results.json under $OUTPUT_DIR and
+        # registers it by path. The uri path MUST equal the marker path the step
+        # emits (LLMB_ARTIFACT_PATH below), which is $OUTPUT_DIR/results.json.
+        results:
+          uri: "env:///gb-workspace/output/results.json"
+          type: dataset
+      steps:
+        - step_uri: space://steps/eval
+          config:
+            eval_config:
+              # Placeholder values — eval.sh echoes model_path/tasks and writes a
+              # stub results.json; nothing is downloaded.
+              model_path: "placeholder-model"
+              tasks: ""
+              # Directory the eval run block creates (mkdir -p) inside the image
+              # on the EC2 node and writes results.json into. The env:// output is
+              # a no-op push that just registers this path, so it need only exist
+              # in the container and match the LLMB_ARTIFACT_PATH marker / the
+              # results uri above — no host persistence is required.
+              output_dir: "/gb-workspace/output"
+              per_device_eval_batch_size: 8
+            compute_config:
+              num_gpus_per_node: 0
+              total_memory_per_node: 1Gi

--- a/test-data/steps/eval/skypilot/aws/buildtest.yaml
+++ b/test-data/steps/eval/skypilot/aws/buildtest.yaml
@@ -1,0 +1,37 @@
+# YAML-driven spec for test_skypilot_aws_eval.py (located by the test/ <-> test-data/
+# helper, so this pairing holds in both test modes; see steps/README.md).
+# The target runs the eval step (space://steps/eval) on the SkyPilot aws
+# environment (a real EC2 backend), pulling the step's PUBLISHED image. HF-free
+# (env:// output) so it needs no HF_TOKEN — only AWS credentials. build_yaml
+# defaults to ./build.yaml (sibling).
+targets:
+  - eval-run
+target_expectations:
+  - target_name: eval-run
+    # One workload runs and registers one env:// output artifact; there are no
+    # inputs. jobstats_count is not asserted under standalone's NoopLineageStore
+    # but is kept accurate for a single step.
+    step_count: 1
+    input_artifact_count: 0
+    output_artifact_count: 1
+    jobstats_count: 1
+# The Space this test resolves the step (and the skypilot/aws environment +
+# monitors) through. In the step dir (Mode 1) it is the local Space rendered by `make space`
+# two levels up (steps/eval/skypilot/space/), which carries steps/eval/step.yaml
+# and chains (base_uris) to configurations/assets. When `make publish-step` copies this
+# fixture into test-data/steps/ (Mode 2), it rewrites this line to point at the
+# shared space configurations/spaces/local, which resolves the PUBLISHED step from
+# the assets tree. Either way the build references the step by space://steps/eval.
+space_uri: ../../../../../configurations/spaces/local
+# A single clean run with no injected synthetic failure: a failed eval command
+# fails the build, so reaching SUCCESS proves the step ran end to end on real EC2.
+simulate_step_failure: false
+# Run only the basic build (skip the cancellation variant) — once the node is up
+# the placeholder eval finishes near-instantly, so there is no stable RUNNING
+# window to cancel.
+tests:
+  - runner
+# EC2 provisioning (and autostop teardown), plus pulling the eval image, is far
+# slower than the local Docker environment: allow for cold-start instance
+# bring-up plus SkyPilot setup and the image pull.
+timeout_minutes: 40

--- a/test/libgbtest/buildrunner/buildtest.py
+++ b/test/libgbtest/buildrunner/buildtest.py
@@ -25,7 +25,7 @@ from datetime import timedelta
 from enum import Enum
 from pathlib import Path
 from time import sleep, time
-from typing import TYPE_CHECKING, ClassVar, List, Optional, Self, Union
+from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, Self, Union
 
 import pytest
 import yaml
@@ -95,6 +95,21 @@ from gbserver.utils.utils import get_time, get_uuid
 logger = get_logger(__name__)
 
 
+class ExpectedStep(BaseModel):
+    """Optional assertions checked against a target's StoredStepRun row(s)."""
+
+    step_uri: Optional[str] = None
+    """Match the step by its definition_uri; if omitted, applies to the target's
+    single step (fails if the target has more than one step)."""
+    metadata: dict[str, str] = {}
+    """Key -> exact value that must be present in StoredStepRun.metadata."""
+    metadata_matches: dict[str, str] = {}
+    """Key -> regex the StoredStepRun.metadata value must fullmatch (for
+    runtime-variable values such as a commit SHA)."""
+    config: dict[str, Any] = {}
+    """Nested subset that must be present in StoredStepRun.config."""
+
+
 class ExpectedTarget(BaseModel):
     target_name: str
     """Name of the target as it appears in the build.yaml"""
@@ -105,6 +120,10 @@ class ExpectedTarget(BaseModel):
     output_artifact_count: int
     """Number of output artifacts to be recorded in the recorded target record."""
     jobstats_count: int
+    expected_steps: list[ExpectedStep] = []
+    """Optional per-step metadata/config assertions checked against the persisted
+    StoredStepRun rows. Empty (default) means not checked, so existing fixtures are
+    unaffected."""
 
 
 class BuildTestSpecification(BaseModel):
@@ -1170,7 +1189,113 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
             )
         self._verify_steplist_status(build_id, step_list, status_list)
 
+        self._verify_step_data(build_id, step_list, expected)
+
         self._verify_lineage(built_target, expected)
+
+    def _verify_step_data(
+        self: Self,
+        build_id: str,
+        step_list: list[StoredStepRun],
+        expected: ExpectedTarget,
+    ) -> None:
+        """Assert each ExpectedStep's metadata/config against the persisted steps.
+
+        No-op when ``expected.expected_steps`` is empty. Each ExpectedStep is
+        matched to a StoredStepRun by ``step_uri`` (its definition_uri), or to the
+        target's sole step when ``step_uri`` is omitted.
+
+        :param build_id: id of the build under test (for failure messages).
+        :param step_list: the target's persisted StoredStepRun rows.
+        :param expected: the target's expectation carrying ``expected_steps``.
+        """
+        for expected_step in expected.expected_steps:
+            step = self._resolve_expected_step(build_id, step_list, expected_step)
+            for key, value in expected_step.metadata.items():
+                assert step.metadata.get(key) == value, self._failed_build_msg(
+                    build_id,
+                    f"step {step.definition_uri} metadata[{key}]: "
+                    f"actual {step.metadata.get(key)!r} expected {value!r}",
+                )
+            for key, pattern in expected_step.metadata_matches.items():
+                actual = step.metadata.get(key, "")
+                assert re.fullmatch(pattern, actual), self._failed_build_msg(
+                    build_id,
+                    f"step {step.definition_uri} metadata[{key}]={actual!r} "
+                    f"does not match /{pattern}/",
+                )
+            self._assert_contains_subset(
+                build_id,
+                step.config,
+                expected_step.config,
+                f"step {step.definition_uri} config",
+            )
+
+    def _resolve_expected_step(
+        self: Self,
+        build_id: str,
+        step_list: list[StoredStepRun],
+        expected_step: ExpectedStep,
+    ) -> StoredStepRun:
+        """Find the StoredStepRun an ExpectedStep refers to.
+
+        Matches by ``expected_step.step_uri`` (definition_uri) when set; otherwise
+        requires the target to have exactly one step.
+
+        :param build_id: id of the build under test (for failure messages).
+        :param step_list: the target's persisted StoredStepRun rows.
+        :param expected_step: the expectation to resolve.
+        :returns: the uniquely matched StoredStepRun.
+        :raises AssertionError: if no unique match exists.
+        """
+        if expected_step.step_uri is not None:
+            matches = [
+                s for s in step_list if s.definition_uri == expected_step.step_uri
+            ]
+            assert len(matches) == 1, self._failed_build_msg(
+                build_id,
+                f"expected exactly one step with uri {expected_step.step_uri}, "
+                f"found {len(matches)}",
+            )
+            return matches[0]
+        assert len(step_list) == 1, self._failed_build_msg(
+            build_id,
+            f"expected_steps entry omits step_uri but target has "
+            f"{len(step_list)} steps",
+        )
+        return step_list[0]
+
+    def _assert_contains_subset(
+        self: Self,
+        build_id: str,
+        actual: Any,
+        expected: Any,
+        ctx: str,
+    ) -> None:
+        """Assert ``expected`` is contained in ``actual`` (recursive for dicts).
+
+        Dicts are matched key-by-key (each expected key must be present and its
+        value contained); all other values must be equal. Lets a fixture assert
+        only the config keys it cares about.
+
+        :param build_id: id of the build under test (for failure messages).
+        :param actual: the persisted value.
+        :param expected: the expected subset.
+        :param ctx: dotted path describing the location, for failure messages.
+        """
+        if isinstance(expected, dict):
+            assert isinstance(actual, dict), self._failed_build_msg(
+                build_id, f"{ctx}: expected a mapping, got {type(actual).__name__}"
+            )
+            for key, sub in expected.items():
+                assert key in actual, self._failed_build_msg(
+                    build_id, f"{ctx}: missing key {key!r}"
+                )
+                self._assert_contains_subset(build_id, actual[key], sub, f"{ctx}.{key}")
+        else:
+            assert actual == expected, self._failed_build_msg(
+                build_id, f"{ctx}: actual {actual!r} expected {expected!r}"
+            )
 
     def _verify_lineage(
         self: Self,

--- a/test/steps/eval/skypilot/aws/test_skypilot_aws_eval.py
+++ b/test/steps/eval/skypilot/aws/test_skypilot_aws_eval.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test: the eval step runs end to end on Skypilot/aws (real EC2).
+
+This is a **step-level** test: it lives beside the eval step's Makefile in a
+per-cluster subdir (``steps/eval/skypilot/test/aws/``), with its fixtures in the
+matching ``test-data/aws/``, and is developed and run independently of the
+repository's central test suite (it is not in ``testpaths``). Run it via
+``make test`` with the repo-root ``.venv`` activated and AWS credentials
+exported::
+
+    make -C steps/eval/skypilot test
+
+``make test`` depends on ``make space`` (and ``make image``), so the git-ignored
+``space/`` directory that the ``buildtest.yaml``'s ``space_uri`` points at is
+always rendered before pytest runs — this test therefore assumes the Space
+already exists and does no rendering of its own. The step is consumed from that
+generated Space by the stable ``space://steps/eval`` URI; the environment and
+monitors resolve through ``space.yaml``'s ``base_uris`` chain to
+``configurations/assets``.
+
+Exercises the custom-image ``eval`` step as a real build on a cloud backend: the
+container runs ``eval.sh``, which writes a stub ``results.json`` (HF-free —
+nothing is downloaded) that the step registers as a single ``env://`` output
+artifact.
+
+**Custom image — must be PUBLISHED first.** Unlike the local Docker environment
+(``pull_policy=if-not-present``, which uses a locally built image), a SkyPilot
+EC2 node **pulls** the eval image from its registry by the reference frozen into
+the step's ``image_id`` (``docker:${IMAGE_REF}``). So this test can only pass
+once that image has been pushed to a **public/pullable** registry — build and
+publish it first with a real ``REGISTRY`` (``make image publish-image
+REGISTRY=...``); the committed default is the ``quay.io/your-org`` placeholder,
+which will not pull.
+
+**Real EC2 — never runs by accident.** It is in the extended suite only AND
+skips unless boto3's credential env vars are present (see
+:func:`gbserver.environment.skypilot.aws_credentials_present`), so no instance
+is ever provisioned without credentials explicitly exported into the
+environment.
+"""
+
+from pathlib import Path
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractYamlBuildRunnerTest,
+    get_test_data_dir_for,
+)
+from libgbtest.constants import extended_testing_only
+
+from gbserver.environment.skypilot import aws_credentials_present
+
+pytestmark = pytest.mark.skypilot_integration
+
+
+# Real-infra build test (provisions a real EC2 instance via Skypilot) — only run
+# in the extended suite (make extended-tests), and only when AWS credentials are
+# present in the environment so it can never provision EC2 by accident. The
+# credential gate is the shared gbserver predicate (aws_credentials_present).
+@extended_testing_only
+@pytest.mark.skipif(
+    not aws_credentials_present(),
+    reason=(
+        "AWS credentials not in environment "
+        "(set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_PROFILE)"
+    ),
+)
+class TestSkypilotAwsEval(AbstractYamlBuildRunnerTest):
+    """eval runs its published image end to end on aws (EC2)."""
+
+    def _get_yaml_spec_dir(self) -> Path:
+        # Fixtures (build.yaml/buildtest.yaml) live in the test-data/ dir that
+        # mirrors this file, resolved by the repo's test/ ↔ test-data/ helper —
+        # which keys off the first `test/` segment, so it works from both homes
+        # of this test (see steps/README.md, "Two test modes"):
+        #   Mode 1 (authoring)  steps/eval/skypilot/test/aws/
+        #       -> steps/eval/skypilot/test-data/aws/  (co-located)
+        #   Mode 2 (published)  test/steps/eval/skypilot/aws/
+        #       -> test-data/steps/eval/skypilot/aws/  (parallel top-level tree)
+        # In Mode 1 the Space is rendered and the image built by `make test`
+        # (its `space`/`image` prerequisites) before this test runs.
+        return get_test_data_dir_for(__file__)

--- a/test/unit/api/test_lineage.py
+++ b/test/unit/api/test_lineage.py
@@ -140,7 +140,12 @@ def test_search_lineage_events_redacts_job_input_params():
         resp = lineage_mod.search_lineage_events(
             _fake_request("member", "member@example.com"), TagSearchRequest(tags=[])
         )
-    assert "SECRET" not in str(resp.runs)
+    # Redact-not-omit: the facet is retained so non-secret step data (e.g. a
+    # commit_hash) still surfaces, but any secret-named key has its VALUE masked.
+    # The key "SECRET" itself is preserved by design; only "should-not-leak" must go.
+    assert "should-not-leak" not in str(resp.runs)
+    params = resp.runs[0]["run"]["facets"]["job_input_params"]
+    assert params == {"SECRET": "<redacted>"}
 
 
 # ---------------------------------------------------------------- artifact graph

--- a/test/unit/api/test_lineage.py
+++ b/test/unit/api/test_lineage.py
@@ -77,6 +77,21 @@ def _graph_node(node_id: str, space_name: str, owner: str, name: str = "a-run"):
     }
 
 
+# ------------------------------------------------ shared redaction accessor
+
+
+def test_get_redacted_job_input_params():
+    """The shared accessor masks secret values, keeps non-secret data, empties absent."""
+    assert lineage_mod.get_redacted_job_input_params({}) == {}
+    assert (
+        lineage_mod.get_redacted_job_input_params({"job_input_params": None}) == {}
+    )
+    out = lineage_mod.get_redacted_job_input_params(
+        {"job_input_params": {"SECRET": "leak", "commit_hash": "abc123"}}
+    )
+    assert out == {"SECRET": "<redacted>", "commit_hash": "abc123"}
+
+
 # --------------------------------------------------------------------- search
 
 
@@ -247,6 +262,34 @@ def test_get_artifact_graph_includes_owned_run_from_any_space():
             ArtifactGraphRequest(artifact_name="dataset-x", direction="both"),
         )
     assert len(resp.runs) == 1, "owner should see their own run regardless of space"
+
+
+def test_get_artifact_graph_redacts_job_input_params():
+    """The artifact-graph read path masks job_input_params like search does.
+
+    Both endpoints are member-readable, so redaction must be applied on each or a
+    secret the write-side missed leaks on one path but not the other. Asserts the
+    returned ArtifactRunEntry carries the masked value, not the raw secret.
+    """
+    node = _graph_node("run-mine", MY_SPACE, "someone_else@example.com")
+    node["metadata"]["job_input_params"] = {"SECRET": "should-not-leak"}
+    fake_service = SimpleNamespace(
+        get_artifact_graph=lambda **kw: _fake_graph_result([node])
+    )
+    is_admin, is_member = _member_of(MY_SPACE)
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.get_artifact_graph(
+            _fake_request("member", "member@example.com"),
+            ArtifactGraphRequest(artifact_name="dataset-x", direction="both"),
+        )
+    assert "should-not-leak" not in str(resp.runs)
+    assert resp.runs[0].job_input_params == {"SECRET": "<redacted>"}
 
 
 def test_get_artifact_graph_excludes_run_with_no_owner_or_namespace():

--- a/test/unit/api/test_lineage.py
+++ b/test/unit/api/test_lineage.py
@@ -148,6 +148,49 @@ def test_search_lineage_events_redacts_job_input_params():
     assert params == {"SECRET": "<redacted>"}
 
 
+def test_search_lineage_events_redacts_step_config_and_metadata():
+    """Search redacts secret-named keys in both step config and metadata (recursively).
+
+    The whole job_input_params facet is redacted unconditionally on the read path:
+    non-secret values (uri, repo, commit_hash) surface intact, while secret-named keys
+    anywhere in the nested config/metadata have their values masked.
+    """
+    my_run = _search_run(MY_SPACE)
+    my_run["run"]["facets"]["job_input_params"] = {
+        "steps": [
+            {
+                "uri": "space://steps/byoc",
+                "config": {
+                    "byoc_config": {"repo": "https://example/r.git", "token": "sekret"}
+                },
+                "metadata": {"commit_hash": "deadbeef", "api_key": "supersecret"},
+            }
+        ]
+    }
+    fake_service = SimpleNamespace(
+        search_lineage_by_tags=lambda tags, limit, offset: (1, [my_run])
+    )
+    is_admin, is_member = _member_of(MY_SPACE)
+    with (
+        is_admin,
+        is_member,
+        patch.object(
+            lineage_mod, "_get_openlineage_service", return_value=fake_service
+        ),
+    ):
+        resp = lineage_mod.search_lineage_events(
+            _fake_request("member", "member@example.com"), TagSearchRequest(tags=[])
+        )
+    step = resp.runs[0]["run"]["facets"]["job_input_params"]["steps"][0]
+    assert step["uri"] == "space://steps/byoc"
+    # config surfaces (redacted), consistent with the by-id jobstats endpoints.
+    assert step["config"]["byoc_config"]["repo"] == "https://example/r.git"
+    assert step["config"]["byoc_config"]["token"] == "<redacted>"
+    # metadata surfaces; non-secret value kept, secret-named key masked.
+    assert step["metadata"]["commit_hash"] == "deadbeef"
+    assert step["metadata"]["api_key"] == "<redacted>"
+
+
 # ---------------------------------------------------------------- artifact graph
 
 

--- a/test/unit/api/test_lineage.py
+++ b/test/unit/api/test_lineage.py
@@ -83,9 +83,7 @@ def _graph_node(node_id: str, space_name: str, owner: str, name: str = "a-run"):
 def test_get_redacted_job_input_params():
     """The shared accessor masks secret values, keeps non-secret data, empties absent."""
     assert lineage_mod.get_redacted_job_input_params({}) == {}
-    assert (
-        lineage_mod.get_redacted_job_input_params({"job_input_params": None}) == {}
-    )
+    assert lineage_mod.get_redacted_job_input_params({"job_input_params": None}) == {}
     out = lineage_mod.get_redacted_job_input_params(
         {"job_input_params": {"SECRET": "leak", "commit_hash": "abc123"}}
     )

--- a/test/unit/buildrunner/test_step_metadata_race.py
+++ b/test/unit/buildrunner/test_step_metadata_race.py
@@ -25,6 +25,7 @@ handler). These tests pin that buffer/flush behavior directly on
 ``BuildRunner._apply_pending_step_metadata`` and the metadata handler, using a
 stub ``self`` so no full BuildRunner has to be constructed.
 """
+
 from types import SimpleNamespace
 
 from gbserver.buildrunner.buildrunner import BuildRunner

--- a/test/unit/buildrunner/test_step_metadata_race.py
+++ b/test/unit/buildrunner/test_step_metadata_race.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the step-metadata event-ordering race.
+
+A STEP_METADATA_UPDATE_EVENT (parsed from step stdout) and the STATUS_EVENT that
+creates the StoredStepRun row come from different producers with no ordering
+guarantee. If the metadata event is processed first, its value must not be lost:
+the buildrunner buffers it in ``_pending_step_metadata`` and flushes it onto the
+row once the row exists (from both the metadata handler and the step status
+handler). These tests pin that buffer/flush behavior directly on
+``BuildRunner._apply_pending_step_metadata`` and the metadata handler, using a
+stub ``self`` so no full BuildRunner has to be constructed.
+"""
+from types import SimpleNamespace
+
+from gbserver.buildrunner.buildrunner import BuildRunner
+from gbserver.storage.stored_step_run import StoredStepRun
+from gbserver.types.buildevent import StepMetadataUpdateEventPayload
+
+_SID = "step-uuid-1"
+
+# The metadata handler is name-mangled (private), so reach it via its mangled name.
+_process_metadata = BuildRunner._BuildRunner__process_step_metadata_update_event
+
+
+class _FakeStepStorage:
+    """Minimal step_storage backed by a dict: supports get_by_uuid / update."""
+
+    def __init__(self):
+        self._rows: dict = {}
+
+    def add(self, item: StoredStepRun) -> None:
+        self._rows[item.uuid] = item
+
+    def get_by_uuid(self, uuid):
+        return self._rows.get(uuid)
+
+    def update(self, item: StoredStepRun) -> None:
+        self._rows[item.uuid] = item
+
+
+def _stub_runner(storage: _FakeStepStorage) -> SimpleNamespace:
+    """A stand-in ``self`` carrying only what the metadata path touches.
+
+    The metadata handler calls ``self._apply_pending_step_metadata`` internally, so
+    the real (unbound) method is wired onto the namespace bound back to it.
+    """
+    runner = SimpleNamespace(
+        _pending_step_metadata={},
+        storage=SimpleNamespace(step_storage=storage),
+    )
+    runner._apply_pending_step_metadata = (
+        lambda tid, _r=runner: BuildRunner._apply_pending_step_metadata(_r, tid)
+    )
+    return runner
+
+
+def _row() -> StoredStepRun:
+    """A minimal StoredStepRun with the fixed test uuid."""
+    return StoredStepRun(
+        uuid=_SID, build_id="b1", target_id="t1", definition_uri="step://x"
+    )
+
+
+def _meta_event(key: str, value: str) -> SimpleNamespace:
+    """A STEP_METADATA_UPDATE_EVENT stand-in with payload + run_metadata."""
+    return SimpleNamespace(
+        payload=StepMetadataUpdateEventPayload(metadata_key=key, metadata_value=value),
+        run_metadata=SimpleNamespace(targetsteprun_id=_SID),
+    )
+
+
+def test_flush_noop_when_row_absent():
+    """Buffered metadata is retained (not dropped) while the row does not exist."""
+    runner = _stub_runner(_FakeStepStorage())
+    runner._pending_step_metadata[_SID] = {"commit_hash": "abc"}
+    BuildRunner._apply_pending_step_metadata(runner, _SID)
+    assert runner._pending_step_metadata[_SID] == {"commit_hash": "abc"}
+
+
+def test_race_metadata_before_row_is_not_lost():
+    """The reviewer's scenario: metadata processed before the row is created.
+
+    The handler runs first (row absent) and buffers; once the row is created and
+    the flush runs again (as the step status handler does), the value lands on the
+    row and the buffer is cleared -- nothing is lost.
+    """
+    storage = _FakeStepStorage()
+    runner = _stub_runner(storage)
+    # Metadata event arrives BEFORE any row exists.
+    _process_metadata(runner, _meta_event("commit_hash", "deadbeef"))
+    assert storage.get_by_uuid(_SID) is None  # no row yet
+    assert runner._pending_step_metadata[_SID] == {"commit_hash": "deadbeef"}
+    # Status event later creates the row and triggers the flush.
+    storage.add(_row())
+    BuildRunner._apply_pending_step_metadata(runner, _SID)
+    assert storage.get_by_uuid(_SID).metadata == {"commit_hash": "deadbeef"}
+    assert _SID not in runner._pending_step_metadata  # buffer cleared
+
+
+def test_metadata_applied_immediately_when_row_present():
+    """Common case: row already exists, so the handler applies in one pass."""
+    storage = _FakeStepStorage()
+    storage.add(_row())
+    runner = _stub_runner(storage)
+    _process_metadata(runner, _meta_event("commit_hash", "cafe"))
+    assert storage.get_by_uuid(_SID).metadata == {"commit_hash": "cafe"}
+    assert _SID not in runner._pending_step_metadata
+
+
+def test_flush_preserves_existing_metadata():
+    """Flushing merges into (does not replace) metadata already on the row."""
+    storage = _FakeStepStorage()
+    row = _row()
+    row.metadata = {"existing": "1"}
+    storage.add(row)
+    runner = _stub_runner(storage)
+    runner._pending_step_metadata[_SID] = {"commit_hash": "abc"}
+    BuildRunner._apply_pending_step_metadata(runner, _SID)
+    assert storage.get_by_uuid(_SID).metadata == {"existing": "1", "commit_hash": "abc"}

--- a/test/unit/buildrunner/test_step_metadata_race.py
+++ b/test/unit/buildrunner/test_step_metadata_race.py
@@ -85,6 +85,27 @@ def _meta_event(key: str, value: str) -> SimpleNamespace:
     )
 
 
+def _meta_event_no_id(targetsteprun_id) -> SimpleNamespace:
+    """A metadata event whose run_metadata carries no usable targetsteprun_id."""
+    return SimpleNamespace(
+        payload=StepMetadataUpdateEventPayload(metadata_key="k", metadata_value="v"),
+        run_metadata=SimpleNamespace(targetsteprun_id=targetsteprun_id),
+    )
+
+
+def test_metadata_event_without_targetsteprun_id_is_dropped():
+    """A stray/uncorrelated marker (no targetsteprun_id) is a no-op, not a raise.
+
+    Guards against an AssertionError here failing the whole build under
+    GBSERVER_RAISE_BUILD_EXCEPTIONS. Both ``None`` and ``""`` are treated as absent.
+    """
+    for bad_id in (None, ""):
+        runner = _stub_runner(_FakeStepStorage())
+        _process_metadata(runner, _meta_event_no_id(bad_id))
+        # Nothing buffered, nothing raised.
+        assert runner._pending_step_metadata == {}
+
+
 def test_flush_noop_when_row_absent():
     """Buffered metadata is retained (not dropped) while the row does not exist."""
     runner = _stub_runner(_FakeStepStorage())

--- a/test/unit/environment/test_step_metadata_marker.py
+++ b/test/unit/environment/test_step_metadata_marker.py
@@ -103,6 +103,21 @@ async def test_all_monitors_parse_marker(monitor):
 
 @pytest.mark.standalone
 @pytest.mark.asyncio
+@pytest.mark.parametrize("monitor", ["bash", "docker", "skypilot"])
+@pytest.mark.parametrize("trailer", ["\r", "  ", "\t", " \r"])
+async def test_trailing_whitespace_trimmed_from_value(monitor, trailer):
+    """Trailing whitespace/CR (e.g. CRLF logs) is not folded into the value.
+
+    Guards the value regex against capturing to end-of-line: a trailing ``\\r`` would
+    otherwise corrupt the recorded SHA and fail a ``^[0-9a-f]{40}$`` assertion.
+    """
+    events = await _parse(monitor, _MARKER + trailer)
+    assert len(events) == 1
+    assert events[0].payload.metadata_value == _SHA
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
 async def test_bash_anchor_rejects_prefixed_line():
     """Bash anchors the marker, so an echoed/prefixed line does not match."""
     assert await _parse("bash", "byoc: echoing " + _MARKER) == []

--- a/test/unit/environment/test_step_metadata_marker.py
+++ b/test/unit/environment/test_step_metadata_marker.py
@@ -17,8 +17,13 @@
 """Unit tests for the LLMB_STEP_METADATA_KEY/VALUE step-metadata stdout hook.
 
 Covers the event/payload plumbing, the StoredStepRun.metadata field, and that all
-three builtin monitor configs (bash/docker/skypilot) parse the marker — including
-the anchoring difference (bash anchors, skypilot/docker do not).
+three builtin monitor configs (bash/docker/skypilot) parse the marker. All three
+anchor the metadata marker to keep it uninjectable by arbitrary mid-stream output
+(bash/docker with `^`; skypilot permits only its own `(name, pid=N) ` log prefix).
+
+ANSI escape sequences (SkyPilot colourises its line prefix) are stripped centrally
+in get_events_from_log_line before any rule runs, so the anchored regexes only ever
+see clean text; test_skypilot_matches_ansi_wrapped_prefixed_line pins that.
 """
 
 from pathlib import Path
@@ -118,15 +123,45 @@ async def test_trailing_whitespace_trimmed_from_value(monitor, trailer):
 
 @pytest.mark.standalone
 @pytest.mark.asyncio
-async def test_bash_anchor_rejects_prefixed_line():
-    """Bash anchors the marker, so an echoed/prefixed line does not match."""
-    assert await _parse("bash", "byoc: echoing " + _MARKER) == []
+@pytest.mark.parametrize("monitor", ["bash", "docker", "skypilot"])
+async def test_anchor_rejects_midline_injection(monitor):
+    """No monitor honors a marker preceded by arbitrary text on the line.
+
+    Guards provenance integrity: cloned-repo code echoing a config that mentions
+    the marker substring must not be able to inject/overwrite step metadata (e.g. a
+    spoofed commit_hash). All three monitors anchor the metadata marker for this
+    reason (bash/docker with `^`, skypilot allowing only its own log prefix).
+    """
+    assert await _parse(monitor, "byoc: echoing " + _MARKER) == []
 
 
 @pytest.mark.standalone
 @pytest.mark.asyncio
-async def test_skypilot_unanchored_matches_prefixed_line():
-    """SkyPilot's retrieved logs are prefixed, so the marker must match unanchored."""
+async def test_skypilot_matches_platform_prefixed_line():
+    """SkyPilot's own `(name, pid=N) ` log prefix is permitted before the marker.
+
+    The anchor tolerates exactly that structured platform prefix (so legitimate
+    scaffold emissions still parse) while rejecting arbitrary leading text.
+    """
     events = await _parse("skypilot", "(job, pid=123) " + _MARKER)
     assert len(events) == 1
     assert events[0].payload.metadata_value == _SHA
+
+    # A prefix followed by other text before the marker is still rejected.
+    assert await _parse("skypilot", "(job, pid=123) config: " + _MARKER) == []
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_skypilot_matches_ansi_wrapped_prefixed_line():
+    """SkyPilot's colourised prefix parses once ANSI is stripped centrally.
+
+    Mirrors a real captured log line, whose `(name, pid=N)` prefix is wrapped in a
+    cyan SGR sequence and which ends with a reset. Escape codes are stripped in
+    get_events_from_log_line before the anchor runs, so the marker still matches and
+    the reset is not folded into the captured value.
+    """
+    line = f"\x1b[36m(gb-b75b5177-f4e, pid=17574)\x1b[0m {_MARKER}\x1b[0m"
+    events = await _parse("skypilot", line)
+    assert len(events) == 1
+    assert events[0].payload.metadata_value == _SHA  # no trailing escape absorbed

--- a/test/unit/environment/test_step_metadata_marker.py
+++ b/test/unit/environment/test_step_metadata_marker.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the LLMB_STEP_METADATA_KEY/VALUE step-metadata stdout hook.
+
+Covers the event/payload plumbing, the StoredStepRun.metadata field, and that all
+three builtin monitor configs (bash/docker/skypilot) parse the marker — including
+the anchoring difference (bash anchors, skypilot/docker do not).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gbserver.environment.environment import Environment, EventLogLineParserConfig
+from gbserver.types.buildevent import (
+    BuildEventType,
+    EntityRunMetadata,
+    EventPayload,
+    StepMetadataUpdateEventPayload,
+)
+
+_MONITORS = Path(__file__).resolve().parents[3] / "src/gbserver/builtins/monitors"
+_SHA = "deadbeefcafe0123456789abcdef012345678901"
+_MARKER = f"LLMB_STEP_METADATA_KEY:commit_hash LLMB_STEP_METADATA_VALUE:{_SHA}"
+
+
+def _configs_for(monitor: str) -> list[EventLogLineParserConfig]:
+    """Load a builtin monitor's event_configs as compiled parser configs.
+
+    :param monitor: monitor subdir name under builtins/monitors (bash/docker/skypilot).
+    :returns: the monitor's event_configs, compiled.
+    """
+    raw = yaml.safe_load((_MONITORS / monitor / "monitor.yaml").read_text())
+    return [EventLogLineParserConfig(**ec) for ec in raw["config"]["event_configs"]]
+
+
+async def _parse(monitor: str, line: str) -> list:
+    """Run a log line through a monitor's configs, returning STEP_METADATA events."""
+    events = await Environment.get_events_from_log_line(
+        line, _configs_for(monitor), entityrun_metadata=EntityRunMetadata()
+    )
+    return [e for e in events if e.type is BuildEventType.STEP_METADATA_UPDATE_EVENT]
+
+
+@pytest.mark.standalone
+def test_payload_parser_builds_step_metadata_payload():
+    """payload_parser maps the event type to StepMetadataUpdateEventPayload."""
+    payload = EventPayload.payload_parser(
+        BuildEventType.STEP_METADATA_UPDATE_EVENT,
+        {"metadata_key": "commit_hash", "metadata_value": _SHA},
+    )
+    assert isinstance(payload, StepMetadataUpdateEventPayload)
+    assert payload.metadata_key == "commit_hash"
+    assert payload.metadata_value == _SHA
+
+
+@pytest.mark.standalone
+def test_event_type_is_not_internal():
+    """The metadata event is history-worthy, not an internal sentinel."""
+    assert not BuildEventType.STEP_METADATA_UPDATE_EVENT.is_internal_event()
+
+
+@pytest.mark.standalone
+def test_stored_step_run_metadata_defaults_and_old_row_compat():
+    """metadata defaults to {} and old rows without the key deserialize to {}."""
+    from gbserver.storage.stored_step_run import StoredStepRun
+
+    fresh = StoredStepRun(build_id="b", target_id="t", definition_uri="d")
+    assert fresh.metadata == {}
+    old_row = StoredStepRun.model_validate(
+        {"uuid": "u", "build_id": "b", "target_id": "t", "definition_uri": "d"}
+    )
+    assert old_row.metadata == {}
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+@pytest.mark.parametrize("monitor", ["bash", "docker", "skypilot"])
+async def test_all_monitors_parse_marker(monitor):
+    """Every builtin monitor parses the marker into the correct payload."""
+    events = await _parse(monitor, _MARKER)
+    assert len(events) == 1, f"{monitor}: expected 1 event, got {len(events)}"
+    payload = events[0].payload
+    assert isinstance(payload, StepMetadataUpdateEventPayload)
+    assert payload.metadata_key == "commit_hash"
+    assert payload.metadata_value == _SHA
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_bash_anchor_rejects_prefixed_line():
+    """Bash anchors the marker, so an echoed/prefixed line does not match."""
+    assert await _parse("bash", "byoc: echoing " + _MARKER) == []
+
+
+@pytest.mark.standalone
+@pytest.mark.asyncio
+async def test_skypilot_unanchored_matches_prefixed_line():
+    """SkyPilot's retrieved logs are prefixed, so the marker must match unanchored."""
+    events = await _parse("skypilot", "(job, pid=123) " + _MARKER)
+    assert len(events) == 1
+    assert events[0].payload.metadata_value == _SHA

--- a/test/unit/uri/test_space_uri_resolver.py
+++ b/test/unit/uri/test_space_uri_resolver.py
@@ -539,9 +539,7 @@ class TestEnvClassPresence:
             base / "skypilot" / "steps" / "digit", env_classes=["Skypilot"]
         )
         env_dir = base / "skypilot" / "aws"
-        _write_step(
-            env_dir / "steps" / "digit", env_classes=["Bash"]  # wrong class
-        )
+        _write_step(env_dir / "steps" / "digit", env_classes=["Bash"])  # wrong class
         _set_bases(base)
 
         with SpaceURI.with_current_env(_make_env("Skypilot", env_dir, subtype="aws")):

--- a/test/unit/uri/test_space_uri_resolver.py
+++ b/test/unit/uri/test_space_uri_resolver.py
@@ -620,6 +620,38 @@ class TestTier2EnvClassMatch:
 
         assert _resolved_dir(resolved).samefile(specific)
 
+    def test_present_but_null_class_entry_wins_specificity(self, tmp_path):
+        """A present-but-null class entry (``{K8s:}``) is admitted by this tier and
+        ranks by specificity like any declared class.
+
+        Pins the fix for the second env-class gate: a value-based
+        ``_env_config_entry(...) is not None`` check would silently drop the
+        null-valued, single-env file, letting the less-specific multi-env catch-all
+        win here — disagreeing with the sibling ``_env_ok`` tier. With presence
+        decided by key, the null-valued split file (1 key) beats the catch-all.
+        This tier must decide (no env dir, so Tier 1 is inert and Tier 3 never runs).
+        """
+        base = tmp_path / "base"
+        _write_step(base / "foo", env_classes=["K8s", "Skypilot"])  # catch-all, 2 keys
+        specific = base / "k8s" / "foo"  # null-valued, single-env
+        specific.mkdir(parents=True, exist_ok=True)
+        (specific / "step.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "foo",
+                    "version": "v1",
+                    "type": "custom",
+                    "environment_configs": {"K8s": None},
+                }
+            )
+        )
+        _set_bases(base)
+
+        with SpaceURI.with_current_env_class_name("K8s"):
+            resolved = _resolve("space://steps/foo")
+
+        assert _resolved_dir(resolved).samefile(specific)
+
     def test_equal_specificity_lexicographic_tiebreak(self, tmp_path):
         """Among equally-specific matches, the lexicographically smaller path
         wins (deterministic tie-break)."""

--- a/test/unit/uri/test_space_uri_resolver.py
+++ b/test/unit/uri/test_space_uri_resolver.py
@@ -145,15 +145,53 @@ def _resolved_dir(uri: URI) -> Path:
 
 
 class TestTier1EnvColocated:
-    def test_env_colocated_hit_wins_over_base(self, tmp_path):
-        """A step inside the active env's own dir wins over a same-named step
-        reachable via base_uris."""
-        base = _write_step(tmp_path / "base" / "steps" / "hello").parent.parent
+    def test_env_colocated_hit_wins_over_inherited_base(self, tmp_path):
+        """A step in the active env's own dir wins over a same-named step in an
+        *inherited* base_uri (base_uris[1:]).  Only the space's own root
+        (base_uris[0]) outranks an env-co-located step (see the space-root tests
+        below); an inherited base does not."""
+        space_root = tmp_path / "space"  # base_uris[0], ships no steps/hello
+        space_root.mkdir()
+        inherited = _write_step(tmp_path / "assets" / "steps" / "hello").parent.parent
         env_dir = tmp_path / "envs" / "bash"
         colocated = _write_step(env_dir / "steps" / "hello")
-        _set_bases(base)
+        _set_bases(space_root, inherited)
 
         with SpaceURI.with_current_env(_make_env("Bash", env_dir)):
+            resolved = _resolve("space://steps/hello")
+
+        assert _resolved_dir(resolved).samefile(colocated)
+
+    def test_space_root_step_wins_over_env_colocated(self, tmp_path):
+        """The space's own root step (base_uris[0]/steps/<name>) overrides an
+        env-co-located step of the same name — so a step developed in its own
+        space is exercised before it is published into an inherited tree."""
+        space_root = tmp_path / "space"
+        space_step = _write_step(space_root / "steps" / "hello")
+        env_dir = tmp_path / "assets" / "skypilot" / "slurm"
+        _write_step(env_dir / "steps" / "hello")  # env-co-located, must lose
+        _set_bases(space_root, tmp_path / "assets")
+
+        with SpaceURI.with_current_env(_make_env("Skypilot", env_dir)):
+            resolved = _resolve("space://steps/hello")
+
+        assert _resolved_dir(resolved).samefile(space_step)
+
+    def test_space_root_step_skipped_when_subtypes_exclude_env(self, tmp_path):
+        """A space-root step whose ``subtypes`` exclude the active env is skipped,
+        so resolution falls through to the env-co-located step (the space-root
+        priority never bypasses the sub-type gate)."""
+        space_root = tmp_path / "space"
+        _write_step(
+            space_root / "steps" / "hello",
+            env_classes=["Skypilot"],
+            subtypes=["kubernetes"],  # excludes aws
+        )
+        env_dir = tmp_path / "assets" / "skypilot" / "aws"
+        colocated = _write_step(env_dir / "steps" / "hello")
+        _set_bases(space_root, tmp_path / "assets")
+
+        with SpaceURI.with_current_env(_make_env("Skypilot", env_dir, subtype="aws")):
             resolved = _resolve("space://steps/hello")
 
         assert _resolved_dir(resolved).samefile(colocated)

--- a/test/unit/uri/test_space_uri_resolver.py
+++ b/test/unit/uri/test_space_uri_resolver.py
@@ -506,6 +506,79 @@ class TestSubtypeMatching:
 
 
 # --------------------------------------------------------------------------- #
+# Env-class presence — directory tiers must reject steps scoped to other classes
+# --------------------------------------------------------------------------- #
+
+
+class TestEnvClassPresence:
+    """The directory-based tiers (space-root, ancestor-walk, Tier-3 fallback)
+    must not admit a step whose ``environment_configs`` declares only *other*
+    env classes — such a step cannot run under the active environment."""
+
+    def test_space_root_mismatch_does_not_shadow_colocated(self, tmp_path):
+        """A space-root step declaring only another class (``Bash``) must NOT
+        shadow a valid co-located step for the active class (``Skypilot``);
+        resolution falls through the space-root priority to the co-located one."""
+        space_root = tmp_path / "space"
+        _write_step(space_root / "steps" / "foo", env_classes=["Bash"])
+        env_dir = tmp_path / "assets" / "skypilot" / "slurm"
+        colocated = _write_step(env_dir / "steps" / "foo", env_classes=["Skypilot"])
+        _set_bases(space_root, tmp_path / "assets")
+
+        with SpaceURI.with_current_env(_make_env("Skypilot", env_dir)):
+            resolved = _resolve("space://steps/foo")
+
+        assert _resolved_dir(resolved).samefile(colocated)
+
+    def test_ancestor_walk_skips_mismatched_class_step(self, tmp_path):
+        """A nearest (own-dir) step keyed for a different class is skipped by the
+        class gate and the walk continues to an admitting ancestor (mirrors the
+        sub-type own-dir-skip test, but for the class dimension)."""
+        base = tmp_path / "assets"
+        ancestor = _write_step(
+            base / "skypilot" / "steps" / "digit", env_classes=["Skypilot"]
+        )
+        env_dir = base / "skypilot" / "aws"
+        _write_step(
+            env_dir / "steps" / "digit", env_classes=["Bash"]  # wrong class
+        )
+        _set_bases(base)
+
+        with SpaceURI.with_current_env(_make_env("Skypilot", env_dir, subtype="aws")):
+            resolved = _resolve("space://steps/digit")
+
+        assert _resolved_dir(resolved).samefile(ancestor)
+
+    def test_fallback_rejects_mismatched_class_step(self, tmp_path):
+        """A Tier-3 env-agnostic fallback hit whose ``environment_configs`` lists
+        only another class is rejected, so resolution raises rather than
+        resolving to a step that cannot run under the active env."""
+        space_root = tmp_path / "space"  # base_uris[0], ships no steps/foo
+        space_root.mkdir()
+        _write_step(tmp_path / "assets" / "steps" / "foo", env_classes=["Bash"])
+        _set_bases(space_root, tmp_path / "assets")
+
+        # No env dir -> Tier 1 walk is inert; Tier 2 skips (class absent); Tier 3
+        # finds assets/steps/foo but the class gate rejects it.
+        with SpaceURI.with_current_env_class_name("Skypilot"):
+            with pytest.raises(ValueError, match="Unresolvable space uri"):
+                _resolve("space://steps/foo")
+
+    def test_step_without_environment_configs_stays_universal(self, tmp_path):
+        """A step that declares no ``environment_configs`` at all is env-agnostic
+        and still resolves for any active class — the class gate only applies to
+        a step that *declares* the block (preserves directory-placed steps)."""
+        base = tmp_path / "assets"
+        universal = _write_step(base / "steps" / "foo")  # no environment_configs
+        _set_bases(base)
+
+        with SpaceURI.with_current_env_class_name("Skypilot"):
+            resolved = _resolve("space://steps/foo")
+
+        assert _resolved_dir(resolved).samefile(universal)
+
+
+# --------------------------------------------------------------------------- #
 # Tier 2 — env-class match (specificity + tie-break)
 # --------------------------------------------------------------------------- #
 

--- a/test/unit/uri/test_space_uri_resolver.py
+++ b/test/unit/uri/test_space_uri_resolver.py
@@ -575,6 +575,31 @@ class TestEnvClassPresence:
 
         assert _resolved_dir(resolved).samefile(universal)
 
+    def test_present_but_null_class_entry_resolves(self, tmp_path):
+        """A step keyed for the active class with a **null** value
+        (``environment_configs: {Skypilot:}``) declares the class and must
+        resolve — presence is by key, not value. A value-based ``is None`` gate
+        would wrongly skip this step, which is scoped to exactly the active env."""
+        base = tmp_path / "assets"
+        step_dir = base / "steps" / "foo"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        (step_dir / "step.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "foo",
+                    "version": "v1",
+                    "type": "custom",
+                    "environment_configs": {"Skypilot": None},
+                }
+            )
+        )
+        _set_bases(base)
+
+        with SpaceURI.with_current_env_class_name("Skypilot"):
+            resolved = _resolve("space://steps/foo")
+
+        assert _resolved_dir(resolved).samefile(step_dir)
+
 
 # --------------------------------------------------------------------------- #
 # Tier 2 — env-class match (specificity + tie-break)

--- a/test/unit/utils/test_redaction.py
+++ b/test/unit/utils/test_redaction.py
@@ -42,6 +42,15 @@ def test_masks_common_secret_key_names():
             "token": "t",
             "credential": "c",
             "SECRET": "s",
+            "authorization": "a",
+            "Authorization": "a",
+            "bearer": "b",
+            "cookie": "c",
+            "ssh_key": "sk",
+            "sshKey": "sk",
+            "auth": "au",
+            "auth_token": "au",
+            "authToken": "au",
         }
     )
     assert set(result.values()) == {REDACTED}
@@ -51,6 +60,17 @@ def test_masks_common_secret_key_names():
 def test_non_secret_keys_pass_through():
     """Operational keys (e.g. commit_hash) are returned unchanged."""
     data = {"commit_hash": "deadbeef", "uri": "space://steps/byoc", "count": 3}
+    assert redact_sensitive(data) == data
+
+
+@pytest.mark.standalone
+def test_auth_prefix_does_not_over_mask():
+    """``auth`` matches as a token but not the ``author``/``authentication`` prefix.
+
+    Guards the bounded ``auth`` alternative: git-oriented metadata legitimately carries
+    ``author``-style keys, which must survive into lineage unmasked.
+    """
+    data = {"author": "octocat", "authored_date": "2026-01-01", "authenticated": True}
     assert redact_sensitive(data) == data
 
 

--- a/test/unit/utils/test_redaction.py
+++ b/test/unit/utils/test_redaction.py
@@ -51,6 +51,7 @@ def test_masks_common_secret_key_names():
             "auth": "au",
             "auth_token": "au",
             "authToken": "au",
+            "AUTH_TOKEN": "au",
         }
     )
     assert set(result.values()) == {REDACTED}
@@ -68,9 +69,20 @@ def test_auth_prefix_does_not_over_mask():
     """``auth`` matches as a token but not the ``author``/``authentication`` prefix.
 
     Guards the bounded ``auth`` alternative: git-oriented metadata legitimately carries
-    ``author``-style keys, which must survive into lineage unmasked.
+    ``author``-style keys, which must survive into lineage unmasked. The exclusion keys
+    on the word stem case-insensitively, so ALL-CAPS env-var-style keys (``AUTHOR``,
+    ``GIT_AUTHOR``, ``AUTHORED_DATE``) are covered too — not just lowercase.
     """
-    data = {"author": "octocat", "authored_date": "2026-01-01", "authenticated": True}
+    data = {
+        "author": "octocat",
+        "authored_date": "2026-01-01",
+        "authenticated": True,
+        "AUTHOR": "octocat",
+        "AUTHOR_EMAIL": "octocat@example.com",
+        "AUTHORED_DATE": "2026-01-01",
+        "GIT_AUTHOR": "octocat",
+        "AUTHENTICATED": True,
+    }
     assert redact_sensitive(data) == data
 
 

--- a/test/unit/utils/test_redaction.py
+++ b/test/unit/utils/test_redaction.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for gbserver.utils.redaction.redact_sensitive.
+
+Guards the key-name based masking used before step config/metadata is emitted into
+the member-readable build-lineage facet.
+"""
+
+import pytest
+
+from gbserver.utils.redaction import REDACTED, redact_sensitive
+
+
+@pytest.mark.standalone
+def test_masks_common_secret_key_names():
+    """Keys whose names look secret are masked; ``-``/``_`` and case tolerant."""
+    result = redact_sensitive(
+        {
+            "password": "p",
+            "PASSWD": "p",
+            "pwd": "p",
+            "db_pwd": "p",
+            "api_key": "k",
+            "api-key": "k",
+            "apiKey": "k",
+            "access_key": "a",
+            "private-key": "pk",
+            "token": "t",
+            "credential": "c",
+            "SECRET": "s",
+        }
+    )
+    assert set(result.values()) == {REDACTED}
+
+
+@pytest.mark.standalone
+def test_non_secret_keys_pass_through():
+    """Operational keys (e.g. commit_hash) are returned unchanged."""
+    data = {"commit_hash": "deadbeef", "uri": "space://steps/byoc", "count": 3}
+    assert redact_sensitive(data) == data
+
+
+@pytest.mark.standalone
+def test_recurses_into_nested_dicts_and_lists():
+    """Nested dicts and dicts inside lists are redacted in place."""
+    result = redact_sensitive(
+        {
+            "outer": {"token": "t", "ok": 1},
+            "items": [{"secret": "s"}, {"name": "n"}],
+        }
+    )
+    assert result == {
+        "outer": {"token": REDACTED, "ok": 1},
+        "items": [{"secret": REDACTED}, {"name": "n"}],
+    }
+
+
+@pytest.mark.standalone
+def test_does_not_mutate_input():
+    """The original mapping is left untouched (a copy is returned)."""
+    original = {"token": "t", "nested": {"password": "p"}}
+    redact_sensitive(original)
+    assert original == {"token": "t", "nested": {"password": "p"}}
+
+
+@pytest.mark.standalone
+def test_scalars_returned_unchanged():
+    """Non-container values pass through as-is."""
+    assert redact_sensitive("plain") == "plain"
+    assert redact_sensitive(42) == 42
+    assert redact_sensitive(None) is None

--- a/test/unit/utils/test_redaction.py
+++ b/test/unit/utils/test_redaction.py
@@ -22,7 +22,11 @@ the member-readable build-lineage facet.
 
 import pytest
 
-from gbserver.utils.redaction import REDACTED, redact_sensitive
+from gbserver.utils.redaction import (
+    REDACTED,
+    redact_sensitive,
+    scrub_url_credentials,
+)
 
 
 @pytest.mark.standalone
@@ -84,6 +88,55 @@ def test_auth_prefix_does_not_over_mask():
         "AUTHENTICATED": True,
     }
     assert redact_sensitive(data) == data
+
+
+@pytest.mark.standalone
+def test_scrubs_credentialed_url_under_non_secret_key():
+    """A ``user:secret`` clone URL under an innocuous key (``repo``) is scrubbed.
+
+    Guards the byoc/BYOS regression: key-name masking alone misses this because the
+    key name isn't secret-looking, so the value pass must strip the credential pair.
+    """
+    result = redact_sensitive(
+        {
+            "repo": "https://x-access-token:ghp_SECRET@github.com/org/repo",
+            "uri": "https://user:pw@github.com/org/repo.git",
+        }
+    )
+    assert result == {
+        "repo": f"https://{REDACTED}@github.com/org/repo",
+        "uri": f"https://{REDACTED}@github.com/org/repo.git",
+    }
+
+
+@pytest.mark.standalone
+def test_scrubs_url_embedded_in_command_string():
+    """Credentials survive inside a larger command line — scrub them there too."""
+    result = redact_sensitive(
+        {"start_command": "git clone https://user:pw@github.com/org/repo.git /w"}
+    )
+    assert result == {
+        "start_command": f"git clone https://{REDACTED}@github.com/org/repo.git /w"
+    }
+
+
+@pytest.mark.standalone
+def test_scrub_url_credentials_leaves_clean_urls_untouched():
+    """URLs with no ``user:secret`` pair are unchanged.
+
+    Only a credential *pair* is masked, so a bare username (``git@``, ``user@``,
+    token-as-username) is preserved — as are clean URLs, ``space://`` refs, and an
+    ``@`` that appears in a path segment rather than the authority.
+    """
+    for clean in (
+        "https://github.com/org/repo.git",
+        "space://steps/byoc",
+        "https://github.com/org/repo/path@ref",  # @ after a path segment, not userinfo
+        "git+ssh://git@github.com/org/repo.git",  # bare username, no password
+        "https://ghp_TOKEN@github.com/org/repo",  # token-as-username, no ':' (see caveat)
+        "just a plain string, no url",
+    ):
+        assert scrub_url_credentials(clean) == clean
 
 
 @pytest.mark.standalone


### PR DESCRIPTION
## Description


The `byoc` ("bring-your-own-code") step clones a user-specified git repo at runtime,
so the **commit that was actually built** was never recorded in lineage — `build.yaml`
may pin only a branch/tag (or nothing), and the resolved SHA is known only on the remote
node after `git clone`. This PR adds a general step-framework hook for recording
runtime-generated key/values on a step, uses it to capture `commit_hash`, and surfaces
that (plus the step config) in build lineage.

It also fixes a step-resolution gap that made local develop-test-before-publish
unreliable for steps.

The branch contains two logically separate changes.

---

## 1. Step metadata → lineage

A step prints a stdout marker; the monitor parses it into a dedicated event; the
buildrunner merges it into a new `metadata` field on the step record; lineage emits it
(secret-redacted) alongside the step config.

**Flow:** `step stdout marker → monitor event → STEP_METADATA_UPDATE_EVENT → buildrunner merges into StoredStepRun.metadata → lineage emits (redacted)`.

The marker is a general hook, not byoc-specific:

```
LLMB_STEP_METADATA_KEY:<key> LLMB_STEP_METADATA_VALUE:<value>
```

### Changes

- **`storage/stored_step_run.py`** — new `metadata: dict = {}` field beside `config`.
  Serializes into the existing JSON blob column, so **no DB/schema migration**; old rows
  deserialize `metadata` to `{}`.
- **`types/buildevent.py`** — new `STEP_METADATA_UPDATE_EVENT` type and
  `StepMetadataUpdateEventPayload(metadata_key, metadata_value)`; wired into the payload
  parser. Kept out of `is_internal_event()` (it's a real, history-worthy event). A
  dedicated event (rather than reusing `STATUS_EVENT`) avoids a late stdout marker
  regressing a step's terminal status.
- **`builtins/monitors/{bash,docker,skypilot}/monitor.yaml`** — parse the marker in all
  three builtin monitors (bash anchored with `^` + `is_json: false`; docker unanchored;
  skypilot unanchored, no event-level `is_json`). Any future monitor gets the hook by
  copying the same block.
- **`buildrunner/buildrunner.py`** — `__process_step_metadata_update_event` merges the
  key/value into the step row (correlated via `run_metadata.targetsteprun_id`), preserving
  existing keys; logs and no-ops if the row isn't present yet. Serial event consumer +
  disjoint field writes (status handler touches `status`, this touches `metadata`) mean
  the row converges regardless of event order.
- **`utils/redaction.py`** (new) — `redact_sensitive()` recursively masks secret-looking
  dict keys (`password`/`token`/`api_key`/`credential`/…, case-insensitive, `-`/`_`
  tolerant) before metadata/config are emitted into lineage.
- **`lineage/wandb_jobstats.py`** — emit each step's `config` and `metadata` (both
  redacted) into `job_input_params.steps[]`. Flips the prior posture from
  omit-everything to **redact-not-omit**. `source_code.commit_hash` is deliberately left
  untouched (it describes the build's `source_uri`, not a step's repo).
- **`api/lineage.py`** — stop dropping the whole `job_input_params` facet on the search
  read path; redact it instead so metadata surfaces with secret-named keys masked.
- **`steps/byoc/skypilot/step-template.yaml`** — after cloning, emit
  `commit_hash = git rev-parse HEAD` via the marker (defensively — never fails the build
  for lineage metadata).
- **`steps/README.md`** — document the `LLMB_STEP_METADATA_KEY/VALUE` hook.

### Tests

- **`test/unit/utils/test_redaction.py`** — secret keys masked, `commit_hash` passes
  through, nested dict/list recursion.
- **`test/unit/environment/test_step_metadata_marker.py`** — `get_events_from_log_line`
  produces a `STEP_METADATA_UPDATE_EVENT` with the right payload; covers both anchored
  (bash) and unanchored (skypilot/docker) regexes.
- **`test/libgbtest/buildrunner/buildtest.py`** — new declarative `ExpectedStep` model
  (`metadata` exact-match, `metadata_matches` regex, `config` subset) verified against the
  persisted `StoredStepRun`, so the hook is covered by the existing YAML-driven harness.
- **`steps/byoc/skypilot/test-data/{aws,slurm}/buildtest.yaml`** — add `expected_steps`
  asserting `commit_hash` is a 40-hex SHA and the rendered config subset matches.

---

## 2. Space-first step resolution

**Problem:** for a step whose active environment lives in the inherited assets tree
(e.g. skypilot under `configurations/assets`), the env-co-located ancestor-walk found the
**published** copy of the step before the space's own `steps/<name>` — so co-located
`make test` exercised the already-published step, not the freshly-rendered local one.
This broke "develop and test in the space, publish only after the test passes."

**Fix (`gbcommon/uri/space.py`):** add a space-root check (`_space_root_step`) that runs
at the head of the ancestor-walk. A step the space ships at `<space>/steps/<name>`
(`base_uris[0]`) now **overrides** any env-co-located or inherited copy. The check honors
the same `subtypes` gate as every other tier and resolves git-backed spaces off their
existing clone.

Environments and asset stores needed **no code change** — they have no env-co-located
walk and resolve directly against `base_uris` in order, so the space (`base_uris[0]`)
already wins. This was verified empirically and is now documented.

### Changes

- **`gbcommon/uri/space.py`** — `_space_root_step` helper + wiring into
  `_walk_colocated_steps`; updated resolver comments/docstrings.
- **`test/unit/uri/test_space_uri_resolver.py`** — new tests: space-root beats
  env-co-located; space-root skipped when `subtypes` exclude the active env; retargeted
  the existing "co-located beats base" test to "beats *inherited* base" under the new
  precedence.
- **`docs/environments/step-resolution.md`** — new "Space-root steps (highest priority)"
  section; callout that environments/asset stores get the same priority for free;
  resolution-order list updated.
- **`docs/spaces/README.md`** — explicit override-of-inherited semantics for all three
  asset kinds.

---

## Testing / verification

- Unit: redactor, marker parsing, and resolver suites pass (51 resolver + 41 adjacent).
- Integration: byoc `expected_steps` assertions run under the existing extended/live
  skypilot byoc specs (SHA + redacted config verified against `step_storage` directly,
  independent of the lineage store).
- `mypy` on the touched modules shows no new errors vs the pre-existing baseline.
## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
