### PR TITLE
Remove support for ~ in skypilot file_mounts 

### DIFF
--- a/docs/environments/skypilot-lsf.md
+++ b/docs/environments/skypilot-lsf.md
@@ -165,9 +165,9 @@ destination shape:
   workdir; requires `shared_workdir` on the environment.
 - **absolute** destinations under a shared, identity-mounted root (e.g. `/proj/…`) are likewise written
   directly — the author's explicit shared-FS location, reachable at the same path in the container.
-- **`~/…`** destinations keep SkyPilot's default behavior and land under the login-node cluster home;
-  they are **not** visible inside the container. Avoid `~/…` for container steps — use a relative
-  destination instead.
+- **`~/…`** destinations are **rejected** by the launcher (`~` is not expanded). They would land under
+  the login-node cluster home and be **invisible inside the container**, so `file_mounts` forbids them —
+  use a relative destination instead.
 
 Prefer a **relative** destination (see [file_mounts](skypilot.md#file_mounts)) — it is the simplest and
 gives per-target isolation, with the payload written onto the shared workdir for the job to read.

--- a/docs/environments/skypilot.md
+++ b/docs/environments/skypilot.md
@@ -271,8 +271,10 @@ its shape:
 | Destination | Lands at | Scope / lifetime |
 |-------------|----------|------------------|
 | **relative** (`payload`, `./payload`, `sub/payload`) | `<per-run-workdir>/<dst>` — the run script's CWD | per-target-run, persistent, shared across the target's steps |
-| **`~/…`** | the container's private home (on containerized LSF, staged then copied inside the container) | per-launch, container-private, ephemeral |
 | **absolute** (`/proj/…`, `/tmp/…`) | that literal path (author's responsibility) | as-is |
+
+A **`~`/`~/…` destination is rejected** (like a `~` source): `~` is not expanded by the launcher, so
+`file_mounts` has a single destination model — relative, or absolute for a fixed location.
 
 **Relative in, relative out.** Because the `run` script's CWD is the per-run workdir, a **relative**
 destination puts the payload at exactly `./<dst>` — the same path, relative to the step, that the
@@ -288,9 +290,8 @@ config:
     ./payload/run-eval.sh   # CWD is the per-run workdir, so the mount is right here
 ```
 
-Use **`~/…`** when you deliberately want the payload private to a single launch (not shared with other
-steps in the target). Use an **absolute** path only when you must hit a fixed location. When
-`shared_workdir` is *not* set, relative destinations fall back to SkyPilot's default (`~/sky_workdir/…`).
+Use an **absolute** path only when you must hit a fixed location. When `shared_workdir` is *not* set,
+relative destinations fall back to SkyPilot's default (`~/sky_workdir/…`).
 
 #### `envs`, `post_launch_task`, `idle_minutes_to_autostop`
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -279,6 +279,27 @@ def _escapes_parent(rel_path: str) -> bool:
     return rel == ".." or rel.startswith(".." + os.sep)
 
 
+def _reject_home_prefixed(path: str, role: str) -> None:
+    """Reject a ``~``/``~/``-prefixed ``file_mounts`` path.
+
+    This launcher never expands ``~``: a ``~`` *source* would resolve to a literal
+    ``~`` directory under the step dir, and a ``~`` *destination* would sidestep
+    the single relative/absolute destination convention (it lands outside the
+    per-run workdir and, on containerized LSF, outside the container). Both roles
+    reject it so ``file_mounts`` has one consistent path model. Shared by the
+    source and destination guards.
+
+    :param path: the source or destination path from a ``file_mounts`` entry.
+    :param role: ``"source"`` or ``"destination"`` — named in the error message.
+    :raises ValueError: if ``path`` equals ``~`` or begins with ``~/``.
+    """
+    if path == "~" or path.startswith("~/"):
+        raise ValueError(
+            f"file_mounts {role} {path!r} uses '~', which is not expanded; "
+            f"use a relative or absolute path instead"
+        )
+
+
 def _resolve_local_mount_source(source: str, asset_dir: Union[Path, str, None]) -> str:
     """Resolve a ``file_mounts`` local source against the step's asset dir.
 
@@ -308,12 +329,7 @@ def _resolve_local_mount_source(source: str, asset_dir: Union[Path, str, None]) 
         return source
     if os.path.isabs(source):
         return source  # absolute host path — author's explicit choice
-    if source == "~" or source.startswith("~/"):
-        raise ValueError(
-            f"file_mounts source {source!r} uses '~', which is not expanded "
-            f"for sources; use an absolute path or one relative to the step "
-            f"directory"
-        )
+    _reject_home_prefixed(source, "source")
     if _escapes_parent(source):
         raise ValueError(
             f"file_mounts source {source!r} uses '..' to escape the step "
@@ -332,19 +348,6 @@ def _resolve_local_mount_source(source: str, asset_dir: Union[Path, str, None]) 
     return str(base / source)
 
 
-def _is_remappable_relative(dst: str) -> bool:
-    """Return whether ``dst`` is a plain relative ``file_mounts`` destination.
-
-    Absolute paths and ``~``/``~/``-prefixed paths opt out of the per-run-workdir
-    remap (they are the author's explicit location); everything else is treated
-    as relative to the build workdir.
-
-    :param dst: a ``file_mounts`` destination key.
-    :returns: ``True`` if the destination should be remapped, else ``False``.
-    """
-    return not (os.path.isabs(dst) or dst == "~" or dst.startswith("~/"))
-
-
 def _remap_relative_dest(dst: str, build_workdir: Optional[str]) -> str:
     """Map a relative ``file_mounts`` destination into the per-run workdir.
 
@@ -360,25 +363,29 @@ def _remap_relative_dest(dst: str, build_workdir: Optional[str]) -> str:
     ``sky/provision/lsf`` runner hook), so no container staging or copy-back is
     needed.
 
-    Absolute and ``~``-prefixed destinations pass through unchanged (author's
-    explicit choice). When ``build_workdir`` is unset (envs without
-    ``shared_workdir``) a relative destination is likewise returned unchanged,
-    preserving SkyPilot's own ``~/sky_workdir/`` rewrite.
+    Absolute destinations pass through unchanged (the author's explicit fixed
+    location). When ``build_workdir`` is unset (envs without ``shared_workdir``) a
+    relative destination is likewise returned unchanged, preserving SkyPilot's own
+    ``~/sky_workdir/`` rewrite.
 
-    A relative destination that uses ``..`` to climb out of its target directory
-    (e.g. ``../foo``) is always rejected — whether or not a remap applies — so it
-    can neither escape the per-run workdir nor SkyPilot's default rewrite. This
-    is an authoring guard, not a security boundary; the step author controls the
-    destination.
+    A ``~``/``~/``-prefixed destination is rejected, mirroring the source guard in
+    :func:`_resolve_local_mount_source`: ``~`` is never expanded by this launcher,
+    so ``file_mounts`` has a single destination convention — relative, or absolute
+    for a fixed location. A relative destination that uses ``..`` to climb out of
+    its target directory (e.g. ``../foo``) is likewise rejected — whether or not a
+    remap applies — so it can leave neither the per-run workdir nor SkyPilot's
+    default rewrite. These are authoring guards, not a security boundary; the step
+    author controls the destination.
 
     :param dst: the destination key from the raw ``file_mounts`` mapping.
     :param build_workdir: absolute per-run workdir, or ``None`` to disable remap.
     :returns: the (possibly rewritten) destination path.
-    :raises ValueError: if a relative ``dst`` escapes its target directory via
-        ``..`` traversal.
+    :raises ValueError: if ``dst`` is ``~``/``~/``-prefixed, or a relative ``dst``
+        escapes its target directory via ``..`` traversal.
     """
-    if not _is_remappable_relative(dst):
-        return dst  # absolute / ~-prefixed: author's explicit location
+    _reject_home_prefixed(dst, "destination")
+    if os.path.isabs(dst):
+        return dst  # absolute: author's explicit fixed location, left as-is
     # Reject ``..`` escapes regardless of whether a build_workdir remap follows,
     # so the destination can leave neither the per-run workdir nor SkyPilot's
     # default rewrite.

--- a/test-data/integration/standalone/buildrunner/skypilot_slurm/filemount/space/steps/filemount-check/step.yaml
+++ b/test-data/integration/standalone/buildrunner/skypilot_slurm/filemount/space/steps/filemount-check/step.yaml
@@ -22,19 +22,20 @@ environment_configs:
           # Copy the `payload/` directory that ships next to THIS step.yaml onto
           # the cluster. The source is relative, so the Skypilot launcher resolves
           # it against the step.yaml's own directory (the per-run asset dir) — this
-          # is the behavior under test. The destination is a fixed remote path,
-          # which the run command below reads back to confirm the copy landed.
+          # is the behavior under test. The destination is also relative, so it
+          # lands under the step's working directory (the run CWD); the run command
+          # below reads it back from there to confirm the copy landed.
           file_mounts:
-            ~/gb-filemount-payload: payload
+            payload: payload
           run: |
             set -euo pipefail
             # Verify file_mounts copied the step-relative payload dir to the
-            # destination declared above. `set -e` + `test` fail the step (=>
-            # build FAILED) if the dir/file is absent.
+            # matching relative path in the run CWD. `set -e` + `test` fail the
+            # step (=> build FAILED) if the dir/file is absent.
             echo "verifying file_mounts copied the step-relative payload dir..."
-            test -d ~/gb-filemount-payload
-            test -f ~/gb-filemount-payload/marker.txt
-            echo "payload marker: $(cat ~/gb-filemount-payload/marker.txt)"
+            test -d ./payload
+            test -f ./payload/marker.txt
+            echo "payload marker: $(cat ./payload/marker.txt)"
             # Build-supplied command (emits the artifact markers, mirroring the
             # builtin command step).
             {{ config.command_config.command }}

--- a/test/unit/environment/test_skypilot.py
+++ b/test/unit/environment/test_skypilot.py
@@ -160,12 +160,20 @@ class TestRemapRelativeDest:
         assert _remap_relative_dest("./foo", "/wd") == "/wd/foo"
         assert _remap_relative_dest("sub/foo", "/wd") == "/wd/sub/foo"
 
-    def test_absolute_and_home_dests_unchanged(self):
+    def test_absolute_dest_unchanged(self):
         from gbserver.environment.skypilot import _remap_relative_dest
 
         assert _remap_relative_dest("/abs/foo", "/wd") == "/abs/foo"
-        assert _remap_relative_dest("~/foo", "/wd") == "~/foo"
-        assert _remap_relative_dest("~", "/wd") == "~"
+
+    @pytest.mark.parametrize("dst", ["~", "~/foo", "~/sub/dir"])
+    def test_home_dest_rejected(self, dst):
+        from gbserver.environment.skypilot import _remap_relative_dest
+
+        # '~' is not expanded for destinations either: it would sidestep the
+        # single relative/absolute convention and land outside the per-run
+        # workdir, so reject it (mirroring the source-side guard).
+        with pytest.raises(ValueError, match="~"):
+            _remap_relative_dest(dst, "/wd")
 
     def test_noop_without_build_workdir(self):
         from gbserver.environment.skypilot import _remap_relative_dest


### PR DESCRIPTION
## Description

The destination of the file_mounts section allowed `~/` in the destination path.  This is duplicate way of specifying a path relative to the step cwd, so that  `~/foo` is equivalent to `foo`.  No reason to allow 2 mechanisms for this. So we remove support for `~` in `file_mounts`

Note: This is removing functionality that was added recently, but I don't expect anyone to have made use of.  And of course, it has been removed from the repo itself.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
