### PR TITLE
Add `gb build continue` and `--show-skipped-targets`

### DIFF
--- a/docs/builds/README.md
+++ b/docs/builds/README.md
@@ -161,6 +161,7 @@ end, try the [demos](../demos/README.md).
 
 - [Retry overview](retry.md) — how build- and step-level retry fit together.
 - [Build retry](build-retry.md) — re-run a failed build as a new attempt.
+- [Build continuation](build-continuation.md) — continue any finished build in a fresh runner, skipping succeeded targets.
 - [Step retry](step-retry-configuration.md) — re-launch a single step on a transient error.
 - [Target reuse](target-reuse.md) — skip unchanged targets across builds.
 - [Lineage tracking](lineage.md) — record build/target/artifact provenance.

--- a/docs/builds/build-continuation.md
+++ b/docs/builds/build-continuation.md
@@ -1,0 +1,89 @@
+# Build Continuation
+
+Build continuation re-runs a previously-executed build in a **fresh** build runner,
+**skipping targets that already succeeded** and re-running the rest. Use it to pick a build
+back up from where it left off after a failure or interruption — without re-running work
+that already completed.
+
+```shell
+gb build continue <BUILD_ID>
+```
+
+`<BUILD_ID>` may be a build id or a build URL. No local build folder is required — the build
+definition, space, and targets are taken from the previous build.
+
+The name is inspired by `curl -C` (resuming a partial download). It is distinct from
+[build-level retry](build-retry.md) and from step-level retry.
+
+## When to use it
+
+A build can fail for many reasons — a build-definition error, a transient cluster problem, a
+cancelled run. Continuation does not care *why* the previous build stopped: any **finished**
+build can be continued. It just continues from where the previous run left off.
+
+Continuation differs from re-initializing a fresh build with
+`gb build init --from-build <ID>` followed by `gb build start`: that path creates a brand-new,
+unrelated build and re-runs **every** target from scratch. Continuation reuses the targets that
+already succeeded.
+
+## Behaviour
+
+`gb build continue <BUILD_ID>` creates a **new** build (a new build id) that extends the
+previous build's chain, and submits it through the ordinary build path — so the BuildWatcher
+dispatches a fresh runner for it, exactly like any other build. The new build:
+
+1. Links to the previous build via `retry_of_build_id` (pointing at the root of the previous
+   build's chain), so the runner's target-reuse machinery is engaged.
+2. Starts with `retry_count = 0`, so the `max_retries` budget from `build.yaml` is counted
+   **fresh** for the continuation, independent of how many retries the previous chain already
+   consumed.
+3. Re-runs the previous build's targets, **skipping** any target that already succeeded
+   anywhere in the chain (see [target reuse](target-reuse.md)). A skipped target's
+   `StoredTargetRun.skipped_for_prerun_target_id` points back to the original successful run.
+
+Because the continuation is an ordinary build, everything that already works for a build works
+for it: it retries its own remaining targets up to `max_retries`, cancellation spans the whole
+chain, and `gb build status` shows the skipped and re-run targets together.
+
+## The previous build must be finished
+
+A continuation spins up a **fresh** runner, so the previous build must not still be active — a
+build that is `PENDING`, `RUNNING`, `RETRY_PENDING`, or `CANCEL_REQUESTED` still has (or is
+about to have) a runner working it. Continuing such a build is rejected (HTTP `409`). Only a
+finished build (`SUCCESS`, `FAILED`, `INVALID`, or `CANCELLED`) can be continued.
+
+Continuing a `SUCCESS` build is allowed and simply re-runs any targets that were not part of
+that build's successful set (or completes immediately if there is nothing left to do).
+
+## Continuing a build that was already retried
+
+If the build you name is part of a retry chain (it was retried, or is itself a retry), the
+continuation is linked to the **root** of that chain, so target reuse spans **all** prior
+attempts in the chain — you may pass **any** member of the chain and the server resolves the
+canonical root for you (it is reported back on the command line and in the `--format json`
+output as `root_build_id`).
+
+Continuations are **appended to the current tip** of the chain, so continuing repeatedly keeps
+the chain linear (`A → B → C`) rather than branching into several chains that share a root. A
+single `gb build status --follow-retries` therefore shows every attempt — original, auto-retries,
+and continuations — in one view.
+
+> **Note:** issuing two continuations of the *same finished tip* at the exact same moment can
+> race on the tip's forward link (last write wins), leaving one continuation reachable only via
+> its `retry_of_build_id` (the root) rather than the forward `--follow-retries` walk. This is a
+> narrow, user-initiated window; continue a build once and wait for it to appear before
+> continuing again.
+
+## Relationship to retry
+
+| | Build-level retry | Build continuation |
+|---|---|---|
+| Trigger | build ends `FAILED` and `retry_count < max_retries` | explicit `gb build continue` |
+| Runner | same, in-process retry loop | a **fresh** runner |
+| Applies to | only a `FAILED` build | **any** finished build |
+| `max_retries` | consumed across the chain | **reset**: counted fresh |
+| New build record | yes (linked via `retry_of_build_id`) | yes (linked via `retry_of_build_id`) |
+| Target reuse | yes, across the chain | yes, across the chain |
+
+Both mechanisms reuse the same [target-reuse](target-reuse.md) machinery; continuation simply
+starts a fresh runner on a fresh `max_retries` budget for an arbitrary finished build.

--- a/docs/builds/build-continuation.md
+++ b/docs/builds/build-continuation.md
@@ -43,7 +43,8 @@ dispatches a fresh runner for it, exactly like any other build. The new build:
 
 Because the continuation is an ordinary build, everything that already works for a build works
 for it: it retries its own remaining targets up to `max_retries`, cancellation spans the whole
-chain, and `gb build status` shows the skipped and re-run targets together.
+chain, and `gb build status --follow-retries` (the default) presents the whole chain as one view
+(reused targets are hidden unless you pass `--show-skipped-targets` — see below).
 
 ## The previous build must be finished
 
@@ -52,8 +53,9 @@ build that is `PENDING`, `RUNNING`, `RETRY_PENDING`, or `CANCEL_REQUESTED` still
 about to have) a runner working it. Continuing such a build is rejected (HTTP `409`). Only a
 finished build (`SUCCESS`, `FAILED`, `INVALID`, or `CANCELLED`) can be continued.
 
-Continuing a `SUCCESS` build is allowed and simply re-runs any targets that were not part of
-that build's successful set (or completes immediately if there is nothing left to do).
+Continuing a `SUCCESS` build is allowed: every target whose prior run still counts as reusable
+(same `target_hash`, all output artifacts still registered) is skipped, so a fully-successful
+build with unchanged artifacts finishes immediately with nothing to re-run.
 
 ## Continuing a build that was already retried
 

--- a/docs/builds/build-continuation.md
+++ b/docs/builds/build-continuation.md
@@ -68,6 +68,10 @@ the chain linear (`A → B → C`) rather than branching into several chains tha
 single `gb build status --follow-retries` therefore shows every attempt — original, auto-retries,
 and continuations — in one view.
 
+Skipped (reused) targets are **hidden by default** in `gb build status` and `gb build monitor`
+output — they run no steps and produce no artifacts, and hiding them keeps the output short. Pass
+`--show-skipped-targets` to include them.
+
 > **Note:** issuing two continuations of the *same finished tip* at the exact same moment can
 > race on the tip's forward link (last write wins), leaving one continuation reachable only via
 > its `retry_of_build_id` (the root) rather than the forward `--follow-retries` walk. This is a

--- a/docs/builds/build-retry.md
+++ b/docs/builds/build-retry.md
@@ -150,3 +150,11 @@ These are two independent mechanisms:
 
 A build-level retry only fires after the build has fully failed — i.e. after all step-level
 retries for that run have been exhausted.
+
+## Relationship to build continuation
+
+Build-level retry runs automatically, in the same runner, only for a `FAILED` build, within the
+`max_retries` budget. To re-run an **arbitrary finished build** (for any reason) in a **fresh**
+runner — skipping targets that already succeeded — use
+[build continuation](build-continuation.md) (`gb build continue <BUILD_ID>`), which reuses the
+same target-reuse machinery but on a fresh `max_retries` budget.

--- a/docs/builds/build-retry.md
+++ b/docs/builds/build-retry.md
@@ -134,6 +134,9 @@ When a target is skipped this way:
 This means a retry build only re-runs the targets that did not succeed in the original build,
 making retries as cheap as possible.
 
+Skipped targets are **hidden by default** in `gb build status` and `gb build monitor` output
+(they run no steps and produce no artifacts); pass `--show-skipped-targets` to include them.
+
 See [target-reuse.md](target-reuse.md) for the full architecture, hash correctness argument,
 and storage details.
 

--- a/docs/cli/gb-cli-reference.md
+++ b/docs/cli/gb-cli-reference.md
@@ -40,6 +40,7 @@ Most-used group. Submit, monitor, and inspect builds.
 | `gb build status <build-id>` | Show status and per-step state. |
 | `gb build log <build-id>` | Stream or fetch build logs. |
 | `gb build cancel <build-id>` | Cancel a running build. |
+| `gb build continue <build-id>` | Continue a finished build in a fresh runner, skipping succeeded targets. |
 | `gb build describe [<build-id> \| -f <build.yaml>]` | Describe targets and steps. |
 | `gb build diff <build-id-1> [<build-id-2>]` | Diff two builds (or one against its `build.yaml`). |
 | `gb build lineage <build-id>` | Show build lineage. |

--- a/docs/cli/gb-cli-reference.md
+++ b/docs/cli/gb-cli-reference.md
@@ -37,7 +37,7 @@ Most-used group. Submit, monitor, and inspect builds.
 | `gb build start [-f <build.yaml>] [TARGETS...]` | Submit a build. Optionally name specific targets. |
 | `gb build validate [TARGETS...]` | Validate without submitting. |
 | `gb build list` | List builds. |
-| `gb build status <build-id>` | Show status and per-step state. |
+| `gb build status <build-id>` | Show status and per-step state. Skipped (reused) targets are hidden unless `--show-skipped-targets` is passed. |
 | `gb build log <build-id>` | Stream or fetch build logs. |
 | `gb build cancel <build-id>` | Cancel a running build. |
 | `gb build continue <build-id>` | Continue a finished build in a fresh runner, skipping succeeded targets. |

--- a/src/gbcli/client/client.py
+++ b/src/gbcli/client/client.py
@@ -39,6 +39,7 @@ from gbcli.services.service_auth import (
 )
 from gbcli.services.service_build import (
     build_cancel,
+    build_continue,
     build_describe,
     build_diff,
     build_init,
@@ -689,6 +690,16 @@ class GBClient:
         ) -> Any:
             return build_cancel(
                 self.github_token, build_id, id_format, space, callback=callback
+            )
+
+        def build_continue(
+            self,
+            build_id: str,
+            id_format: Optional[str] = None,
+            callback=None,
+        ) -> Optional[dict]:
+            return build_continue(
+                self.github_token, build_id, id_format, callback=callback
             )
 
         def build_lineage(self, build_id: str, id_format: str, callback=None):

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -1155,6 +1155,106 @@ def cancel(ctx, space, build_id, format, skip_version_check, quiet):
         ctx.exit(1)  # Exit with a non-zero status
 
 
+@cli.command("continue")
+@click.pass_context
+@click.argument("build_id", required=True)
+@click.option(
+    "--format",
+    "format",
+    default="simple",
+    type=click.Choice(["simple", "json"], case_sensitive=True),
+    help="Output format: simple (default), json",
+)
+@common_options
+def continue_build_cmd(ctx, build_id, format, skip_version_check, quiet):
+    """
+    Continue a previously-executed build
+
+    Provide build ID or URL. A fresh build runner re-runs the build, skipping
+    targets that already succeeded and re-running the rest. The build must be
+    finished (not currently running). No local build folder is required — the
+    build definition is sourced from the previous build.
+    """
+    if format == "json":
+        quiet = True
+    if not skip_version_check:
+        try:
+            outdated_version = check_current_and_latest_versions()
+        except Exception as e:
+            click.echo(f"❌ {str(e)}.", err=True)
+            ctx.exit(1)  # Exit with a non-zero status
+        if outdated_version:
+            click.echo(outdated_version, err=True)
+            ctx.exit(1)  # Exit with a non-zero status
+
+    id_format = parse_build_identifier(build_id)
+    if id_format not in ["uuid", "url"]:
+        click.echo(
+            f"❌ Build identifier formatted incorrectly. Please try again with valid build ID or URL.",
+            err=True,
+        )
+        sys.exit(1)
+
+    if id_format == "uuid" and len(build_id) < 36:
+        click.echo(
+            f"❌ Build ID formatted incorrectly. Please try again with a valid build ID.",
+            err=True,
+        )
+        sys.exit(1)
+
+    if not quiet:
+        click.echo(f"🏁 {PROJECT_NAME} build continue")
+
+    build_client = GBClient.Build(get_user_token())
+
+    def echo_callback(callback_event: str, callback_args: Dict):
+        match callback_event:
+            case "error":
+                reason = callback_args.get("reason", "")
+                click.echo(
+                    f"\n❌ Build can't be continued at this moment... Reason: {reason}",
+                    err=True,
+                )
+                sys.exit(1)  # Exit with a non-zero status
+            case _:
+                pass
+
+    try:
+        result = build_client.build_continue(
+            build_id, id_format, callback=echo_callback
+        )
+
+        if result:
+            new_build_id = result["build_id"]
+            # The server resolves the chain root from whichever member was passed.
+            root_build_id = result.get("root_build_id")
+            details_page = f"{WEB_UI_URL}/builds/{new_build_id}"
+            if not quiet:
+                click.echo(
+                    f"✅ Continuing build {build_id} as new build: {details_page}"
+                )
+                if root_build_id and root_build_id != build_id:
+                    click.echo(f"   (continues build chain rooted at {root_build_id})")
+                click.echo(f"""To get the build status of the whole chain:
+```
+gb build status {new_build_id}
+```""")
+            if format == "json":
+                click.echo(
+                    json.dumps(
+                        {
+                            "build_id": new_build_id,
+                            "root_build_id": root_build_id,
+                            "continued_from": build_id,
+                        }
+                    )
+                )
+
+    except Exception as e:
+        click.echo(str_exc_chain(e), err=True)
+        ctx.exit(1)  # Exit with a non-zero status
+
+
 @cli.command()
 @pass_context_and_reject_standalone("build lineage")
 @click.argument("build_id", required=True)

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -110,8 +110,11 @@ def execution_status_plain_output(
 
     # A skipped target was reused from an earlier attempt (retry or continuation):
     # it ran no steps and produced no artifacts, so hide it by default to keep the
-    # output short. --show-skipped-targets brings them back.
+    # output short. --show-skipped-targets brings them back. Number targets by their
+    # position in the FULL list (captured before filtering) so hiding some does not
+    # renumber the rest — a displayed "Target #N" always matches the build's order.
     total_target_count = len(targets)
+    target_number = {name: idx + 1 for idx, name in enumerate(targets)}
     if not show_skipped_targets:
         targets = {
             name: info
@@ -121,8 +124,8 @@ def execution_status_plain_output(
     hidden_skipped_count = total_target_count - len(targets)
 
     targets_overview = [
-        f"\n\tTarget #{index + 1} {target}: {target_status_emoji(targets[target])} {target_status_label(targets[target])}\n"
-        for index, target in enumerate(targets)
+        f"\n\tTarget #{target_number[target]} {target}: {target_status_emoji(targets[target])} {target_status_label(targets[target])}\n"
+        for target in targets
     ]
     if hidden_skipped_count > 0:
         targets_overview.append(
@@ -156,7 +159,7 @@ def execution_status_plain_output(
     """
 
     target_outputs = []
-    for index, target in enumerate(targets):
+    for target in targets:
         input_artifacts_table = [
             [i["artifact_id"], i["uri"]] for i in targets[target]["input_artifacts"]
         ]
@@ -226,7 +229,7 @@ def execution_status_plain_output(
         target_output = f"""
 ---
 
-## Target #{index + 1} {target}
+## Target #{target_number[target]} {target}
 
 {target_status_emoji(targets[target])} **Status**: {status_line}{build_id_line}
 {sections}

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -1250,12 +1250,16 @@ def continue_build_cmd(ctx, build_id, format, skip_version_check, quiet):
             new_build_id = result["build_id"]
             # The server resolves the chain root from whichever member was passed.
             root_build_id = result.get("root_build_id")
+            # Resolved uuid of the continued build (a passed URL is resolved to a
+            # uuid in the service layer); use it — not the raw argument — so the
+            # root comparison and JSON never see a URL.
+            continued_from = result.get("continued_from", build_id)
             details_page = f"{WEB_UI_URL}/builds/{new_build_id}"
             if not quiet:
                 click.echo(
-                    f"✅ Continuing build {build_id} as new build: {details_page}"
+                    f"✅ Continuing build {continued_from} as new build: {details_page}"
                 )
-                if root_build_id and root_build_id != build_id:
+                if root_build_id and root_build_id != continued_from:
                     click.echo(f"   (continues build chain rooted at {root_build_id})")
                 click.echo(f"""To get the build status of the whole chain:
 ```
@@ -1267,7 +1271,7 @@ gb build status {new_build_id}
                         {
                             "build_id": new_build_id,
                             "root_build_id": root_build_id,
-                            "continued_from": build_id,
+                            "continued_from": continued_from,
                         }
                     )
                 )

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -1250,16 +1250,17 @@ def continue_build_cmd(ctx, build_id, format, skip_version_check, quiet):
             new_build_id = result["build_id"]
             # The server resolves the chain root from whichever member was passed.
             root_build_id = result.get("root_build_id")
-            # Resolved uuid of the continued build (a passed URL is resolved to a
-            # uuid in the service layer); use it — not the raw argument — so the
-            # root comparison and JSON never see a URL.
-            continued_from = result.get("continued_from", build_id)
+            # Resolved uuid of the continued build (service resolves any URL). Fall
+            # back to None, never the raw build_id (which may be a URL), so a URL
+            # can't leak into the uuid-only JSON/comparison.
+            continued_from = result.get("continued_from")
             details_page = f"{WEB_UI_URL}/builds/{new_build_id}"
             if not quiet:
+                continued_label = continued_from or build_id
                 click.echo(
-                    f"✅ Continuing build {continued_from} as new build: {details_page}"
+                    f"✅ Continuing build {continued_label} as new build: {details_page}"
                 )
-                if root_build_id and root_build_id != continued_from:
+                if root_build_id and continued_from and root_build_id != continued_from:
                     click.echo(f"   (continues build chain rooted at {root_build_id})")
                 click.echo(f"""To get the build status of the whole chain:
 ```

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -94,6 +94,7 @@ def execution_status_plain_output(
     targets: List[Any],
     history: Any,
     show_events: bool,
+    show_skipped_targets: bool = False,
 ):
 
     def target_status_label(target_info: Any) -> str:
@@ -107,10 +108,28 @@ def execution_status_plain_output(
             return "⏩"
         return get_status_emoji(target_info["status"])
 
+    # A skipped target was reused from an earlier attempt (retry or continuation):
+    # it ran no steps and produced no artifacts, so hide it by default to keep the
+    # output short. --show-skipped-targets brings them back.
+    total_target_count = len(targets)
+    if not show_skipped_targets:
+        targets = {
+            name: info
+            for name, info in targets.items()
+            if not info.get("skipped_for_prerun_target_id")
+        }
+    hidden_skipped_count = total_target_count - len(targets)
+
     targets_overview = [
         f"\n\tTarget #{index + 1} {target}: {target_status_emoji(targets[target])} {target_status_label(targets[target])}\n"
         for index, target in enumerate(targets)
     ]
+    if hidden_skipped_count > 0:
+        targets_overview.append(
+            f"\n\t({hidden_skipped_count} skipped target"
+            f"{'s' if hidden_skipped_count != 1 else ''} hidden; "
+            "use --show-skipped-targets to show)\n"
+        )
     source_pr = f"<{details['source_pr']}>" if details["source_pr"] else "-"
     retry_of = details.get("retry_of_build_ids") or []
     retried_by = details.get("retried_by_build_ids") or []
@@ -1799,6 +1818,14 @@ def list(
     default=True,
     help="Follow the build retry chain and show all targets across attempts (default: follow).",
 )
+@click.option(
+    "--show-skipped-targets",
+    is_flag=True,
+    default=False,
+    help="Show targets that were skipped because they already succeeded in an "
+    "earlier attempt (retry or continuation). Hidden by default since they run "
+    "no steps and produce no artifacts.",
+)
 @common_options
 def status(
     ctx,
@@ -1807,6 +1834,7 @@ def status(
     show_events,
     fetch_pr,
     follow_retries,
+    show_skipped_targets,
     skip_version_check,
     quiet,
 ):
@@ -1979,7 +2007,7 @@ def status(
         if details:
             if format == "plain":
                 status = execution_status_plain_output(
-                    details, targets, history, show_events
+                    details, targets, history, show_events, show_skipped_targets
                 )
             else:
                 if error:
@@ -2832,8 +2860,24 @@ def diff(ctx, build_id_1, build_id_2, space, format, skip_version_check, quiet):
     default=False,
     help="Fetch build PR events.",
 )
+@click.option(
+    "--show-skipped-targets",
+    is_flag=True,
+    default=False,
+    help="Show targets that were skipped because they already succeeded in an "
+    "earlier attempt (retry or continuation). Hidden by default since they run "
+    "no steps and produce no artifacts.",
+)
 @common_options
-def monitor(ctx, build_id, show_events, fetch_pr, skip_version_check, quiet):
+def monitor(
+    ctx,
+    build_id,
+    show_events,
+    fetch_pr,
+    show_skipped_targets,
+    skip_version_check,
+    quiet,
+):
     """
     Monitor a build execution
 
@@ -2944,6 +2988,7 @@ def monitor(ctx, build_id, show_events, fetch_pr, skip_version_check, quiet):
                 targets,
                 history,
                 show_events,
+                show_skipped_targets,
             )
 
             click.echo(f"{erase_sequence}{monitor_obj}")

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -52,6 +52,7 @@ from gbcli.utils.gbconstants import (
 from gbcli.utils.gbcredentials import GBCredentials
 from gbcli.utils.gbserver import (
     cancel_build,
+    continue_build,
     get_build,
     get_build_events,
     get_build_lineage,
@@ -498,6 +499,49 @@ def build_start(
         )
 
     return gbserver_build["build_id"]
+
+
+def build_continue(
+    github_token: str,
+    build_id: str,
+    id_format: Optional[str] = None,
+    callback=None,
+) -> Optional[dict]:
+    """Continue a previously-executed build.
+
+    Unlike build_start there is no local build folder to zip: the server sources
+    the build definition, space, and targets from the prior build. Only the prior
+    build's id (or URL) is needed.
+
+    Returns the server response dict ``{"build_id", "root_build_id"}`` — the new
+    continuation build's id and the resolved chain root it links to — or None on
+    a server/connection error.
+    """
+    if id_format == "url":
+        build_id_from_url = get_build_id_from_url(github_token, build_id, callback)
+        build_id = build_id_from_url[0]["uuid"]
+
+    if callback is not None:
+        callback(
+            callback_event="continuing_build",
+            callback_args={"steps": 1, "build_id": build_id},
+        )
+
+    gbserver_build = make_gbserver_call(
+        lambda: continue_build(build_id, github_token, GBSERVER_BUILD_API),
+        callback,
+    )
+
+    if not gbserver_build:
+        return None
+
+    if callback is not None:
+        callback(
+            callback_event="continued_build",
+            callback_args={"steps": 100, "build_id": gbserver_build["build_id"]},
+        )
+
+    return gbserver_build
 
 
 def build_validate(

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -513,9 +513,12 @@ def build_continue(
     the build definition, space, and targets from the prior build. Only the prior
     build's id (or URL) is needed.
 
-    Returns the server response dict ``{"build_id", "root_build_id"}`` — the new
-    continuation build's id and the resolved chain root it links to — or None on
-    a server/connection error.
+    Returns the server response dict augmented with ``continued_from`` — the
+    resolved uuid of the build that was continued (``build_id`` after any URL is
+    resolved to a uuid), alongside the server's ``build_id`` (new continuation)
+    and ``root_build_id`` (resolved chain root) — or None on a server/connection
+    error. Callers report ``continued_from`` rather than the raw identifier so a
+    passed URL never leaks into uuid-valued output or a uuid-vs-URL comparison.
     """
     if id_format == "url":
         build_id_from_url = get_build_id_from_url(github_token, build_id, callback)
@@ -541,6 +544,10 @@ def build_continue(
             callback_args={"steps": 100, "build_id": gbserver_build["build_id"]},
         )
 
+    # Report the resolved uuid, not the raw argument: build_id is now the uuid even
+    # when a URL was passed, so the CLI can compare it against root_build_id and
+    # emit it in JSON without a URL sneaking in.
+    gbserver_build["continued_from"] = build_id
     return gbserver_build
 
 

--- a/src/gbcli/services/service_build.py
+++ b/src/gbcli/services/service_build.py
@@ -521,7 +521,18 @@ def build_continue(
     passed URL never leaks into uuid-valued output or a uuid-vs-URL comparison.
     """
     if id_format == "url":
+        # get_build_id_from_url returns None when the URL matches no build; guard
+        # the deref so it surfaces the error message, not a raw IndexError/TypeError.
         build_id_from_url = get_build_id_from_url(github_token, build_id, callback)
+        if not build_id_from_url:
+            if callback is not None:
+                callback(
+                    callback_event="error",
+                    callback_args={
+                        "reason": f"No build found for URL {build_id}.",
+                    },
+                )
+            return None
         build_id = build_id_from_url[0]["uuid"]
 
     if callback is not None:

--- a/src/gbcli/utils/gbserver.py
+++ b/src/gbcli/utils/gbserver.py
@@ -362,6 +362,18 @@ def cancel_build(build_id: str, token: str, gbserver_api: str) -> Any:
     )
 
 
+def continue_build(build_id: str, token: str, gbserver_api: str) -> Any:
+    continue_build_url = f"{gbserver_api}continue"
+
+    return gb_server_request(
+        user_token=token,
+        url=continue_build_url,
+        http_method="post",
+        body={"build_id": build_id},
+        params=None,
+    )
+
+
 def get_artifacts(
     token: str,
     server_artifact_url: str,

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -34,6 +34,7 @@ from gbserver.api.utils import (
     confirm_space_write_access,
     get_query_control,
     get_row_filter,
+    has_space_write_access,
     is_space_admin,
     is_super_admin,
     split_tags,
@@ -343,26 +344,28 @@ def continue_build(
     build_storage: IStoredBuildStorage = storage.build_storage
     space_storage: IStoredSpaceStorage = storage.space_storage
 
+    # Authorize before disclosing anything about the prior build — including
+    # whether it exists. Reading the build is unavoidable (authz is scoped to its
+    # space), but every "you may not see this build" path (missing build, missing
+    # space, no write access) must return the SAME 404: otherwise a caller lacking
+    # access could tell a real build id (401) from a nonexistent one (404) and
+    # enumerate ids across spaces they cannot reach.
+    not_found = HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Build {req.build_id} not found",
+    )
     prior = build_storage.get_by_uuid(req.build_id)
     if not isinstance(prior, StoredBuild):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Build {req.build_id} not found",
-        )
+        raise not_found
 
-    # Authorize BEFORE disclosing the prior build's status: the build runs under
-    # its space and identity, so gate the caller the same way submit_build does.
-    # Doing this ahead of the is_finished() check keeps the 409 (which leaks the
-    # build's liveness) from reaching a caller who lacks write access.
     stored_space = space_storage.get_by_name(prior.space_name)
     if stored_space is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Space {prior.space_name} not found in space storage",
-        )
-    confirm_space_write_access(
+        raise not_found
+    has_access, _ = has_space_write_access(
         request, username_on_target=prior.username, space_name=stored_space.name
     )
+    if not has_access:
+        raise not_found
 
     # A continuation always extends (and its runner reuses targets from) the chain
     # *tip* — the most recent attempt — regardless of which member was passed. So
@@ -370,7 +373,11 @@ def continue_build(
     # member: continuing an old finished member while a newer attempt is still
     # active would otherwise attach a fresh runner to a live tip. There is no
     # runner-liveness table; the build status is the signal.
-    tip = get_retry_chain_members(build_storage, prior)[-1]
+    #
+    # Resolve the chain once and hand it to create_continuation_build: each member
+    # is an unindexed point read, so re-walking there would double the reads.
+    chain = get_retry_chain_members(build_storage, prior)
+    tip = chain[-1]
     if not tip.status.is_finished():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -381,7 +388,7 @@ def continue_build(
             ),
         )
 
-    continuation = create_continuation_build(build_storage, prior)
+    continuation = create_continuation_build(build_storage, prior, chain=chain)
     logger.info(
         "created continuation build %s from build %s (chain root %s)",
         continuation.uuid,

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -44,7 +44,11 @@ from gbserver.storage.artifact_registration import ArtifactRegistration
 from gbserver.storage.build_storage import IStoredBuildStorage
 from gbserver.storage.singleton_storage import SingletonAdminStorage, get_admin_storage
 from gbserver.storage.space_storage import IStoredSpaceStorage
-from gbserver.storage.stored_build import StoredBuild, get_retry_chain_members
+from gbserver.storage.stored_build import (
+    StoredBuild,
+    create_continuation_build,
+    get_retry_chain_members,
+)
 from gbserver.storage.stored_event import StoredEvent
 from gbserver.storage.stored_step_run import StoredStepRun
 from gbserver.storage.stored_target_run import StoredTargetRun
@@ -91,10 +95,44 @@ class BuildSubmitRequest(BaseModel):
         return self
 
 
+class BuildContinueRequest(BaseModel):
+    """
+    A build continuation request.
+
+    Continues a previously-executed build: a *fresh* build runner re-runs the
+    prior build, skipping targets that already succeeded and re-running the rest.
+    The build definition (``build_archive``), space, and targets are sourced from
+    the prior build, so only its id is required.
+
+        build_id: uuid of any member of the prior build's retry chain to continue.
+    """
+
+    build_id: str
+
+    @model_validator(mode="after")
+    def validate_build_id(self: Self) -> Self:
+        if self.build_id == "":
+            raise ValueError("build_id cannot be empty")
+        return self
+
+
 class BuildSubmitResponse(BaseModel):
     """Response to a build submission."""
 
     build_id: str
+
+
+class BuildContinueResponse(BaseModel):
+    """Response to a build continuation.
+
+    build_id: uuid of the new (continuation) build.
+    root_build_id: uuid of the chain root the continuation links to via
+        retry_of_build_id. This is resolved server-side from whichever chain
+        member was passed, so the client can report the canonical root.
+    """
+
+    build_id: str
+    root_build_id: str
 
 
 class BuildValidateRequest(BaseModel):
@@ -287,6 +325,69 @@ def submit_build(request: Request, req: BuildSubmitRequest) -> BuildSubmitRespon
 
     return BuildSubmitResponse(
         build_id=stored_build.uuid,
+    )
+
+
+@builds_api.post("/continue")
+def continue_build(
+    request: Request, req: BuildContinueRequest
+) -> BuildContinueResponse:
+    """Continue a previously-executed build in a fresh runner.
+
+    Creates a new build that extends the prior build's retry chain, so the runner
+    skips targets that already succeeded (anywhere in the chain) and re-runs the
+    rest. The prior build must be finished — continuing a build that is still
+    active (there may be a live runner) is rejected.
+    """
+    storage = get_admin_storage()
+    build_storage: IStoredBuildStorage = storage.build_storage
+    space_storage: IStoredSpaceStorage = storage.space_storage
+
+    prior = build_storage.get_by_uuid(req.build_id)
+    if not isinstance(prior, StoredBuild):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Build {req.build_id} not found",
+        )
+
+    # A continuation spins up a fresh runner, so the prior build must not still be
+    # active — otherwise the continuation could race a live runner working the same
+    # chain. There is no runner-liveness table; the build status is the signal.
+    if not prior.status.is_finished():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Build {req.build_id} has status {prior.status}; only a finished "
+                "build (SUCCESS, FAILED, INVALID, or CANCELLED) can be continued"
+            ),
+        )
+
+    # The build runs under the prior build's space and identity; gate the caller
+    # the same way submit_build does.
+    stored_space = space_storage.get_by_name(prior.space_name)
+    if stored_space is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Space {prior.space_name} not found in space storage",
+        )
+    confirm_space_write_access(
+        request, username_on_target=prior.username, space_name=stored_space.name
+    )
+
+    continuation = create_continuation_build(build_storage, prior)
+    logger.info(
+        "created continuation build %s from build %s (chain root %s)",
+        continuation.uuid,
+        req.build_id,
+        continuation.retry_of_build_id,
+    )
+
+    # retry_of_build_id is the resolved chain root (set server-side regardless of
+    # which chain member was passed), so the client can report the canonical root.
+    assert continuation.retry_of_build_id is not None
+    return BuildContinueResponse(
+        build_id=continuation.uuid,
+        root_build_id=continuation.retry_of_build_id,
     )
 
 

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -344,12 +344,11 @@ def continue_build(
     build_storage: IStoredBuildStorage = storage.build_storage
     space_storage: IStoredSpaceStorage = storage.space_storage
 
-    # Authorize before disclosing anything about the prior build — including
-    # whether it exists. Reading the build is unavoidable (authz is scoped to its
-    # space), but every "you may not see this build" path (missing build, missing
-    # space, no write access) must return the SAME 404: otherwise a caller lacking
-    # access could tell a real build id (401) from a nonexistent one (404) and
-    # enumerate ids across spaces they cannot reach.
+    # Every "you may not see this build" path (missing build, missing space, no
+    # write access) must return the SAME 404: otherwise a caller lacking access
+    # could tell a real build id (401) from a nonexistent one (404) and enumerate
+    # ids across spaces they cannot reach. Authorize before disclosing the build's
+    # existence or (below) its liveness.
     not_found = HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"Build {req.build_id} not found",
@@ -358,26 +357,31 @@ def continue_build(
     if not isinstance(prior, StoredBuild):
         raise not_found
 
-    stored_space = space_storage.get_by_name(prior.space_name)
-    if stored_space is None:
-        raise not_found
-    has_access, _ = has_space_write_access(
-        request, username_on_target=prior.username, space_name=stored_space.name
-    )
-    if not has_access:
-        raise not_found
-
-    # A continuation always extends (and its runner reuses targets from) the chain
-    # *tip* — the most recent attempt — regardless of which member was passed. So
-    # the "must be finished" guard has to apply to the tip, not to the passed-in
-    # member: continuing an old finished member while a newer attempt is still
-    # active would otherwise attach a fresh runner to a live tip. There is no
-    # runner-liveness table; the build status is the signal.
-    #
-    # Resolve the chain once and hand it to create_continuation_build: each member
-    # is an unindexed point read, so re-walking there would double the reads.
+    # A continuation always extends the chain *tip* (the most recent attempt) and
+    # is seeded from it (space/user/build_archive), regardless of which member was
+    # passed. Resolve the chain once here — each member is an unindexed point read,
+    # so re-walking inside create_continuation_build would double the reads.
     chain = get_retry_chain_members(build_storage, prior)
     tip = chain[-1]
+
+    # Authorize against BOTH the passed-in build and the tip: the tip is what the
+    # continuation runs as (its space/user/secrets), so checking only `prior` while
+    # seeding from `tip` would, if members ever diverge, run under an unchecked
+    # space/user. Today every member shares these fields, so it's one real check.
+    for build in {prior.uuid: prior, tip.uuid: tip}.values():
+        stored_space = space_storage.get_by_name(build.space_name)
+        if stored_space is None:
+            raise not_found
+        has_access, _ = has_space_write_access(
+            request, username_on_target=build.username, space_name=stored_space.name
+        )
+        if not has_access:
+            raise not_found
+
+    # The "must be finished" guard applies to the tip, not the passed-in member:
+    # continuing an old finished member while a newer attempt is still active would
+    # otherwise attach a fresh runner to a live tip. There is no runner-liveness
+    # table; the build status is the signal.
     if not tip.status.is_finished():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -388,7 +392,15 @@ def continue_build(
             ),
         )
 
-    continuation = create_continuation_build(build_storage, prior, chain=chain)
+    try:
+        continuation = create_continuation_build(build_storage, prior, chain=chain)
+    except ValueError as e:
+        # create_continuation_build refuses to link off an untrustworthy chain
+        # (e.g. the root row became unreadable mid-request) — a consistency failure.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Build {req.build_id} cannot be continued: {e}",
+        ) from e
     logger.info(
         "created continuation build %s from build %s (chain root %s)",
         continuation.uuid,

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -364,15 +364,20 @@ def continue_build(
         request, username_on_target=prior.username, space_name=stored_space.name
     )
 
-    # A continuation spins up a fresh runner, so the prior build must not still be
-    # active — otherwise the continuation could race a live runner working the same
-    # chain. There is no runner-liveness table; the build status is the signal.
-    if not prior.status.is_finished():
+    # A continuation always extends (and its runner reuses targets from) the chain
+    # *tip* — the most recent attempt — regardless of which member was passed. So
+    # the "must be finished" guard has to apply to the tip, not to the passed-in
+    # member: continuing an old finished member while a newer attempt is still
+    # active would otherwise attach a fresh runner to a live tip. There is no
+    # runner-liveness table; the build status is the signal.
+    tip = get_retry_chain_members(build_storage, prior)[-1]
+    if not tip.status.is_finished():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                f"Build {req.build_id} has status {prior.status}; only a finished "
-                "build (SUCCESS, FAILED, INVALID, or CANCELLED) can be continued"
+                f"Build chain (latest attempt {tip.uuid}) has status {tip.status}; "
+                "only a chain whose latest attempt is finished (SUCCESS, FAILED, "
+                "INVALID, or CANCELLED) can be continued"
             ),
         )
 
@@ -386,10 +391,17 @@ def continue_build(
 
     # retry_of_build_id is the resolved chain root (set server-side regardless of
     # which chain member was passed), so the client can report the canonical root.
-    assert continuation.retry_of_build_id is not None
+    # Guard explicitly (not via assert, which -O strips) since it feeds a required
+    # response field.
+    root_build_id = continuation.retry_of_build_id
+    if root_build_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="continuation build was created without a chain root link",
+        )
     return BuildContinueResponse(
         build_id=continuation.uuid,
-        root_build_id=continuation.retry_of_build_id,
+        root_build_id=root_build_id,
     )
 
 

--- a/src/gbserver/api/builds.py
+++ b/src/gbserver/api/builds.py
@@ -350,6 +350,20 @@ def continue_build(
             detail=f"Build {req.build_id} not found",
         )
 
+    # Authorize BEFORE disclosing the prior build's status: the build runs under
+    # its space and identity, so gate the caller the same way submit_build does.
+    # Doing this ahead of the is_finished() check keeps the 409 (which leaks the
+    # build's liveness) from reaching a caller who lacks write access.
+    stored_space = space_storage.get_by_name(prior.space_name)
+    if stored_space is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Space {prior.space_name} not found in space storage",
+        )
+    confirm_space_write_access(
+        request, username_on_target=prior.username, space_name=stored_space.name
+    )
+
     # A continuation spins up a fresh runner, so the prior build must not still be
     # active — otherwise the continuation could race a live runner working the same
     # chain. There is no runner-liveness table; the build status is the signal.
@@ -361,18 +375,6 @@ def continue_build(
                 "build (SUCCESS, FAILED, INVALID, or CANCELLED) can be continued"
             ),
         )
-
-    # The build runs under the prior build's space and identity; gate the caller
-    # the same way submit_build does.
-    stored_space = space_storage.get_by_name(prior.space_name)
-    if stored_space is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Space {prior.space_name} not found in space storage",
-        )
-    confirm_space_write_access(
-        request, username_on_target=prior.username, space_name=stored_space.name
-    )
 
     continuation = create_continuation_build(build_storage, prior)
     logger.info(

--- a/src/gbserver/buildrunner/buildrunner.py
+++ b/src/gbserver/buildrunner/buildrunner.py
@@ -1311,18 +1311,23 @@ Download : {download_msg}
         self.storage.target_storage.update(stored_target_run)
 
     def __get_retry_chain_build_ids(self: Self) -> list[str]:
-        """Return all build UUIDs in the retry chain of the current build, from the current
-        build back to the original (root) build, by following retry_of_build_id links.
+        """Return the UUIDs of *every* build in the current build's retry chain.
+
+        Uses the forward walk (``get_retry_chain_members``: resolve root via
+        ``retry_of_build_id``, then follow ``retry_build_id`` through every member)
+        so the result includes intermediate attempts, not just the current build
+        and the root. This matters because ``retry_of_build_id`` is flat-to-root
+        (every retry/continuation points at the original), so a naive backward
+        walk would yield only ``[self, root]`` and miss any member in between —
+        causing target reuse to re-run a target that first succeeded in an
+        intermediate attempt.
         """
-        build_ids = [self.stored_build.uuid]
-        current_id = self.stored_build.retry_of_build_id
-        while current_id:
-            build_ids.append(current_id)
-            ancestor = self.storage.build_storage.get_by_uuid(current_id)
-            if not isinstance(ancestor, StoredBuild):
-                break
-            current_id = ancestor.retry_of_build_id
-        return build_ids
+        return [
+            member.uuid
+            for member in get_retry_chain_members(
+                self.storage.build_storage, self.stored_build
+            )
+        ]
 
     def __is_target_already_run(
         self: Self,

--- a/src/gbserver/storage/stored_build.py
+++ b/src/gbserver/storage/stored_build.py
@@ -293,16 +293,21 @@ def create_continuation_build(
     chain = get_retry_chain_members(build_storage, prior)
     root = chain[0]
     tip = chain[-1]
+    # Seed the continuation from the chain *tip* (the most recent attempt), not the
+    # arbitrary member that was passed: the continuation extends the tip, so its
+    # definition/targets should match the latest attempt. (Today every member
+    # shares the same build_archive, but sourcing from the tip keeps that true even
+    # if attempts ever diverge.)
     continuation = StoredBuild(
-        name=prior.name,
-        space_name=prior.space_name,
+        name=tip.name,
+        space_name=tip.space_name,
         source_uri="",
-        username=prior.username,
-        build_archive=prior.build_archive,
+        username=tip.username,
+        build_archive=tip.build_archive,
         status=Status.SUBMITTED,
-        targets=prior.targets,
-        description=prior.description,
-        tags=prior.tags,
+        targets=tip.targets,
+        description=tip.description,
+        tags=tip.tags,
         retry_of_build_id=root.uuid,
         retry_count=0,
     )

--- a/src/gbserver/storage/stored_build.py
+++ b/src/gbserver/storage/stored_build.py
@@ -298,7 +298,23 @@ def create_continuation_build(
     """
     if chain is None:
         chain = get_retry_chain_members(build_storage, prior)
+    # This is the single linkage authority, so fail loudly rather than corrupt the
+    # chain when it can't be trusted: a passed-in chain missing ``prior``, or
+    # get_retry_chain_members' `members or [build]` fallback returning just [prior]
+    # when the root row was unreadable (a mid-chain member wrongly treated as its
+    # own root would link off the wrong root and orphan the tail).
+    if not chain or prior.uuid not in {member.uuid for member in chain}:
+        raise ValueError(
+            f"cannot continue build {prior.uuid}: its retry chain could not be "
+            "resolved (chain does not contain the build)"
+        )
     root = chain[0]
+    if prior.retry_of_build_id and root.uuid != prior.retry_of_build_id:
+        raise ValueError(
+            f"cannot continue build {prior.uuid}: its retry chain could not be "
+            f"resolved (chain root {root.uuid} does not match the build's "
+            f"recorded root {prior.retry_of_build_id})"
+        )
     tip = chain[-1]
     # Seed the continuation from the chain *tip* (the most recent attempt), not the
     # arbitrary member that was passed: the continuation extends the tip, so its

--- a/src/gbserver/storage/stored_build.py
+++ b/src/gbserver/storage/stored_build.py
@@ -265,7 +265,9 @@ def get_retry_chain_members(
 
 
 def create_continuation_build(
-    build_storage: "IStoredBuildStorage", prior: StoredBuild
+    build_storage: "IStoredBuildStorage",
+    prior: StoredBuild,
+    chain: Optional[List[StoredBuild]] = None,
 ) -> StoredBuild:
     """Create, store, and return a new build that continues ``prior``.
 
@@ -289,8 +291,13 @@ def create_continuation_build(
     This helper is the single place that decides how a continuation links to its
     predecessor. If build-retry ever switches to reusing a single/shared build id,
     this is the one function that changes.
+
+    ``chain`` may be passed by a caller that already resolved ``prior``'s chain
+    (each member is an unindexed point read, so re-walking is not free); when
+    omitted it is walked here. It must be the full chain of ``prior`` root-first.
     """
-    chain = get_retry_chain_members(build_storage, prior)
+    if chain is None:
+        chain = get_retry_chain_members(build_storage, prior)
     root = chain[0]
     tip = chain[-1]
     # Seed the continuation from the chain *tip* (the most recent attempt), not the

--- a/src/gbserver/storage/stored_build.py
+++ b/src/gbserver/storage/stored_build.py
@@ -262,3 +262,58 @@ def get_retry_chain_members(
         next_id = current.retry_build_id
         current = build_storage.get_by_uuid(next_id) if next_id else None
     return members or [build]
+
+
+def create_continuation_build(
+    build_storage: "IStoredBuildStorage", prior: StoredBuild
+) -> StoredBuild:
+    """Create, store, and return a new build that continues ``prior``.
+
+    A continuation is a *fresh* build (new uuid) that extends ``prior``'s retry
+    chain, so the runner's existing target-reuse machinery
+    (``BuildRunner.__is_target_already_run``, which is enabled whenever
+    ``retry_of_build_id`` is set) skips targets that already succeeded anywhere in
+    the chain. Unlike an automatic retry (see ``BuildRunner.__prepare_retry``):
+
+    - ``retry_count`` is reset to ``0`` so the build.yaml ``max_retries`` budget is
+      counted fresh for the continuation.
+    - the new build starts as ``SUBMITTED`` (not ``RETRY_PENDING``) so it flows
+      through the ordinary BuildWatcher dispatch path and gets its own fresh
+      runner, rather than being owned by an in-process retry loop.
+
+    ``prior`` may be *any* member of an existing chain; the continuation is linked
+    to the chain root via ``retry_of_build_id`` (matching ``__prepare_retry``'s
+    flat-to-root convention) and the back-link (``retry_build_id``) is set on the
+    chain *tip* so an existing chain is never corrupted.
+
+    This helper is the single place that decides how a continuation links to its
+    predecessor. If build-retry ever switches to reusing a single/shared build id,
+    this is the one function that changes.
+    """
+    chain = get_retry_chain_members(build_storage, prior)
+    root = chain[0]
+    tip = chain[-1]
+    continuation = StoredBuild(
+        name=prior.name,
+        space_name=prior.space_name,
+        source_uri="",
+        username=prior.username,
+        build_archive=prior.build_archive,
+        status=Status.SUBMITTED,
+        targets=prior.targets,
+        description=prior.description,
+        tags=prior.tags,
+        retry_of_build_id=root.uuid,
+        retry_count=0,
+    )
+    build_storage.add(continuation)
+    tip.retry_build_id = continuation.uuid
+    build_storage.update(tip)
+    logger.info(
+        "Continuing build %s (chain root %s, tip %s) as new build %s",
+        prior.uuid,
+        root.uuid,
+        tip.uuid,
+        continuation.uuid,
+    )
+    return continuation

--- a/test-data/integration/standalone/buildrunner/bash/continue/build.yaml
+++ b/test-data/integration/standalone/buildrunner/bash/continue/build.yaml
@@ -1,0 +1,24 @@
+granite.build:
+  name: bash-continue-skip-test
+  # Build continuation: a finished build is continued in a FRESH runner. Because
+  # the single target already succeeded earlier in the same (continuation) chain,
+  # the continuation SKIPS it via skipped_for_prerun_target_id — the same
+  # target-reuse machinery build-level retry uses, triggered purely by the
+  # continuation's retry_of_build_id link.
+  #
+  # max_retries is intentionally 0: continuation does not require a retry budget,
+  # and the continuation build re-runs remaining targets exactly once by default.
+  targets:
+    succeed-target:
+      allow_unknown: true
+      environment_uri: space://environments/bash
+      steps:
+        # The general-purpose `command` bash step runs an arbitrary shell command.
+        # `exit 0` SUCCEEDS the target, leaving a reusable SUCCESS target run that
+        # the continuation can skip via skipped_for_prerun_target_id.
+        - step_uri: space://steps/command
+          config:
+            command_config:
+              command: "exit 0"
+            compute_config:
+              num_nodes: 1

--- a/test-data/integration/standalone/buildrunner/bash/continue/buildtest.yaml
+++ b/test-data/integration/standalone/buildrunner/bash/continue/buildtest.yaml
@@ -1,0 +1,22 @@
+# Fixture for the build-continuation-with-target-reuse test
+# (test/integration/standalone/buildrunner/bash/test_buildrunner_continue.py).
+#
+# build_yaml defaults to ./build.yaml (sibling) when omitted.  The build's single
+# target succeeds, so Phase 1 ends SUCCESS; the test then marks it FAILED and
+# continues it in a fresh runner to exercise the continuation/skip path.
+expected_status: success
+# The target succeeds on its own; no step-failure simulation.
+simulate_step_failure: false
+# Use the shared standalone space at <repo>/configurations/spaces/local so the
+# BuildRunner resolves space:// URIs (the bash environment and the command step)
+# without cloning from GitHub.  Relative path resolves against this YAML's
+# directory and is returned as an absolute file:// URI by from_yaml.
+space_uri: ../../../../../../configurations/spaces/local
+# A single bash target with one command step and no input/output artifacts.
+target_expectations:
+  - target_name: succeed-target
+    step_count: 1
+    input_artifact_count: 0
+    output_artifact_count: 0
+    jobstats_count: 0
+timeout_minutes: 10

--- a/test/integration/standalone/buildrunner/bash/test_buildrunner_continue.py
+++ b/test/integration/standalone/buildrunner/bash/test_buildrunner_continue.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build continuation with target reuse, in the local Bash environment.
+
+Mirrors the build-level retry test (``test_buildrunner_retry.py``) but exercises
+``gb build continue`` semantics: a *finished* build is continued by a *fresh*
+BuildRunner rather than by the original runner's in-process retry loop.
+
+Flow:
+  1. Run a build whose single target succeeds (``command: exit 0``) to SUCCESS.
+  2. Mark that build FAILED (so it is a plausible continuation candidate;
+     continuation accepts any finished build), leaving its target/steps SUCCESS
+     so they can be reused.
+  3. Create a continuation via ``create_continuation_build`` (the same helper the
+     ``POST /builds/continue`` endpoint uses) — a fresh build linked to the prior
+     via ``retry_of_build_id`` with ``retry_count`` reset to 0 — and run it in a
+     *new* BuildRunner. Because the target already succeeded in the chain, the
+     continuation SKIPS it (``skipped_for_prerun_target_id`` points back to the
+     original target). The continuation build completes SUCCESS.
+
+The continuation linkage (``retry_of_build_id`` / ``retry_build_id`` /
+``retry_count``) and the target-skip are verified across gb_builds and
+gb_targets.
+"""
+
+from typing import Self
+
+import pytest
+from libgbtest.buildrunner.buildtest import (
+    AbstractBuildTest,
+    BuildTestSpecification,
+    ClassTestedEnum,
+    get_test_data_dir_for,
+)
+from libgbtest.buildrunner.utils import ExceptionRaisingThread
+from libgbtest.constants import GBTEST_USER_NAME
+
+from gbserver.buildrunner.buildrunner import BuildRunner
+from gbserver.storage.stored_build import StoredBuild, create_continuation_build
+from gbserver.storage.stored_target_run import StoredTargetRun
+from gbserver.types.status import Status
+from gbserver.utils.logger import get_logger
+
+pytestmark = pytest.mark.standalone
+
+logger = get_logger(__name__)
+
+
+@pytest.mark.xdist_group(name="buildrunner_bash_continue")
+class TestBuildRunnerContinueBash(AbstractBuildTest):
+    """Verifies build continuation and target reuse in the local Bash environment."""
+
+    def setup_method(self, method):
+        # Run in-process via the local Bash environment — no cluster login.
+        self.run_locally = True
+        super().setup_method(method)
+
+    def _get_spec(self) -> BuildTestSpecification:
+        return BuildTestSpecification.from_yaml(
+            get_test_data_dir_for(__file__) / "continue" / "buildtest.yaml"
+        )
+
+    def test_buildrunner_continue_skips_succeeded_target(self: Self):
+        spec = self._get_spec()
+        space = self._check_and_setup_space(spec)
+        timeout_seconds = spec.timeout_minutes * 60
+
+        # --- Phase 1: run the build to SUCCESS ---
+        original_build = StoredBuild.create(
+            name="test-continue",
+            space_name=space.name,
+            source_uri="",
+            username=GBTEST_USER_NAME,
+            build_yaml_path=spec.build_yaml,
+            status=Status.PENDING,
+        )
+        original_id = original_build.uuid
+        self._run_build_test_build(
+            stored_build=original_build,
+            tested_class=ClassTestedEnum.TEST_BUILDRUNNER,
+            test_cancel=False,
+            expected_status=Status.SUCCESS,
+            timeout_seconds=timeout_seconds,
+            space_uri=spec.space_uri,
+        )
+
+        # --- Phase 2: mark the successful build FAILED (a finished build to
+        # continue). Targets/steps/artifacts are left SUCCESS so they are reused
+        # (skipped) by the continuation. ---
+        original_stored = self.storage.build_storage.get_by_uuid(original_id)
+        assert isinstance(original_stored, StoredBuild)
+        original_stored.status = Status.FAILED
+        self.storage.build_storage.update(original_stored)
+
+        # --- Phase 3: create the continuation (fresh build, fresh runner) ---
+        # create_continuation_build stores the continuation as SUBMITTED, exactly
+        # as POST /builds/continue does. In production the BuildWatcher then flips
+        # SUBMITTED -> PENDING before dispatching a runner; here we drive the runner
+        # directly, so make that same transition first (the runner only advances a
+        # build whose status is PENDING/RUNNING/RETRY_PENDING).
+        continuation = create_continuation_build(
+            self.storage.build_storage, original_stored
+        )
+        continuation_id = continuation.uuid
+        assert continuation_id != original_id
+        assert continuation.status == Status.SUBMITTED
+        continuation.status = Status.PENDING
+        self.storage.build_storage.update(continuation)
+
+        runner2 = BuildRunner(continuation, space_uri=spec.space_uri, create_pr=False)
+        runner_thread = ExceptionRaisingThread(
+            name="Run continuation build", target=runner2.start_and_wait, args=()
+        )
+        runner_thread.start()
+        try:
+            self._wait_for_build_status(
+                continuation_id, [Status.SUCCESS], timeout_seconds
+            )
+        finally:
+            runner_thread.join(timeout=60)
+
+        # --- gb_builds: verify continuation linkage ---
+        original = self.storage.build_storage.get_by_uuid(original_id)
+        assert isinstance(original, StoredBuild)
+        assert original.retry_build_id == continuation_id, self._failed_build_msg(
+            original_id, "Original build should point to the continuation"
+        )
+        assert original.retry_of_build_id is None, self._failed_build_msg(
+            original_id, "Original build should not have a retry_of_build_id"
+        )
+
+        cont = self.storage.build_storage.get_by_uuid(continuation_id)
+        assert isinstance(cont, StoredBuild)
+        assert cont.retry_of_build_id == original_id, self._failed_build_msg(
+            continuation_id, "Continuation should point back to the prior chain root"
+        )
+        # max_retries is counted fresh for a continuation.
+        assert cont.retry_count == 0, self._failed_build_msg(
+            continuation_id, f"Expected retry_count=0, got {cont.retry_count}"
+        )
+
+        # --- gb_targets: every original target was skipped in the continuation ---
+        original_targets = self.storage.target_storage.get_by_where(
+            {"build_id": original_id}
+        )
+        assert len(original_targets) > 0, self._failed_build_msg(
+            original_id, "Expected targets in original build"
+        )
+        for original_target in original_targets:
+            assert isinstance(original_target, StoredTargetRun)
+            cont_targets = self.storage.target_storage.get_by_where(
+                {"build_id": continuation_id, "name": original_target.name}
+            )
+            assert len(cont_targets) == 1, self._failed_build_msg(
+                continuation_id,
+                f"Expected exactly one continuation target named '{original_target.name}'",
+            )
+            cont_target = cont_targets[0]
+            assert isinstance(cont_target, StoredTargetRun)
+            assert (
+                cont_target.skipped_for_prerun_target_id == original_target.uuid
+            ), self._failed_build_msg(
+                continuation_id,
+                f"Continuation target '{original_target.name}' "
+                f"skipped_for_prerun_target_id ({cont_target.skipped_for_prerun_target_id}) "
+                f"does not point to the original target ({original_target.uuid})",
+            )

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -376,8 +376,51 @@ def test_repeated_continuations_linearize_into_one_chain():
     assert c.retry_of_build_id == root.uuid
 
 
+def test_chain_walk_includes_intermediate_members_from_any_member():
+    """get_retry_chain_members must return EVERY member of a flat-to-root chain
+    (root -> mid -> tip), not just [self, root], regardless of which member it is
+    called from. Target reuse (BuildRunner.__get_retry_chain_build_ids) relies on
+    this: retry_of_build_id points every member at the root, so a backward walk
+    would miss `mid` and re-run a target that first succeeded there."""
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    mid = _prior_build(ATTACKER, status=Status.FAILED)
+    tip = _prior_build(ATTACKER, status=Status.FAILED)
+    # Flat-to-root: mid and tip both point their retry_of_build_id at the root.
+    mid.retry_of_build_id = root.uuid
+    tip.retry_of_build_id = root.uuid
+    root.retry_build_id = mid.uuid
+    mid.retry_build_id = tip.uuid
+    bs = _fake_build_storage({root.uuid: root, mid.uuid: mid, tip.uuid: tip})
+
+    expected = [root.uuid, mid.uuid, tip.uuid]
+    # The full chain is recovered from any starting member, and always includes mid.
+    for member in (root, mid, tip):
+        chain = [m.uuid for m in get_retry_chain_members(bs, member)]
+        assert chain == expected
+        assert mid.uuid in chain
+
+
 def test_continue_build_rejects_forged_username():
     prior = _prior_build(VICTIM, status=Status.FAILED)
+    with (
+        _patched_continue_storage({prior.uuid: prior}),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            continue_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                BuildContinueRequest(build_id=prior.uuid),
+            )
+    assert exc.value.status_code == 401
+
+
+def test_continue_build_authz_precedes_status_disclosure():
+    """An unauthorized caller must not learn a prior build's liveness: authz
+    (401) is enforced BEFORE the is_finished() 409, so continuing another user's
+    *active* build returns 401, not 409."""
+    prior = _prior_build(VICTIM, status=Status.RUNNING)
     with (
         _patched_continue_storage({prior.uuid: prior}),
         _real_authz(),

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -402,6 +402,27 @@ def test_repeated_continuations_linearize_into_one_chain():
     assert c.retry_of_build_id == root.uuid
 
 
+def test_create_continuation_build_uses_passed_chain_without_rewalking():
+    """When the caller (the /continue endpoint) has already resolved the chain, it
+    passes it in and create_continuation_build must NOT walk it again — each member
+    is an unindexed point read, so re-walking would double the reads."""
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    tip = _prior_build(ATTACKER, status=Status.FAILED)
+    tip.retry_of_build_id = root.uuid
+    root.retry_build_id = tip.uuid
+    builds = {root.uuid: root, tip.uuid: tip}
+    bs = _fake_build_storage(builds)
+    chain = get_retry_chain_members(bs, root)
+
+    with patch("gbserver.storage.stored_build.get_retry_chain_members") as walk:
+        cont = create_continuation_build(bs, root, chain=chain)
+
+    walk.assert_not_called()
+    # Same linkage as the walk-it-yourself path: linked to root, back-link on tip.
+    assert cont.retry_of_build_id == root.uuid
+    assert builds[tip.uuid].retry_build_id == cont.uuid
+
+
 def test_chain_walk_includes_intermediate_members_from_any_member():
     """get_retry_chain_members must return EVERY member of a flat-to-root chain
     (root -> mid -> tip), not just [self, root], regardless of which member it is
@@ -426,7 +447,11 @@ def test_chain_walk_includes_intermediate_members_from_any_member():
         assert mid.uuid in chain
 
 
-def test_continue_build_rejects_forged_username():
+def test_continue_build_rejects_forged_username_as_404():
+    """An unauthorized caller gets 404, identical to a nonexistent build — not a
+    401 that would confirm the id is real. Collapsing the two removes the id
+    oracle: a caller without space access cannot tell a build id they may not
+    reach from one that does not exist, so cannot enumerate ids across spaces."""
     prior = _prior_build(VICTIM, status=Status.FAILED)
     with (
         _patched_continue_storage({prior.uuid: prior}),
@@ -439,13 +464,15 @@ def test_continue_build_rejects_forged_username():
                 _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
                 BuildContinueRequest(build_id=prior.uuid),
             )
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 404
+    # Same detail as the missing-build 404, so the two are indistinguishable.
+    assert exc.value.detail == f"Build {prior.uuid} not found"
 
 
 def test_continue_build_authz_precedes_status_disclosure():
-    """An unauthorized caller must not learn a prior build's liveness: authz
-    (401) is enforced BEFORE the is_finished() 409, so continuing another user's
-    *active* build returns 401, not 409."""
+    """An unauthorized caller must not learn a prior build's liveness: authz is
+    enforced BEFORE the is_finished() 409, so continuing another user's *active*
+    build returns the not-found 404, not a 409 that would leak that it is live."""
     prior = _prior_build(VICTIM, status=Status.RUNNING)
     with (
         _patched_continue_storage({prior.uuid: prior}),
@@ -458,4 +485,4 @@ def test_continue_build_authz_precedes_status_disclosure():
                 _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
                 BuildContinueRequest(build_id=prior.uuid),
             )
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 404

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -41,9 +41,11 @@ from fastapi import HTTPException
 
 from gbserver.api import builds as builds_module
 from gbserver.api.builds import (
+    BuildContinueRequest,
     BuildSubmitRequest,
     BuildValidateRequest,
     BuildValidation,
+    continue_build,
     submit_build,
     validate_build,
 )
@@ -51,7 +53,13 @@ from gbserver.api.utils import (
     confirm_space_write_access as _real_confirm_space_write_access,
 )
 from gbserver.api.utils import has_space_write_access as _real_has_space_write_access
+from gbserver.storage.stored_build import (
+    StoredBuild,
+    create_continuation_build,
+    get_retry_chain_members,
+)
 from gbserver.storage.stored_space import StoredSpace
+from gbserver.types.status import Status
 
 SPACE = "space-B"
 VICTIM = "victim_b"
@@ -227,10 +235,6 @@ def test_validate_build_allows_admin_impersonation_via_space_name():
 
 # ------------------------------------------------------------------ continue_build
 
-from gbserver.api.builds import BuildContinueRequest, continue_build
-from gbserver.storage.stored_build import StoredBuild
-from gbserver.types.status import Status
-
 
 def _fake_build_storage(builds: dict):
     """A build_storage mock backed by a {uuid: StoredBuild} dict that supports
@@ -245,7 +249,7 @@ def _fake_build_storage(builds: dict):
         return b
 
     return SimpleNamespace(
-        get_by_uuid=lambda uuid: builds.get(uuid),
+        get_by_uuid=builds.get,
         add=_add,
         update=_update,
     )
@@ -354,11 +358,6 @@ def test_repeated_continuations_linearize_into_one_chain():
     chain stays linear (A -> B -> C) rather than branching into multiple chains
     sharing a root. `gb build status --follow-retries` then shows every
     continuation in a single walk."""
-    from gbserver.storage.stored_build import (
-        create_continuation_build,
-        get_retry_chain_members,
-    )
-
     root = _prior_build(ATTACKER, status=Status.FAILED)
     builds = {root.uuid: root}
     bs = _fake_build_storage(builds)

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -299,6 +299,26 @@ def test_continue_build_rejects_active_build_409():
     assert exc.value.status_code == 409
 
 
+def test_continue_build_rejects_when_chain_tip_still_active():
+    """The finished-check applies to the chain TIP, not the passed-in member:
+    continuing a finished root while a newer attempt is still RUNNING is a 409,
+    so a fresh runner is never attached to a live tip."""
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    tip = _prior_build(ATTACKER, status=Status.RUNNING)
+    tip.retry_of_build_id = root.uuid
+    root.retry_build_id = tip.uuid
+    with _patched_continue_storage({root.uuid: root, tip.uuid: tip}):
+        with pytest.raises(HTTPException) as exc:
+            # Pass the (finished) ROOT; the tip is still running.
+            continue_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                BuildContinueRequest(build_id=root.uuid),
+            )
+    assert exc.value.status_code == 409
+    # The 409 names the actual live attempt (the tip), not the passed-in build.
+    assert tip.uuid in exc.value.detail
+
+
 def test_continue_build_creates_linked_continuation():
     prior = _prior_build(ATTACKER, status=Status.FAILED)
     builds = {prior.uuid: prior}
@@ -327,13 +347,17 @@ def test_continue_build_creates_linked_continuation():
 
 
 def test_continue_build_accepts_mid_chain_member_and_links_to_root():
-    # root -> mid (any member may be continued; continuation links to the root
+    # root -> tip (any member may be continued; continuation links to the root
     # and the back-link lands on the chain tip, not the passed-in member).
     root = _prior_build(ATTACKER, status=Status.FAILED)
-    mid = _prior_build(ATTACKER, status=Status.FAILED)
-    mid.retry_of_build_id = root.uuid
-    root.retry_build_id = mid.uuid
-    builds = {root.uuid: root, mid.uuid: mid}
+    tip = _prior_build(ATTACKER, status=Status.FAILED)
+    tip.retry_of_build_id = root.uuid
+    root.retry_build_id = tip.uuid
+    # Give the tip a distinct definition to prove the continuation is seeded from
+    # the tip (latest attempt), not from the passed-in root.
+    tip.targets = ["tip-target"]
+    root.targets = ["root-target"]
+    builds = {root.uuid: root, tip.uuid: tip}
     with (
         _patched_continue_storage(builds),
         _real_authz(),
@@ -348,9 +372,11 @@ def test_continue_build_accepts_mid_chain_member_and_links_to_root():
     assert continuation.retry_of_build_id == root.uuid
     # The response reports the resolved root even though a mid-chain member was passed.
     assert resp.root_build_id == root.uuid
-    # Tip (mid) gets the back-link; root's existing link is untouched.
-    assert builds[mid.uuid].retry_build_id == resp.build_id
-    assert builds[root.uuid].retry_build_id == mid.uuid
+    # Definition is sourced from the tip (latest attempt), not the passed-in root.
+    assert continuation.targets == ["tip-target"]
+    # Tip gets the back-link; root's existing link is untouched.
+    assert builds[tip.uuid].retry_build_id == resp.build_id
+    assert builds[root.uuid].retry_build_id == tip.uuid
 
 
 def test_repeated_continuations_linearize_into_one_chain():

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -223,3 +223,171 @@ def test_validate_build_allows_admin_impersonation_via_space_name():
             _validate_req(VICTIM, space_name=SPACE),
         )
     assert resp.status_code == 200
+
+
+# ------------------------------------------------------------------ continue_build
+
+from gbserver.api.builds import BuildContinueRequest, continue_build
+from gbserver.storage.stored_build import StoredBuild
+from gbserver.types.status import Status
+
+
+def _fake_build_storage(builds: dict):
+    """A build_storage mock backed by a {uuid: StoredBuild} dict that supports
+    the get_by_uuid / add / update surface create_continuation_build uses."""
+
+    def _add(b):
+        builds[b.uuid] = b
+        return b.uuid
+
+    def _update(b):
+        builds[b.uuid] = b
+        return b
+
+    return SimpleNamespace(
+        get_by_uuid=lambda uuid: builds.get(uuid),
+        add=_add,
+        update=_update,
+    )
+
+
+def _patched_continue_storage(builds: dict):
+    space = StoredSpace(name=SPACE, git_repo_uri="")
+    fake_storage = SimpleNamespace(
+        space_storage=SimpleNamespace(
+            get_by_name=lambda name: space if name == SPACE else None
+        ),
+        build_storage=_fake_build_storage(builds),
+    )
+    return patch.object(builds_module, "get_admin_storage", return_value=fake_storage)
+
+
+def _prior_build(username: str, status: Status = Status.FAILED) -> StoredBuild:
+    return StoredBuild(
+        name="poc",
+        space_name=SPACE,
+        source_uri="",
+        username=username,
+        build_archive="dGVzdA==",
+        status=status,
+        targets=["a", "b"],
+    )
+
+
+def test_continue_build_missing_build_returns_404():
+    with _patched_continue_storage({}):
+        with pytest.raises(HTTPException) as exc:
+            continue_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                BuildContinueRequest(build_id="does-not-exist"),
+            )
+    assert exc.value.status_code == 404
+
+
+def test_continue_build_rejects_active_build_409():
+    prior = _prior_build(ATTACKER, status=Status.RUNNING)
+    with _patched_continue_storage({prior.uuid: prior}):
+        with pytest.raises(HTTPException) as exc:
+            continue_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                BuildContinueRequest(build_id=prior.uuid),
+            )
+    assert exc.value.status_code == 409
+
+
+def test_continue_build_creates_linked_continuation():
+    prior = _prior_build(ATTACKER, status=Status.FAILED)
+    builds = {prior.uuid: prior}
+    with (
+        _patched_continue_storage(builds),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        resp = continue_build(
+            _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+            BuildContinueRequest(build_id=prior.uuid),
+        )
+    assert resp.build_id and resp.build_id != prior.uuid
+    # The response reports the resolved chain root (here the prior build itself).
+    assert resp.root_build_id == prior.uuid
+    continuation = builds[resp.build_id]
+    # Fresh build, linked to the prior chain root, fresh retry budget, SUBMITTED.
+    assert continuation.retry_of_build_id == prior.uuid
+    assert continuation.retry_count == 0
+    assert continuation.status == Status.SUBMITTED
+    assert continuation.build_archive == prior.build_archive
+    assert continuation.targets == prior.targets
+    # Back-link set on the prior (chain tip) so the chain advances.
+    assert builds[prior.uuid].retry_build_id == resp.build_id
+
+
+def test_continue_build_accepts_mid_chain_member_and_links_to_root():
+    # root -> mid (any member may be continued; continuation links to the root
+    # and the back-link lands on the chain tip, not the passed-in member).
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    mid = _prior_build(ATTACKER, status=Status.FAILED)
+    mid.retry_of_build_id = root.uuid
+    root.retry_build_id = mid.uuid
+    builds = {root.uuid: root, mid.uuid: mid}
+    with (
+        _patched_continue_storage(builds),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        resp = continue_build(
+            _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+            BuildContinueRequest(build_id=root.uuid),
+        )
+    continuation = builds[resp.build_id]
+    assert continuation.retry_of_build_id == root.uuid
+    # The response reports the resolved root even though a mid-chain member was passed.
+    assert resp.root_build_id == root.uuid
+    # Tip (mid) gets the back-link; root's existing link is untouched.
+    assert builds[mid.uuid].retry_build_id == resp.build_id
+    assert builds[root.uuid].retry_build_id == mid.uuid
+
+
+def test_repeated_continuations_linearize_into_one_chain():
+    """Continuing the same root repeatedly appends to the current tip, so the
+    chain stays linear (A -> B -> C) rather than branching into multiple chains
+    sharing a root. `gb build status --follow-retries` then shows every
+    continuation in a single walk."""
+    from gbserver.storage.stored_build import (
+        create_continuation_build,
+        get_retry_chain_members,
+    )
+
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    builds = {root.uuid: root}
+    bs = _fake_build_storage(builds)
+
+    # Continue root -> B, then continue root again -> C. Both attach to the tip.
+    b = create_continuation_build(bs, builds[root.uuid])
+    c = create_continuation_build(bs, builds[root.uuid])
+
+    chain = [m.uuid for m in get_retry_chain_members(bs, builds[root.uuid])]
+    assert chain == [root.uuid, b.uuid, c.uuid]
+    # No back-link was overwritten: root -> B -> C, each single forward hop.
+    assert builds[root.uuid].retry_build_id == b.uuid
+    assert builds[b.uuid].retry_build_id == c.uuid
+    # Every continuation links to the same resolved root.
+    assert b.retry_of_build_id == root.uuid
+    assert c.retry_of_build_id == root.uuid
+
+
+def test_continue_build_rejects_forged_username():
+    prior = _prior_build(VICTIM, status=Status.FAILED)
+    with (
+        _patched_continue_storage({prior.uuid: prior}),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            continue_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                BuildContinueRequest(build_id=prior.uuid),
+            )
+    assert exc.value.status_code == 401

--- a/test/unit/api/test_builds.py
+++ b/test/unit/api/test_builds.py
@@ -423,6 +423,66 @@ def test_create_continuation_build_uses_passed_chain_without_rewalking():
     assert builds[tip.uuid].retry_build_id == cont.uuid
 
 
+def test_create_continuation_build_rejects_chain_missing_prior():
+    """create_continuation_build must refuse to link off a chain that does not
+    contain `prior`. This guards get_retry_chain_members' `members or [build]`
+    fallback (root row unreadable) and a stale/mismatched passed-in chain, either
+    of which would otherwise link to the wrong root and orphan the chain tail."""
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    mid = _prior_build(ATTACKER, status=Status.FAILED)
+    mid.retry_of_build_id = root.uuid
+    root.retry_build_id = mid.uuid
+    bs = _fake_build_storage({root.uuid: root, mid.uuid: mid})
+    # A chain that does not contain `mid` (e.g. resolved before mid was linked, or
+    # the fallback returned just [root]).
+    with pytest.raises(ValueError, match="does not contain"):
+        create_continuation_build(bs, mid, chain=[root])
+    # The valid mid is untouched — no back-link overwritten.
+    assert root.retry_build_id == mid.uuid
+
+
+def test_create_continuation_build_rewalk_fallback_does_not_corrupt_chain():
+    """If get_retry_chain_members can only see `prior` (root row unreadable, so it
+    hits `members or [build]`), the guard fires rather than silently treating a
+    mid-chain member as its own root and overwriting its forward link."""
+    root = _prior_build(ATTACKER, status=Status.FAILED)
+    mid = _prior_build(ATTACKER, status=Status.FAILED)
+    mid.retry_of_build_id = root.uuid
+    root.retry_build_id = mid.uuid
+    # Only `mid` is readable; the root read fails, so get_retry_chain_members
+    # returns [mid] via its fallback — mid would wrongly be its own root/tip.
+    bs = _fake_build_storage({mid.uuid: mid})
+    with pytest.raises(ValueError, match="does not contain|could not be resolved"):
+        create_continuation_build(bs, mid)
+    # mid's forward link is NOT clobbered (it never pointed anywhere, and stays so).
+    assert mid.retry_build_id is None
+
+
+def test_continue_build_authorizes_tip_space_not_just_prior():
+    """Authz is checked against the tip's space/user (what the continuation runs
+    as), not only the passed-in member. A caller authorized on the passed-in
+    build's space but NOT the tip's is rejected with the not-found 404."""
+    # prior (passed-in) is in SPACE and owned by the caller; the tip diverges to a
+    # different owner the caller has no access to.
+    prior = _prior_build(ATTACKER, status=Status.FAILED)
+    tip = _prior_build(VICTIM, status=Status.FAILED)
+    tip.retry_of_build_id = prior.uuid
+    prior.retry_build_id = tip.uuid
+    with (
+        _patched_continue_storage({prior.uuid: prior, tip.uuid: tip}),
+        _real_authz(),
+        patch("gbserver.api.utils.is_super_admin", return_value=False),
+        patch("gbserver.api.utils.is_space_admin", return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            continue_build(
+                _fake_request(ATTACKER, f"{ATTACKER}@example.com"),
+                BuildContinueRequest(build_id=prior.uuid),
+            )
+    # Same 404 as every other "you may not see this" path — no oracle.
+    assert exc.value.status_code == 404
+
+
 def test_chain_walk_includes_intermediate_members_from_any_member():
     """get_retry_chain_members must return EVERY member of a flat-to-root chain
     (root -> mid -> tip), not just [self, root], regardless of which member it is

--- a/test/unit/buildrunner/test_artifact_reuse.py
+++ b/test/unit/buildrunner/test_artifact_reuse.py
@@ -51,33 +51,36 @@ _BINDING = "model_out"
 def _make_runner(retry_chain_ids):
     """Build a BuildRunner with mocked storage, bypassing __init__.
 
-    ``retry_chain_ids[0]`` is treated as the current (retry) build; the rest are
-    ancestors reachable via ``retry_of_build_id``.
+    ``retry_chain_ids[0]`` is the current (tip/retry) build; the rest are
+    ancestors toward the root, so ``retry_chain_ids[-1]`` is the root. The mocks
+    model the real linkage the chain walk relies on: every non-root member's
+    ``retry_of_build_id`` points at the root (flat-to-root), and each member's
+    ``retry_build_id`` forward-links to the next-newer member. All members are
+    resolvable via ``get_by_uuid`` (get_retry_chain_members walks forward from
+    the root).
     """
     runner = object.__new__(BuildRunner)
 
-    current_id = retry_chain_ids[0]
-    parent_id = retry_chain_ids[1] if len(retry_chain_ids) > 1 else ""
+    root_id = retry_chain_ids[-1]
+    # Order root -> ... -> tip for building the forward retry_build_id links.
+    ordered = list(reversed(retry_chain_ids))
 
-    stored_build = MagicMock(spec=StoredBuild)
-    stored_build.uuid = current_id
-    stored_build.space_name = _SPACE
-    stored_build.username = _USER
-    stored_build.retry_of_build_id = parent_id
-    runner.stored_build = stored_build
+    members = {}
+    for idx, bid in enumerate(ordered):
+        member = MagicMock(spec=StoredBuild)
+        member.uuid = bid
+        member.space_name = _SPACE
+        member.username = _USER
+        # Flat-to-root: non-root members point at the root; the root has none.
+        member.retry_of_build_id = "" if bid == root_id else root_id
+        # Forward link to the next-newer member (None on the tip).
+        member.retry_build_id = ordered[idx + 1] if idx + 1 < len(ordered) else None
+        members[bid] = member
 
-    # build_storage walks the retry chain via get_by_uuid(retry_of_build_id).
-    ancestors = {}
-    for idx, bid in enumerate(retry_chain_ids[1:], start=1):
-        ancestor = MagicMock(spec=StoredBuild)
-        ancestor.uuid = bid
-        ancestor.retry_of_build_id = (
-            retry_chain_ids[idx + 1] if idx + 1 < len(retry_chain_ids) else ""
-        )
-        ancestors[bid] = ancestor
+    runner.stored_build = members[retry_chain_ids[0]]
 
     storage = MagicMock()
-    storage.build_storage.get_by_uuid.side_effect = lambda uuid: ancestors.get(uuid)
+    storage.build_storage.get_by_uuid.side_effect = members.get
     runner.storage = storage
 
     runner.build_run = None

--- a/test/unit/gbcli/commands/test_status_skipped_targets.py
+++ b/test/unit/gbcli/commands/test_status_skipped_targets.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for `gb build status` skipped-target filtering.
+
+Targets reused from an earlier attempt (retry or continuation) carry a
+`skipped_for_prerun_target_id`. They run no steps and produce no artifacts, so
+`execution_status_plain_output` hides them by default and only shows them when
+`--show-skipped-targets` is passed. Both the targets overview (summary) and the
+per-target sections are affected.
+"""
+
+import pytest
+
+from gbcli.commands.command_build import execution_status_plain_output
+
+pytestmark = pytest.mark.standalone
+
+
+_DETAILS = {
+    "build_id": "b-123",
+    "name": "demo",
+    "description": "",
+    "status": "success",
+    "started_at": "2026-08-20T10:00:00Z",
+    "updated_at": "2026-08-20T10:05:00Z",
+    "source_pr": "",
+}
+
+
+def _target(status="success", skipped_id=""):
+    return {
+        "status": status,
+        "build_id": "b-123",
+        "skipped_for_prerun_target_id": skipped_id,
+        "input_artifacts": [],
+        "output_artifacts": [],
+        "steps": [],
+    }
+
+
+def _targets():
+    # One target that actually ran, one reused/skipped from a prior attempt.
+    return {
+        "ran-target (u1)": _target(status="success"),
+        "skipped-target (u2)": _target(status="success", skipped_id="prior-u2"),
+    }
+
+
+def test_skipped_targets_hidden_by_default():
+    out = execution_status_plain_output(
+        _DETAILS, _targets(), history=[], show_events=False
+    )
+    assert "ran-target (u1)" in out
+    # Hidden from both the overview and the per-target sections. Match on the
+    # unique target key (the flag name in the hint also contains the substring
+    # "skipped-target", so assert on the target identity instead).
+    assert "skipped-target (u2)" not in out
+    assert "SKIPPED" not in out
+    # A hint tells the user how to reveal them.
+    assert "1 skipped target hidden" in out
+    assert "--show-skipped-targets" in out
+
+
+def test_skipped_targets_shown_with_flag():
+    out = execution_status_plain_output(
+        _DETAILS,
+        _targets(),
+        history=[],
+        show_events=False,
+        show_skipped_targets=True,
+    )
+    assert "ran-target (u1)" in out
+    assert "skipped-target (u2)" in out
+    assert "SKIPPED" in out
+    # No "hidden" hint when nothing is hidden.
+    assert "hidden" not in out
+
+
+def test_no_hint_when_no_skipped_targets():
+    targets = {"ran-target (u1)": _target(status="success")}
+    out = execution_status_plain_output(
+        _DETAILS, targets, history=[], show_events=False
+    )
+    assert "ran-target" in out
+    assert "hidden" not in out

--- a/test/unit/gbcli/commands/test_status_skipped_targets.py
+++ b/test/unit/gbcli/commands/test_status_skipped_targets.py
@@ -97,3 +97,20 @@ def test_no_hint_when_no_skipped_targets():
     )
     assert "ran-target" in out
     assert "hidden" not in out
+
+
+def test_hiding_skipped_targets_preserves_original_numbering():
+    """Hiding a skipped target must not renumber the survivors: a "Target #N"
+    always reflects the build's real target order, so a visible target keeps its
+    original position even when earlier targets are hidden."""
+    # Order: #1 is skipped, #2 actually ran. Hiding #1 must leave the runner as #2.
+    targets = {
+        "skipped-first (u1)": _target(status="success", skipped_id="prior-u1"),
+        "ran-second (u2)": _target(status="success"),
+    }
+    out = execution_status_plain_output(
+        _DETAILS, targets, history=[], show_events=False
+    )
+    assert "Target #2 ran-second (u2)" in out
+    # It must NOT be renumbered to #1.
+    assert "Target #1 ran-second (u2)" not in out

--- a/test/unit/gbcli/services/test_build_continue.py
+++ b/test/unit/gbcli/services/test_build_continue.py
@@ -96,3 +96,45 @@ def test_build_continue_returns_none_on_server_error():
         )
 
     assert result is None
+
+
+def test_build_continue_unresolvable_url_returns_none_not_exception():
+    """get_build_id_from_url returns None when a URL matches no build; build_continue
+    must guard the deref and return None (surfacing the intended error) instead of
+    raising a raw IndexError/TypeError — even with callback=None (no early exit)."""
+    calls = []
+
+    def _capture(callback_event, callback_args):
+        calls.append((callback_event, callback_args))
+
+    with (
+        patch.object(service_build, "get_build_id_from_url", return_value=None),
+        patch.object(service_build, "make_gbserver_call") as server_call,
+    ):
+        result = service_build.build_continue(
+            github_token="tok",
+            build_id=BUILD_URL,
+            id_format="url",
+            callback=_capture,
+        )
+
+    assert result is None
+    # Never reached the server call — bailed out at the unresolved URL.
+    server_call.assert_not_called()
+    # Surfaced the intended error event rather than a raw exception.
+    assert any(event == "error" for event, _ in calls)
+
+
+def test_build_continue_unresolvable_url_none_callback_no_crash():
+    """The deref guard must also hold with callback=None (a programmatic caller):
+    it returns None rather than raising."""
+    with (
+        patch.object(service_build, "get_build_id_from_url", return_value=None),
+        patch.object(service_build, "make_gbserver_call") as server_call,
+    ):
+        result = service_build.build_continue(
+            github_token="tok", build_id=BUILD_URL, id_format="url", callback=None
+        )
+
+    assert result is None
+    server_call.assert_not_called()

--- a/test/unit/gbcli/services/test_build_continue.py
+++ b/test/unit/gbcli/services/test_build_continue.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``build_continue`` service layer.
+
+The key behaviour under test is that ``build_continue`` reports the *resolved
+uuid* of the continued build via ``continued_from`` — even when the caller
+passed a build URL. The CLI reads that field (not the raw argument) so a URL
+never leaks into uuid-valued JSON output or a uuid-vs-URL root comparison.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gbcli.services import service_build
+
+pytestmark = pytest.mark.standalone
+
+PRIOR_UUID = "11111111-1111-1111-1111-111111111111"
+NEW_UUID = "22222222-2222-2222-2222-222222222222"
+ROOT_UUID = "33333333-3333-3333-3333-333333333333"
+BUILD_URL = "https://example.com/builds/11111111-1111-1111-1111-111111111111"
+
+
+def _server_response():
+    # The server only returns the new build id and the resolved chain root; it
+    # does not echo back which member was continued.
+    return {"build_id": NEW_UUID, "root_build_id": ROOT_UUID}
+
+
+def test_build_continue_reports_resolved_uuid_when_url_passed():
+    """A URL is resolved to a uuid before the server call; continued_from must be
+    that resolved uuid, not the URL the caller typed."""
+    with (
+        patch.object(
+            service_build,
+            "get_build_id_from_url",
+            return_value=[{"uuid": PRIOR_UUID}],
+        ) as resolve,
+        patch.object(
+            service_build, "make_gbserver_call", return_value=_server_response()
+        ),
+    ):
+        result = service_build.build_continue(
+            github_token="tok", build_id=BUILD_URL, id_format="url"
+        )
+
+    resolve.assert_called_once()
+    assert result["continued_from"] == PRIOR_UUID
+    assert result["continued_from"] != BUILD_URL
+    # Server-provided fields are passed through untouched.
+    assert result["build_id"] == NEW_UUID
+    assert result["root_build_id"] == ROOT_UUID
+
+
+def test_build_continue_reports_uuid_unchanged_when_uuid_passed():
+    """When a uuid is passed there is nothing to resolve; continued_from is that
+    same uuid, so the CLI's `root != continued_from` hint compares uuid-to-uuid."""
+    with (
+        patch.object(service_build, "get_build_id_from_url") as resolve,
+        patch.object(
+            service_build, "make_gbserver_call", return_value=_server_response()
+        ),
+    ):
+        result = service_build.build_continue(
+            github_token="tok", build_id=PRIOR_UUID, id_format="uuid"
+        )
+
+    resolve.assert_not_called()
+    assert result["continued_from"] == PRIOR_UUID
+
+
+def test_build_continue_returns_none_on_server_error():
+    """A server/connection failure (make_gbserver_call -> None) yields None and no
+    continued_from is fabricated."""
+    with (
+        patch.object(service_build, "get_build_id_from_url"),
+        patch.object(service_build, "make_gbserver_call", return_value=None),
+    ):
+        result = service_build.build_continue(
+            github_token="tok", build_id=PRIOR_UUID, id_format="uuid"
+        )
+
+    assert result is None


### PR DESCRIPTION
## Summary

Adds **build continuation** and a related **status-output** improvement.

**`gb build continue <BUILD_ID>`** — continue any *finished* build in a fresh runner, skipping targets that already succeeded and re-running the rest. It fills the gap between:
- build-level retry (same live runner, `FAILED`-only, shares the `max_retries` budget), and
- `gb build init --from-build` + `gb build start` (an unrelated build that re-runs *everything*).

A continuation is a fresh `StoredBuild` linked to the prior chain **root** via `retry_of_build_id`, with `retry_count` reset to `0` (so `max_retries` is counted fresh), submitted as `SUBMITTED` so the BuildWatcher dispatches a fresh runner. The `retry_of_build_id` link alone engages the existing target-reuse machinery, so completed targets are skipped with **no runner changes**. Any chain member may be passed; the server resolves the canonical root and returns it (`root_build_id`), which the CLI reports. Continuations attach to the current chain tip, so repeated continuations **linearize** (`A → B → C`) rather than branch, and one `gb build status --follow-retries` shows every attempt.

- **Server**: `POST /api/v1/builds/continue` (`BuildContinueRequest` → `BuildContinueResponse`). `404` if the prior build is missing, `409` unless it is finished (no runner-liveness table — status is the signal). `create_continuation_build()` in `stored_build.py` is the single linkage helper.
- **Client**: `gb build continue`, `service_build.build_continue`, and the `continue_build` transport — no local build folder needed.

**`--show-skipped-targets`** (default off) on `gb build status` and `gb build monitor` — skipped/reused targets run no steps and produce no artifacts and make the output long, so they are now hidden by default (both the summary and per-target sections), with a one-line hint of how many were hidden. The flag restores them. Applies uniformly to retry and continuation chains. JSON output (`--format json`) is left complete for programmatic consumers.

## Test plan

- **Unit** (`test/unit/api/test_builds.py`): continuation endpoint — 404 (missing), 409 (active build), linkage to root, mid-chain-member normalization, repeated-continuation linearization, and identity gating.
- **Unit** (`test/unit/gbcli/commands/test_status_skipped_targets.py`): skipped targets hidden by default, shown with `--show-skipped-targets`, and no hint when there are none.
- **Integration** (`test/integration/standalone/buildrunner/bash/test_buildrunner_continue.py`, standalone bash / thread runner): run a target to SUCCESS, mark the build FAILED, continue it in a fresh runner, and assert the target is skipped (`skipped_for_prerun_target_id` set) with the chain linkage correct.
- `make format` clean; `pylint`/`mypy` show no findings in the changed code (`src/gbserver/` is clean).

## Docs

New `docs/builds/build-continuation.md`, with cross-links from `build-retry.md`, the builds `README`, and the `gb` CLI reference.

Refs ibm-granite/granite.build#285

Generated with [Claude Code](https://claude.com/claude-code)
