### PR TITLE
Remove GB_BUILD_WORKDIR from skypilot steps and undocument

### DIFF
--- a/configurations/assets/environments/skypilot/lsf/ibm-bluevela/environment.yaml
+++ b/configurations/assets/environments/skypilot/lsf/ibm-bluevela/environment.yaml
@@ -5,8 +5,9 @@ config:
   default_cloud: lsf
   # Env-level shared filesystem root for per-run build workdirs. gbserver
   # derives ${shared_workdir}/builds/<build_id>/runs/<targetrun_id>/ from this
-  # (see skypilot.py:_compute_run_workdir), exports it as GB_BUILD_WORKDIR, and
-  # makes it the run script's CWD. On bluevela this must be on /proj (the shared
+  # (see skypilot.py:setup_skypilot), exports it as GB_BUILD_WORKDIR, and makes
+  # it the CWD of both the setup and run scripts (falling back to $HOME when no
+  # shared_workdir is configured). On bluevela this must be on /proj (the shared
   # network FS that is bind-mounted identity into the enroot container), so a
   # step's relative file_mounts destination — remapped under this dir — is
   # visible inside the container at the same relative path.

--- a/configurations/assets/environments/skypilot/steps/byoc/.gbignore
+++ b/configurations/assets/environments/skypilot/steps/byoc/.gbignore
@@ -1,0 +1,4 @@
+# The following allows the docs to contain {{ ... }} but be ignored by the g.b build process.
+**/*.md
+# Ship the src/ tree verbatim — do not jinja-process step scripts/helpers.
+src/**

--- a/configurations/assets/environments/skypilot/steps/byoc/README.md
+++ b/configurations/assets/environments/skypilot/steps/byoc/README.md
@@ -24,7 +24,7 @@ All fields live under the step's `config.byoc_config`.
 | Field | Type | Purpose |
 |---|---|---|
 | `repo` | string | Public git repository URL cloned during `setup`. An empty value fails the step. |
-| `command` | string | Bash command executed during `run`, from inside the cloned repo directory. |
+| `command` | string | Bash command executed during `run`, from the step's working directory (the workdir root). `cd` into the cloned repo yourself if needed, e.g. `cd code && python main.py`. |
 
 ### Optional
 
@@ -32,8 +32,8 @@ All fields live under the step's `config.byoc_config`.
 |---|---|---|
 | `image` | string | Public container image the step runs in, e.g. `python:3.12-slim`. Rendered at runtime as SkyPilot `docker:<image>`. Defaults to `quay.io/fedora/fedora-minimal:42`; set to `""` to run on the bare launcher node instead (e.g. a cluster without Pyxis, which cannot run container images). |
 | `ref` | string | Branch, tag, or commit checked out after cloning. Default: the repo's default branch. |
-| `workdir` | string | Subdirectory (under `$GB_BUILD_WORKDIR`) the repo is cloned into. Default: `code`. |
-| `setup_command` | string | Bash command run during `setup`, **after** the clone, from `$GB_BUILD_WORKDIR` (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
+| `workdir` | string | Subdirectory (under the workdir root) the repo is cloned into. Default: `code`. |
+| `setup_command` | string | Bash command run during `setup`, **after** the clone, from the workdir root. Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
 
 > **`image` is a runtime choice, not a built image.** Unlike custom-image steps (which
 > build a Dockerfile), `byoc` builds no image; `image` selects an existing public image
@@ -61,7 +61,7 @@ for `mem://`) — byoc accesses bindings explicitly, so there is no auto-exporte
 `GB_BYOC_INPUT_*` env var.
 
 **File mounts** — the optional `src/` directory beside the template is mounted to
-`$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
+`./src` at the workdir root on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
 demonstrating the SkyPilot `file_mounts` input.
 
 ### Outputs (any number)
@@ -83,11 +83,13 @@ For the full target I/O schema and the `bindings.*` Jinja variables, see
 anchoring, the shipped monitors), see `docs/steps/monitoring-and-artifact-events.md` in
 the granite.build repository.
 
-## Env vars the step provides to your commands
+## Working directory and paths
 
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into both `setup` and `run`: the
-per-run workdir and the run script's initial CWD. `repo` is cloned to
-`$GB_BUILD_WORKDIR/<workdir>` and `src/` is mounted at `$GB_BUILD_WORKDIR/src`.
+Both `setup` and `run` start in the same **working directory** (the step's per-run
+workdir), so the step never needs to know its absolute location. `repo` is cloned
+into `<workdir>` (default `code/`) beneath it, and `src/` is mounted at `./src`.
+Use relative paths from there; when you need an absolute path — e.g. for an
+`LLMB_ARTIFACT_PATH` marker — derive it at run time with `$(pwd)`.
 
 ## Example build.yaml
 
@@ -124,13 +126,14 @@ granite.build:
               workdir: "code"
               setup_command: "cd code && pip install -r requirements.txt"
               command: >-
+                cd code;
                 python main.py
                 --dataset "{{ bindings.dataset.binding.path }}"
                 --init-model "{{ bindings.upstream_model.binding.path }}"
-                --out-dir "$GB_BUILD_WORKDIR/out";
-                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-1.ckpt";
-                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-2.ckpt";
-                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/report.json"
+                --out-dir "$(pwd)/out";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-1.ckpt";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-2.ckpt";
+                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$(pwd)/out/report.json"
 ```
 
 A single direct input and output are just the one-entry case of the above.

--- a/configurations/assets/environments/skypilot/steps/byoc/src/helpers.sh
+++ b/configurations/assets/environments/skypilot/steps/byoc/src/helpers.sh
@@ -2,11 +2,14 @@
 # Optional helper functions for the byoc step.
 #
 # This directory is file-mounted into ./src at the workdir root on the cluster
-# (see file_mounts in step-template.yaml). The run command executes from inside
-# the cloned repo (a sibling of src/), so the user command can source it, e.g.:
+# (see file_mounts in step-template.yaml). Both setup and run start in the
+# workdir root, so the user command can source it from there, e.g.:
 #
-#   source "../src/helpers.sh"
+#   source "src/helpers.sh"
 #   byoc_log "starting"
+#
+# (If your command cd's into the cloned repo first, adjust the path accordingly,
+# e.g. "source ../src/helpers.sh".)
 #
 # It is intentionally minimal — byoc's real code comes from the cloned git repo.
 

--- a/configurations/assets/environments/skypilot/steps/byoc/src/helpers.sh
+++ b/configurations/assets/environments/skypilot/steps/byoc/src/helpers.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Optional helper functions for the byoc step.
 #
-# This directory is file-mounted into $GB_BUILD_WORKDIR/src on the cluster (see
-# file_mounts in step-template.yaml). The user command can source it, e.g.:
+# This directory is file-mounted into ./src at the workdir root on the cluster
+# (see file_mounts in step-template.yaml). The run command executes from inside
+# the cloned repo (a sibling of src/), so the user command can source it, e.g.:
 #
-#   source "$GB_BUILD_WORKDIR/src/helpers.sh"
+#   source "../src/helpers.sh"
 #   byoc_log "starting"
 #
 # It is intentionally minimal — byoc's real code comes from the cloned git repo.

--- a/configurations/assets/environments/skypilot/steps/byoc/step.yaml
+++ b/configurations/assets/environments/skypilot/steps/byoc/step.yaml
@@ -17,7 +17,9 @@ config:
     ref: ""
     # Subdirectory (under the build workdir) the repo is cloned into.
     workdir: "code"
-    # Command executed by `run`, from inside the cloned repo directory.
+    # Command executed by `run`, from the step's working directory (the workdir
+    # root — the same directory setup runs in). cd into the cloned repo yourself
+    # if needed, e.g. "cd code && python main.py".
     command: ""
     # Optional bash command run during `setup`, after the repo is cloned, from
     # the step's working directory (the workdir root — cd into the repo yourself
@@ -76,17 +78,17 @@ environment_configs:
               echo "byoc: running setup_command in $(pwd)"
               {{ config.byoc_config.setup_command }}
             fi
-          # run executes the user-defined command from inside the cloned repo.
-          # The launcher starts run in the per-run workdir, so CODE_DIR is
-          # relative; file-mounted helpers are available at ./src.
+          # run executes the user-defined command from the workdir root — the
+          # same directory setup starts in (the launcher cd's both here). The
+          # command cd's into the cloned repo itself if it needs to; CODE_DIR is
+          # relative and file-mounted helpers are available at ./src.
           run: |
             set -eu
             CODE_DIR="{{ config.byoc_config.workdir }}"
-            cd "$CODE_DIR"
             # Record the resolved commit as step metadata so build lineage captures
             # exactly which commit was built (build.yaml may pin only a branch/tag,
             # or nothing). Defensive: never fail the build for lineage metadata,
-            # even though set -eu is in effect.
+            # even though set -eu is in effect. `-C` reads the repo without cd'ing.
             COMMIT_SHA="$(git -C "$CODE_DIR" rev-parse HEAD 2>/dev/null || true)"
             [ -n "$COMMIT_SHA" ] && echo "LLMB_STEP_METADATA_KEY:commit_hash LLMB_STEP_METADATA_VALUE:$COMMIT_SHA"
             echo "byoc: running command in $(pwd)"

--- a/configurations/assets/environments/skypilot/steps/byoc/step.yaml
+++ b/configurations/assets/environments/skypilot/steps/byoc/step.yaml
@@ -11,11 +11,11 @@ config:
     # choice (rendered by Jinja from the build.yaml), not a custom image built by
     # this step's Makefile.
     image: "quay.io/fedora/fedora-minimal:42"
-    # Public git repository cloned into the build workdir during `setup`.
+    # Public git repository cloned into the step's working directory during `setup`.
     repo: ""
     # Optional branch, tag, or commit to check out after cloning.
     ref: ""
-    # Subdirectory (under the build workdir) the repo is cloned into.
+    # Subdirectory (under the step's working directory) the repo is cloned into.
     workdir: "code"
     # Command executed by `run`, from the step's working directory (the workdir
     # root — the same directory setup runs in). cd into the cloned repo yourself
@@ -42,14 +42,14 @@ environment_configs:
           # Cloud-agnostic: the build supplies cpus/memory/accelerators via
           # config.launcher_config.resources.
           resources: {}
-          # Optional helper assets shipped alongside the step. A relative dest is
-          # remapped into the per-run workdir, which is also the step's working
-          # directory, so these land at ./src.
+          # Optional helper assets shipped alongside the step. A relative dest
+          # lands at ./src, relative to the step's working directory (the same
+          # directory setup and run start in).
           file_mounts:
             src: src
-          # setup runs once at cluster bring-up: fetch the code. The launcher
-          # starts this script in the per-run workdir, so a relative CODE_DIR
-          # clones under it without the step needing to know the absolute path.
+          # setup runs once at cluster bring-up: fetch the code. setup starts in
+          # the step's working directory, so a relative CODE_DIR clones under it
+          # without the step needing to know its absolute path.
           setup: |
             set -eu
             REPO="{{ config.byoc_config.repo }}"
@@ -73,15 +73,15 @@ environment_configs:
             # fails the build, just as a failed clone does.
             SETUP_ENABLED="{{ 'yes' if config.byoc_config.setup_command else '' }}"
             if [ -n "$SETUP_ENABLED" ]; then
-              # Already in the workdir root (the launcher cd's here), so the
-              # command runs relative to it — e.g. "cd code && pip install ...".
+              # Still in setup's working directory, so the command runs relative
+              # to it — e.g. "cd code && pip install ...".
               echo "byoc: running setup_command in $(pwd)"
               {{ config.byoc_config.setup_command }}
             fi
-          # run executes the user-defined command from the workdir root — the
-          # same directory setup starts in (the launcher cd's both here). The
-          # command cd's into the cloned repo itself if it needs to; CODE_DIR is
-          # relative and file-mounted helpers are available at ./src.
+          # run executes the user-defined command from the step's working
+          # directory — the same directory setup starts in. The command cd's into
+          # the cloned repo itself if it needs to; CODE_DIR is relative and
+          # file-mounted helpers are available at ./src.
           run: |
             set -eu
             CODE_DIR="{{ config.byoc_config.workdir }}"

--- a/configurations/assets/environments/skypilot/steps/byoc/step.yaml
+++ b/configurations/assets/environments/skypilot/steps/byoc/step.yaml
@@ -20,8 +20,9 @@ config:
     # Command executed by `run`, from inside the cloned repo directory.
     command: ""
     # Optional bash command run during `setup`, after the repo is cloned, from
-    # $GB_BUILD_WORKDIR (the workdir root — cd into the repo yourself if needed,
-    # e.g. "cd code && pip install -r requirements.txt"). Empty => skipped.
+    # the step's working directory (the workdir root — cd into the repo yourself
+    # if needed, e.g. "cd code && pip install -r requirements.txt"). Empty =>
+    # skipped.
     setup_command: ""
 
 environment_configs:
@@ -40,16 +41,18 @@ environment_configs:
           # config.launcher_config.resources.
           resources: {}
           # Optional helper assets shipped alongside the step. A relative dest is
-          # remapped under $GB_BUILD_WORKDIR, so these land at
-          # $GB_BUILD_WORKDIR/src on the cluster.
+          # remapped into the per-run workdir, which is also the step's working
+          # directory, so these land at ./src.
           file_mounts:
             src: src
-          # setup runs once at cluster bring-up: fetch the code.
+          # setup runs once at cluster bring-up: fetch the code. The launcher
+          # starts this script in the per-run workdir, so a relative CODE_DIR
+          # clones under it without the step needing to know the absolute path.
           setup: |
             set -eu
             REPO="{{ config.byoc_config.repo }}"
             REF="{{ config.byoc_config.ref }}"
-            CODE_DIR="${GB_BUILD_WORKDIR:-$HOME}/{{ config.byoc_config.workdir }}"
+            CODE_DIR="{{ config.byoc_config.workdir }}"
             if [ -z "$REPO" ]; then
               echo "byoc: config.byoc_config.repo is empty; nothing to clone" >&2
               exit 1
@@ -68,15 +71,17 @@ environment_configs:
             # fails the build, just as a failed clone does.
             SETUP_ENABLED="{{ 'yes' if config.byoc_config.setup_command else '' }}"
             if [ -n "$SETUP_ENABLED" ]; then
-              cd "${GB_BUILD_WORKDIR:-$HOME}"
+              # Already in the workdir root (the launcher cd's here), so the
+              # command runs relative to it — e.g. "cd code && pip install ...".
               echo "byoc: running setup_command in $(pwd)"
               {{ config.byoc_config.setup_command }}
             fi
           # run executes the user-defined command from inside the cloned repo.
-          # File-mounted helpers are available at $GB_BUILD_WORKDIR/src.
+          # The launcher starts run in the per-run workdir, so CODE_DIR is
+          # relative; file-mounted helpers are available at ./src.
           run: |
             set -eu
-            CODE_DIR="${GB_BUILD_WORKDIR:-$HOME}/{{ config.byoc_config.workdir }}"
+            CODE_DIR="{{ config.byoc_config.workdir }}"
             cd "$CODE_DIR"
             echo "byoc: running command in $(pwd)"
             {{ config.byoc_config.command }}

--- a/docs/environments/skypilot-lsf.md
+++ b/docs/environments/skypilot-lsf.md
@@ -158,9 +158,9 @@ filesystem roots (e.g. `/proj`), which are bind-mounted **identity** into the co
 therefore delivers container-bound mounts by writing them straight to the shared filesystem, routing by
 destination shape:
 
-- **relative** destinations are remapped to `$GB_BUILD_WORKDIR/<dst>` — an absolute path under the
+- **relative** destinations are remapped to `<workdir>/<dst>` — an absolute path under the
   per-target-run workdir on `/proj`. The payload is rsynced there directly on the (sudo-less) login node
-  and, because `/proj` is identity-mounted, the job (whose CWD is `$GB_BUILD_WORKDIR`) reads it at exactly
+  and, because `/proj` is identity-mounted, the job (whose CWD is that workdir) reads it at exactly
   `./<dst>`. No container staging or copy-back is involved. Persistent and per-target-run on the shared
   workdir; requires `shared_workdir` on the environment.
 - **absolute** destinations under a shared, identity-mounted root (e.g. `/proj/…`) are likewise written
@@ -179,7 +179,7 @@ gives per-target isolation, with the payload written onto the shared workdir for
 > `get_unwrapped_mount_prefixes()` (wired with `shared_fs_roots` in `instance.py`), and
 > `_execute_file_mounts` in `cloud_vm_ray_backend.py` skips the wrap for destinations under those roots.
 > gbserver's launcher (`_remap_relative_dest` in `environment/skypilot.py`) does the relative→
-> `$GB_BUILD_WORKDIR` remap for every backend; on shared-FS backends the remapped absolute path is what
+> per-run-workdir remap for every backend; on shared-FS backends the remapped absolute path is what
 > makes the payload land in the per-run workdir.
 
 ## See also

--- a/docs/environments/skypilot.md
+++ b/docs/environments/skypilot.md
@@ -201,9 +201,18 @@ it runs via Docker on the provisioned EC2 host.
 
 `run` is the job body executed on every launch; `setup` runs once at cluster bring-up and is cached
 across cluster reuse (put `pip install`/downloads here, not in `run`). Both are shell scripts and are
-Jinja-templated against the step `config` — reference build inputs with `{{ config.<key> }}`. To fail
-the step on any error, start `run` with `set -euo pipefail`.
+Jinja-templated against the step `config` — reference build inputs with `{{ config.<key> }}`. Both
+bodies run under `set -eu` (see **Failure semantics** below).
 
+- **Failure semantics (`set -eu`):** the launcher prepends `set -eu` to every `run` and `setup` body,
+  so a non-zero exit *anywhere* aborts the step and referencing an unset variable errors out — a body
+  need not add its own `set -eu`. This also governs the raw command a step interpolates: the
+  [`command`](../steps/command.md) step runs `{{ config.command_config.command }}` verbatim, so
+  `python train.py; echo done` never reaches `echo done` if `train.py` exits non-zero, and
+  `deploy.sh $OPTIONAL_FLAG` fails under `set -u` when `OPTIONAL_FLAG` is unset. Guard optional
+  variables with `${VAR:-}` and append `|| true` where a non-zero exit is acceptable. `pipefail` is
+  *not* enabled by default (it would change pipeline semantics for every step); add `set -o pipefail`
+  yourself if a failing command *within a pipeline* should fail the step.
 - **Artifacts:** emit a line matching `LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>` (or
   `... LLMB_ARTIFACT_STATE:<value>` for an in-memory value) and the monitor registers it as the step's
   output binding. The marker need not be at column 0 — retrieved SkyPilot logs prefix stdout lines.

--- a/docs/environments/skypilot.md
+++ b/docs/environments/skypilot.md
@@ -91,9 +91,10 @@ admin provisions — gbserver does not create or mount it. When set, `shared_wor
 - is the default base for gbserver-managed caches (currently the HF asset cache);
 - is exported to every step's `run` as `GB_SHARED_WORKDIR`;
 - gets a per-target-run subdir `${shared_workdir}/builds/<build_id>/runs/<targetrun_id>/` that is the
-  **initial CWD** of both the `setup` and `run` scripts (they fall back to `$HOME` when no
-  `shared_workdir` is configured). It is created lazily before the first step and `rm -rf`'d at
-  target-run teardown; retries get a fresh dir.
+  **initial CWD** of both the `setup` and `run` scripts (with no `shared_workdir` both phases instead
+  share SkyPilot's default `~/sky_workdir` — either way the two phases start in the same directory). It
+  is created lazily before the first step and `rm -rf`'d at target-run teardown; retries get a fresh
+  dir.
 
 When unset, gbserver-managed caches fall back to `~/.cache/gbserver/<store>` on the worker, which only
 works when consecutive steps land on the same machine. Example paths per backend: `slurm: /shared`
@@ -206,9 +207,13 @@ the step on any error, start `run` with `set -euo pipefail`.
 - **Artifacts:** emit a line matching `LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>` (or
   `... LLMB_ARTIFACT_STATE:<value>` for an in-memory value) and the monitor registers it as the step's
   output binding. The marker need not be at column 0 — retrieved SkyPilot logs prefix stdout lines.
-- **Working directory:** when the env defines `shared_workdir`, both `setup` and `run` start in a
-  per-target-run workdir, so relative output paths are isolated per run; without `shared_workdir` they
-  start in `$HOME`. Prefer relative paths — steps need not know where they run.
+- **Working directory:** `setup` and `run` always start in the **same** directory, so a relative path
+  one phase writes (e.g. a repo `setup` clones) is read at the same place by the other. When the env
+  defines `shared_workdir`, that directory is a per-target-run workdir, so relative output paths are
+  isolated per run; without `shared_workdir` both phases run in SkyPilot's default `~/sky_workdir`
+  (where relative `file_mounts` also land — see [file_mounts](#file_mounts)). The shared CWD is
+  guaranteed by SkyPilot, which wraps both scripts with the same prologue that `cd`s into it. Prefer
+  relative paths — steps need not know where they run.
 
 #### `resources`
 

--- a/docs/environments/skypilot.md
+++ b/docs/environments/skypilot.md
@@ -90,9 +90,10 @@ admin provisions — gbserver does not create or mount it. When set, `shared_wor
 
 - is the default base for gbserver-managed caches (currently the HF asset cache);
 - is exported to every step's `run` as `GB_SHARED_WORKDIR`;
-- gets a per-target-run subdir `${shared_workdir}/builds/<build_id>/runs/<targetrun_id>/`, exported as
-  `GB_BUILD_WORKDIR` and set as the **initial CWD** of the `run` command. It is created lazily before
-  the first step and `rm -rf`'d at target-run teardown; retries get a fresh dir.
+- gets a per-target-run subdir `${shared_workdir}/builds/<build_id>/runs/<targetrun_id>/` that is the
+  **initial CWD** of both the `setup` and `run` scripts (they fall back to `$HOME` when no
+  `shared_workdir` is configured). It is created lazily before the first step and `rm -rf`'d at
+  target-run teardown; retries get a fresh dir.
 
 When unset, gbserver-managed caches fall back to `~/.cache/gbserver/<store>` on the worker, which only
 works when consecutive steps land on the same machine. Example paths per backend: `slurm: /shared`
@@ -146,8 +147,8 @@ environment_configs:
           # ---- sky.Task ----
           setup: |                # Optional. Run once at cluster bring-up (cached across reuse).
             pip install foo bar
-          run: |                  # Required. The actual job each launch. CWD is GB_BUILD_WORKDIR when
-            echo "LLMB_ARTIFACT_ID:my_out LLMB_ARTIFACT_PATH:/tmp/out.json"   # shared_workdir is set.
+          run: |                  # Required. The actual job each launch. CWD is the per-run workdir
+            echo "LLMB_ARTIFACT_ID:my_out LLMB_ARTIFACT_PATH:/tmp/out.json"   # (or $HOME).
           envs:                   # Optional. Extra env vars. Merged AFTER env-level secrets and
             FOO: bar              # BEFORE config.launcher_config.envs. GB_* vars are auto-injected.
           file_mounts:            # Optional. Two forms (see "file_mounts" below):
@@ -205,9 +206,9 @@ the step on any error, start `run` with `set -euo pipefail`.
 - **Artifacts:** emit a line matching `LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>` (or
   `... LLMB_ARTIFACT_STATE:<value>` for an in-memory value) and the monitor registers it as the step's
   output binding. The marker need not be at column 0 — retrieved SkyPilot logs prefix stdout lines.
-- **Working directory:** when the env defines `shared_workdir`, `run` starts in `GB_BUILD_WORKDIR`
-  (a per-target-run subdir), so relative output paths are isolated per run. See the auto-injected env
-  vars below.
+- **Working directory:** when the env defines `shared_workdir`, both `setup` and `run` start in a
+  per-target-run workdir, so relative output paths are isolated per run; without `shared_workdir` they
+  start in `$HOME`. Prefer relative paths — steps need not know where they run.
 
 #### `resources`
 
@@ -250,16 +251,16 @@ source instead. A **relative source that uses `..` to climb out of the `step.yam
 `../other`) is likewise rejected, keeping sources confined to the step's own assets.
 
 **Destination path resolution — the destination *shape* decides where the payload lands.** When the
-environment defines `shared_workdir` (so `$GB_BUILD_WORKDIR` exists), the destination key is routed by
+environment defines `shared_workdir` (so a per-run workdir exists), the destination key is routed by
 its shape:
 
 | Destination | Lands at | Scope / lifetime |
 |-------------|----------|------------------|
-| **relative** (`payload`, `./payload`, `sub/payload`) | `$GB_BUILD_WORKDIR/<dst>` — the run script's CWD | per-target-run, persistent, shared across the target's steps |
+| **relative** (`payload`, `./payload`, `sub/payload`) | `<per-run-workdir>/<dst>` — the run script's CWD | per-target-run, persistent, shared across the target's steps |
 | **`~/…`** | the container's private home (on containerized LSF, staged then copied inside the container) | per-launch, container-private, ephemeral |
 | **absolute** (`/proj/…`, `/tmp/…`) | that literal path (author's responsibility) | as-is |
 
-**Relative in, relative out.** Because the `run` script's CWD is `$GB_BUILD_WORKDIR`, a **relative**
+**Relative in, relative out.** Because the `run` script's CWD is the per-run workdir, a **relative**
 destination puts the payload at exactly `./<dst>` — the same path, relative to the step, that the
 source occupies next to your `step.yaml`. On shared-FS backends (bluevela `/proj`) that path is also
 visible **inside** the step container. This is the simplest option and gives implicit per-target
@@ -268,9 +269,9 @@ isolation:
 ```yaml
 config:
   file_mounts:
-    payload: payload        # <step.yaml dir>/payload  →  $GB_BUILD_WORKDIR/payload
+    payload: payload        # <step.yaml dir>/payload  →  <per-run-workdir>/payload
   run: |
-    ./payload/run-eval.sh   # CWD is $GB_BUILD_WORKDIR, so the mount is right here
+    ./payload/run-eval.sh   # CWD is the per-run workdir, so the mount is right here
 ```
 
 Use **`~/…`** when you deliberately want the payload private to a single launch (not shared with other
@@ -296,7 +297,6 @@ Added on top of (and overriding) anything in `envs`:
 | `GB_TARGETRUN_ID` | The enclosing target run id, when present. |
 | `GB_BUILD_ID` | The build id, when present. |
 | `GB_SHARED_WORKDIR` | The env-level `shared_workdir` path, when set. |
-| `GB_BUILD_WORKDIR` | Per-target-run subdir under `shared_workdir`, when set (also the run's initial CWD). |
 | `<env secrets>` | All secrets resolved from the env's `secret_refs`, merged before launcher `envs`. |
 
 ### `skypilot_monitor` config

--- a/docs/steps/command.md
+++ b/docs/steps/command.md
@@ -110,7 +110,7 @@ steps:
     config:
       command_config:
         image: "python:3.12-slim"
-        command: "python main.py --out $GB_BUILD_WORKDIR/out"
+        command: "python main.py --out $(pwd)/out"
       launcher_config:
         resources: { cpus: "4+", accelerators: "A100:1" }
 ```

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -394,32 +394,41 @@ def _remap_relative_dest(dst: str, build_workdir: Optional[str]) -> str:
 
 
 def _get_cli_prefix(build_workdir: Optional[str]) -> str:
-    """Build a shell snippet that changes into the per-run build workdir.
+    """Build the shell snippet prepended to each step's setup and run scripts.
+
+    The snippet always leads with ``set -eu`` so any failure in the prefix aborts
+    before the step body runs, rather than silently executing the body in a wrong
+    or unexpected state. The prefix is prepended ahead of each body's own
+    ``set -eu``, so without this the body's flags would not yet be in effect while
+    the prefix runs.
 
     When a ``build_workdir`` was provisioned (the env configures
-    ``shared_workdir``), emit ``mkdir -p`` + ``cd "$GB_BUILD_WORKDIR"`` so both
-    the ``setup`` and ``run`` scripts start in that per-run workdir. Making the
-    launcher own the ``cd`` lets step authors write outputs with relative paths
-    and stay agnostic about where the step runs: they never need to reference
-    ``$GB_BUILD_WORKDIR`` themselves.
+    ``shared_workdir``), the snippet also emits ``mkdir -p`` + ``cd
+    "$GB_BUILD_WORKDIR"`` so both the ``setup`` and ``run`` scripts start in that
+    per-run workdir. Making the launcher own the ``cd`` lets step authors write
+    outputs with relative paths and stay agnostic about where the step runs: they
+    never need to reference ``$GB_BUILD_WORKDIR`` themselves. With ``set -eu`` in
+    front, a failing ``mkdir``/``cd`` (or an unset ``$GB_BUILD_WORKDIR``) aborts
+    fast instead of leaving the body running in the wrong directory.
 
-    When no ``build_workdir`` is set (envs without ``shared_workdir``), return an
-    empty string — prepend no ``cd`` at all. SkyPilot then runs the scripts in
-    its own default working directory (``~/sky_workdir``), which is exactly where
-    its relative ``file_mounts`` rewrite places payloads (see
-    ``_remap_relative_dest``, which leaves relative destinations untouched in
-    this case). Injecting a ``cd`` elsewhere (e.g. ``$HOME``) would move the CWD
-    away from the mounted payloads, so relative-in/relative-out steps would fail
-    to find them; not cd'ing keeps the run CWD aligned with the mount location.
+    When no ``build_workdir`` is set (envs without ``shared_workdir``), no ``cd``
+    is emitted — only ``set -eu``. SkyPilot then runs the scripts in its own
+    default working directory (``~/sky_workdir``), which is exactly where its
+    relative ``file_mounts`` rewrite places payloads (see ``_remap_relative_dest``,
+    which leaves relative destinations untouched in this case). Injecting a ``cd``
+    elsewhere (e.g. ``$HOME``) would move the CWD away from the mounted payloads,
+    so relative-in/relative-out steps would fail to find them; not cd'ing keeps
+    the run CWD aligned with the mount location.
 
     :param build_workdir: the provisioned per-run workdir path, or ``None`` when
         no ``shared_workdir`` is configured (no ``cd`` is emitted).
-    :returns: a shell snippet terminated by a trailing newline, or ``""`` when
-        no ``build_workdir`` is set.
+    :returns: a shell snippet terminated by a trailing newline; always at least
+        ``set -eu``, plus ``mkdir``/``cd`` when a ``build_workdir`` is set.
     """
-    if not build_workdir:
-        return ""
-    return 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
+    prefix = "set -eu\n"
+    if build_workdir:
+        prefix += 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
+    return prefix
 
 
 def _build_skypilot_mounts(
@@ -1041,13 +1050,14 @@ class Skypilot(Environment):
                     build_workdir,
                 )
 
-            # When a per-run workdir was provisioned, prepend a `cd` into it to
-            # both setup and run so step scripts start in a known directory and
-            # can use relative paths without referencing $GB_BUILD_WORKDIR. With
-            # no shared_workdir, _get_cli_prefix returns "" so the scripts stay in
-            # SkyPilot's default ~/sky_workdir, where relative file_mounts land.
-            # Only prefix setup when there is a setup script, so steps without one
-            # don't acquire a spurious (cd-only) setup phase.
+            # The prefix always leads with `set -eu` (fail fast). When a per-run
+            # workdir was provisioned, it also prepends a `cd` into it to both
+            # setup and run so step scripts start in a known directory and can use
+            # relative paths without referencing $GB_BUILD_WORKDIR. With no
+            # shared_workdir, _get_cli_prefix emits only `set -eu` (no cd), so the
+            # scripts stay in SkyPilot's default ~/sky_workdir, where relative
+            # file_mounts land. Only prefix setup when there is a setup script, so
+            # steps without one don't acquire a spurious setup phase.
             cli_prefix = _get_cli_prefix(build_workdir)
             run_script = cli_prefix + launcher_config.get("run", "")
             if setup_script:

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -393,6 +393,28 @@ def _remap_relative_dest(dst: str, build_workdir: Optional[str]) -> str:
     return os.path.normpath(os.path.join(build_workdir, dst))
 
 
+def _get_cli_prefix(build_workdir: Optional[str]) -> str:
+    """Build a shell snippet that changes into the step's working directory.
+
+    Emits ``cd "${GB_BUILD_WORKDIR:-$HOME}"`` so ``setup``/``run`` scripts start
+    in the per-run build workdir when one was provisioned, and otherwise fall
+    back to the execution environment's ``HOME``. The fallback is expressed as a
+    shell parameter expansion so ``$HOME`` is resolved remotely by the step's own
+    shell — gbserver never computes it. When a ``build_workdir`` is known, a
+    ``mkdir -p`` precedes the ``cd`` so the directory exists before use.
+
+    Making the launcher own the ``cd`` lets step authors write outputs with
+    relative paths and stay agnostic about where the step runs: they never need
+    to reference ``$GB_BUILD_WORKDIR`` themselves.
+
+    :param build_workdir: the provisioned per-run workdir path, or ``None`` when
+        no ``shared_workdir`` is configured (falls back to ``$HOME``).
+    :returns: a shell snippet terminated by a trailing newline.
+    """
+    mkdir = 'mkdir -p "$GB_BUILD_WORKDIR"\n' if build_workdir else ""
+    return f'{mkdir}cd "${{GB_BUILD_WORKDIR:-$HOME}}"\n'
+
+
 def _build_skypilot_mounts(
     file_mounts_raw: dict,
     asset_dir: Union[Path, str, None],
@@ -1012,13 +1034,15 @@ class Skypilot(Environment):
                     build_workdir,
                 )
 
-            run_script = launcher_config.get("run", "")
-            if build_workdir:
-                run_script = (
-                    'mkdir -p "$GB_BUILD_WORKDIR"\n'
-                    'cd "$GB_BUILD_WORKDIR"\n'
-                    f"{run_script}"
-                )
+            # Prepend a `cd` into the per-run workdir (or $HOME) to both setup
+            # and run so step scripts start in a known directory and can use
+            # relative paths without referencing $GB_BUILD_WORKDIR. Only prefix
+            # setup when there is a setup script, so steps without one don't
+            # acquire a spurious (cd-only) setup phase.
+            cli_prefix = _get_cli_prefix(build_workdir)
+            run_script = cli_prefix + launcher_config.get("run", "")
+            if setup_script:
+                setup_script = cli_prefix + setup_script
 
             # Build sky.Task
             task = sky.Task(

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -394,25 +394,32 @@ def _remap_relative_dest(dst: str, build_workdir: Optional[str]) -> str:
 
 
 def _get_cli_prefix(build_workdir: Optional[str]) -> str:
-    """Build a shell snippet that changes into the step's working directory.
+    """Build a shell snippet that changes into the per-run build workdir.
 
-    Emits ``cd "${GB_BUILD_WORKDIR:-$HOME}"`` so ``setup``/``run`` scripts start
-    in the per-run build workdir when one was provisioned, and otherwise fall
-    back to the execution environment's ``HOME``. The fallback is expressed as a
-    shell parameter expansion so ``$HOME`` is resolved remotely by the step's own
-    shell — gbserver never computes it. When a ``build_workdir`` is known, a
-    ``mkdir -p`` precedes the ``cd`` so the directory exists before use.
+    When a ``build_workdir`` was provisioned (the env configures
+    ``shared_workdir``), emit ``mkdir -p`` + ``cd "$GB_BUILD_WORKDIR"`` so both
+    the ``setup`` and ``run`` scripts start in that per-run workdir. Making the
+    launcher own the ``cd`` lets step authors write outputs with relative paths
+    and stay agnostic about where the step runs: they never need to reference
+    ``$GB_BUILD_WORKDIR`` themselves.
 
-    Making the launcher own the ``cd`` lets step authors write outputs with
-    relative paths and stay agnostic about where the step runs: they never need
-    to reference ``$GB_BUILD_WORKDIR`` themselves.
+    When no ``build_workdir`` is set (envs without ``shared_workdir``), return an
+    empty string — prepend no ``cd`` at all. SkyPilot then runs the scripts in
+    its own default working directory (``~/sky_workdir``), which is exactly where
+    its relative ``file_mounts`` rewrite places payloads (see
+    ``_remap_relative_dest``, which leaves relative destinations untouched in
+    this case). Injecting a ``cd`` elsewhere (e.g. ``$HOME``) would move the CWD
+    away from the mounted payloads, so relative-in/relative-out steps would fail
+    to find them; not cd'ing keeps the run CWD aligned with the mount location.
 
     :param build_workdir: the provisioned per-run workdir path, or ``None`` when
-        no ``shared_workdir`` is configured (falls back to ``$HOME``).
-    :returns: a shell snippet terminated by a trailing newline.
+        no ``shared_workdir`` is configured (no ``cd`` is emitted).
+    :returns: a shell snippet terminated by a trailing newline, or ``""`` when
+        no ``build_workdir`` is set.
     """
-    mkdir = 'mkdir -p "$GB_BUILD_WORKDIR"\n' if build_workdir else ""
-    return f'{mkdir}cd "${{GB_BUILD_WORKDIR:-$HOME}}"\n'
+    if not build_workdir:
+        return ""
+    return 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
 
 
 def _build_skypilot_mounts(
@@ -1034,11 +1041,13 @@ class Skypilot(Environment):
                     build_workdir,
                 )
 
-            # Prepend a `cd` into the per-run workdir (or $HOME) to both setup
-            # and run so step scripts start in a known directory and can use
-            # relative paths without referencing $GB_BUILD_WORKDIR. Only prefix
-            # setup when there is a setup script, so steps without one don't
-            # acquire a spurious (cd-only) setup phase.
+            # When a per-run workdir was provisioned, prepend a `cd` into it to
+            # both setup and run so step scripts start in a known directory and
+            # can use relative paths without referencing $GB_BUILD_WORKDIR. With
+            # no shared_workdir, _get_cli_prefix returns "" so the scripts stay in
+            # SkyPilot's default ~/sky_workdir, where relative file_mounts land.
+            # Only prefix setup when there is a setup script, so steps without one
+            # don't acquire a spurious (cd-only) setup phase.
             cli_prefix = _get_cli_prefix(build_workdir)
             run_script = cli_prefix + launcher_config.get("run", "")
             if setup_script:

--- a/steps/README.md
+++ b/steps/README.md
@@ -286,7 +286,7 @@ sed "s#\${IMAGE_REF}#$ref#g" step-template.yaml > $(SPACE_DIR)/steps/<step-name>
 Because only the literal `${IMAGE_REF}` is replaced, everything else passes through
 untouched — importantly, the **runtime Jinja** `{{ ... }}` (resolved later by the
 build, e.g. `{{ config.eval_config.model_path }}`) and shell expansions like
-`${GB_BUILD_WORKDIR}` / `$(hostname)` inside `run:`/`setup:` blocks. (The image ref
+`${HOME}` / `$(hostname)` inside `run:`/`setup:` blocks. (The image ref
 is escaped first so a value containing `#`, `&`, or `\` can't corrupt the
 substitution.) This is factored into the `render-step-template` helper in
 [`common.mk`](common.mk), shared by both targets.

--- a/steps/byoc/skypilot/README.md
+++ b/steps/byoc/skypilot/README.md
@@ -39,8 +39,8 @@ All fields live under the step's `config.byoc_config`.
 |---|---|---|
 | `image` | string | Public container image the step runs in, e.g. `python:3.12-slim`. Rendered at runtime as SkyPilot `docker:<image>`. Defaults to `quay.io/fedora/fedora-minimal:42`; set to `""` to run on the bare launcher node instead (e.g. a cluster without Pyxis, which cannot run container images). |
 | `ref` | string | Branch, tag, or commit checked out after cloning. Default: the repo's default branch. |
-| `workdir` | string | Subdirectory (under `$GB_BUILD_WORKDIR`) the repo is cloned into. Default: `code`. |
-| `setup_command` | string | Bash command run during `setup`, **after** the clone, from `$GB_BUILD_WORKDIR` (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
+| `workdir` | string | Subdirectory (relative to the step's working directory) the repo is cloned into. Default: `code`. |
+| `setup_command` | string | Bash command run during `setup`, **after** the clone, from the step's working directory (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
 
 > **`image` is a runtime choice, not a built image.** Unlike custom-image steps
 > (e.g. [eval](../../eval/skypilot/README.md)), `byoc` builds no Dockerfile;
@@ -53,7 +53,7 @@ All fields live under the step's `config.byoc_config`.
   code by cloning `repo`. Bind target inputs in your `build.yaml` as usual if the
   cloned command needs them (they are resolved by the environment before `run`).
 - **File mounts** — the optional `src/` directory beside the template is mounted
-  to `$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
+  to `./src` at the workdir root on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
   demonstrating the SkyPilot `file_mounts` input.
 - **Outputs** — to register an artifact, have your `command` print a line that
   begins with the Granite.build marker (captured by `skypilot_monitor`):
@@ -64,11 +64,15 @@ All fields live under the step's `config.byoc_config`.
 
   `<output-id>` must match an `outputs.<id>` declared on the target.
 
-## Env vars the step provides to your commands
+## Working directory and paths
 
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into both `setup` and `run`: the
-per-run workdir and the run script's initial CWD. `repo` is cloned to
-`$GB_BUILD_WORKDIR/<workdir>` and `src/` is mounted at `$GB_BUILD_WORKDIR/src`.
+The SkyPilot launcher starts both `setup` and `run` in a per-run working
+directory (falling back to `$HOME` when the environment defines no
+`shared_workdir`), so your commands don't need to know where they run — use
+**relative paths**. `repo` is cloned to `<workdir>` (default `code`), `src/` is
+mounted at `./src`, and `run` executes from inside the cloned repo. When you need
+an **absolute** path (e.g. for the artifact marker below), derive it from the CWD
+with `$(pwd)`, e.g. `$(pwd)/result` — don't hard-code a location.
 
 ## Generating and deploying the step
 
@@ -110,7 +114,7 @@ granite.build:
               ref: "main"
               workdir: "code"
               setup_command: "cd code && pip install -r requirements.txt"
-              command: "python main.py --out $GB_BUILD_WORKDIR/result"
+              command: "python main.py --out $(pwd)/result"
 ```
 
 ## Notes and limitations

--- a/steps/byoc/skypilot/USAGE.md
+++ b/steps/byoc/skypilot/USAGE.md
@@ -24,7 +24,7 @@ All fields live under the step's `config.byoc_config`.
 | Field | Type | Purpose |
 |---|---|---|
 | `repo` | string | Public git repository URL cloned during `setup`. An empty value fails the step. |
-| `command` | string | Bash command executed during `run`, from inside the cloned repo directory. |
+| `command` | string | Bash command executed during `run`, from the step's working directory (the workdir root). `cd` into the cloned repo yourself if needed, e.g. `cd code && python main.py`. |
 
 ### Optional
 
@@ -32,8 +32,8 @@ All fields live under the step's `config.byoc_config`.
 |---|---|---|
 | `image` | string | Public container image the step runs in, e.g. `python:3.12-slim`. Rendered at runtime as SkyPilot `docker:<image>`. Defaults to `quay.io/fedora/fedora-minimal:42`; set to `""` to run on the bare launcher node instead (e.g. a cluster without Pyxis, which cannot run container images). |
 | `ref` | string | Branch, tag, or commit checked out after cloning. Default: the repo's default branch. |
-| `workdir` | string | Subdirectory (under `$GB_BUILD_WORKDIR`) the repo is cloned into. Default: `code`. |
-| `setup_command` | string | Bash command run during `setup`, **after** the clone, from `$GB_BUILD_WORKDIR` (the workdir root). Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
+| `workdir` | string | Subdirectory (under the workdir root) the repo is cloned into. Default: `code`. |
+| `setup_command` | string | Bash command run during `setup`, **after** the clone, from the workdir root. Use it for dependency installation, e.g. `cd code && pip install -r requirements.txt`. `set -eu` is in effect, so a failure fails the build. Empty (default) => skipped. |
 
 > **`image` is a runtime choice, not a built image.** Unlike custom-image steps (which
 > build a Dockerfile), `byoc` builds no image; `image` selects an existing public image
@@ -61,7 +61,7 @@ for `mem://`) — byoc accesses bindings explicitly, so there is no auto-exporte
 `GB_BYOC_INPUT_*` env var.
 
 **File mounts** — the optional `src/` directory beside the template is mounted to
-`$GB_BUILD_WORKDIR/src` on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
+`./src` at the workdir root on the cluster (see [`src/helpers.sh`](src/helpers.sh)),
 demonstrating the SkyPilot `file_mounts` input.
 
 ### Outputs (any number)
@@ -83,11 +83,13 @@ For the full target I/O schema and the `bindings.*` Jinja variables, see
 anchoring, the shipped monitors), see `docs/steps/monitoring-and-artifact-events.md` in
 the granite.build repository.
 
-## Env vars the step provides to your commands
+## Working directory and paths
 
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into both `setup` and `run`: the
-per-run workdir and the run script's initial CWD. `repo` is cloned to
-`$GB_BUILD_WORKDIR/<workdir>` and `src/` is mounted at `$GB_BUILD_WORKDIR/src`.
+Both `setup` and `run` start in the same **working directory** (the step's per-run
+workdir), so the step never needs to know its absolute location. `repo` is cloned
+into `<workdir>` (default `code/`) beneath it, and `src/` is mounted at `./src`.
+Use relative paths from there; when you need an absolute path — e.g. for an
+`LLMB_ARTIFACT_PATH` marker — derive it at run time with `$(pwd)`.
 
 ## Example build.yaml
 
@@ -124,13 +126,14 @@ granite.build:
               workdir: "code"
               setup_command: "cd code && pip install -r requirements.txt"
               command: >-
+                cd code;
                 python main.py
                 --dataset "{{ bindings.dataset.binding.path }}"
                 --init-model "{{ bindings.upstream_model.binding.path }}"
-                --out-dir "$GB_BUILD_WORKDIR/out";
-                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-1.ckpt";
-                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/epoch-2.ckpt";
-                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$GB_BUILD_WORKDIR/out/report.json"
+                --out-dir "$(pwd)/out";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-1.ckpt";
+                echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-2.ckpt";
+                echo "LLMB_ARTIFACT_ID:report LLMB_ARTIFACT_PATH:$(pwd)/out/report.json"
 ```
 
 A single direct input and output are just the one-entry case of the above.

--- a/steps/byoc/skypilot/src/helpers.sh
+++ b/steps/byoc/skypilot/src/helpers.sh
@@ -2,11 +2,14 @@
 # Optional helper functions for the byoc step.
 #
 # This directory is file-mounted into ./src at the workdir root on the cluster
-# (see file_mounts in step-template.yaml). The run command executes from inside
-# the cloned repo (a sibling of src/), so the user command can source it, e.g.:
+# (see file_mounts in step-template.yaml). Both setup and run start in the
+# workdir root, so the user command can source it from there, e.g.:
 #
-#   source "../src/helpers.sh"
+#   source "src/helpers.sh"
 #   byoc_log "starting"
+#
+# (If your command cd's into the cloned repo first, adjust the path accordingly,
+# e.g. "source ../src/helpers.sh".)
 #
 # It is intentionally minimal — byoc's real code comes from the cloned git repo.
 

--- a/steps/byoc/skypilot/src/helpers.sh
+++ b/steps/byoc/skypilot/src/helpers.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Optional helper functions for the byoc step.
 #
-# This directory is file-mounted into $GB_BUILD_WORKDIR/src on the cluster (see
-# file_mounts in step-template.yaml). The user command can source it, e.g.:
+# This directory is file-mounted into ./src at the workdir root on the cluster
+# (see file_mounts in step-template.yaml). The run command executes from inside
+# the cloned repo (a sibling of src/), so the user command can source it, e.g.:
 #
-#   source "$GB_BUILD_WORKDIR/src/helpers.sh"
+#   source "../src/helpers.sh"
 #   byoc_log "starting"
 #
 # It is intentionally minimal — byoc's real code comes from the cloned git repo.

--- a/steps/byoc/skypilot/step-template.yaml
+++ b/steps/byoc/skypilot/step-template.yaml
@@ -17,7 +17,9 @@ config:
     ref: ""
     # Subdirectory (under the build workdir) the repo is cloned into.
     workdir: "code"
-    # Command executed by `run`, from inside the cloned repo directory.
+    # Command executed by `run`, from the step's working directory (the workdir
+    # root — the same directory setup runs in). cd into the cloned repo yourself
+    # if needed, e.g. "cd code && python main.py".
     command: ""
     # Optional bash command run during `setup`, after the repo is cloned, from
     # the step's working directory (the workdir root — cd into the repo yourself
@@ -76,17 +78,17 @@ environment_configs:
               echo "byoc: running setup_command in $(pwd)"
               {{ config.byoc_config.setup_command }}
             fi
-          # run executes the user-defined command from inside the cloned repo.
-          # The launcher starts run in the per-run workdir, so CODE_DIR is
-          # relative; file-mounted helpers are available at ./src.
+          # run executes the user-defined command from the workdir root — the
+          # same directory setup starts in (the launcher cd's both here). The
+          # command cd's into the cloned repo itself if it needs to; CODE_DIR is
+          # relative and file-mounted helpers are available at ./src.
           run: |
             set -eu
             CODE_DIR="{{ config.byoc_config.workdir }}"
-            cd "$CODE_DIR"
             # Record the resolved commit as step metadata so build lineage captures
             # exactly which commit was built (build.yaml may pin only a branch/tag,
             # or nothing). Defensive: never fail the build for lineage metadata,
-            # even though set -eu is in effect.
+            # even though set -eu is in effect. `-C` reads the repo without cd'ing.
             COMMIT_SHA="$(git -C "$CODE_DIR" rev-parse HEAD 2>/dev/null || true)"
             [ -n "$COMMIT_SHA" ] && echo "LLMB_STEP_METADATA_KEY:commit_hash LLMB_STEP_METADATA_VALUE:$COMMIT_SHA"
             echo "byoc: running command in $(pwd)"

--- a/steps/byoc/skypilot/step-template.yaml
+++ b/steps/byoc/skypilot/step-template.yaml
@@ -11,11 +11,11 @@ config:
     # choice (rendered by Jinja from the build.yaml), not a custom image built by
     # this step's Makefile.
     image: "quay.io/fedora/fedora-minimal:42"
-    # Public git repository cloned into the build workdir during `setup`.
+    # Public git repository cloned into the step's working directory during `setup`.
     repo: ""
     # Optional branch, tag, or commit to check out after cloning.
     ref: ""
-    # Subdirectory (under the build workdir) the repo is cloned into.
+    # Subdirectory (under the step's working directory) the repo is cloned into.
     workdir: "code"
     # Command executed by `run`, from the step's working directory (the workdir
     # root — the same directory setup runs in). cd into the cloned repo yourself
@@ -42,14 +42,14 @@ environment_configs:
           # Cloud-agnostic: the build supplies cpus/memory/accelerators via
           # config.launcher_config.resources.
           resources: {}
-          # Optional helper assets shipped alongside the step. A relative dest is
-          # remapped into the per-run workdir, which is also the step's working
-          # directory, so these land at ./src.
+          # Optional helper assets shipped alongside the step. A relative dest
+          # lands at ./src, relative to the step's working directory (the same
+          # directory setup and run start in).
           file_mounts:
             src: src
-          # setup runs once at cluster bring-up: fetch the code. The launcher
-          # starts this script in the per-run workdir, so a relative CODE_DIR
-          # clones under it without the step needing to know the absolute path.
+          # setup runs once at cluster bring-up: fetch the code. setup starts in
+          # the step's working directory, so a relative CODE_DIR clones under it
+          # without the step needing to know its absolute path.
           setup: |
             set -eu
             REPO="{{ config.byoc_config.repo }}"
@@ -73,15 +73,15 @@ environment_configs:
             # fails the build, just as a failed clone does.
             SETUP_ENABLED="{{ 'yes' if config.byoc_config.setup_command else '' }}"
             if [ -n "$SETUP_ENABLED" ]; then
-              # Already in the workdir root (the launcher cd's here), so the
-              # command runs relative to it — e.g. "cd code && pip install ...".
+              # Still in setup's working directory, so the command runs relative
+              # to it — e.g. "cd code && pip install ...".
               echo "byoc: running setup_command in $(pwd)"
               {{ config.byoc_config.setup_command }}
             fi
-          # run executes the user-defined command from the workdir root — the
-          # same directory setup starts in (the launcher cd's both here). The
-          # command cd's into the cloned repo itself if it needs to; CODE_DIR is
-          # relative and file-mounted helpers are available at ./src.
+          # run executes the user-defined command from the step's working
+          # directory — the same directory setup starts in. The command cd's into
+          # the cloned repo itself if it needs to; CODE_DIR is relative and
+          # file-mounted helpers are available at ./src.
           run: |
             set -eu
             CODE_DIR="{{ config.byoc_config.workdir }}"

--- a/steps/byoc/skypilot/step-template.yaml
+++ b/steps/byoc/skypilot/step-template.yaml
@@ -20,8 +20,9 @@ config:
     # Command executed by `run`, from inside the cloned repo directory.
     command: ""
     # Optional bash command run during `setup`, after the repo is cloned, from
-    # $GB_BUILD_WORKDIR (the workdir root — cd into the repo yourself if needed,
-    # e.g. "cd code && pip install -r requirements.txt"). Empty => skipped.
+    # the step's working directory (the workdir root — cd into the repo yourself
+    # if needed, e.g. "cd code && pip install -r requirements.txt"). Empty =>
+    # skipped.
     setup_command: ""
 
 environment_configs:
@@ -40,16 +41,18 @@ environment_configs:
           # config.launcher_config.resources.
           resources: {}
           # Optional helper assets shipped alongside the step. A relative dest is
-          # remapped under $GB_BUILD_WORKDIR, so these land at
-          # $GB_BUILD_WORKDIR/src on the cluster.
+          # remapped into the per-run workdir, which is also the step's working
+          # directory, so these land at ./src.
           file_mounts:
             src: src
-          # setup runs once at cluster bring-up: fetch the code.
+          # setup runs once at cluster bring-up: fetch the code. The launcher
+          # starts this script in the per-run workdir, so a relative CODE_DIR
+          # clones under it without the step needing to know the absolute path.
           setup: |
             set -eu
             REPO="{{ config.byoc_config.repo }}"
             REF="{{ config.byoc_config.ref }}"
-            CODE_DIR="${GB_BUILD_WORKDIR:-$HOME}/{{ config.byoc_config.workdir }}"
+            CODE_DIR="{{ config.byoc_config.workdir }}"
             if [ -z "$REPO" ]; then
               echo "byoc: config.byoc_config.repo is empty; nothing to clone" >&2
               exit 1
@@ -68,15 +71,17 @@ environment_configs:
             # fails the build, just as a failed clone does.
             SETUP_ENABLED="{{ 'yes' if config.byoc_config.setup_command else '' }}"
             if [ -n "$SETUP_ENABLED" ]; then
-              cd "${GB_BUILD_WORKDIR:-$HOME}"
+              # Already in the workdir root (the launcher cd's here), so the
+              # command runs relative to it — e.g. "cd code && pip install ...".
               echo "byoc: running setup_command in $(pwd)"
               {{ config.byoc_config.setup_command }}
             fi
           # run executes the user-defined command from inside the cloned repo.
-          # File-mounted helpers are available at $GB_BUILD_WORKDIR/src.
+          # The launcher starts run in the per-run workdir, so CODE_DIR is
+          # relative; file-mounted helpers are available at ./src.
           run: |
             set -eu
-            CODE_DIR="${GB_BUILD_WORKDIR:-$HOME}/{{ config.byoc_config.workdir }}"
+            CODE_DIR="{{ config.byoc_config.workdir }}"
             cd "$CODE_DIR"
             echo "byoc: running command in $(pwd)"
             {{ config.byoc_config.command }}

--- a/steps/byoc/skypilot/test-data/aws/build.yaml
+++ b/steps/byoc/skypilot/test-data/aws/build.yaml
@@ -20,7 +20,7 @@ granite.build:
       steps:
         # The byoc step, resolved from the Space rendered by `make space` (see the
         # test's _get_yaml_spec_dir). It git-clones the repo below during `setup`
-        # and runs `command` from inside the clone during `run`. Identical byoc
+        # and runs `command` from the workdir root during `run`. Identical byoc
         # config to the slurm fixture — only environment_uri differs — so the same
         # step is proven on a real cloud (EC2) backend.
         - step_uri: space://steps/byoc
@@ -44,13 +44,14 @@ granite.build:
               setup_command: >-
                 echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
-              # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so the marker written into code/ is right here.
-              # `test -f` fails the step (set -eu) unless setup_command wrote the
-              # sentinel, so reaching SUCCESS proves the setup phase ran it.
+              # equal the env:// output uri path above. run starts in the workdir
+              # root (same as setup), so the marker setup wrote lives at
+              # code/setup_marker. `test -f` fails the step (set -eu) unless
+              # setup_command wrote the sentinel, so reaching SUCCESS proves the
+              # setup phase ran it.
               command: >-
-                test -f setup_marker;
-                echo "setup marker: $(cat setup_marker)";
+                test -f code/setup_marker;
+                echo "setup marker: $(cat code/setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/steps/byoc/skypilot/test-data/aws/build.yaml
+++ b/steps/byoc/skypilot/test-data/aws/build.yaml
@@ -36,19 +36,21 @@ granite.build:
               # Default branch; the command does not depend on repo contents.
               ref: ""
               workdir: "code"
-              # Exercises setup_command: write a sentinel into $GB_BUILD_WORKDIR
-              # during setup. The run command below requires it (set -eu), so the
-              # build only reaches SUCCESS if setup_command actually ran.
+              # Exercises setup_command: write a sentinel into the cloned repo
+              # dir (code/) during setup, using a path relative to the workdir
+              # root (setup_command's CWD). The run command below requires it
+              # (set -eu), so the build only reaches SUCCESS if setup_command
+              # actually ran.
               setup_command: >-
-                echo byoc-setup-ran > "$GB_BUILD_WORKDIR/setup_marker"
+                echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
               # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so this runs from inside the cloned repo.
+              # the clone first, so the marker written into code/ is right here.
               # `test -f` fails the step (set -eu) unless setup_command wrote the
               # sentinel, so reaching SUCCESS proves the setup phase ran it.
               command: >-
-                test -f "$GB_BUILD_WORKDIR/setup_marker";
-                echo "setup marker: $(cat "$GB_BUILD_WORKDIR/setup_marker")";
+                test -f setup_marker;
+                echo "setup marker: $(cat setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/steps/byoc/skypilot/test-data/slurm/build.yaml
+++ b/steps/byoc/skypilot/test-data/slurm/build.yaml
@@ -35,19 +35,21 @@ granite.build:
               # Default branch; the command does not depend on repo contents.
               ref: ""
               workdir: "code"
-              # Exercises setup_command: write a sentinel into $GB_BUILD_WORKDIR
-              # during setup. The run command below requires it (set -eu), so the
-              # build only reaches SUCCESS if setup_command actually ran.
+              # Exercises setup_command: write a sentinel into the cloned repo
+              # dir (code/) during setup, using a path relative to the workdir
+              # root (setup_command's CWD). The run command below requires it
+              # (set -eu), so the build only reaches SUCCESS if setup_command
+              # actually ran.
               setup_command: >-
-                echo byoc-setup-ran > "$GB_BUILD_WORKDIR/setup_marker"
+                echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
               # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so this runs from inside the cloned repo.
+              # the clone first, so the marker written into code/ is right here.
               # `test -f` fails the step (set -eu) unless setup_command wrote the
               # sentinel, so reaching SUCCESS proves the setup phase ran it.
               command: >-
-                test -f "$GB_BUILD_WORKDIR/setup_marker";
-                echo "setup marker: $(cat "$GB_BUILD_WORKDIR/setup_marker")";
+                test -f setup_marker;
+                echo "setup marker: $(cat setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/steps/byoc/skypilot/test-data/slurm/build.yaml
+++ b/steps/byoc/skypilot/test-data/slurm/build.yaml
@@ -20,7 +20,7 @@ granite.build:
       steps:
         # The byoc step, resolved from the Space rendered by `make space` (see the
         # test's _get_test_specification). It git-clones the repo below during
-        # `setup` and runs `command` from inside the clone during `run`.
+        # `setup` and runs `command` from the workdir root during `run`.
         - step_uri: space://steps/byoc
           config:
             # Fast completion detection for the test (base skypilot default is
@@ -43,13 +43,14 @@ granite.build:
               setup_command: >-
                 echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
-              # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so the marker written into code/ is right here.
-              # `test -f` fails the step (set -eu) unless setup_command wrote the
-              # sentinel, so reaching SUCCESS proves the setup phase ran it.
+              # equal the env:// output uri path above. run starts in the workdir
+              # root (same as setup), so the marker setup wrote lives at
+              # code/setup_marker. `test -f` fails the step (set -eu) unless
+              # setup_command wrote the sentinel, so reaching SUCCESS proves the
+              # setup phase ran it.
               command: >-
-                test -f setup_marker;
-                echo "setup marker: $(cat setup_marker)";
+                test -f code/setup_marker;
+                echo "setup marker: $(cat code/setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/steps/common.mk
+++ b/steps/common.mk
@@ -346,6 +346,7 @@ endef
 
 # Render a self-contained Space into $(SPACE_DIR)/:
 #   $(SPACE_DIR)/steps/$(STEP_NAME)/step.yaml   (+ bundled src/)
+#   $(SPACE_DIR)/steps/$(STEP_NAME)/.gbignore   (skip Jinja for **/*.md + src/)
 #   $(SPACE_DIR)/space.yaml                       (base_uris -> $(SPACE_BASE_URI))
 # step-template.yaml is rendered substituting ONLY ${IMAGE_REF} so runtime Jinja
 # ({{ ... }}) and shell expansions (${VAR}, $(cmd)) in the run/setup blocks pass
@@ -360,6 +361,7 @@ space:
 		cp -R "$(SRC_DIR)" "$(SPACE_DIR)/steps/$(STEP_NAME)/$(SRC_DIR)"; \
 		echo "[$(STEP_NAME)] bundled $(SRC_DIR)/ into $(SPACE_DIR)/steps/$(STEP_NAME)/"; \
 	fi
+	$(call write-gbignore,$(SPACE_DIR)/steps/$(STEP_NAME))
 	@printf 'name: %s\nsecret_manager:\n  type: local\n  config: {}\nbase_uris:\n  - %s\n' \
 		"$(SPACE_NAME)" "$(SPACE_BASE_URI)" > $(SPACE_DIR)/space.yaml
 	@if [ -n "$(DEFAULT_ENVIRONMENT)" ]; then \

--- a/steps/common.mk
+++ b/steps/common.mk
@@ -282,6 +282,25 @@ define render-step-template
 	sed "s#\$${IMAGE_REF}#$$ref#g" "$(TEMPLATE)" > "$(1)"
 endef
 
+# write-gbignore — drop a .gbignore next to the published step.yaml so the g.b
+# build process ships the listed files verbatim instead of Jinja-rendering them.
+# The .gbignore is an ADDITIVE glob list (this impl has NO gitignore-style "!"
+# negation — see utils/filesystem.py:_get_matching_ignored_files), so it must
+# enumerate what to SKIP rather than "ignore all but step.yaml": that keeps
+# step.yaml's runtime {{ ... }} rendered while sparing the docs (README.md, which
+# may show {{ ... }} examples) and the whole src/ tree (step scripts/helpers,
+# shipped as-is). The .gbignore is itself a dotfile, so the renderer's glob never
+# picks it up — its own {{ ... }} in the comment is safe. $(1) is the target dir.
+define write-gbignore
+	@printf '%s\n' \
+		'# The following allows the docs to contain {{ ... }} but be ignored by the g.b build process.' \
+		'**/*.md' \
+		'# Ship the src/ tree verbatim — do not jinja-process step scripts/helpers.' \
+		'src/**' \
+		> "$(1)/.gbignore"
+	@echo "[$(STEP_NAME)] wrote $(1)/.gbignore (skip Jinja for docs + src/)"
+endef
+
 # guard-publish-paths — fail fast before `publish-step` runs any rm -rf. The publish
 # destinations are absolute paths built from STEP_NAME/STEP_ENV; a stray empty
 # override (e.g. `make publish-step STEP_ENV=`) would collapse one to a broad path
@@ -354,11 +373,15 @@ space:
 # the repo's parallel top-level test/ <-> test-data/ trees:
 #   $(PUBLISH_STEP_DIR)/step.yaml               (+ bundled src/)   — the published step
 #   $(PUBLISH_STEP_DIR)/README.md               (from USAGE.md)    — user-facing usage doc
+#   $(PUBLISH_STEP_DIR)/.gbignore                                  — skip Jinja for **/*.md + src/
 #   $(PUBLISH_TEST_DIR)/<cluster>/              — per-cluster build tests (copied)
 #   $(PUBLISH_TESTDATA_DIR)/<cluster>/          — their fixtures, with space_uri rewritten
 #
 # The step's own README.md (development-oriented) is NOT published; only USAGE.md is,
 # renamed to README.md so a user browsing the released assets tree finds usage docs.
+# A .gbignore is written beside step.yaml so the g.b build process ships the docs
+# (**/*.md) and the src/ tree verbatim instead of Jinja-rendering them — docs may
+# contain {{ ... }} examples and src scripts must not be templated (see write-gbignore).
 #
 # The step's own `test/<cluster>/` nesting is flattened on copy (the inner `test`
 # segment is dropped) so the published test lands at test/steps/<name>/<env>/<cluster>/
@@ -391,6 +414,7 @@ publish-step:
 	else \
 		echo "[$(STEP_NAME)] WARNING: no USAGE.md to publish as README.md"; \
 	fi
+	$(call write-gbignore,$(PUBLISH_STEP_DIR))
 	@rm -rf "$(PUBLISH_TEST_DIR)" "$(PUBLISH_TESTDATA_DIR)"
 	@mkdir -p "$(PUBLISH_TEST_DIR)" "$(PUBLISH_TESTDATA_DIR)"
 	@copied=0; for d in $(TEST_DIR)/*/; do \

--- a/steps/eval/skypilot/README.md
+++ b/steps/eval/skypilot/README.md
@@ -75,11 +75,12 @@ All fields live under the step's `config.eval_config` and are templated into the
   `run:` block (see [Who emits the artifact line?](#who-emits-the-artifact-line)),
   not by `eval.sh`. Bind a matching `outputs.results` on the target to persist it.
 
-## Env vars the step provides to your commands
+## Working directory and paths
 
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into `run`: the per-run workdir
-and the run script's initial CWD. Relative `output_dir` values resolve here, giving
-per-run isolation.
+The SkyPilot launcher starts `run` in a per-run working directory (falling back
+to `$HOME` when the environment defines no `shared_workdir`), so commands need
+not know where they run — use relative paths. Relative `output_dir` values
+resolve against this CWD, giving per-run isolation.
 
 The eval script runs inside the **image** (built from `Dockerfile`); the exemplar
 is a shell script, so the image needs no Python interpreter or runtime venv.

--- a/steps/eval/skypilot/USAGE.md
+++ b/steps/eval/skypilot/USAGE.md
@@ -65,11 +65,11 @@ All fields live under the step's `config.eval_config` and are templated into the
   `run:` block (see [Who emits the artifact line?](#who-emits-the-artifact-line)),
   not by `eval.sh`. Bind a matching `outputs.results` on the target to persist it.
 
-## Env vars the step provides to your commands
+## Working directory and paths
 
-The SkyPilot launcher exports `$GB_BUILD_WORKDIR` into `run`: the per-run workdir
-and the run script's initial CWD. Relative `output_dir` values resolve here, giving
-per-run isolation.
+`run` starts in the step's per-run **working directory**, so the step never needs to
+know its absolute location. Relative `output_dir` values resolve there, giving per-run
+isolation; derive an absolute path with `$(pwd)` when you need one.
 
 ## Example build.yaml
 

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/build.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/build.yaml
@@ -9,8 +9,8 @@ granite.build:
   # fails the build if it did not. This is the AWS analog of the
   # skypilot/bluevela/filemount fixture (which mounts through LSF's enroot).
   #
-  # Runs BARE (empty command_config.image): file_mounts land in the VM run workdir
-  # (${GB_BUILD_WORKDIR}), which is the run command's CWD, so ./payload is
+  # Runs BARE (empty command_config.image): file_mounts land in the VM run workdir,
+  # which is the run command's CWD, so ./payload is
   # reachable directly. (bluevela used an enroot container to also exercise
   # in-container visibility; on AWS we test the core relative-source resolution on
   # the bare VM, mirroring the aws/2target fixture.)

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/step.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/step.yaml
@@ -25,17 +25,18 @@ environment_configs:
           # Copy the `payload/` directory that ships next to THIS step.yaml onto the
           # instance. The source is relative, so the SkyPilot launcher resolves it
           # against the step.yaml's own directory (the per-run asset dir) — this is
-          # the behavior under test. The DESTINATION is also relative, which gbserver
-          # remaps under the per-run build workdir. The run
-          # script's CWD is that same workdir, so the payload is reachable at exactly
-          # ./payload — the same step-relative path the source occupies on disk
-          # (relative in, relative out).
+          # the behavior under test. The DESTINATION is also relative: this env has
+          # no shared_workdir, so gbserver leaves it to SkyPilot's own ~/sky_workdir
+          # rewrite, and the run script (no cd injected) starts in that same
+          # ~/sky_workdir. So the payload is reachable at exactly ./payload — the
+          # same step-relative path the source occupies on disk (relative in,
+          # relative out).
           file_mounts:
             payload: payload
           run: |
             set -euo pipefail
             # Verify file_mounts copied the step-relative payload dir to the matching
-            # relative path in the run CWD (the per-run workdir). `set -e` + `test`
+            # relative path in the run CWD (SkyPilot's ~/sky_workdir). `set -e` + `test`
             # fail the step (=> build FAILED) if it is absent.
             echo "verifying file_mounts copied the step-relative payload dir..."
             test -d ./payload

--- a/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/step.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/aws/filemount/space/steps/filemount-check/step.yaml
@@ -26,7 +26,7 @@ environment_configs:
           # instance. The source is relative, so the SkyPilot launcher resolves it
           # against the step.yaml's own directory (the per-run asset dir) — this is
           # the behavior under test. The DESTINATION is also relative, which gbserver
-          # remaps under the per-run build workdir (${GB_BUILD_WORKDIR}). The run
+          # remaps under the per-run build workdir. The run
           # script's CWD is that same workdir, so the payload is reachable at exactly
           # ./payload — the same step-relative path the source occupies on disk
           # (relative in, relative out).
@@ -35,7 +35,7 @@ environment_configs:
           run: |
             set -euo pipefail
             # Verify file_mounts copied the step-relative payload dir to the matching
-            # relative path in the run CWD (${GB_BUILD_WORKDIR}). `set -e` + `test`
+            # relative path in the run CWD (the per-run workdir). `set -e` + `test`
             # fail the step (=> build FAILED) if it is absent.
             echo "verifying file_mounts copied the step-relative payload dir..."
             test -d ./payload

--- a/test-data/integration/ibm/buildrunner/skypilot/bluevela/filemount/space/steps/filemount-check/step.yaml
+++ b/test-data/integration/ibm/buildrunner/skypilot/bluevela/filemount/space/steps/filemount-check/step.yaml
@@ -26,9 +26,9 @@ environment_configs:
           # the cluster. The source is relative, so the Skypilot launcher resolves
           # it against the step.yaml's own directory (the per-run asset dir) — this
           # is the behavior under test. The DESTINATION is also relative, which
-          # gbserver remaps under the per-run build workdir (${GB_BUILD_WORKDIR},
-          # on the shared /proj FS that is bind-mounted identity into the enroot
-          # container). The run script's CWD is that same workdir, so the payload
+          # gbserver remaps under the per-run build workdir (on the shared /proj FS
+          # that is bind-mounted identity into the enroot container). The run
+          # script's CWD is that same workdir, so the payload
           # is reachable at exactly ./payload — the same path, relative to the
           # step, that the source occupies on disk (relative in, relative out).
           # This exercises both container-visibility and per-target isolation.
@@ -37,7 +37,7 @@ environment_configs:
           run: |
             set -euo pipefail
             # Verify file_mounts copied the step-relative payload dir to the
-            # matching relative path in the run CWD (${GB_BUILD_WORKDIR}).
+            # matching relative path in the run CWD (the per-run workdir).
             # `set -e` + `test` fail the step (=> build FAILED) if it is absent.
             echo "verifying file_mounts copied the step-relative payload dir..."
             test -d ./payload

--- a/test-data/steps/byoc/skypilot/aws/build.yaml
+++ b/test-data/steps/byoc/skypilot/aws/build.yaml
@@ -20,7 +20,7 @@ granite.build:
       steps:
         # The byoc step, resolved from the Space rendered by `make space` (see the
         # test's _get_yaml_spec_dir). It git-clones the repo below during `setup`
-        # and runs `command` from inside the clone during `run`. Identical byoc
+        # and runs `command` from the workdir root during `run`. Identical byoc
         # config to the slurm fixture — only environment_uri differs — so the same
         # step is proven on a real cloud (EC2) backend.
         - step_uri: space://steps/byoc
@@ -44,13 +44,14 @@ granite.build:
               setup_command: >-
                 echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
-              # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so the marker written into code/ is right here.
-              # `test -f` fails the step (set -eu) unless setup_command wrote the
-              # sentinel, so reaching SUCCESS proves the setup phase ran it.
+              # equal the env:// output uri path above. run starts in the workdir
+              # root (same as setup), so the marker setup wrote lives at
+              # code/setup_marker. `test -f` fails the step (set -eu) unless
+              # setup_command wrote the sentinel, so reaching SUCCESS proves the
+              # setup phase ran it.
               command: >-
-                test -f setup_marker;
-                echo "setup marker: $(cat setup_marker)";
+                test -f code/setup_marker;
+                echo "setup marker: $(cat code/setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/test-data/steps/byoc/skypilot/aws/build.yaml
+++ b/test-data/steps/byoc/skypilot/aws/build.yaml
@@ -36,19 +36,21 @@ granite.build:
               # Default branch; the command does not depend on repo contents.
               ref: ""
               workdir: "code"
-              # Exercises setup_command: write a sentinel into $GB_BUILD_WORKDIR
-              # during setup. The run command below requires it (set -eu), so the
-              # build only reaches SUCCESS if setup_command actually ran.
+              # Exercises setup_command: write a sentinel into the cloned repo
+              # dir (code/) during setup, using a path relative to the workdir
+              # root (setup_command's CWD). The run command below requires it
+              # (set -eu), so the build only reaches SUCCESS if setup_command
+              # actually ran.
               setup_command: >-
-                echo byoc-setup-ran > "$GB_BUILD_WORKDIR/setup_marker"
+                echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
               # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so this runs from inside the cloned repo.
+              # the clone first, so the marker written into code/ is right here.
               # `test -f` fails the step (set -eu) unless setup_command wrote the
               # sentinel, so reaching SUCCESS proves the setup phase ran it.
               command: >-
-                test -f "$GB_BUILD_WORKDIR/setup_marker";
-                echo "setup marker: $(cat "$GB_BUILD_WORKDIR/setup_marker")";
+                test -f setup_marker;
+                echo "setup marker: $(cat setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/test-data/steps/byoc/skypilot/slurm/build.yaml
+++ b/test-data/steps/byoc/skypilot/slurm/build.yaml
@@ -35,19 +35,21 @@ granite.build:
               # Default branch; the command does not depend on repo contents.
               ref: ""
               workdir: "code"
-              # Exercises setup_command: write a sentinel into $GB_BUILD_WORKDIR
-              # during setup. The run command below requires it (set -eu), so the
-              # build only reaches SUCCESS if setup_command actually ran.
+              # Exercises setup_command: write a sentinel into the cloned repo
+              # dir (code/) during setup, using a path relative to the workdir
+              # root (setup_command's CWD). The run command below requires it
+              # (set -eu), so the build only reaches SUCCESS if setup_command
+              # actually ran.
               setup_command: >-
-                echo byoc-setup-ran > "$GB_BUILD_WORKDIR/setup_marker"
+                echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
               # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so this runs from inside the cloned repo.
+              # the clone first, so the marker written into code/ is right here.
               # `test -f` fails the step (set -eu) unless setup_command wrote the
               # sentinel, so reaching SUCCESS proves the setup phase ran it.
               command: >-
-                test -f "$GB_BUILD_WORKDIR/setup_marker";
-                echo "setup marker: $(cat "$GB_BUILD_WORKDIR/setup_marker")";
+                test -f setup_marker;
+                echo "setup marker: $(cat setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/test-data/steps/byoc/skypilot/slurm/build.yaml
+++ b/test-data/steps/byoc/skypilot/slurm/build.yaml
@@ -20,7 +20,7 @@ granite.build:
       steps:
         # The byoc step, resolved from the Space rendered by `make space` (see the
         # test's _get_test_specification). It git-clones the repo below during
-        # `setup` and runs `command` from inside the clone during `run`.
+        # `setup` and runs `command` from the workdir root during `run`.
         - step_uri: space://steps/byoc
           config:
             # Fast completion detection for the test (base skypilot default is
@@ -43,13 +43,14 @@ granite.build:
               setup_command: >-
                 echo byoc-setup-ran > code/setup_marker
               # Emits the artifact marker skypilot_monitor captures. The path must
-              # equal the env:// output uri path above. byoc's run block cd's into
-              # the clone first, so the marker written into code/ is right here.
-              # `test -f` fails the step (set -eu) unless setup_command wrote the
-              # sentinel, so reaching SUCCESS proves the setup phase ran it.
+              # equal the env:// output uri path above. run starts in the workdir
+              # root (same as setup), so the marker setup wrote lives at
+              # code/setup_marker. `test -f` fails the step (set -eu) unless
+              # setup_command wrote the sentinel, so reaching SUCCESS proves the
+              # setup phase ran it.
               command: >-
-                test -f setup_marker;
-                echo "setup marker: $(cat setup_marker)";
+                test -f code/setup_marker;
+                echo "setup marker: $(cat code/setup_marker)";
                 echo "env input path: {{ bindings.env_input.binding.path }}";
                 echo "LLMB_ARTIFACT_ID:env_output LLMB_ARTIFACT_PATH:/tmp/gb-byoc-output.txt"
             compute_config:

--- a/test/integration/ibm/buildrunner/skypilot/aws/test_filemount.py
+++ b/test/integration/ibm/buildrunner/skypilot/aws/test_filemount.py
@@ -24,7 +24,7 @@ missing), exercising the SkyPilot launcher's relative-source resolution against
 the step.yaml dir on the AWS path.
 
 Runs BARE (empty ``command_config.image``): file_mounts land in the VM run
-workdir (``${GB_BUILD_WORKDIR}``), which is the run command's CWD, so
+workdir, which is the run command's CWD, so
 ``./payload`` is reachable directly — no container indirection (bluevela used
 enroot to also exercise in-container visibility).
 

--- a/test/unit/environment/test_skypilot_slurm.py
+++ b/test/unit/environment/test_skypilot_slurm.py
@@ -255,8 +255,8 @@ class TestBuildWorkdir:
         self, slurm_env
     ):
         """launch_skypilot reads setup_config.skypilot.build_workdir,
-        exports GB_BUILD_WORKDIR, and prepends mkdir+cd to both the setup and
-        run scripts so step authors can use relative paths."""
+        exports GB_BUILD_WORKDIR, and prepends set -eu + mkdir+cd to both the
+        setup and run scripts so step authors can use relative paths."""
         mock_sky = _mock_sky()
 
         with (
@@ -277,7 +277,7 @@ class TestBuildWorkdir:
 
         task_kwargs = mock_sky.Task.call_args[1]
         assert task_kwargs["envs"]["GB_BUILD_WORKDIR"] == "/shared/builds/b/runs/r"
-        cd_prefix = 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
+        cd_prefix = 'set -eu\nmkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
         run_script = task_kwargs["run"]
         assert run_script.startswith(cd_prefix)
         assert run_script.endswith("hostname")
@@ -288,8 +288,8 @@ class TestBuildWorkdir:
     @pytest.mark.asyncio
     async def test_launch_skypilot_skips_cd_when_workdir_unset(self, slurm_env):
         """No build_workdir in setup_config -> GB_BUILD_WORKDIR is not exported
-        and no cd is prepended, so the run script is left untouched and runs in
-        SkyPilot's default ~/sky_workdir (where relative file_mounts land)."""
+        and no cd is prepended (only the leading set -eu), so the run script runs
+        in SkyPilot's default ~/sky_workdir (where relative file_mounts land)."""
         mock_sky = _mock_sky()
 
         with (
@@ -306,7 +306,8 @@ class TestBuildWorkdir:
         task_kwargs = mock_sky.Task.call_args[1]
         envs = task_kwargs["envs"] or {}
         assert "GB_BUILD_WORKDIR" not in envs
-        assert task_kwargs["run"] == "hostname"
+        # set -eu is always prepended; no mkdir/cd is injected without a workdir.
+        assert task_kwargs["run"] == "set -eu\nhostname"
 
     @pytest.mark.asyncio
     async def test_teardown_skypilot_removes_stashed_workdir(self, slurm_env):

--- a/test/unit/environment/test_skypilot_slurm.py
+++ b/test/unit/environment/test_skypilot_slurm.py
@@ -277,8 +277,7 @@ class TestBuildWorkdir:
 
         task_kwargs = mock_sky.Task.call_args[1]
         assert task_kwargs["envs"]["GB_BUILD_WORKDIR"] == "/shared/builds/b/runs/r"
-        # The cd falls back to $HOME (resolved remotely) when the var is unset.
-        cd_prefix = 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "${GB_BUILD_WORKDIR:-$HOME}"\n'
+        cd_prefix = 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
         run_script = task_kwargs["run"]
         assert run_script.startswith(cd_prefix)
         assert run_script.endswith("hostname")
@@ -287,10 +286,10 @@ class TestBuildWorkdir:
         assert setup_script.endswith("echo prep")
 
     @pytest.mark.asyncio
-    async def test_launch_skypilot_cds_to_home_when_workdir_unset(self, slurm_env):
+    async def test_launch_skypilot_skips_cd_when_workdir_unset(self, slurm_env):
         """No build_workdir in setup_config -> GB_BUILD_WORKDIR is not exported
-        and the run script cd's into $HOME (via ${GB_BUILD_WORKDIR:-$HOME}, with
-        no mkdir) so the step still starts in a known directory."""
+        and no cd is prepended, so the run script is left untouched and runs in
+        SkyPilot's default ~/sky_workdir (where relative file_mounts land)."""
         mock_sky = _mock_sky()
 
         with (
@@ -307,7 +306,7 @@ class TestBuildWorkdir:
         task_kwargs = mock_sky.Task.call_args[1]
         envs = task_kwargs["envs"] or {}
         assert "GB_BUILD_WORKDIR" not in envs
-        assert task_kwargs["run"] == 'cd "${GB_BUILD_WORKDIR:-$HOME}"\nhostname'
+        assert task_kwargs["run"] == "hostname"
 
     @pytest.mark.asyncio
     async def test_teardown_skypilot_removes_stashed_workdir(self, slurm_env):

--- a/test/unit/environment/test_skypilot_slurm.py
+++ b/test/unit/environment/test_skypilot_slurm.py
@@ -255,7 +255,8 @@ class TestBuildWorkdir:
         self, slurm_env
     ):
         """launch_skypilot reads setup_config.skypilot.build_workdir,
-        exports GB_BUILD_WORKDIR, and prepends mkdir+cd to the run script."""
+        exports GB_BUILD_WORKDIR, and prepends mkdir+cd to both the setup and
+        run scripts so step authors can use relative paths."""
         mock_sky = _mock_sky()
 
         with (
@@ -265,23 +266,31 @@ class TestBuildWorkdir:
             slurm_env._get_launch_ready_event("bw-1")
             await slurm_env.launch_skypilot(
                 launch_id="bw-1",
-                launcher_config={"run": "hostname", "resources": {}},
+                launcher_config={
+                    "run": "hostname",
+                    "setup": "echo prep",
+                    "resources": {},
+                },
                 config={},
                 setup_config={"skypilot": {"build_workdir": "/shared/builds/b/runs/r"}},
             )
 
         task_kwargs = mock_sky.Task.call_args[1]
         assert task_kwargs["envs"]["GB_BUILD_WORKDIR"] == "/shared/builds/b/runs/r"
+        # The cd falls back to $HOME (resolved remotely) when the var is unset.
+        cd_prefix = 'mkdir -p "$GB_BUILD_WORKDIR"\ncd "${GB_BUILD_WORKDIR:-$HOME}"\n'
         run_script = task_kwargs["run"]
-        assert run_script.startswith(
-            'mkdir -p "$GB_BUILD_WORKDIR"\ncd "$GB_BUILD_WORKDIR"\n'
-        )
+        assert run_script.startswith(cd_prefix)
         assert run_script.endswith("hostname")
+        setup_script = task_kwargs["setup"]
+        assert setup_script.startswith(cd_prefix)
+        assert setup_script.endswith("echo prep")
 
     @pytest.mark.asyncio
-    async def test_launch_skypilot_skips_workdir_wiring_when_unset(self, slurm_env):
-        """No build_workdir in setup_config -> run script is unchanged
-        and GB_BUILD_WORKDIR is not exported."""
+    async def test_launch_skypilot_cds_to_home_when_workdir_unset(self, slurm_env):
+        """No build_workdir in setup_config -> GB_BUILD_WORKDIR is not exported
+        and the run script cd's into $HOME (via ${GB_BUILD_WORKDIR:-$HOME}, with
+        no mkdir) so the step still starts in a known directory."""
         mock_sky = _mock_sky()
 
         with (
@@ -298,7 +307,7 @@ class TestBuildWorkdir:
         task_kwargs = mock_sky.Task.call_args[1]
         envs = task_kwargs["envs"] or {}
         assert "GB_BUILD_WORKDIR" not in envs
-        assert task_kwargs["run"] == "hostname"
+        assert task_kwargs["run"] == 'cd "${GB_BUILD_WORKDIR:-$HOME}"\nhostname'
 
     @pytest.mark.asyncio
     async def test_teardown_skypilot_removes_stashed_workdir(self, slurm_env):


### PR DESCRIPTION
## Description
Steps should not be aware of where they are running their commands.  And for skypilot/aws or any skypilot env w/o a `shared_work`dir defined, there is no GB_BUILD_WORKDIR.  So, we update the setup and run scripts to cd to a  GB_BUILD_WORKDIR only when available, otherwise we use whatever skypilot's workdir is.  we do not use GB_BUILD_WORKDIR in the step.yaml or document in the .md files.

Also change the `byoc` step to not cd into the cloned repo.  All steps should start in whatever working dir is provided to them.

This also fixes a regression created in #274 that failed steps that have `README.md` next to the `step.yaml`. Problem was that jinja was applied to the `README.md` incorrectly.  Solution is to add a `.gbignore` to ignore this - and the optional `src` directory.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
