### PR TITLE
Bound lineage scan to tracked builds; release wandb runs on failure

### DIFF
--- a/src/gbserver/lineage/jobstats.py
+++ b/src/gbserver/lineage/jobstats.py
@@ -21,7 +21,7 @@ Abstract interface for lineage storage and singleton accessor.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 from gbserver.storage.artifact_registration import ArtifactRegistration
 from gbserver.storage.singleton_storage import SingletonAdminStorage
@@ -85,6 +85,7 @@ class ILineageStore(ABC):
         self,
         target_ids: set[str],
         expected_counts: Optional[dict[str, int]] = None,
+        on_query_error: Optional[Callable[[Exception], None]] = None,
     ) -> set[str]:
         """Return the subset of ``target_ids`` not yet recorded in *this* store.
 
@@ -100,6 +101,18 @@ class ILineageStore(ABC):
         — idempotent recording preserves correctness regardless — so
         implementations must never raise; on failure they return ``target_ids``
         unchanged, degrading to re-recording the candidates (harmless).
+
+        That degradation is *safe* but not *free*, and it is indistinguishable
+        from a genuine "none of these are recorded" answer. A caller that swept a
+        wide candidate range and hit a sink timeout would re-record the entire
+        range — turning one failed query into a write storm against the sink that
+        just failed. Worse, a caller deciding something irreversible (e.g.
+        retiring a build from a tracking set once its lineage is confirmed) must
+        not read a failure as a verdict at all. ``on_query_error`` exists for
+        that: when provided, implementations invoke it with the exception before
+        returning the fail-open set, so the caller can tell "the sink says these
+        are unrecorded" from "the sink did not answer". Callers that do not care
+        omit it and keep the historical behavior.
 
         ``expected_counts`` maps a target uuid to the number of records the sink
         should hold for a *fully* recorded target (one W&B run per output

--- a/src/gbserver/lineage/lineage_reconciler.py
+++ b/src/gbserver/lineage/lineage_reconciler.py
@@ -201,6 +201,7 @@ def select_recordable_targets(
     finished_after: datetime,
     build_id: Optional[str] = None,
     stop_at: Optional[tuple[str, datetime]] = None,
+    allowed_build_ids: Optional[set[str]] = None,
 ) -> list[StoredTargetRun]:
     """Select successful target runs whose lineage should be recorded.
 
@@ -250,8 +251,27 @@ def select_recordable_targets(
     moves forward it is never re-surfaced — lineage lost silently. Anchoring on a
     row instead lets the walk retreat to a known point however far back in time
     that is; because the query filters on ``status`` alone and never on
-    ``build_id``, sweeping that range also picks up the straggling targets of
-    *every other* build, which is what closes the gap for concurrent builds.
+    ``build_id``, sweeping that range also reaches the straggling targets of
+    *other* builds, which is what closes the gap for concurrent builds.
+
+    ``allowed_build_ids`` bounds *which* builds that sweep may record for. The
+    retreat above is by row identity, so its reach back in time is set by the
+    anchor build's oldest target and is unbounded in principle: on a deployment
+    with history, a walk anchored at a build that finished yesterday can page
+    back months and select every unrelated build's targets along the way. Left
+    unfiltered that is not merely slow — paired with ``filter_unrecorded``'s
+    fail-open (see ``reconcile_once``), one sink timeout turns the whole swept
+    range into a re-record storm. Passing a membership set keeps the retreat
+    (the anchor still bounds *how far* the walk goes) while restricting what it
+    yields to builds the caller is actually tracking.
+
+    Membership, not a time comparison, is the test on purpose: ``finished_at``
+    can place a late-committing row behind the caller's watermark (the paragraph
+    above), so "is this build newer than the mark" would drop exactly the rows
+    the anchored walk exists to recover. A build stays eligible because it is in
+    the set, however its timestamps land. ``None`` disables the filter and
+    restores the unfiltered sweep, which is what the build-scoped callers
+    (``build_id``) and one-shot backfills want.
 
     The anchor row is included in the result, mirroring the inclusive ``>=`` of
     the cutoff: re-reading it is a harmless idempotent no-op, and treating it as
@@ -334,6 +354,15 @@ def select_recordable_targets(
                         len(selected),
                     )
                     return selected
+                if (
+                    allowed_build_ids is not None
+                    and target.build_id not in allowed_build_ids
+                ):
+                    # Outside the tracked build set: skip the row but keep
+                    # walking. The anchor above is checked *before* this, so a
+                    # filtered-out anchor still stops the walk — dropping it here
+                    # would remove the bound and page to the end of the table.
+                    continue
                 selected.append(target)
                 continue
             # Sorted newest-finished-first: once we reach a target that finished
@@ -451,7 +480,7 @@ def get_oldest_successful_target(
         page_index += 1
 
 
-def _expected_run_count(target: StoredTargetRun) -> int:
+def expected_run_count(target: StoredTargetRun) -> int:
     """Number of lineage runs a fully-recorded ``target`` should have in a sink.
 
     Must mirror how ``WandBLineageStore._build_events_for_target`` emits events:
@@ -478,6 +507,7 @@ def reconcile_once(
     build_id: Optional[str] = None,
     watermark_build_id: Optional[str] = None,
     stop_at: Optional[tuple[str, datetime]] = None,
+    allowed_build_ids: Optional[set[str]] = None,
 ) -> int:
     """Reconcile admin-DB lineage into the store once (the central mechanism).
 
@@ -498,7 +528,7 @@ def reconcile_once(
       admin DB can feed W&B and other sinks independently. It never raises; on
       failure it returns the full candidate set, degrading to re-recording
       (harmless — recording is idempotent). It is given each candidate's expected
-      run count (``_expected_run_count``) so a target whose runs were only
+      run count (``expected_run_count``) so a target whose runs were only
       partially emitted on a prior crashed scan is reported unrecorded and
       re-recorded, rather than masked by its already-present runs.
 
@@ -563,6 +593,11 @@ def reconcile_once(
             straggling target in scope. The steady-state scan passes this (with
             ``finished_after=UTC_MIN``, since the anchor is then the real bound);
             the build-scoped verification sweep does not.
+        allowed_build_ids: Restrict which builds the walk may record for, as a
+            membership test — see ``select_recordable_targets``. The steady-state
+            scan passes the watcher's in-flight build set so an anchored retreat
+            cannot select unrelated history; ``None`` (the build-scoped sweep and
+            deliberate backfills) leaves the walk unfiltered.
 
     Returns:
         How many targets were newly recorded this pass. Where the watermark
@@ -582,6 +617,7 @@ def reconcile_once(
                 finished_after=finished_after,
                 build_id=build_id,
                 stop_at=stop_at,
+                allowed_build_ids=allowed_build_ids,
             )
         )
     )
@@ -671,11 +707,37 @@ def reconcile_once(
     # output_artifacts would give the wrong count; omit it and let it fall back to
     # the presence check (a rare case; re-recording is a harmless idempotent no-op).
     expected_counts = {
-        uuid: _expected_run_count(target)
+        uuid: expected_run_count(target)
         for uuid, target in by_uuid.items()
         if not target.skipped_for_prerun_target_id
     }
-    unrecorded = store.filter_unrecorded(set(by_uuid), expected_counts)
+    # Track whether the sink actually answered. A failed query fails open and
+    # returns every candidate, which reads downstream as "none of these are
+    # recorded" — so a single sink timeout over a wide candidate range becomes a
+    # full re-record of that range, aimed at the sink that just timed out. The
+    # re-records are harmless individually (recording is idempotent) but the
+    # volume is not, and the log line below would report them as a real verdict.
+    sink_query_failed = False
+
+    def _note_sink_failure(_exc: Exception) -> None:
+        nonlocal sink_query_failed
+        sink_query_failed = True
+
+    unrecorded = store.filter_unrecorded(
+        set(by_uuid), expected_counts, on_query_error=_note_sink_failure
+    )
+    if sink_query_failed:
+        # Say so explicitly: without this the line below claims "0 already
+        # recorded", which looks like a genuine backlog rather than an
+        # unanswered query. Recording still proceeds — idempotency keeps it
+        # correct, and skipping the pass entirely would stall lineage whenever
+        # the sink is briefly unreachable.
+        logger.warning(
+            "The lineage sink did not answer the recorded-state query for this "
+            "scan's %d candidate(s); treating all of them as unrecorded. Counts "
+            "below are a fail-open default, not the sink's verdict.",
+            len(by_uuid),
+        )
     # Log the selection *and* the sink's verdict on it, since "found candidates
     # but recorded none" (all already in the sink) and "found no candidates at
     # all" are very different states that otherwise look the same.

--- a/src/gbserver/lineage/lineage_reconciler.py
+++ b/src/gbserver/lineage/lineage_reconciler.py
@@ -284,6 +284,12 @@ def select_recordable_targets(
     restores the unfiltered sweep, which is what the build-scoped callers
     (``build_id``) and one-shot backfills want.
 
+    The filter applies **only on the anchored path** (``stop_at`` given), and is
+    inert when it is not: without an anchor the walk is already bounded by the
+    ``finished_after`` cutoff, so the unbounded retreat this defends against
+    cannot arise, and the rows it would exclude are ones that sweep wants. Do not
+    read this parameter as unconditionally bounding the selection.
+
     The anchor row is included in the result, mirroring the inclusive ``>=`` of
     the cutoff: re-reading it is a harmless idempotent no-op, and treating it as
     already-handled would reintroduce a boundary to lose targets on. Matching is

--- a/src/gbserver/lineage/lineage_reconciler.py
+++ b/src/gbserver/lineage/lineage_reconciler.py
@@ -77,6 +77,17 @@ LINEAGE_WATCHER_CHECKPOINT_KEY = "lineage_store_latest_build_id"
 # {"target_ids": [str, ...]}.
 LINEAGE_WATCHER_DROPPED_KEY = "lineage_store_dropped_target_ids"
 
+# gb_kv_pairs key under which the LineageWatcher records builds it retired while
+# some of their targets had been dropped rather than recorded — so their lineage
+# in the sink is knowingly partial. Retiring them is deliberate: a run deleted
+# from wandb cannot be regenerated (run ids are derived from the target, and the
+# sink will not accept a deleted id again), so retaining the build would pin it
+# forever for lineage that can never land. Without this key the gap would live
+# only in a log line that rotates away; here it stays queryable, which is what
+# makes a build's completeness analyzable after the fact. Value shape:
+# {"builds": {<build_id>: {"target_ids": [str, ...], "retired_at": <ISO 8601>}}}.
+LINEAGE_WATCHER_INCOMPLETE_KEY = "lineage_store_incomplete_builds"
+
 # Column the reconciliation scan sorts/paginates successful targets by. A target
 # gets finished_at set when it succeeds, so it is the moment the target becomes
 # recordable — the correct watermark for "finished since I last scanned" (unlike

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -25,6 +25,7 @@ from gbserver.lineage.jobstats import ILineageStore, get_lineage_store
 from gbserver.lineage.lineage_reconciler import (
     LINEAGE_WATCHER_CHECKPOINT_KEY,
     LINEAGE_WATCHER_DROPPED_KEY,
+    LINEAGE_WATCHER_INCOMPLETE_KEY,
     UTC_MIN,
     as_aware,
     expected_run_count,
@@ -43,95 +44,49 @@ logger = get_logger(__name__)
 class LineageWatcher:
     """Async background thread that reconciles lineage from the admin DB.
 
-    Runs a single background daemon thread that periodically calls
-    ``reconcile_once`` (see ``lineage_reconciler``), which scans the admin DB for
-    successful target runs and records their lineage into the configured store,
-    off the build's hot path.
+    A single daemon thread periodically calls ``reconcile_once`` (see
+    ``lineage_reconciler``), which scans the admin DB for successful target runs and
+    records their lineage into the configured store, off the build's hot path.
 
-    Reconciliation — not the event stream — is the authoritative mechanism: the
-    admin DB persists the complete lineage graph, so the full lineage is
-    recoverable by re-reading it alone. Because each scan re-derives the
-    recordable set from the DB, a target that succeeded while this process was
-    down is picked up on the next scan; there is no restart blind spot. Recording
-    is idempotent (deterministic runIds + resume="allow" + content-dedupe), so a
-    re-recorded target is a harmless backend no-op.
+    Reconciliation — not the event stream — is authoritative: the admin DB persists
+    the complete lineage graph, so full lineage is recoverable by re-reading it
+    alone. Each scan re-derives the recordable set from the DB, so a target that
+    succeeded while this process was down is picked up next scan; there is no restart
+    blind spot. Recording is idempotent (deterministic runIds + resume="allow" +
+    content-dedupe), making a re-record a harmless no-op.
 
-    Single-writer guarantee: the watcher is deployed as its own single-replica
-    ``lineage-watch`` command/pod (see ``command_lineage_watch.py`` and
-    ``dep-lineage-watcher.yaml``), so exactly one process reconciles lineage. It
-    must not be wired into any other entrypoint. Even if that were violated,
-    idempotent recording means a duplicate watcher would waste I/O but not
-    corrupt lineage.
+    Single-writer: deployed as its own single-replica ``lineage-watch`` command/pod
+    (see ``command_lineage_watch.py``, ``dep-lineage-watcher.yaml``), so exactly one
+    process reconciles lineage; it must not be wired into another entrypoint. Even
+    violated, idempotent recording means a duplicate wastes I/O without corrupting.
 
-    Steady state keeps per-scan work bounded with a ``finished_at`` checkpoint,
-    but does not query straight from it: each scan bounds its walk at the
-    *anchor* row — the checkpoint build's oldest successful target — so a target
-    whose row surfaced behind the checkpoint is still reached (see
-    ``_reconcile``). The checkpoint lives solely in the ``gb_kv_pairs`` key (see
-    ``lineage_reconciler.LINEAGE_WATCHER_CHECKPOINT_KEY``), rewritten after each
-    individually-recorded target and re-read at the top of every scan — so a
-    restart resumes from the last successfully-recorded target rather than
-    rescanning the whole admin DB, and a key seeded or corrected while the
-    watcher runs takes effect on the next scan.
+    How a scan is bounded, in two independent ways — each documented in full at
+    its own site:
 
-    The checkpoint is never created implicitly: with no checkpoint the watcher
-    records *nothing* and every scan is a no-op until the key is seeded
-    explicitly (see ``gbserver lineage-watch --base-build-id``). Choosing where
-    centralized recording begins — "from now", from a given build, or the full
-    history — is the operator's call, so a fresh deployment stays silent rather
-    than picking a starting point on its own. When the checkpoint does exist,
-    ``start()`` verifies its build against the store's own recorded-state
-    (``filter_unrecorded``, via a build-scoped ``reconcile_once``) and re-records
-    what is missing, closing any gap left by a crash between recording
-    and persisting the checkpoint (or vice versa). That sweep is scoped to one
-    build, though, so the general safety net is the scan's *anchor*: each scan
-    bounds its walk by the checkpoint build's oldest successful target rather than
-    by a timestamp, and because the query filters on status alone the sweep back to
-    that row re-surfaces the straggling targets of other builds, not just the
-    checkpoint's. Idempotent recording makes the re-reads harmless. See
-    ``_reconcile`` for why a row anchor and not a time window, and for the residual
-    gap it does not close.
+    - *How far back*: not the ``finished_at`` checkpoint directly but the *anchor* row
+      it names (the checkpoint build's oldest successful target), so a row that
+      surfaced behind the watermark is still reached. The checkpoint lives solely in
+      ``LINEAGE_WATCHER_CHECKPOINT_KEY``, rewritten per recorded target and re-read
+      each scan. Never created implicitly — an unseeded watcher records *nothing*,
+      leaving the operator to choose where recording begins (``--base-build-id``).
+      See ``_reconcile``, ``_verify_checkpoint``.
+    - *Which builds*: an in-memory allowlist floored at the checkpoint build. Without
+      it an anchor at a recent build still selects every older build's targets behind
+      it — hundreds of unrelated candidates per scan on a deployment with history, and
+      a re-record storm of that size the first time the sink fails to answer. See
+      ``_refresh_allowed_builds``, ``_admit_builds_in_anchored_range``,
+      ``_retire_finished_builds``.
 
-    That sweep is bounded by *which* builds it may record for, not only by how far
-    back it reaches: the watcher tracks an in-memory allowlist of builds — the
-    checkpoint build as a permanent floor, plus every build seen since or found
-    inside the anchored range — and the scan records only for those. Without it an
-    anchor at a recent build still selects every older build's targets behind it,
-    which on a deployment with history means hundreds of unrelated candidates per
-    scan, and a re-record storm of exactly that size the first time the sink fails
-    to answer. Builds older than the floor are ignored for the life of the
-    process. See ``_refresh_allowed_builds``,
-    ``_admit_builds_in_anchored_range`` and ``_retire_finished_builds``.
+    Which selected targets get recorded is decided per-sink by
+    ``store.filter_unrecorded``: the watermark is sink-neutral and each sink owns its
+    recorded-state, so one admin DB can feed W&B and other sinks independently.
 
-    Which of those newly-finished targets actually get recorded is decided
-    per-sink by ``store.filter_unrecorded`` (see ``reconcile_once``): the time
-    watermark is sink-neutral, and each sink owns its own recorded-state, so the
-    same admin DB can feed W&B and other sinks independently.
-
-    A target whose recording raises is retried on the next scan: the checkpoint
-    stops advancing at the failed target for the remainder of that pass (even
-    though newer targets in the same pass may still record), so the durable
-    watermark never moves past unrecorded lineage and the failed target is
-    re-surfaced by the next scan — including after a restart, which is what makes
-    retry survive process death rather than depending on in-memory state. A
-    target that keeps failing is dropped after ``_MAX_RECORD_ATTEMPTS`` (into
-    ``_dropped``, passed as ``skip``) so a persistent failure cannot wedge later
-    scans or hold the checkpoint back forever. That drop set is itself persisted
-    to ``gb_kv_pairs`` (``LINEAGE_WATCHER_DROPPED_KEY``) and reloaded by
-    ``start()``: because the checkpoint deliberately refuses to advance past an
-    unrecorded target, an in-memory-only drop set would let a dropped target
-    return after a restart, block the watermark, exhaust its attempts again, and
-    repeat on every restart — permanently wedging all newer lineage behind a
-    target that is never going to record. Dropping is a terminal decision, so it
-    is durable; the per-target attempt *counts* stay in memory, since a restart
-    may legitimately retry from zero.
-
-    One class of failure skips the retry budget entirely: a sink rejection that no
-    retry can clear, namely a run id the sink has seen created and deleted and
-    will not accept again. Run ids are deterministic (that is what makes
-    re-recording idempotent), so there is no new id to try and every attempt is a
-    guaranteed failure that also holds the checkpoint back. Such a target is
-    dropped on first sighting — see ``_is_permanent_sink_rejection``.
+    Failures retry on later scans and the checkpoint stops advancing at the failed
+    target, so the durable watermark never moves past unrecorded lineage, restarts
+    included. A target that keeps failing is dropped durably
+    (``LINEAGE_WATCHER_DROPPED_KEY``); one whose run id the sink permanently rejected
+    is dropped on first sighting, since deterministic ids leave no new id to try. See
+    ``_on_record_error``, ``_is_permanent_sink_rejection``.
     """
 
     # A target whose lineage recording keeps failing is retried this many times
@@ -164,52 +119,45 @@ class LineageWatcher:
         self.stop_event = threading.Event()
         self.worker_thread: Optional[threading.Thread] = None
         self._store: Optional[ILineageStore] = None
-        # Target uuids dropped after exhausting retries; skipped on later scans
-        # so a persistently failing target cannot wedge every scan. Loaded from
-        # (and persisted to) gb_kv_pairs, because the checkpoint refuses to advance
-        # past an unrecorded target: an in-memory-only drop set would let a
-        # dropped target return after a restart and block the watermark forever.
+        # Target uuids dropped after exhausting retries; skipped on later scans so a
+        # persistently failing target cannot wedge every scan. Persisted to
+        # gb_kv_pairs because the checkpoint refuses to advance past an unrecorded
+        # target: an in-memory-only drop set would let a dropped target return after a
+        # restart and block the watermark forever.
         self._dropped: set[str] = set()
-        # target_uuid -> attempts so far, for targets whose recording failed and
-        # should be retried on a subsequent scan.
+        # target_uuid -> attempts so far, for targets to retry on a later scan.
         self._failed_attempts: dict[str, int] = {}
         # Builds whose targets this watcher may record for: the checkpoint build
-        # (the floor) plus every build seen since, minus those retired by
-        # _retire_finished_builds. Passed to reconcile_once as
-        # `allowed_build_ids`, and the reason an anchored retreat cannot wander
-        # into unrelated history (see select_recordable_targets).
+        # (the floor) plus every build seen since, minus those retired. Passed to
+        # reconcile_once as `allowed_build_ids` — the reason an anchored retreat
+        # cannot wander into unrelated history.
         #
-        # Deliberately in-memory and NOT persisted: it is a working set, and the
-        # floor makes it reconstructible — a restart reseeds from the durable
-        # checkpoint and re-adds whatever is still live. Persisting it would add
-        # an unbounded value to gb_kv_pairs for no recoverable state.
-        #
-        # Safe across restarts only because the checkpoint never advances past an
-        # unrecorded target (see _on_checkpoint_advance and reconcile_once's
-        # contiguity rule). A mark that outran pending work would leave the
-        # regenerated set unable to reach it, since the walk starts at the floor.
+        # NOT persisted: a working set the floor makes reconstructible, so a restart
+        # reseeds from the checkpoint and re-adds whatever is live; persisting would
+        # add an unbounded gb_kv_pairs value for no recoverable state. Safe across
+        # restarts only because the checkpoint never advances past an unrecorded
+        # target — a mark that outran pending work would leave the regenerated set
+        # unable to reach it, since the walk starts at the floor.
         self._allowed_build_ids: set[str] = set()
-        # Whether the floor has been seeded into _allowed_build_ids. Seeding
-        # needs a checkpoint, which may not exist yet at start(), so like
-        # _checkpoint_verified this is retried at the top of each scan.
+        # Builds retired by _retire_finished_builds. Discarding from
+        # _allowed_build_ids is not enough: anchored-range admission keys off
+        # absence from that set, so a retired build would match its "not yet
+        # tracked" test and return on the next scan. In-memory like the allowlist
+        # — a restart re-derives it from the sink.
+        self._retired_build_ids: set[str] = set()
+        # Whether the floor has been seeded into _allowed_build_ids. Needs a
+        # checkpoint, which may not exist at start(), so retried each scan.
         self._allowlist_seeded = False
-        # Whether the start-up verification sweep has run against a checkpoint.
-        # It cannot run while the key is absent, so it stays pending and is
-        # retried at the top of each scan until a checkpoint is seeded — a
-        # watcher started before seeding must still get the sweep, otherwise the
-        # unrecorded targets behind the seeded watermark would have no path back
-        # until the next restart. Latches on the first True and is never cleared:
-        # the sweep repairs a crash gap in the checkpoint this process started
-        # from, which a later checkpoint does not reintroduce (see
-        # _verify_checkpoint).
+        # Whether the start-up verification sweep has run. It cannot run while the
+        # key is absent, so it is retried each scan until one is seeded — a watcher
+        # started before seeding must still get the sweep, or targets behind the
+        # seeded watermark have no path back until the next restart. Latches on the
+        # first True and is never cleared (see _verify_checkpoint).
         self._checkpoint_verified = False
-        # Whether the "no checkpoint yet" notice has been logged. The check runs
-        # every scan, so without this the message would repeat forever at the
-        # monitoring interval; it is a one-time operator notice, not a per-scan
-        # event. Reset once a checkpoint is seen — defensive only: nothing in the
-        # codebase deletes the key (seeding either keeps or overwrites it, see
-        # seed_if_absent), so the absent -> present -> absent cycle this reset
-        # covers is not a path any caller can currently drive.
+        # Whether the "no checkpoint yet" notice has been logged, so a one-time
+        # operator notice does not repeat every scan forever. Reset once a
+        # checkpoint is seen — defensive only: nothing deletes the key, so the
+        # absent -> present -> absent cycle is not currently reachable.
         self._missing_checkpoint_logged = False
 
     def start(self) -> None:
@@ -250,39 +198,60 @@ class LineageWatcher:
             LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": sorted(self._dropped)}
         )
 
+    def _record_incomplete_build(
+        self, storage: SingletonAdminStorage, build_id: str, dropped: set[str]
+    ) -> None:
+        """Record that ``build_id`` was retired with some lineage never recorded.
+
+        Retiring such a build is deliberate — a run deleted from wandb cannot be
+        regenerated, so retaining it would pin the build forever for lineage that can
+        never land. This adds the audit trail: the drop is already logged at ERROR,
+        but logs rotate and "was this build's lineage complete?" is asked long after.
+        Read back from ``LINEAGE_WATCHER_INCOMPLETE_KEY``.
+
+        Read-modify-write on one key, safe only because a single watcher thread
+        retires builds. Failures are swallowed — this runs inside retirement, itself
+        a post-scan optimization, so losing the entry must never abort a scan whose
+        recording succeeded; the original ERROR line remains either way.
+        """
+        try:
+            value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_INCOMPLETE_KEY)
+            builds = dict((value or {}).get("builds", {}))
+            builds[build_id] = {
+                "target_ids": sorted(dropped),
+                "retired_at": datetime.now(timezone.utc).isoformat(),
+            }
+            storage.kv_pair_storage.set_value(
+                LINEAGE_WATCHER_INCOMPLETE_KEY, {"builds": builds}
+            )
+        except Exception as exc:  # noqa: BLE001 — audit write must not break a scan
+            logger.warning(
+                "Could not record build %s as having incomplete lineage (%s); its "
+                "%d dropped target(s) are still in the ERROR log above.",
+                build_id,
+                exc,
+                len(dropped),
+            )
+
     def _verify_checkpoint(self, storage: SingletonAdminStorage) -> bool:
         """Re-record any unrecorded target in the checkpoint's own build.
 
-        Runs once against the checkpoint: at ``start()`` when the key is already
-        seeded, otherwise at the first scan that finds one. Returns ``True`` when
-        the sweep is done with (including the malformed-checkpoint case, which no
-        amount of retrying fixes) and ``False`` while it is still pending because
-        no checkpoint exists yet.
+        Runs once: at ``start()`` when the key is already seeded, otherwise at the
+        first scan that finds one. ``True`` means done with (including the malformed
+        case, which retrying cannot fix), ``False`` still pending for want of a
+        checkpoint.
 
-        Once it returns ``True`` the caller latches ``_checkpoint_verified`` and
-        this never runs again for the process's lifetime — deliberately, and it is
-        not a recovery gap. The sweep exists to close a *crash* gap (below), which
-        is a property of the checkpoint the process started from, not something a
-        later checkpoint reintroduces: a ``--force-build-id`` overwrite resolves a
-        fresh anchor from a chosen build, so there is no interrupted
-        record-then-persist to repair, and re-sweeping would re-drive that build
-        for nothing. There is likewise no delete-then-reseed cycle to handle,
-        since no code path removes the key.
+        On ``True`` the caller latches ``_checkpoint_verified`` and this never runs
+        again — deliberately, not a recovery gap. It closes the gap left by a crash
+        between recording a target and persisting its checkpoint (or vice versa),
+        where the checkpoint may name a target whose lineage never reached the sink
+        and the scan, starting *at* that watermark, would not re-surface its build.
+        That is a property of the checkpoint this process started from: a
+        ``--force-build-id`` overwrite resolves a fresh anchor with nothing to
+        repair, and no code path deletes the key.
 
-        This closes the gap left by a crash between
-        recording a target and persisting its checkpoint (or vice versa): the
-        checkpoint may name a target whose lineage never reached the sink, and
-        the steady-state scan — which starts *at* that watermark — would not
-        re-surface everything in its build.
-
-        The checkpoint is never created here, or anywhere else implicitly. When
-        ``LINEAGE_WATCHER_CHECKPOINT_KEY`` is absent this defers (and so does
-        every scan) until the key is seeded explicitly (see
-        ``gbserver lineage-watch --base-build-id``). Auto-seeding it from the
-        newest successful target would silently pick a starting point for the
-        operator; deciding where centralized recording begins — "from now", from
-        a chosen build, or the full history — belongs to whoever seeds it, not to
-        whichever process happens to start first.
+        The checkpoint is never created here or anywhere else implicitly: when the
+        key is absent this defers, as does every scan (see the class docstring).
         """
         checkpoint = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_CHECKPOINT_KEY)
         if checkpoint is None:
@@ -313,27 +282,17 @@ class LineageWatcher:
             )
             return True
 
-        # Verify/re-record via reconcile_once — the same central selector the
-        # steady-state scan uses — scoped to the checkpoint's own build, so the
-        # per-sink filter_unrecorded check, expected-run-count derivation and
-        # prerun-skip handling are shared rather than reimplemented here.
+        # Via reconcile_once, scoped to the checkpoint's build, so
+        # filter_unrecorded, expected-run-count derivation and prerun-skip handling
+        # are shared rather than reimplemented.
         #
-        # Failures are recorded and swallowed rather than aborting start(): the
-        # checkpoint is already durable, so nothing is lost by continuing, and a
-        # watcher that refused to start would record nothing at all. Note what
-        # each kind of failure costs, though. A target at or after the scan's
-        # anchor is re-surfaced by the very next scan. A target further back than
-        # the anchor is NOT — the steady-state scan stops at that row and never
-        # looks behind it, so this start()-time
-        # sweep is its only path back, and a failure here defers it to the next
-        # start(). That is the gap this call exists to close, so its failures are
-        # worth reading in the log even though they are non-fatal.
-        #
-        # Failures route through the same ``_on_record_error`` bookkeeping the
-        # steady-state scan uses, not a log-only callback. A target that fails
-        # this sweep is one the sweep is the *only* path back for, so it must be
-        # able to exhaust ``_MAX_RECORD_ATTEMPTS`` and be dropped durably;
-        # otherwise a permanently-unrecordable target behind the watermark blocks
+        # Failures are swallowed rather than aborting start() (the checkpoint is
+        # already durable, and a watcher that refused to start would record
+        # nothing), but they cost differently: a target at or after the anchor is
+        # re-surfaced by the next scan, one further back is NOT, so this sweep is
+        # its only path back. They route through the same _on_record_error
+        # bookkeeping, not a log-only callback, so such a target can still exhaust
+        # _MAX_RECORD_ATTEMPTS and be dropped durably — otherwise it blocks
         # checkpoint advancement for this build on every restart, forever.
         def _on_error(build_id: str, target_id: str, exc: Exception) -> None:
             self._on_record_error(storage, build_id, target_id, exc)
@@ -379,61 +338,47 @@ class LineageWatcher:
     def _reconcile(self) -> None:
         """Run one reconciliation scan over the admin DB.
 
-        Delegates target selection and recording to ``reconcile_once`` (the
-        central mechanism), bounding the walk at the anchor row derived from the
-        checkpoint so a scan reads only the targets above it.
+        Delegates selection and recording to ``reconcile_once``, bounding the walk
+        at the anchor row derived from the checkpoint.
 
-        The checkpoint is read from ``gb_kv_pairs`` on every scan
-        rather than cached in memory: the checkpoint is the single source of
-        truth, and re-reading it means a key seeded (or corrected) while the
-        watcher is running takes effect on the next scan instead of at the next
-        restart. A missing key is a no-op — "record nothing" until it is seeded
-        — and must never fall back to scanning the whole admin DB, which would
-        turn an unseeded deployment into a full historical backfill.
+        The checkpoint is re-read every scan rather than cached: it is the single
+        source of truth, so a key seeded or corrected mid-run takes effect on the
+        next scan instead of the next restart. A missing key is a no-op — "record
+        nothing" until seeded — and must never fall back to scanning the whole admin
+        DB, which would turn an unseeded deployment into a full backfill.
 
-        Recording failures are routed to ``_on_record_error`` to drive the
-        bounded per-target retry. The checkpoint is persisted immediately after
-        each individually-recorded target (``_on_checkpoint_advance``) rather
-        than once at the end of the scan, so a mid-scan crash leaves it at the
-        last target actually recorded.
+        Failures route to ``_on_record_error`` for the bounded per-target retry. The
+        checkpoint is persisted after each individually-recorded target, not once at
+        the end, so a mid-scan crash leaves it at the last target recorded.
         """
         if self._store is None:
             logger.error("lineage store not initialized; start() must run first")
             return
         storage = get_admin_storage()
         if not self._checkpoint_verified:
-            # A checkpoint seeded after start() still needs the verification
-            # sweep, and only this retry can give it one: the steady-state scan
-            # below stops at the anchor row and never looks behind it, so
-            # unrecorded targets that finished before the checkpoint build's
-            # oldest one would otherwise wait for a restart.
+            # A checkpoint seeded after start() still needs the sweep, and only this
+            # retry can give it one: the scan below stops at the anchor row and never
+            # looks behind it, so targets that finished before the checkpoint build's
+            # oldest would otherwise wait for a restart.
             self._checkpoint_verified = self._verify_checkpoint(storage)
         watermark = self._checkpoint_watermark(storage)
         if watermark is None:
-            # No checkpoint: recording is deliberately off until the key is
-            # seeded. Return before querying targets or touching the sink.
+            # No checkpoint: recording is off until seeded. Return before querying
+            # targets or touching the sink.
             return
-        # Bound the walk by a *row*, not a timestamp. ``finished_at`` is stamped
-        # when the build event is created, not when its row is committed, so a row
-        # can become visible already carrying a timestamp behind an advanced
-        # watermark; a time cutoff excludes it from the query outright and the
-        # monotonic watermark never re-surfaces it. Anchoring on the checkpoint
-        # build's *oldest* successful target instead lets the walk retreat to a
-        # known row, and since the query never filters on build_id, that sweep
-        # also picks up the straggling targets of every concurrent build.
-        #
-        # The oldest rather than the checkpoint's own finished_at: the checkpoint
-        # names whichever target recorded last, so a build whose targets finished
-        # at staggered times would leave its earlier ones behind that row.
-        #
-        # The anchor can fail to resolve: a malformed checkpoint (no build_id), or
-        # a build whose successful targets are all gone or carry no finish time.
-        # There is then no row to aim at, so the scan falls back to the plain
-        # watermark cutoff — see below for what that costs.
+        # Bound the walk by a *row*, not a timestamp. finished_at is stamped when the
+        # build event is created, not when its row is committed, so a row can become
+        # visible already carrying a timestamp behind an advanced watermark; a time
+        # cutoff excludes it outright and the monotonic watermark never re-surfaces
+        # it. Anchoring on the checkpoint build's *oldest* successful target lets the
+        # walk retreat to a known row, and since the query never filters on build_id
+        # it also picks up concurrent builds' stragglers. The oldest, not the
+        # checkpoint's own finished_at: it names whichever target recorded last, so
+        # staggered finishes would leave earlier ones behind the row. It can fail to
+        # resolve, in which case the scan falls back to the watermark — see below.
         checkpoint_build_id = self._checkpoint_build_id(storage)
-        # Seed the allowlist floor from the checkpoint build before selecting, so
-        # the very first scan after a (re)start is already bounded. Seeding needs
-        # the checkpoint, so it is retried here rather than done once in start().
+        # Seed the floor before selecting, so the first scan after a (re)start is
+        # already bounded. Needs the checkpoint, so retried here, not in start().
         if not self._allowlist_seeded and checkpoint_build_id is not None:
             self._allowed_build_ids.add(checkpoint_build_id)
             self._allowlist_seeded = True
@@ -447,24 +392,20 @@ class LineageWatcher:
             oldest = get_oldest_successful_target(storage, build_id=checkpoint_build_id)
             if oldest is not None and oldest.finished_at is not None:
                 stop_at = (checkpoint_build_id, as_aware(oldest.finished_at))
-        # Order matters here. Admission needs the resolved anchor to know what
-        # "within range" means, and both must run before the filtered scan below:
-        # a build admitted after the scan would have its targets dropped on this
-        # pass and only picked up on the next one.
+        # Order matters: admission needs the resolved anchor to know what "within
+        # range" means, and both must run before the filtered scan — a build admitted
+        # after it would have its targets dropped until the next pass.
         self._admit_builds_in_anchored_range(storage, stop_at)
         self._refresh_allowed_builds(storage)
         # The anchor is the real bound, so the timestamp cutoff opens all the way
         # up; select_recordable_targets stops at the anchor row instead.
         #
-        # With no anchor the walk falls back to the watermark cutoff, which is
-        # inclusive of the boundary row (the selector compares `<`) but reaches no
-        # further back. A target that finished strictly behind the watermark is
-        # therefore out of reach on this scan, and stays so while the anchor cannot
-        # be resolved — the one case where this design is no better than the fixed
-        # window it replaced. Nothing is subtracted to soften it: without a row to
-        # aim at there is no principled width to pick, and inventing one is exactly
-        # what the old overlap did. Logged as a warning so it is visible instead of
-        # silent.
+        # With no anchor the walk falls back to the watermark cutoff: inclusive of the
+        # boundary row but reaching no further, so a target strictly behind it is out
+        # of reach while the anchor cannot be resolved — the one case this design is
+        # no better than the fixed window it replaced. Nothing is subtracted to soften
+        # it: without a row to aim at there is no principled width, and inventing one
+        # is what the old overlap did. Warned so it is visible.
         if stop_at is not None:
             finished_after = UTC_MIN
         else:
@@ -477,12 +418,10 @@ class LineageWatcher:
                 checkpoint_build_id,
                 watermark,
             )
-        # Stamped before the scan, not after: a target that finishes while the
-        # scan is running must stay in scope for the next one. Retiring the
-        # anchor to an after-the-fact timestamp would step over it.
-        # Aware, so it compares against the targets' own aware timestamps (see
-        # as_aware). UTC here because this is a sentinel stamped from the clock
-        # rather than a value read off a gb_targets row; utcnow() is deprecated.
+        # Stamped before the scan, not after: a target finishing mid-scan must stay in
+        # scope for the next one, and an after-the-fact stamp would step over it.
+        # Aware, to compare against the targets' own aware timestamps; UTC because
+        # this is a sentinel off the clock, not a gb_targets value.
         scan_started = datetime.now(timezone.utc)
         reconcile_once(
             self._store,
@@ -501,54 +440,45 @@ class LineageWatcher:
                 )
             ),
             skip=self._dropped,
-            # Log-only: names the build whose target set the watermark, so a
-            # steady-state line reads as "starting here because of that row"
-            # rather than as a bare epoch. This names the build for the log; the
-            # build's role in *selection* is carried by ``stop_at`` below, which
-            # bounds the walk at that build's oldest target.
+            # Log-only: names the build whose target set the watermark, so the line
+            # reads as "starting here because of that row" rather than a bare epoch.
+            # Its role in *selection* is carried by stop_at below.
             watermark_build_id=checkpoint_build_id,
             stop_at=stop_at,
-            # Bounds *which* builds the anchored retreat may record for. Only
-            # once seeded: an unseeded set is empty, and an empty membership
-            # filter selects nothing, which would silently stall recording
-            # rather than merely widening it. Unseeded means no checkpoint build
-            # resolved, in which case the scan is already on its fallback path.
+            # Bounds *which* builds the retreat may record for. Only once seeded: an
+            # empty membership filter selects nothing, silently stalling recording
+            # rather than merely widening it, and unseeded means no checkpoint build
+            # resolved — the scan is already on its fallback path.
             allowed_build_ids=(
                 self._allowed_build_ids if self._allowlist_seeded else None
             ),
         )
         # After the scan, never before: retirement asks the sink whether a build's
-        # lineage is recorded, and running it first would ask that question about
-        # targets this pass was about to record — retiring a build a moment before
-        # its own targets were written, and (because a retired build is not
-        # re-admitted from build state) dropping them.
+        # lineage is recorded, and running it first would ask about targets this pass
+        # had yet to write — retiring a build just before its own targets landed and,
+        # since a retired build is not re-admitted from build state, dropping them.
         self._retire_finished_builds(storage)
 
     def _refresh_allowed_builds(self, storage: SingletonAdminStorage) -> None:
         """Add builds that have appeared since the last refresh.
 
-        Purely additive: a build enters the set when first seen and leaves only
-        through ``_retire_finished_builds``, which runs *after* the scan rather
-        than from here — retiring before recording would ask the sink about
-        targets the pass had not written yet. Nothing is ever dropped for
-        being *old*, because "old" would have to be judged on ``finished_at``,
-        which can place a late-committing row behind the watermark — the very case
-        the anchored walk exists to recover (see ``select_recordable_targets``).
+        Purely additive: a build enters when first seen and leaves only through
+        ``_retire_finished_builds``, which runs *after* the scan — retiring first
+        would ask the sink about targets the pass had not written yet. Nothing is
+        dropped for being *old*: that would be judged on ``finished_at``, which can
+        place a late-committing row behind the watermark — the case the anchored walk
+        exists to recover.
 
-        Only builds that are not yet finished are added *here*. A build that was
-        already finished before this watcher ever saw it is either behind the
-        floor (deliberately out of scope) or already recorded, so adding it would
-        re-open the history the floor exists to exclude.
+        Only builds not yet finished are added *here*. One already finished before
+        this watcher saw it is either behind the floor (deliberately out of scope) or
+        already recorded, so adding it would re-open the history the floor excludes.
 
-        That rule alone is too narrow, though, and the gap is the one the anchored
-        walk exists for: a build concurrent with the floor can finish *inside* the
-        anchored range and be finished by the time any refresh runs — it is
-        neither the checkpoint build nor unfinished, so it would never be added,
-        and filtering would drop the very target the retreat reached back for. So
-        membership is also granted from below, by
-        ``_admit_builds_in_anchored_range``, which admits any build whose target
-        the walk actually surfaced at or after the anchor. This method covers
-        builds that are still live; that one covers builds that finished inside
+        That rule alone is too narrow: a build concurrent with the floor can finish
+        *inside* the anchored range and already be finished when a refresh runs —
+        neither the checkpoint build nor unfinished, so never added here, and
+        filtering would drop the very target the retreat reached back for.
+        ``_admit_builds_in_anchored_range`` grants membership from below for those.
+        This method covers builds still live; that one, builds that finished inside
         the window.
         """
         if not self._allowlist_seeded:
@@ -575,6 +505,8 @@ class LineageWatcher:
         for build in live:
             if build.uuid in self._allowed_build_ids:
                 continue
+            # Also keeps retired builds out of this path without consulting
+            # _retired_build_ids: retirement requires is_finished().
             if build.status.is_finished():
                 continue
             self._allowed_build_ids.add(build.uuid)
@@ -594,25 +526,24 @@ class LineageWatcher:
         """Admit every build whose targets lie within the anchored range.
 
         This is what keeps the allowlist from turning the anchored retreat into a
-        lineage-loss bug. The retreat exists because a target's row can become
-        visible carrying a ``finished_at`` behind the watermark, and because a
-        concurrent build can finish between two targets of the checkpoint's build.
-        Such a build is already finished by the time a refresh looks at build rows,
-        so ``_refresh_allowed_builds`` will not add it — and a membership filter
-        would then discard the target the walk retreated to collect.
+        lineage-loss bug. A concurrent build can finish between two targets of the
+        checkpoint's build and so be finished before any refresh sees it, meaning
+        ``_refresh_allowed_builds`` will not add it — and a membership filter would
+        then discard the target the walk retreated to collect.
 
         Admitting from the *swept range* rather than from build state closes that:
-        anything the unfiltered walk can still reach is in scope by definition, so
-        the filter only ever removes what lies outside the anchor. The range is
-        bounded by the same anchor the scan uses, so this is not a full-history
-        read — and it is exactly the range the scan was going to walk anyway.
-
-        Without an anchor there is no bounded range to admit from, so this is a
-        no-op and the scan runs on its fallback path.
+        whatever the walk can reach is in scope by definition, so the filter only
+        removes what lies outside the anchor. Bounded by the same anchor the scan
+        uses, so this is not a full-history read — it is the range the scan was
+        going to walk anyway. Without an anchor there is no bounded range, so this
+        is a no-op and the scan runs on its fallback path.
         """
         if stop_at is None or not self._allowlist_seeded:
             return
         try:
+            # stop_at is the bound, not finished_after: UTC_MIN opens the
+            # timestamp cutoff all the way up and the walk stops at the anchor
+            # row, same as the scan's own call. Not a full-history read.
             in_range = select_recordable_targets(
                 storage, finished_after=UTC_MIN, stop_at=stop_at
             )
@@ -630,10 +561,9 @@ class LineageWatcher:
             t.build_id
             for t in in_range
             if t.build_id not in self._allowed_build_ids
-            # A build retired earlier in this process is deliberately done: its
-            # lineage was confirmed in the sink, so re-admitting it here would
-            # undo retirement on every scan and pin it forever.
-            and t.uuid not in self._dropped
+            # A retired build is deliberately done; re-admitting would undo
+            # retirement every scan. Not _dropped: that holds *target* uuids.
+            and t.build_id not in self._retired_build_ids
         }
         if admitted:
             self._allowed_build_ids |= admitted
@@ -649,23 +579,25 @@ class LineageWatcher:
         """Drop builds that are finished, have nothing pending, and are recorded.
 
         Keeps the in-memory set proportional to real concurrency rather than to
-        the process's uptime. All three conditions are required, and each guards a
-        distinct way a build can still owe work:
+        uptime. All three conditions are required, each guarding a distinct way a
+        build can still owe work:
 
-        - ``status.is_finished()``: excludes ``RETRY_PENDING`` (a build queued for
-          a build-level retry is still going to produce targets) as well as
-          ``RUNNING``/``PENDING``.
-        - Nothing pending locally: no target of this build is mid-retry in
-          ``_failed_attempts``. Targets in ``_dropped`` do NOT count as pending —
-          they were given up on deliberately, and treating them as pending would
-          pin their build in the set forever.
-        - Recorded in the sink: local state cannot answer this. Only the sink
-          knows whether the runs actually landed, so this asks it.
+        - ``status.is_finished()``: excludes ``RETRY_PENDING`` (a build queued for a
+          build-level retry will still produce targets) and ``RUNNING``/``PENDING``.
+        - Nothing pending locally: no target mid-retry in ``_failed_attempts``.
+          Targets in ``_dropped`` do NOT count as pending — treating them so would
+          pin the build forever, and a run deleted from wandb cannot be regenerated
+          (its id derives from the target and the sink refuses a deleted id), so
+          that pin would never release. Retiring anyway is the deliberate choice;
+          the gap is recorded under ``LINEAGE_WATCHER_INCOMPLETE_KEY`` rather than
+          left to a rotating log, so completeness stays analyzable.
+        - Recorded in the sink: only the sink knows whether the runs landed.
 
-        Retirement is irreversible for this process: a retired build is not
-        re-added (``_refresh_allowed_builds`` skips finished builds), and the walk
-        will no longer select its targets. So every uncertain case must retain,
-        never retire — including a sink that fails to answer.
+        Retirement is irreversible here, and both admission paths are closed to keep
+        it so: ``_refresh_allowed_builds`` skips finished builds, and
+        ``_admit_builds_in_anchored_range`` (admitting from the swept range, so it
+        never sees that check) tests ``_retired_build_ids``. Every uncertain case must
+        retain, never retire — including a sink that fails to answer.
         """
         if self._store is None or not self._allowed_build_ids:
             return
@@ -692,7 +624,7 @@ class LineageWatcher:
             candidates.append(build_id)
         for build_id in candidates:
             try:
-                confirmed = self._build_lineage_is_confirmed(storage, build_id)
+                confirmed, dropped = self._build_lineage_is_confirmed(storage, build_id)
             except (
                 Exception
             ) as exc:  # noqa: BLE001 — retirement must never break the scan
@@ -709,27 +641,54 @@ class LineageWatcher:
                 continue
             if not confirmed:
                 continue
+            if dropped:
+                # Retired with lineage knowingly missing. Recorded before the
+                # discard so a crash between the two cannot lose the gap: a
+                # re-recorded entry is harmless, an unrecorded one is invisible.
+                self._record_incomplete_build(storage, build_id, dropped)
             self._allowed_build_ids.discard(build_id)
-            logger.info(
-                "Retired build %s from the lineage allowlist: finished, nothing "
-                "pending, and its lineage is recorded in the sink. Allowlist now "
-                "tracks %d build(s).",
-                build_id,
-                len(self._allowed_build_ids),
-            )
+            # Keeps _admit_builds_in_anchored_range from re-admitting it: that
+            # path admits from the swept range, so it never sees the
+            # finished-build check _refresh_allowed_builds applies.
+            self._retired_build_ids.add(build_id)
+            if dropped:
+                # Not "recorded in the sink": these targets never landed there.
+                logger.info(
+                    "Retired build %s from the lineage allowlist: finished and "
+                    "nothing pending, but %d target(s) were dropped, so its "
+                    "lineage in the sink is incomplete and will stay that way "
+                    "(recorded under %s). Allowlist now tracks %d build(s).",
+                    build_id,
+                    len(dropped),
+                    LINEAGE_WATCHER_INCOMPLETE_KEY,
+                    len(self._allowed_build_ids),
+                )
+            else:
+                logger.info(
+                    "Retired build %s from the lineage allowlist: finished, nothing "
+                    "pending, and its lineage is recorded in the sink. Allowlist now "
+                    "tracks %d build(s).",
+                    build_id,
+                    len(self._allowed_build_ids),
+                )
 
     def _build_lineage_is_confirmed(
         self, storage: SingletonAdminStorage, build_id: str
-    ) -> bool:
+    ) -> tuple[bool, set[str]]:
         """Whether ``build_id`` has nothing pending and its lineage is in the sink.
 
         The last two of the three retirement conditions (the caller has already
         checked that the build is finished). Split out so the caller can treat any
         failure as "not confirmed" in one place: every path here either answers
         definitively or raises, and a raise must never mean "retire".
+
+        Returns ``(confirmed, dropped_target_ids)``. The second element is what
+        makes a retirement's completeness auditable: "confirmed" covers both
+        *recorded* and *deliberately dropped*, and only the caller can tell those
+        apart to record the gap. Empty means every target actually recorded.
         """
         if self._store is None:
-            return False
+            return False, set()
         # Re-select this build's successful targets to ask the sink about them.
         # Scoped to the one build and only reached for finished builds, so this is
         # not the unbounded walk `allowed_build_ids` exists to prevent.
@@ -738,12 +697,15 @@ class LineageWatcher:
         )
         if any(t.uuid in self._failed_attempts for t in targets):
             # Mid-retry: still owes work locally.
-            return False
+            return False, set()
+        dropped = {t.uuid for t in targets if t.uuid in self._dropped}
         pending = {t.uuid for t in targets if t.uuid not in self._dropped}
         if not pending:
             # Nothing left to confirm: every target either recorded or was
-            # deliberately dropped.
-            return True
+            # deliberately dropped. Report the dropped ones so the caller can
+            # record the gap — if `dropped` covers every target, this build's
+            # lineage never landed at all.
+            return True, dropped
         # A sink that fails to answer returns the full candidate set (fail-open),
         # which is indistinguishable from a real "none recorded" verdict.
         # Retirement is irreversible, so it must act only on a real answer: this
@@ -759,7 +721,7 @@ class LineageWatcher:
         unrecorded = self._store.filter_unrecorded(
             pending, expected, on_query_error=_note_failure
         )
-        return not sink_failed and not unrecorded
+        return (not sink_failed and not unrecorded), dropped
 
     def _checkpoint_build_id(self, storage: SingletonAdminStorage) -> Optional[str]:
         """Return the checkpoint's ``build_id``, or ``None`` if unset/malformed.
@@ -786,25 +748,19 @@ class LineageWatcher:
         the same way: recording stays off until it is corrected, which is the
         safe direction — the alternative is raising out of every scan.
 
-        The parsed value is made aware, keeping whatever offset it carries. The
-        checkpoint holds ``finished_at`` as a plain string inside a JSON dict, so
-        it is backend-opaque and round-trips its offset on both SQLite and
-        Postgres; every writer persists it aware-ISO, which is why the naive case
-        is defensive rather than expected. Filling in the local offset for a naive
-        value is what lets the caller compare it against the targets' own
-        timestamps without a ``TypeError`` from mixing awareness. Note the offset
-        that gets filled in is the *local* one, so a caller testing for the
-        ``datetime.min`` backfill anchor must compare within the watermark's own
-        offset rather than against ``UTC_MIN`` (see ``_retire_backfill_anchor``).
-        The offset is not rewritten to UTC — aware values already compare as
-        instants, and rewriting made the key disagree textually with the
-        ``gb_targets`` row behind it (see ``_on_checkpoint_advance``).
+        The parsed value is made aware, keeping whatever offset it carries — the key
+        holds ``finished_at`` as a string in a JSON dict, so it is backend-opaque and
+        round-trips its offset on SQLite and Postgres alike, and since every writer
+        persists aware-ISO the naive case is defensive. Filling a missing offset lets
+        the caller compare against targets' own timestamps without a ``TypeError``;
+        the offset filled in is *local*, so a caller testing for the ``datetime.min``
+        anchor must compare within the watermark's own offset (see
+        ``_retire_backfill_anchor``). Not rewritten to UTC — see
+        ``_on_checkpoint_advance``.
 
-        ``OverflowError`` is still caught alongside the parse errors: it is
-        reachable from arithmetic on an extreme parsed value (the
-        ``--base-build-id all`` anchor is ``datetime.min``). Uncaught it would
-        escape to ``_run``'s blanket handler and fail every scan forever, the same
-        wedge this guard exists to prevent for unparseable values.
+        ``OverflowError`` is caught alongside the parse errors: reachable from
+        arithmetic on an extreme value (the ``all`` anchor is ``datetime.min``), and
+        uncaught it would escape to ``_run`` and fail every scan forever.
         """
         checkpoint = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_CHECKPOINT_KEY)
         if checkpoint is None:
@@ -838,34 +794,22 @@ class LineageWatcher:
     ) -> None:
         """Move a spent ``datetime.min`` backfill anchor up to the scan time.
 
-        ``--base-build-id all`` anchors the checkpoint at ``datetime.min`` so the first
-        scan walks the entire history. Normally the first recorded target
-        advances the checkpoint off that anchor via ``_on_checkpoint_advance``.
-        When the backfill records nothing, though — an empty DB, or one where
-        every candidate is in the drop set — nothing advances it, and *every*
-        subsequent scan re-walks the whole table at ``finished_after=datetime.min``
-        instead of reading only newly-finished rows.
+        ``--base-build-id all`` anchors the checkpoint at ``datetime.min`` so the
+        first scan walks all history, and normally the first recorded target advances
+        it off that anchor. When the backfill records nothing — empty DB, or every
+        candidate dropped — nothing advances it and every later scan re-walks the
+        whole table. Safe only under both conditions checked here:
 
-        Retiring the anchor is safe only under both conditions checked here:
-
-        - The watermark really is the backfill anchor. A normal watermark must
-          never be moved by anything but a recorded target, so this is scoped to
-          ``datetime.min`` and nothing else. Compared against ``datetime.min`` in
-          the watermark's *own* offset, not against ``UTC_MIN``: the anchor is
-          written as ``UTC_MIN.isoformat()``, but ``as_aware`` preserves whatever
-          offset the backend returned, and a backend that drops the offset
-          (SQLite does; Postgres ``timestamptz`` does not) hands back a naive
-          ``datetime.min`` that is then re-tagged *local*. That is the same
-          instant only when the reader sits at UTC, so a bare ``!= UTC_MIN`` would
-          leave the anchor in place on every non-UTC deployment and re-walk the
-          whole target table on every scan, forever.
-        - ``watermark_untouched``: the pass recorded nothing, failed nothing and
-          dropped nothing (see ``reconcile_once``). Any of those would mean
-          unrecorded lineage sits *behind* the new anchor, and the steady-state
-          scan never looks behind its watermark, so moving it would strand that
-          lineage permanently. A record in the same pass has already advanced the
-          checkpoint to the right place via ``_on_checkpoint_advance``; moving it
-          again to the scan time would step over every target after it.
+        - The watermark really is the anchor (a normal one moves only via a recorded
+          target). Compared in the watermark's *own* offset, not against ``UTC_MIN``:
+          a backend that drops the offset (SQLite does, Postgres ``timestamptz`` does
+          not) hands back a naive ``datetime.min`` re-tagged *local* — the same instant
+          only at UTC, so a bare ``!= UTC_MIN`` would leave the anchor in place on
+          every non-UTC deployment, re-walking the table forever.
+        - ``watermark_untouched``: the pass recorded, failed and dropped nothing.
+          Otherwise unrecorded lineage sits *behind* the new anchor, which the scan
+          never looks behind, stranding it. A record in the same pass has already
+          advanced the checkpoint; moving it again would step over later targets.
         """
         anchor = datetime.min.replace(tzinfo=watermark.tzinfo)
         if not watermark_untouched or watermark != anchor:
@@ -888,43 +832,26 @@ class LineageWatcher:
         never a target merely considered or one that failed to record. The next
         scan reads it back, so this write alone advances the watermark.
 
-        The watermark is monotonic: a target swept in behind the current
-        watermark legitimately finished there (its row became visible late, or
-        builds interleaved — see the anchor rationale in ``_reconcile``), and
-        recording it must not drag the durable watermark back down with it.
-        Without this guard such a target lowers the watermark, and if no newer
-        target in the same pass pushes it back up it stays lowered, re-reading
-        that range on every later scan. Recording still happens either way; only
-        the watermark write is suppressed.
+        The watermark is monotonic: a target swept in behind it legitimately finished
+        there (late-visible row, or interleaved builds) and must not drag the durable
+        value down, which would re-read that range on every later scan. Recording
+        still happens; only the watermark write is suppressed. Compared against the
+        *durable* value, not an in-process high-water mark, so a restart cannot forget
+        it; the ``datetime.min`` anchor sits below every real timestamp, so
+        ``_retire_backfill_anchor`` still advances off it.
 
-        The comparison is against the *durable* value rather than an in-process
-        high-water mark so a restart cannot forget it and re-open the same
-        regression. The ``datetime.min`` backfill anchor compares below every
-        real timestamp, so ``_retire_backfill_anchor`` still advances off it.
+        ``finished_at`` comes off a ``StoredTargetRun``, so in production it is aware
+        *local* (from ``BuildEvent.timestamp`` → ``get_time()``), not UTC. ``as_aware``
+        only fills a missing offset, so what is persisted is the ``gb_targets`` row's
+        timestamp verbatim — the checkpoint adopts that table's form and ``gb_targets``
+        is untouched. Rewriting to UTC would still compare correctly but made the key
+        disagree *textually* with its source row, unreadable in a log.
 
-        ``finished_at`` arrives straight off a ``StoredTargetRun`` (see
-        ``reconcile_once``), so it is timezone-*aware* in production: it is
-        stamped from ``BuildEvent.timestamp``, which defaults to
-        ``get_time()`` (``datetime.now().astimezone()``) — aware *local*, not
-        UTC. ``as_aware`` only fills in an offset when one is missing, which the
-        JSON-column read path does not produce, so the value persisted here is the
-        ``gb_targets`` row's own timestamp verbatim, in the same form that table
-        holds it. ``gb_targets`` is untouched by this; the checkpoint is what
-        adopts its form.
-
-        Rewriting the offset to UTC instead would still compare correctly — aware
-        datetimes compare as instants — but it made the checkpoint disagree
-        *textually* with the row it came from, so the same target read three hours
-        apart depending on whether it was loaded from ``gb_targets`` or
-        ``gb_kv_pairs``, which is unreadable in a log and in the key itself.
-
-        Ensuring awareness is still required: the watermark read back by
-        ``_checkpoint_watermark`` was once naive, and comparing the two raised
-        ``TypeError: can't compare offset-naive and offset-aware datetimes``.
-        That raise happens inside ``reconcile_once``'s per-target ``try``, so it
-        is misattributed to recording (which already succeeded), blocks the
-        checkpoint, and after ``_MAX_RECORD_ATTEMPTS`` scans lands the target in
-        the durable dropped set.
+        Ensuring awareness is still required: ``_checkpoint_watermark`` once returned
+        naive, and comparing raised ``TypeError: can't compare offset-naive and
+        offset-aware datetimes`` inside ``reconcile_once``'s per-target ``try`` —
+        misattributed to recording (already succeeded), blocking the checkpoint, and
+        after ``_MAX_RECORD_ATTEMPTS`` scans landing the target in the dropped set.
         """
         finished_at = as_aware(finished_at)
         current = self._checkpoint_watermark(storage)
@@ -970,23 +897,18 @@ class LineageWatcher:
         it still falls within the scan's anchored range each scan, so the skip set is
         what keeps it from wedging the scan.
 
-        The drop is persisted to ``gb_kv_pairs``: giving up is permanent, and since
-        the checkpoint never advances past an unrecorded target, a drop that was
-        forgotten on restart would block the watermark forever.
-
-        The attempt *counts* stay in memory on purpose — they are a
-        within-process backoff, and a restart legitimately re-tries a target from
-        zero (the failure may well have been the crash itself). Only the terminal
-        decision is durable.
+        The drop is persisted: giving up is permanent, and since the checkpoint never
+        advances past an unrecorded target, a drop forgotten on restart would block
+        the watermark forever. The attempt *counts* stay in memory — a within-process
+        backoff, and a restart legitimately retries from zero (the failure may have
+        been the crash itself). Only the terminal decision is durable.
         """
         if self._is_permanent_sink_rejection(exc):
-            # No number of retries can clear this, so spend none: retrying would
-            # be _MAX_RECORD_ATTEMPTS scans of guaranteed failures against the
-            # sink, and would hold the checkpoint at this target the whole time
-            # (it never advances past unrecorded lineage). Drop on the first
-            # sighting instead, and say plainly why — this is an operational
-            # condition (someone deleted runs in the sink), not a flaky write, and
-            # the operator's response is different.
+            # No retry can clear this, so spend none: it would be
+            # _MAX_RECORD_ATTEMPTS scans of guaranteed failures, holding the
+            # checkpoint at this target throughout. Drop on first sighting and say
+            # why — an operational condition (someone deleted runs in the sink),
+            # not a flaky write, and the operator's response differs.
             self._failed_attempts.pop(target_id, None)
             self._dropped.add(target_id)
             self._persist_dropped(storage)

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -125,12 +125,33 @@ class LineageWatcher:
     target that is never going to record. Dropping is a terminal decision, so it
     is durable; the per-target attempt *counts* stay in memory, since a restart
     may legitimately retry from zero.
+
+    One class of failure skips the retry budget entirely: a sink rejection that no
+    retry can clear, namely a run id the sink has seen created and deleted and
+    will not accept again. Run ids are deterministic (that is what makes
+    re-recording idempotent), so there is no new id to try and every attempt is a
+    guaranteed failure that also holds the checkpoint back. Such a target is
+    dropped on first sighting — see ``_is_permanent_sink_rejection``.
     """
 
     # A target whose lineage recording keeps failing is retried this many times
     # on subsequent scans before being dropped, so a transient failure (e.g. a
     # network blip) is recovered without a persistent failure wedging the scan.
     _MAX_RECORD_ATTEMPTS = 3
+
+    # Substring identifying a sink rejection that no retry can clear: the run id
+    # was created and then deleted in the sink, which remembers the id as deleted
+    # and refuses it permanently ("... was previously created and deleted; try a
+    # new run id"). Matched on the message rather than the exception type because
+    # wandb raises the same CommError for ordinary transient network failures,
+    # which MUST stay retryable — the type alone cannot separate them.
+    #
+    # The sink's advice ("try a new run id") is not actionable here: run ids are
+    # derived deterministically from the target and output uuids
+    # (WandBLineageStore._build_events_for_target), and that determinism is what
+    # makes re-recording idempotent. Changing it to dodge a deleted id would
+    # trade a bounded, visible gap for silent duplicate lineage everywhere else.
+    _PERMANENT_SINK_REJECTION = "previously created and deleted"
 
     def __init__(self, monitoring_interval: float = 30.0) -> None:
         """Initialize the LineageWatcher.
@@ -958,6 +979,30 @@ class LineageWatcher:
         zero (the failure may well have been the crash itself). Only the terminal
         decision is durable.
         """
+        if self._is_permanent_sink_rejection(exc):
+            # No number of retries can clear this, so spend none: retrying would
+            # be _MAX_RECORD_ATTEMPTS scans of guaranteed failures against the
+            # sink, and would hold the checkpoint at this target the whole time
+            # (it never advances past unrecorded lineage). Drop on the first
+            # sighting instead, and say plainly why — this is an operational
+            # condition (someone deleted runs in the sink), not a flaky write, and
+            # the operator's response is different.
+            self._failed_attempts.pop(target_id, None)
+            self._dropped.add(target_id)
+            self._persist_dropped(storage)
+            logger.error(
+                "The lineage sink permanently rejected the run id for target %s "
+                "in build %s: its run was created and then deleted in the sink, "
+                "which will not accept that id again. Run ids are derived "
+                "deterministically from the target, so no retry can succeed; "
+                "dropping this target's lineage without retrying. Its lineage "
+                "will stay absent from the sink unless the deleted run is "
+                "restored there. Underlying error: %s",
+                target_id,
+                build_id,
+                exc,
+            )
+            return
         attempts = self._failed_attempts.get(target_id, 0) + 1
         if attempts >= self._MAX_RECORD_ATTEMPTS:
             self._failed_attempts.pop(target_id, None)
@@ -983,6 +1028,30 @@ class LineageWatcher:
                 self._MAX_RECORD_ATTEMPTS,
                 exc,
             )
+
+    @classmethod
+    def _is_permanent_sink_rejection(cls, exc: Exception) -> bool:
+        """Whether ``exc`` is a sink rejection that retrying can never clear.
+
+        Walks the exception chain rather than checking only ``exc``: the failure
+        surfaces from the store's own ``except`` blocks, so the rejection can
+        arrive wrapped (``raise ... from`` sets ``__cause__``; a bare re-raise
+        inside a handler sets ``__context__``). Matching only the outermost
+        exception would miss it and spend the full retry budget.
+
+        Deliberately conservative — a false negative just means the target takes
+        the normal retry path (the pre-existing behavior), while a false positive
+        would drop a recoverable target's lineage without retrying. That is why
+        this matches a specific message rather than an exception type.
+        """
+        seen: set[int] = set()
+        current: Optional[BaseException] = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            if cls._PERMANENT_SINK_REJECTION in str(current):
+                return True
+            current = current.__cause__ or current.__context__
+        return False
 
     def stop(self, timeout: float = 5.0) -> None:
         """Signal the watcher thread to stop and wait for it to exit.

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -36,9 +36,20 @@ from gbserver.lineage.lineage_reconciler import (
 from gbserver.lineage.lineage_seeding import BACKFILL_BUILD_ID
 from gbserver.storage.singleton_storage import SingletonAdminStorage, get_admin_storage
 from gbserver.storage.stored_build import StoredBuild
+from gbserver.types.status import Status
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# The statuses a build can hold while still live, as stored in the queryable
+# ``status`` column. Derived from ``is_finished()`` rather than listed by hand so a
+# new non-finished status cannot silently drop out of the allowlist refresh's query.
+#
+# ``BuildStorage._get_column_values`` stores ``status.name`` (upper case), while
+# ``Status`` is a ``StrEnum`` whose *values* are lower case — so the query must carry
+# the names. Passing the members themselves would match no row, silently emptying the
+# allowlist and stopping lineage for every new build.
+_LIVE_BUILD_STATUS_NAMES = sorted(s.name for s in Status if not s.is_finished())
 
 
 class LineageWatcher:
@@ -487,7 +498,13 @@ class LineageWatcher:
             # start bounding the scan by a set that has no floor behind it.
             return
         try:
-            live = storage.build_storage.get_by_where({})
+            # Filtered server-side: a dict ``where`` with a list value matches any one
+            # of them (an IN), so the read stays proportional to live concurrency
+            # instead of to all history. Reading every row and filtering here would
+            # partly reinstate the full-table scan this allowlist exists to avoid.
+            live = storage.build_storage.get_by_where(
+                {"status": _LIVE_BUILD_STATUS_NAMES}
+            )
         except (
             Exception
         ) as exc:  # noqa: BLE001 — a refresh failure must not stop the scan
@@ -505,8 +522,11 @@ class LineageWatcher:
         for build in live:
             if build.uuid in self._allowed_build_ids:
                 continue
-            # Also keeps retired builds out of this path without consulting
-            # _retired_build_ids: retirement requires is_finished().
+            # Redundant against the query above, kept as the authoritative check: a
+            # build can finish between the read and here, and this is what makes the
+            # rule hold regardless of how the rows were fetched. Also keeps retired
+            # builds out of this path without consulting _retired_build_ids, since
+            # retirement requires is_finished().
             if build.status.is_finished():
                 continue
             self._allowed_build_ids.add(build.uuid)
@@ -624,7 +644,9 @@ class LineageWatcher:
             candidates.append(build_id)
         for build_id in candidates:
             try:
-                confirmed, dropped = self._build_lineage_is_confirmed(storage, build_id)
+                confirmed, dropped, recordable = self._build_lineage_is_confirmed(
+                    storage, build_id
+                )
             except (
                 Exception
             ) as exc:  # noqa: BLE001 — retirement must never break the scan
@@ -663,18 +685,31 @@ class LineageWatcher:
                     LINEAGE_WATCHER_INCOMPLETE_KEY,
                     len(self._allowed_build_ids),
                 )
+            elif recordable == 0:
+                # No successful targets, so nothing was ever recordable and the sink
+                # was never asked. Saying its lineage "is recorded in the sink" would
+                # assert a recording that never happened — the usual reason to be
+                # here is a build that failed before any target succeeded.
+                logger.info(
+                    "Retired build %s from the lineage allowlist: finished with no "
+                    "successful targets, so it had no lineage to record. Allowlist "
+                    "now tracks %d build(s).",
+                    build_id,
+                    len(self._allowed_build_ids),
+                )
             else:
                 logger.info(
                     "Retired build %s from the lineage allowlist: finished, nothing "
-                    "pending, and its lineage is recorded in the sink. Allowlist now "
-                    "tracks %d build(s).",
+                    "pending, and its lineage for all %d target(s) is recorded in the "
+                    "sink. Allowlist now tracks %d build(s).",
                     build_id,
+                    recordable,
                     len(self._allowed_build_ids),
                 )
 
     def _build_lineage_is_confirmed(
         self, storage: SingletonAdminStorage, build_id: str
-    ) -> tuple[bool, set[str]]:
+    ) -> tuple[bool, set[str], int]:
         """Whether ``build_id`` has nothing pending and its lineage is in the sink.
 
         The last two of the three retirement conditions (the caller has already
@@ -682,13 +717,17 @@ class LineageWatcher:
         failure as "not confirmed" in one place: every path here either answers
         definitively or raises, and a raise must never mean "retire".
 
-        Returns ``(confirmed, dropped_target_ids)``. The second element is what
-        makes a retirement's completeness auditable: "confirmed" covers both
-        *recorded* and *deliberately dropped*, and only the caller can tell those
-        apart to record the gap. Empty means every target actually recorded.
+        Returns ``(confirmed, dropped_target_ids, recordable_count)``. The second
+        element is what makes a retirement's completeness auditable: "confirmed"
+        covers both *recorded* and *deliberately dropped*, and only the caller can
+        tell those apart to record the gap. Empty means every target actually
+        recorded. The third is how many targets were candidates at all, letting the
+        caller distinguish "everything recorded" from "there was nothing to record"
+        — a build with no successful targets is confirmed without the sink ever
+        being asked, so claiming its lineage landed there would be false.
         """
         if self._store is None:
-            return False, set()
+            return False, set(), 0
         # Re-select this build's successful targets to ask the sink about them.
         # Scoped to the one build and only reached for finished builds, so this is
         # not the unbounded walk `allowed_build_ids` exists to prevent.
@@ -697,7 +736,7 @@ class LineageWatcher:
         )
         if any(t.uuid in self._failed_attempts for t in targets):
             # Mid-retry: still owes work locally.
-            return False, set()
+            return False, set(), len(targets)
         dropped = {t.uuid for t in targets if t.uuid in self._dropped}
         pending = {t.uuid for t in targets if t.uuid not in self._dropped}
         if not pending:
@@ -705,7 +744,7 @@ class LineageWatcher:
             # deliberately dropped. Report the dropped ones so the caller can
             # record the gap — if `dropped` covers every target, this build's
             # lineage never landed at all.
-            return True, dropped
+            return True, dropped, len(targets)
         # A sink that fails to answer returns the full candidate set (fail-open),
         # which is indistinguishable from a real "none recorded" verdict.
         # Retirement is irreversible, so it must act only on a real answer: this
@@ -721,7 +760,7 @@ class LineageWatcher:
         unrecorded = self._store.filter_unrecorded(
             pending, expected, on_query_error=_note_failure
         )
-        return (not sink_failed and not unrecorded), dropped
+        return (not sink_failed and not unrecorded), dropped, len(targets)
 
     def _checkpoint_build_id(self, storage: SingletonAdminStorage) -> Optional[str]:
         """Return the checkpoint's ``build_id``, or ``None`` if unset/malformed.

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -27,11 +27,14 @@ from gbserver.lineage.lineage_reconciler import (
     LINEAGE_WATCHER_DROPPED_KEY,
     UTC_MIN,
     as_aware,
+    expected_run_count,
     get_oldest_successful_target,
     reconcile_once,
+    select_recordable_targets,
 )
 from gbserver.lineage.lineage_seeding import BACKFILL_BUILD_ID
 from gbserver.storage.singleton_storage import SingletonAdminStorage, get_admin_storage
+from gbserver.storage.stored_build import StoredBuild
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -84,10 +87,21 @@ class LineageWatcher:
     build, though, so the general safety net is the scan's *anchor*: each scan
     bounds its walk by the checkpoint build's oldest successful target rather than
     by a timestamp, and because the query filters on status alone the sweep back to
-    that row re-surfaces the straggling targets of every build, not just the
+    that row re-surfaces the straggling targets of other builds, not just the
     checkpoint's. Idempotent recording makes the re-reads harmless. See
     ``_reconcile`` for why a row anchor and not a time window, and for the residual
     gap it does not close.
+
+    That sweep is bounded by *which* builds it may record for, not only by how far
+    back it reaches: the watcher tracks an in-memory allowlist of builds — the
+    checkpoint build as a permanent floor, plus every build seen since or found
+    inside the anchored range — and the scan records only for those. Without it an
+    anchor at a recent build still selects every older build's targets behind it,
+    which on a deployment with history means hundreds of unrelated candidates per
+    scan, and a re-record storm of exactly that size the first time the sink fails
+    to answer. Builds older than the floor are ignored for the life of the
+    process. See ``_refresh_allowed_builds``,
+    ``_admit_builds_in_anchored_range`` and ``_retire_finished_builds``.
 
     Which of those newly-finished targets actually get recorded is decided
     per-sink by ``store.filter_unrecorded`` (see ``reconcile_once``): the time
@@ -138,6 +152,26 @@ class LineageWatcher:
         # target_uuid -> attempts so far, for targets whose recording failed and
         # should be retried on a subsequent scan.
         self._failed_attempts: dict[str, int] = {}
+        # Builds whose targets this watcher may record for: the checkpoint build
+        # (the floor) plus every build seen since, minus those retired by
+        # _retire_finished_builds. Passed to reconcile_once as
+        # `allowed_build_ids`, and the reason an anchored retreat cannot wander
+        # into unrelated history (see select_recordable_targets).
+        #
+        # Deliberately in-memory and NOT persisted: it is a working set, and the
+        # floor makes it reconstructible — a restart reseeds from the durable
+        # checkpoint and re-adds whatever is still live. Persisting it would add
+        # an unbounded value to gb_kv_pairs for no recoverable state.
+        #
+        # Safe across restarts only because the checkpoint never advances past an
+        # unrecorded target (see _on_checkpoint_advance and reconcile_once's
+        # contiguity rule). A mark that outran pending work would leave the
+        # regenerated set unable to reach it, since the walk starts at the floor.
+        self._allowed_build_ids: set[str] = set()
+        # Whether the floor has been seeded into _allowed_build_ids. Seeding
+        # needs a checkpoint, which may not exist yet at start(), so like
+        # _checkpoint_verified this is retried at the top of each scan.
+        self._allowlist_seeded = False
         # Whether the start-up verification sweep has run against a checkpoint.
         # It cannot run while the key is absent, so it stays pending and is
         # retried at the top of each scan until a checkpoint is seeded — a
@@ -376,11 +410,28 @@ class LineageWatcher:
         # There is then no row to aim at, so the scan falls back to the plain
         # watermark cutoff — see below for what that costs.
         checkpoint_build_id = self._checkpoint_build_id(storage)
+        # Seed the allowlist floor from the checkpoint build before selecting, so
+        # the very first scan after a (re)start is already bounded. Seeding needs
+        # the checkpoint, so it is retried here rather than done once in start().
+        if not self._allowlist_seeded and checkpoint_build_id is not None:
+            self._allowed_build_ids.add(checkpoint_build_id)
+            self._allowlist_seeded = True
+            logger.info(
+                "Lineage allowlist seeded with checkpoint build %s as its floor; "
+                "builds older than it are ignored for the life of this process.",
+                checkpoint_build_id,
+            )
         stop_at: Optional[tuple[str, datetime]] = None
         if checkpoint_build_id is not None:
             oldest = get_oldest_successful_target(storage, build_id=checkpoint_build_id)
             if oldest is not None and oldest.finished_at is not None:
                 stop_at = (checkpoint_build_id, as_aware(oldest.finished_at))
+        # Order matters here. Admission needs the resolved anchor to know what
+        # "within range" means, and both must run before the filtered scan below:
+        # a build admitted after the scan would have its targets dropped on this
+        # pass and only picked up on the next one.
+        self._admit_builds_in_anchored_range(storage, stop_at)
+        self._refresh_allowed_builds(storage)
         # The anchor is the real bound, so the timestamp cutoff opens all the way
         # up; select_recordable_targets stops at the anchor row instead.
         #
@@ -436,7 +487,258 @@ class LineageWatcher:
             # bounds the walk at that build's oldest target.
             watermark_build_id=checkpoint_build_id,
             stop_at=stop_at,
+            # Bounds *which* builds the anchored retreat may record for. Only
+            # once seeded: an unseeded set is empty, and an empty membership
+            # filter selects nothing, which would silently stall recording
+            # rather than merely widening it. Unseeded means no checkpoint build
+            # resolved, in which case the scan is already on its fallback path.
+            allowed_build_ids=(
+                self._allowed_build_ids if self._allowlist_seeded else None
+            ),
         )
+        # After the scan, never before: retirement asks the sink whether a build's
+        # lineage is recorded, and running it first would ask that question about
+        # targets this pass was about to record — retiring a build a moment before
+        # its own targets were written, and (because a retired build is not
+        # re-admitted from build state) dropping them.
+        self._retire_finished_builds(storage)
+
+    def _refresh_allowed_builds(self, storage: SingletonAdminStorage) -> None:
+        """Add builds that have appeared since the last refresh.
+
+        Purely additive: a build enters the set when first seen and leaves only
+        through ``_retire_finished_builds``, which runs *after* the scan rather
+        than from here — retiring before recording would ask the sink about
+        targets the pass had not written yet. Nothing is ever dropped for
+        being *old*, because "old" would have to be judged on ``finished_at``,
+        which can place a late-committing row behind the watermark — the very case
+        the anchored walk exists to recover (see ``select_recordable_targets``).
+
+        Only builds that are not yet finished are added *here*. A build that was
+        already finished before this watcher ever saw it is either behind the
+        floor (deliberately out of scope) or already recorded, so adding it would
+        re-open the history the floor exists to exclude.
+
+        That rule alone is too narrow, though, and the gap is the one the anchored
+        walk exists for: a build concurrent with the floor can finish *inside* the
+        anchored range and be finished by the time any refresh runs — it is
+        neither the checkpoint build nor unfinished, so it would never be added,
+        and filtering would drop the very target the retreat reached back for. So
+        membership is also granted from below, by
+        ``_admit_builds_in_anchored_range``, which admits any build whose target
+        the walk actually surfaced at or after the anchor. This method covers
+        builds that are still live; that one covers builds that finished inside
+        the window.
+        """
+        if not self._allowlist_seeded:
+            # Without a floor there is nothing to add *to*: an unseeded set is
+            # empty and is not used as a filter, so populating it here would
+            # start bounding the scan by a set that has no floor behind it.
+            return
+        try:
+            live = storage.build_storage.get_by_where({})
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 — a refresh failure must not stop the scan
+            # Fail *open* on the set: keep the builds already tracked and scan
+            # with them. Losing an addition delays a new build's lineage by a
+            # scan; raising here would stop recording entirely.
+            logger.warning(
+                "Could not refresh the lineage build allowlist (%s); scanning "
+                "with the %d build(s) already tracked.",
+                exc,
+                len(self._allowed_build_ids),
+            )
+            return
+        added = 0
+        for build in live:
+            if build.uuid in self._allowed_build_ids:
+                continue
+            if build.status.is_finished():
+                continue
+            self._allowed_build_ids.add(build.uuid)
+            added += 1
+        if added:
+            logger.info(
+                "Lineage allowlist tracking %d build(s) (%d newly added).",
+                len(self._allowed_build_ids),
+                added,
+            )
+
+    def _admit_builds_in_anchored_range(
+        self,
+        storage: SingletonAdminStorage,
+        stop_at: Optional[tuple[str, datetime]],
+    ) -> None:
+        """Admit every build whose targets lie within the anchored range.
+
+        This is what keeps the allowlist from turning the anchored retreat into a
+        lineage-loss bug. The retreat exists because a target's row can become
+        visible carrying a ``finished_at`` behind the watermark, and because a
+        concurrent build can finish between two targets of the checkpoint's build.
+        Such a build is already finished by the time a refresh looks at build rows,
+        so ``_refresh_allowed_builds`` will not add it — and a membership filter
+        would then discard the target the walk retreated to collect.
+
+        Admitting from the *swept range* rather than from build state closes that:
+        anything the unfiltered walk can still reach is in scope by definition, so
+        the filter only ever removes what lies outside the anchor. The range is
+        bounded by the same anchor the scan uses, so this is not a full-history
+        read — and it is exactly the range the scan was going to walk anyway.
+
+        Without an anchor there is no bounded range to admit from, so this is a
+        no-op and the scan runs on its fallback path.
+        """
+        if stop_at is None or not self._allowlist_seeded:
+            return
+        try:
+            in_range = select_recordable_targets(
+                storage, finished_after=UTC_MIN, stop_at=stop_at
+            )
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 — admission failure must not stop the scan
+            logger.warning(
+                "Could not admit builds from the anchored range (%s); scanning "
+                "with the %d build(s) already tracked.",
+                exc,
+                len(self._allowed_build_ids),
+            )
+            return
+        admitted = {
+            t.build_id
+            for t in in_range
+            if t.build_id not in self._allowed_build_ids
+            # A build retired earlier in this process is deliberately done: its
+            # lineage was confirmed in the sink, so re-admitting it here would
+            # undo retirement on every scan and pin it forever.
+            and t.uuid not in self._dropped
+        }
+        if admitted:
+            self._allowed_build_ids |= admitted
+            logger.info(
+                "Admitted %d build(s) whose targets fall within the anchored "
+                "range: %s. Allowlist now tracks %d build(s).",
+                len(admitted),
+                ", ".join(sorted(admitted)),
+                len(self._allowed_build_ids),
+            )
+
+    def _retire_finished_builds(self, storage: SingletonAdminStorage) -> None:
+        """Drop builds that are finished, have nothing pending, and are recorded.
+
+        Keeps the in-memory set proportional to real concurrency rather than to
+        the process's uptime. All three conditions are required, and each guards a
+        distinct way a build can still owe work:
+
+        - ``status.is_finished()``: excludes ``RETRY_PENDING`` (a build queued for
+          a build-level retry is still going to produce targets) as well as
+          ``RUNNING``/``PENDING``.
+        - Nothing pending locally: no target of this build is mid-retry in
+          ``_failed_attempts``. Targets in ``_dropped`` do NOT count as pending —
+          they were given up on deliberately, and treating them as pending would
+          pin their build in the set forever.
+        - Recorded in the sink: local state cannot answer this. Only the sink
+          knows whether the runs actually landed, so this asks it.
+
+        Retirement is irreversible for this process: a retired build is not
+        re-added (``_refresh_allowed_builds`` skips finished builds), and the walk
+        will no longer select its targets. So every uncertain case must retain,
+        never retire — including a sink that fails to answer.
+        """
+        if self._store is None or not self._allowed_build_ids:
+            return
+        candidates: list[str] = []
+        for build_id in self._allowed_build_ids:
+            try:
+                build = storage.build_storage.get_by_uuid(build_id)
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 — unreadable build: retain, retry next scan
+                logger.debug(
+                    "Could not read build %s while considering it for lineage "
+                    "allowlist retirement (%s); retaining it.",
+                    build_id,
+                    exc,
+                )
+                continue
+            # get_by_uuid is typed as scalar-or-list (it returns a list when given
+            # one), so narrow explicitly rather than trusting the scalar shape.
+            if not isinstance(build, StoredBuild):
+                continue
+            if not build.status.is_finished():
+                continue
+            candidates.append(build_id)
+        for build_id in candidates:
+            try:
+                confirmed = self._build_lineage_is_confirmed(storage, build_id)
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 — retirement must never break the scan
+                # Retirement is a memory optimization running *after* the pass
+                # already recorded. Letting a storage error escape here would
+                # abort a scan whose real work is done, so a failure only means
+                # "not confirmed": retain the build and re-check next scan.
+                logger.warning(
+                    "Could not confirm whether build %s can leave the lineage "
+                    "allowlist (%s); retaining it.",
+                    build_id,
+                    exc,
+                )
+                continue
+            if not confirmed:
+                continue
+            self._allowed_build_ids.discard(build_id)
+            logger.info(
+                "Retired build %s from the lineage allowlist: finished, nothing "
+                "pending, and its lineage is recorded in the sink. Allowlist now "
+                "tracks %d build(s).",
+                build_id,
+                len(self._allowed_build_ids),
+            )
+
+    def _build_lineage_is_confirmed(
+        self, storage: SingletonAdminStorage, build_id: str
+    ) -> bool:
+        """Whether ``build_id`` has nothing pending and its lineage is in the sink.
+
+        The last two of the three retirement conditions (the caller has already
+        checked that the build is finished). Split out so the caller can treat any
+        failure as "not confirmed" in one place: every path here either answers
+        definitively or raises, and a raise must never mean "retire".
+        """
+        if self._store is None:
+            return False
+        # Re-select this build's successful targets to ask the sink about them.
+        # Scoped to the one build and only reached for finished builds, so this is
+        # not the unbounded walk `allowed_build_ids` exists to prevent.
+        targets = select_recordable_targets(
+            storage, finished_after=UTC_MIN, build_id=build_id
+        )
+        if any(t.uuid in self._failed_attempts for t in targets):
+            # Mid-retry: still owes work locally.
+            return False
+        pending = {t.uuid for t in targets if t.uuid not in self._dropped}
+        if not pending:
+            # Nothing left to confirm: every target either recorded or was
+            # deliberately dropped.
+            return True
+        # A sink that fails to answer returns the full candidate set (fail-open),
+        # which is indistinguishable from a real "none recorded" verdict.
+        # Retirement is irreversible, so it must act only on a real answer: this
+        # flag turns an unanswered query into "not confirmed", independently of
+        # what the returned set looks like.
+        sink_failed = False
+
+        def _note_failure(_exc: Exception) -> None:
+            nonlocal sink_failed
+            sink_failed = True
+
+        expected = {t.uuid: expected_run_count(t) for t in targets}
+        unrecorded = self._store.filter_unrecorded(
+            pending, expected, on_query_error=_note_failure
+        )
+        return not sink_failed and not unrecorded
 
     def _checkpoint_build_id(self, storage: SingletonAdminStorage) -> Optional[str]:
         """Return the checkpoint's ``build_id``, or ``None`` if unset/malformed.

--- a/src/gbserver/lineage/openlineage_service.py
+++ b/src/gbserver/lineage/openlineage_service.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Callable, Dict, List, Optional, Tuple, Type
 
 
 class LineageService(ABC):
@@ -48,6 +48,7 @@ class LineageService(ABC):
         self,
         target_ids: set[str],
         expected_counts: Optional[dict[str, int]] = None,
+        on_query_error: Optional[Callable[[Exception], None]] = None,
     ) -> set[str]:
         """Return the subset of ``target_ids`` not yet recorded in this backend.
 
@@ -103,6 +104,7 @@ class NoopLineageService(LineageService):
         self,
         target_ids: set[str],
         expected_counts: Optional[dict[str, int]] = None,
+        on_query_error: Optional[Callable[[Exception], None]] = None,
     ) -> set[str]:
         return target_ids
 

--- a/src/gbserver/lineage/wandb_jobstats.py
+++ b/src/gbserver/lineage/wandb_jobstats.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN, is_public_github
 from gbserver.lineage.jobstats import ILineageStore
@@ -301,7 +301,7 @@ class WandBLineageStore(ILineageStore):
 
         # NOTE: the number of events emitted here (one per output artifact across
         # all output-artifact lists, or one "no-output" event below) must stay in
-        # lockstep with lineage_reconciler._expected_run_count, which derives the
+        # lockstep with lineage_reconciler.expected_run_count, which derives the
         # same count from the target in memory to detect partial records.
         for (
             target_artifact_name,
@@ -500,6 +500,7 @@ class WandBLineageStore(ILineageStore):
         self,
         target_ids: set[str],
         expected_counts: Optional[dict[str, int]] = None,
+        on_query_error: Optional[Callable[[Exception], None]] = None,
     ) -> set[str]:
         # Drop candidates whose "fully recorded" verdict is still within its TTL,
         # so a steady-state scan that re-selects the same target does not re-ask
@@ -528,7 +529,11 @@ class WandBLineageStore(ILineageStore):
         # target rather than mere presence (see ILineageStore.filter_unrecorded).
         # Never raises: returns the candidates unchanged on failure so the caller
         # re-records them (a harmless idempotent no-op).
-        unrecorded = self._service.filter_unrecorded(to_check, expected_counts)
+        # ``on_query_error`` is forwarded rather than handled here: this layer only
+        # caches verdicts, and the service is where the query can fail.
+        unrecorded = self._service.filter_unrecorded(
+            to_check, expected_counts, on_query_error=on_query_error
+        )
 
         # Cache only the positive verdicts, and only for targets we actually
         # asked about. A failed query returns its candidates unchanged, so those

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import re
 from collections import deque
-from typing import Any, Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, cast
 
 import wandb
 from huggingface_hub import dataset_info, model_info
@@ -827,6 +827,7 @@ class WandBLineageService(LineageService):
         self,
         target_ids: set[str],
         expected_counts: Optional[dict[str, int]] = None,
+        on_query_error: Optional[Callable[[Exception], None]] = None,
     ) -> set[str]:
         """Return the subset of ``target_ids`` not yet recorded in wandb.
 
@@ -906,6 +907,20 @@ class WandBLineageService(LineageService):
             Exception
         ) as e:  # noqa: BLE001 — best-effort; any failure re-records the candidates
             logger.error("Failed to filter unrecorded target ids from wandb: %s", e)
+            if on_query_error is not None:
+                # Tell the caller this set is a fail-open default, not a verdict
+                # from wandb. Reported before returning so a caller that must not
+                # act on an unanswered query (e.g. retiring a build) can tell the
+                # two apart. Kept inside the handler: the contract is that this
+                # method never raises, so a misbehaving callback must not turn a
+                # degraded query into one.
+                try:
+                    on_query_error(e)
+                except Exception:  # noqa: BLE001 — callback must not break the contract
+                    logger.exception(
+                        "on_query_error callback raised while reporting a "
+                        "filter_unrecorded failure; ignoring it."
+                    )
             return target_ids
 
     def search_lineage_by_tags(

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -77,7 +77,32 @@ class WandBLineageService(LineageService):
         if run_id in self._runs:
             return self._runs[run_id]
 
-        run = wandb.init(
+        try:
+            run = self._init_run(run_id, job_name)
+        except Exception:
+            # init() registers the run before it can fail, and the next scan
+            # retries this same deterministic id — which wandb then rejects as
+            # "run ID <id> is in use", making a transient error permanent. A late
+            # failure leaves the partial run on wandb.run, an early one nothing.
+            self._finish_quietly(getattr(wandb, "run", None), run_id)
+            raise
+
+        self._runs[run_id] = run
+        return run
+
+    @staticmethod
+    def _finish_quietly(run: Any, run_id: str) -> None:
+        """Finish a run, never letting a teardown error mask the real one."""
+        if run is None:
+            return
+        try:
+            run.finish(exit_code=1)
+        except Exception as cleanup_error:  # pragma: no cover - defensive
+            logger.warning("Failed to release wandb run %s: %s", run_id, cleanup_error)
+
+    def _init_run(self, run_id: str, job_name: str):
+        """Open (or resume) the wandb run backing this lineage event."""
+        return wandb.init(
             project=GBSERVER_WANDB_PROJECT,
             entity=GBSERVER_WANDB_ENTITY,
             id=run_id,
@@ -105,8 +130,13 @@ class WandBLineageService(LineageService):
             ),
         )
 
-        self._runs[run_id] = run
-        return run
+    def _release_run(self, run_id: str) -> None:
+        """Finish and forget a run so its deterministic id can be reused.
+
+        A no-op for an id with no open run, so error paths need not know whether
+        the run was ever opened or a terminal event already finished it.
+        """
+        self._finish_quietly(self._runs.pop(run_id, None), run_id)
 
     # wandb run modes in which a live backend IS available, so artifact
     # registration can proceed. Any other mode (offline/disabled/dryrun/...) is
@@ -162,6 +192,7 @@ class WandBLineageService(LineageService):
                         run.use_artifact(artifact)
 
     def emit_event(self, event: Dict) -> None:
+        run_id: Optional[str] = None
         try:
             run_id = event["run"]["runId"]
             job_name = event["job"]["name"]
@@ -245,6 +276,11 @@ class WandBLineageService(LineageService):
 
         except Exception as e:
             logger.error("Failed to process lineage event: %s", e)
+            # Free the id for the retry, as in _get_run. A terminal event already
+            # finished and popped the run, so this is a no-op there — not a
+            # second finish().
+            if run_id is not None:
+                self._release_run(run_id)
             raise
 
     def _get_run_lineage(self, run_id: str) -> Optional[Dict]:

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -105,7 +105,15 @@ class WandBLineageService(LineageService):
         run = getattr(wandb, "run", None)
         if run is None:
             return None
-        return run if getattr(run, "id", None) == run_id else None
+        try:
+            # ``Run.id`` is a decorated property, so reading it can raise more than
+            # AttributeError. This runs inside the caller's ``except`` block, ahead of
+            # a bare ``raise`` — letting anything escape here would mask the init
+            # error that is the real failure. Unreadable therefore means not-ours.
+            observed_id = run.id
+        except Exception:  # noqa: BLE001 — any failure to read the id means not-ours
+            return None
+        return run if observed_id == run_id else None
 
     @staticmethod
     def _finish_quietly(run: Any, run_id: str) -> None:

--- a/src/gbserver/lineage/wandb_service.py
+++ b/src/gbserver/lineage/wandb_service.py
@@ -84,11 +84,28 @@ class WandBLineageService(LineageService):
             # retries this same deterministic id — which wandb then rejects as
             # "run ID <id> is in use", making a transient error permanent. A late
             # failure leaves the partial run on wandb.run, an early one nothing.
-            self._finish_quietly(getattr(wandb, "run", None), run_id)
+            self._finish_quietly(self._partial_run_for(run_id), run_id)
             raise
 
         self._runs[run_id] = run
         return run
+
+    @staticmethod
+    def _partial_run_for(run_id: str) -> Any:
+        """The global wandb run, but only if it is the one opened for ``run_id``.
+
+        ``wandb.init`` publishes near the end of a successful init, so a *late*
+        init failure leaves this call's partial run on the module-global
+        ``wandb.run`` and it must be released. The global is shared, though: it
+        may hold an unrelated run, and finishing that would mark a healthy run
+        failed. An unreadable id counts as not-ours — releasing the wrong run
+        corrupts it, while failing to release ours only leaves the id in use
+        until restart.
+        """
+        run = getattr(wandb, "run", None)
+        if run is None:
+            return None
+        return run if getattr(run, "id", None) == run_id else None
 
     @staticmethod
     def _finish_quietly(run: Any, run_id: str) -> None:

--- a/test/integration/standalone/lineage/test_openlineage_service.py
+++ b/test/integration/standalone/lineage/test_openlineage_service.py
@@ -176,7 +176,9 @@ class MockLineageService(LineageService):
             "truncated": max_depth <= 1,
         }
 
-    def filter_unrecorded(self, target_ids: set[str], expected_counts=None) -> set[str]:
+    def filter_unrecorded(
+        self, target_ids: set[str], expected_counts=None, on_query_error=None
+    ) -> set[str]:
         # Mirror the real service: count the distinct runs carrying each
         # ``target_id=<uuid>`` tag on emitted events, then treat a candidate as
         # recorded only when its run count meets its expected count. A ``None``

--- a/test/libgbtest/lineage/lineage.py
+++ b/test/libgbtest/lineage/lineage.py
@@ -279,7 +279,7 @@ class AbstractLineageTest(AbstractSingletonStorageUsingTest):
         # The reconciler's in-memory count must match what the builder emits.
         assert expected_run_count(targetrun) == len(events)
 
-    def testexpected_run_count_matches_events_built(self):
+    def test_expected_run_count_matches_events_built(self):
         """``expected_run_count`` must equal the events the builder emits.
 
         The reconciler derives a target's expected run count from the in-memory

--- a/test/libgbtest/lineage/lineage.py
+++ b/test/libgbtest/lineage/lineage.py
@@ -9,7 +9,7 @@ from libgbtest.storage.target_storage import TargetStorageTestSupport
 from libgbtest.utils import AbstractSingletonStorageUsingTest
 
 from gbcommon.uri.lh import LhURI
-from gbserver.lineage.lineage_reconciler import _expected_run_count
+from gbserver.lineage.lineage_reconciler import expected_run_count
 from gbserver.storage.singleton_storage import get_storage_factory
 
 
@@ -277,10 +277,10 @@ class AbstractLineageTest(AbstractSingletonStorageUsingTest):
         assert events[0].get("inputs", []) == []
         assert events[0].get("outputs", []) == []
         # The reconciler's in-memory count must match what the builder emits.
-        assert _expected_run_count(targetrun) == len(events)
+        assert expected_run_count(targetrun) == len(events)
 
-    def test_expected_run_count_matches_events_built(self):
-        """``_expected_run_count`` must equal the events the builder emits.
+    def testexpected_run_count_matches_events_built(self):
+        """``expected_run_count`` must equal the events the builder emits.
 
         The reconciler derives a target's expected run count from the in-memory
         ``StoredTargetRun`` (to avoid a storage read) while the sink emits one run
@@ -318,8 +318,8 @@ class AbstractLineageTest(AbstractSingletonStorageUsingTest):
             self.storage, targetrun, build
         )
 
-        assert _expected_run_count(targetrun) == 3
-        assert _expected_run_count(targetrun) == len(events)
+        assert expected_run_count(targetrun) == 3
+        assert expected_run_count(targetrun) == len(events)
 
     def test_filter_unrecorded_requires_full_run_count(self):
         """A partially-recorded target stays unrecorded until all its runs exist.

--- a/test/libgbtest/lineage/mock_lineage_service.py
+++ b/test/libgbtest/lineage/mock_lineage_service.py
@@ -47,7 +47,10 @@ class MockLineageService(LineageService):
         return total
 
     def filter_unrecorded(
-        self, target_ids: set, expected_counts: Optional[Dict[str, int]] = None
+        self,
+        target_ids: set,
+        expected_counts: Optional[Dict[str, int]] = None,
+        on_query_error=None,
     ) -> set:
         # Mirror the real service: count the distinct runs carrying each
         # ``target_id=<uuid>`` tag (emitted events are the in-memory stand-in for

--- a/test/unit/lineage/test_lineage_reconciler.py
+++ b/test/unit/lineage/test_lineage_reconciler.py
@@ -31,8 +31,8 @@ import pytest
 
 from gbserver.lineage.lineage_reconciler import (
     UTC_MIN,
-    _expected_run_count,
     as_aware,
+    expected_run_count,
     get_most_recent_successful_target,
     get_oldest_successful_target,
     reconcile_once,
@@ -145,7 +145,10 @@ class _StubStore:
         self._recorded.add(target_id)
 
     def filter_unrecorded(
-        self, target_ids: set[str], expected_counts: dict[str, int] = None
+        self,
+        target_ids: set[str],
+        expected_counts: dict[str, int] = None,
+        on_query_error=None,
     ) -> set[str]:
         self.last_expected_counts = expected_counts
         return set(target_ids) - self._recorded
@@ -583,7 +586,7 @@ class TestReconcileOnce:
         # ...but the checkpoint stops at t1, the last target before the failure.
         assert advances == [("b1", _BASE)]
 
-    def test_passes_expected_run_counts_derived_from_outputs(self):
+    def test_passesexpected_run_counts_derived_from_outputs(self):
         store = _StubStore()
         # t1: two output-artifact names, the second holding two artifacts -> 3
         # runs. t2: no outputs -> the single "no-output" run.
@@ -622,10 +625,10 @@ class TestReconcileOnce:
 class TestExpectedRunCount:
     def test_counts_all_output_artifacts_across_lists(self):
         t = _target("b1", "t1", output_artifacts={"a": ["o1"], "b": ["o2", "o3"]})
-        assert _expected_run_count(t) == 3
+        assert expected_run_count(t) == 3
 
     def test_no_outputs_expects_one_run(self):
-        assert _expected_run_count(_target("b1", "t1")) == 1
+        assert expected_run_count(_target("b1", "t1")) == 1
 
 
 class TestRecordSelectedTargets:

--- a/test/unit/lineage/test_lineage_reconciler.py
+++ b/test/unit/lineage/test_lineage_reconciler.py
@@ -586,7 +586,7 @@ class TestReconcileOnce:
         # ...but the checkpoint stops at t1, the last target before the failure.
         assert advances == [("b1", _BASE)]
 
-    def test_passesexpected_run_counts_derived_from_outputs(self):
+    def test_passes_expected_run_counts_derived_from_outputs(self):
         store = _StubStore()
         # t1: two output-artifact names, the second holding two artifacts -> 3
         # runs. t2: no outputs -> the single "no-output" run.

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -39,6 +39,7 @@ from gbserver.lineage.lineage_reconciler import (
     LINEAGE_WATCHER_DROPPED_KEY,
 )
 from gbserver.lineage.lineage_watcher import LineageWatcher
+from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_target_run import StoredTargetRun
 from gbserver.types.status import Status
 
@@ -74,7 +75,9 @@ class _StubStore:
         self.calls.append((build_id, target_id))
         self._recorded.add(target_id)
 
-    def filter_unrecorded(self, target_ids: set, expected_counts=None) -> set:
+    def filter_unrecorded(
+        self, target_ids: set, expected_counts=None, on_query_error=None
+    ) -> set:
         return set(target_ids) - self._recorded
 
 
@@ -225,6 +228,95 @@ class TestLineageWatcher:
         watcher._reconcile()
 
         assert "t_b" in {c[1] for c in store.calls}
+
+    def test_history_behind_the_anchor_build_is_not_selected(self):
+        """The reported bug: an anchored scan must not reach unrelated history.
+
+        The anchor is the checkpoint build's *oldest* target, and the walk filters
+        on status alone, so before the allowlist a scan anchored at a recent build
+        selected every successful target finished after that anchor — on a real
+        deployment, months of unrelated builds (441 candidates reaching back ~10
+        months). They were masked whenever the sink answered "already recorded",
+        and became a re-record storm the moment it timed out.
+
+        Here `old-build` finished long before the anchor build and is not tracked,
+        so it must not be selected at all.
+        """
+        self._targets = [
+            _target("old-build", "t_old", _BASE - timedelta(days=300)),
+            _target("build-c", "t_c", _BASE),
+        ]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+
+        watcher._reconcile()
+
+        recorded = {c[1] for c in store.calls}
+        assert "t_c" in recorded
+        assert "t_old" not in recorded
+
+    def test_sink_failure_does_not_retire_a_finished_build(self):
+        """An unanswered sink query must never confirm a build as recorded.
+
+        ``filter_unrecorded`` fails open — on error it returns every candidate,
+        which is indistinguishable from "none are recorded". Retirement is
+        irreversible for the process, so it must act only on a real answer: a
+        failing sink has to leave the build in the allowlist.
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowed_build_ids = {"build-c"}
+        watcher._allowlist_seeded = True
+
+        def _failing(target_ids, expected_counts=None, on_query_error=None):
+            if on_query_error is not None:
+                on_query_error(RuntimeError("wandb read timed out"))
+            return set(target_ids)
+
+        store.filter_unrecorded = _failing
+
+        watcher._retire_finished_builds(self.storage)
+
+        assert "build-c" in watcher._allowed_build_ids
+
+    def test_retirement_failure_does_not_abort_the_scan(self):
+        """A storage error during retirement must not break a completed scan.
+
+        Retirement runs *after* the pass has already recorded, and is only a
+        memory optimization: letting an error escape would abort a scan whose real
+        work is done. The build stays in the allowlist ("not confirmed") and the
+        scan still reports its recording as successful.
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowed_build_ids = {"build-c"}
+        watcher._allowlist_seeded = True
+
+        # A real finished build, so retirement gets past the build-status check and
+        # reaches the target re-selection below — the path that was unguarded.
+        self.storage.build_storage.get_by_uuid = lambda _uuid: StoredBuild(
+            uuid="build-c",
+            name="c",
+            space_name="s",
+            source_uri="file://x",
+            username="u",
+            status=Status.SUCCESS,
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("storage is down")
+
+        self.storage.target_storage.get_by_where.side_effect = _boom
+
+        # Must not raise.
+        watcher._retire_finished_builds(self.storage)
+
+        assert "build-c" in watcher._allowed_build_ids
 
     def test_staggered_targets_within_checkpoint_build_are_not_lost(self):
         """The checkpoint's build keeps its own earlier targets in scope.

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -570,6 +570,60 @@ class TestLineageWatcher:
         # Dropped target is in the skip set so it stops wedging every scan.
         assert "target-p" in watcher._dropped
 
+    def test_deleted_run_is_dropped_without_retrying(self):
+        """A run id the sink deleted is unrecoverable, so it must not be retried.
+
+        wandb remembers a deleted run id and refuses it permanently. Run ids are
+        deterministic, so there is no new id to try: every retry is a guaranteed
+        failure that also pins the checkpoint at this target. It must drop on the
+        first sighting, not after the full attempt budget.
+        """
+        self._targets = [_target("build-d", "target-d", _BASE)]
+        watcher, store = self._make_watcher()
+        deleted_msg = (
+            "run 552f5de9-c0da-4bed-961d-d5b2624035d6-99237962-f197-469c-91c1-"
+            "e8c529bf9c5c was previously created and deleted; try a new run id"
+        )
+
+        def _raise_deleted(_storage, build_id, target_id):
+            raise RuntimeError(deleted_msg)
+
+        store.add_jobstats_for_build_target = _raise_deleted
+
+        watcher._reconcile()
+
+        # Dropped on the very first failure, with no retry budget spent.
+        assert "target-d" in watcher._dropped
+        assert watcher._failed_attempts == {}
+        assert self.storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY) == {
+            "target_ids": ["target-d"]
+        }
+
+    def test_deleted_run_is_detected_through_a_wrapped_exception(self):
+        """The rejection still counts when it arrives wrapped by another error.
+
+        The store re-raises from its own handlers, so the rejection can reach the
+        watcher as a ``__cause__``/``__context__`` rather than as the outermost
+        exception. Checking only the outer one would spend the whole retry budget.
+        """
+        inner = RuntimeError("run abc-def was previously created and deleted")
+        outer = RuntimeError("Failed to process lineage event")
+        outer.__cause__ = inner
+
+        assert LineageWatcher._is_permanent_sink_rejection(outer) is True
+
+    def test_transient_failure_still_gets_its_full_retry_budget(self):
+        """The drop-immediate path must not swallow ordinary retryable failures.
+
+        wandb raises the same exception type for transient network trouble, so a
+        false positive here would discard recoverable lineage without retrying.
+        """
+        exc = RuntimeError(
+            "HTTPSConnectionPool(...): Read timed out. (read timeout=19)"
+        )
+
+        assert LineageWatcher._is_permanent_sink_rejection(exc) is False
+
     def test_dropped_target_survives_restart_and_unblocks_checkpoint(self):
         """A permanently-dropped target must not come back after a restart.
 

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -393,6 +393,45 @@ class TestLineageWatcher:
 
         assert "build-c" not in watcher._allowed_build_ids
 
+    def test_refresh_queries_only_live_builds_server_side(self):
+        """The refresh must not read every build row to find the live ones.
+
+        ``get_by_where({})`` returns all builds ever, every scan, deserializing
+        months of history to find the few new-and-unfinished ones — partly
+        reinstating the full-table read the allowlist exists to avoid.
+
+        The stored form matters: ``BuildStorage._get_column_values`` persists
+        ``status.name`` (upper case) while ``Status`` is a ``StrEnum`` with lower-case
+        values, so querying with the members themselves silently matches nothing,
+        empties the allowlist and stops lineage for every new build.
+        """
+        watcher, _store = self._make_watcher()
+        watcher._allowlist_seeded = True
+        running = StoredBuild(
+            name="live", space_name="sp", source_uri="https://x", username="u"
+        )
+        running.status = Status.RUNNING
+        done = StoredBuild(
+            name="done", space_name="sp", source_uri="https://x", username="u"
+        )
+        done.status = Status.SUCCESS
+        self.storage.build_storage.get_by_where = MagicMock(
+            return_value=[running, done]
+        )
+
+        watcher._refresh_allowed_builds(self.storage)
+
+        (where,), _kwargs = self.storage.build_storage.get_by_where.call_args
+        assert where != {}, "the refresh must filter server-side, not read every row"
+        assert set(where) == {"status"}
+        # Exactly the complement of is_finished(), in the stored upper-case form.
+        assert set(where["status"]) == {s.name for s in Status if not s.is_finished()}
+        assert all(name.isupper() for name in where["status"])
+        # The filter must not cost the additions the refresh exists to make, and a
+        # build that finished between the query and the loop is still kept out.
+        assert running.uuid in watcher._allowed_build_ids
+        assert done.uuid not in watcher._allowed_build_ids
+
     def test_retirement_records_the_build_as_retired(self):
         """Retiring a build must mark it, not just drop it from the allowlist.
 

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -37,6 +37,7 @@ import pytest
 from gbserver.lineage.lineage_reconciler import (
     LINEAGE_WATCHER_CHECKPOINT_KEY,
     LINEAGE_WATCHER_DROPPED_KEY,
+    LINEAGE_WATCHER_INCOMPLETE_KEY,
 )
 from gbserver.lineage.lineage_watcher import LineageWatcher
 from gbserver.storage.stored_build import StoredBuild
@@ -317,6 +318,229 @@ class TestLineageWatcher:
         watcher._retire_finished_builds(self.storage)
 
         assert "build-c" in watcher._allowed_build_ids
+
+    def test_admission_is_bounded_by_the_anchor_not_full_history(self):
+        """Admission must stop at the anchor row, not page the whole table.
+
+        ``_admit_builds_in_anchored_range`` passes ``finished_after=UTC_MIN``,
+        which on its own would mean "no lower bound" — a full historical read.
+        The actual bound is ``stop_at``, which takes over when given (see
+        ``select_recordable_targets``). This pins that: a build far behind the
+        anchor must not be admitted, however many scans run.
+
+        Asserted on the observable effect rather than on the call arguments, so
+        it stays true if the bound is expressed some other way.
+        """
+        self._targets = [
+            _target("ancient-build", "t_ancient", _BASE - timedelta(days=300)),
+            _target("build-c", "t_c", _BASE),
+        ]
+        watcher, _store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowlist_seeded = True
+        watcher._allowed_build_ids = {"build-c"}
+
+        watcher._admit_builds_in_anchored_range(self.storage, ("build-c", _BASE))
+
+        # Behind the anchor, so the walk must never have reached it.
+        assert "ancient-build" not in watcher._allowed_build_ids
+
+    def test_admission_admits_a_build_that_finished_inside_the_anchor(self):
+        """The other half of the bound: in-range builds must still be admitted.
+
+        Guards against "fixing" the bound by narrowing it into uselessness — a
+        concurrent build that finished inside the anchored range is exactly what
+        this method exists to catch, since it is already finished by the time
+        ``_refresh_allowed_builds`` looks at build rows.
+        """
+        self._targets = [
+            _target("concurrent-build", "t_conc", _BASE + timedelta(seconds=5)),
+            _target("build-c", "t_c", _BASE),
+        ]
+        watcher, _store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowlist_seeded = True
+        watcher._allowed_build_ids = {"build-c"}
+
+        watcher._admit_builds_in_anchored_range(self.storage, ("build-c", _BASE))
+
+        assert "concurrent-build" in watcher._allowed_build_ids
+
+    def test_retired_build_is_not_re_admitted_from_the_anchored_range(self):
+        """Retirement must survive the next scan's admission pass.
+
+        ``_admit_builds_in_anchored_range`` admits from the *swept range* rather
+        than from build state, so it never sees the finished-build check that
+        keeps ``_refresh_allowed_builds`` from re-adding a retired build. Its
+        guard originally tested ``t.uuid not in self._dropped`` — a target uuid
+        against the dropped-*targets* set, which never holds build ids — so the
+        guard could not fire and a retired build whose targets still sat inside
+        the anchor was re-admitted on every scan, undoing retirement.
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, _store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowlist_seeded = True
+        # Retired on an earlier scan: gone from the allowlist, recorded as retired.
+        watcher._allowed_build_ids = set()
+        watcher._retired_build_ids = {"build-c"}
+
+        # The anchor still spans build-c's target, so admission sees it.
+        watcher._admit_builds_in_anchored_range(self.storage, ("build-c", _BASE))
+
+        assert "build-c" not in watcher._allowed_build_ids
+
+    def test_retirement_records_the_build_as_retired(self):
+        """Retiring a build must mark it, not just drop it from the allowlist.
+
+        Discarding alone leaves nothing for admission to test against, which is
+        what let a retired build return on the next scan.
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowed_build_ids = {"build-c"}
+        watcher._allowlist_seeded = True
+
+        self.storage.build_storage.get_by_uuid = lambda _uuid: StoredBuild(
+            uuid="build-c",
+            name="c",
+            space_name="s",
+            source_uri="file://x",
+            username="u",
+            status=Status.SUCCESS,
+        )
+        # Nothing unrecorded left in the sink, so its lineage is confirmed.
+        store.filter_unrecorded = (
+            lambda target_ids, expected_counts=None, on_query_error=None: set()
+        )
+
+        watcher._retire_finished_builds(self.storage)
+
+        assert "build-c" not in watcher._allowed_build_ids
+        assert "build-c" in watcher._retired_build_ids
+
+    def _finished_build(self, build_id: str = "build-c") -> None:
+        """Make ``build_id`` read as a real finished build, so retirement gets
+        past the build-status check and reaches the confirmation path."""
+        self.storage.build_storage.get_by_uuid = lambda _uuid: StoredBuild(
+            uuid=build_id,
+            name="c",
+            space_name="s",
+            source_uri="file://x",
+            username="u",
+            status=Status.SUCCESS,
+        )
+
+    def test_retiring_with_dropped_targets_records_the_incomplete_build(self):
+        """A build retired with dropped lineage must leave a durable record.
+
+        Retiring it is deliberate: a run deleted from wandb cannot be regenerated,
+        so retaining the build would pin it forever for lineage that can never
+        land. But "confirmed" then covers *dropped* as well as *recorded*, so
+        without this key the build would look complete while its lineage is
+        absent — and the ERROR line explaining why rotates away.
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowed_build_ids = {"build-c"}
+        watcher._allowlist_seeded = True
+        # t_c was permanently rejected by the sink (deleted run), so it is dropped
+        # and never recorded — the whole build's lineage is therefore missing.
+        watcher._dropped = {"t_c"}
+        self._finished_build()
+        store.filter_unrecorded = (
+            lambda target_ids, expected_counts=None, on_query_error=None: set()
+        )
+
+        watcher._retire_finished_builds(self.storage)
+
+        assert "build-c" not in watcher._allowed_build_ids
+        recorded = self.storage.kv_pair_storage.get_value(
+            LINEAGE_WATCHER_INCOMPLETE_KEY
+        )
+        assert recorded["builds"]["build-c"]["target_ids"] == ["t_c"]
+        assert "retired_at" in recorded["builds"]["build-c"]
+
+    def test_retiring_a_fully_recorded_build_records_nothing_incomplete(self):
+        """The key must stay empty for the normal case.
+
+        Otherwise every retirement would look like a lineage gap and the record
+        would be useless for the question it exists to answer.
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowed_build_ids = {"build-c"}
+        watcher._allowlist_seeded = True
+        self._finished_build()
+        # Nothing dropped, and the sink confirms the target landed.
+        store.filter_unrecorded = (
+            lambda target_ids, expected_counts=None, on_query_error=None: set()
+        )
+
+        watcher._retire_finished_builds(self.storage)
+
+        assert "build-c" not in watcher._allowed_build_ids
+        assert (
+            self.storage.kv_pair_storage.get_value(LINEAGE_WATCHER_INCOMPLETE_KEY)
+            is None
+        )
+
+    def test_incomplete_record_accumulates_across_builds(self):
+        """Recording one build must not overwrite an earlier one.
+
+        The value is a single key holding a map, so this is a read-modify-write;
+        clobbering would silently lose every prior gap.
+        """
+        watcher, _store = self._make_watcher()
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_INCOMPLETE_KEY,
+            {"builds": {"older-build": {"target_ids": ["t_old"], "retired_at": "x"}}},
+        )
+
+        watcher._record_incomplete_build(self.storage, "build-c", {"t_c"})
+
+        builds = self.storage.kv_pair_storage.get_value(LINEAGE_WATCHER_INCOMPLETE_KEY)[
+            "builds"
+        ]
+        assert set(builds) == {"older-build", "build-c"}
+
+    def test_incomplete_record_failure_does_not_block_retirement(self):
+        """A failing audit write must not abort retirement or the scan.
+
+        Retirement runs after the pass has already recorded; losing the audit
+        entry is worse than nothing but far better than aborting a completed scan
+        (the ERROR line from the original drop still stands).
+        """
+        self._targets = [_target("build-c", "t_c", _BASE)]
+        watcher, store = self._make_watcher()
+        _seed(self.storage, "build-c", _BASE)
+        watcher._checkpoint_verified = True
+        watcher._allowed_build_ids = {"build-c"}
+        watcher._allowlist_seeded = True
+        watcher._dropped = {"t_c"}
+        self._finished_build()
+        store.filter_unrecorded = (
+            lambda target_ids, expected_counts=None, on_query_error=None: set()
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("kv store is down")
+
+        self.storage.kv_pair_storage.set_value = _boom
+
+        # Must not raise, and must still retire.
+        watcher._retire_finished_builds(self.storage)
+
+        assert "build-c" not in watcher._allowed_build_ids
 
     def test_staggered_targets_within_checkpoint_build_are_not_lost(self):
         """The checkpoint's build keeps its own earlier targets in scope.

--- a/test/unit/lineage/test_wandb_service_run_release.py
+++ b/test/unit/lineage/test_wandb_service_run_release.py
@@ -1,0 +1,170 @@
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for WandBLineageService run release on failure paths.
+
+Run ids here are deterministic (derived from the target uuid) and the watcher
+retries a failed target on its next scan with that same id. So a run left
+registered as in-flight in wandb's service process makes every retry fail with
+``ServerResponseError: run ID <id> is in use`` — a one-off failure becomes a
+permanent one. These tests assert both leak paths release the run: a failure
+inside ``wandb.init()``, and a failure after the run was opened.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gbserver.lineage.wandb_service import WandBLineageService
+
+
+def _service() -> WandBLineageService:
+    """Construct the service without running __init__ (no wandb.login)."""
+    service = WandBLineageService.__new__(WandBLineageService)
+    service._runs = {}
+    return service
+
+
+def _event(event_type: str = "START") -> dict:
+    return {
+        "run": {"runId": "run-1", "facets": {}},
+        "job": {"name": "job-1", "facets": {}, "namespace": "ns"},
+        "eventType": event_type,
+        "inputs": [],
+        "outputs": [],
+    }
+
+
+def _make_run() -> MagicMock:
+    run = MagicMock()
+    run.settings = SimpleNamespace(mode="online")
+    run.tags = []
+    run.config = MagicMock()
+    run.summary = {}
+    return run
+
+
+def test_init_failure_releases_partially_created_run():
+    """A run that init() created before raising is finished, not left in use.
+
+    This is the observed production loop: attempt 1 fails with CommError
+    ("previously created and deleted"), leaving the run registered; attempt 2
+    then fails with "run ID ... is in use" forever.
+    """
+    service = _service()
+    leaked = _make_run()
+
+    with (
+        patch.object(service, "_init_run", side_effect=RuntimeError("boom")),
+        patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
+    ):
+        wandb_mod.run = leaked
+        with pytest.raises(RuntimeError):
+            service._get_run("run-1", "job-1")
+
+    leaked.finish.assert_called_once()
+    # Nothing cached, so the retry does a fresh init rather than reusing a
+    # dead handle.
+    assert service._runs == {}
+
+
+def test_init_failure_with_no_partial_run_is_a_clean_reraise():
+    """When init() left nothing behind there is nothing to finish."""
+    service = _service()
+
+    with (
+        patch.object(service, "_init_run", side_effect=RuntimeError("boom")),
+        patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
+    ):
+        wandb_mod.run = None
+        with pytest.raises(RuntimeError):
+            service._get_run("run-1", "job-1")
+
+    assert service._runs == {}
+
+
+def test_init_failure_teardown_error_does_not_mask_original():
+    """A finish() error during cleanup must not replace the real exception."""
+    service = _service()
+    leaked = _make_run()
+    leaked.finish.side_effect = RuntimeError("teardown exploded")
+
+    with (
+        patch.object(service, "_init_run", side_effect=ValueError("original")),
+        patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
+    ):
+        wandb_mod.run = leaked
+        with pytest.raises(ValueError, match="original"):
+            service._get_run("run-1", "job-1")
+
+
+def test_mid_event_failure_releases_the_open_run():
+    """A failure after the run opened releases it before re-raising."""
+    service = _service()
+    run = _make_run()
+    service._runs["run-1"] = run
+
+    with (
+        patch.object(service, "_get_run", return_value=run),
+        patch.object(service, "_register_artifacts", side_effect=RuntimeError("boom")),
+    ):
+        with pytest.raises(RuntimeError):
+            service.emit_event(_event())
+
+    run.finish.assert_called_once()
+    assert service._runs == {}
+
+
+def test_terminal_event_is_not_released_twice():
+    """COMPLETE already finished the run; the failure path must not re-finish.
+
+    The logger.info after the terminal branch is patched to raise so the except
+    block runs with the run already finished and popped.
+    """
+    service = _service()
+    run = _make_run()
+
+    with (
+        patch.object(service, "_get_run", return_value=run),
+        patch.object(service, "_register_artifacts"),
+        patch(
+            "gbserver.lineage.wandb_service.logger.info",
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        with pytest.raises(RuntimeError):
+            service.emit_event(_event("COMPLETE"))
+
+    # Exactly one finish(): the COMPLETE one, not a second from cleanup.
+    run.finish.assert_called_once_with()
+    assert service._runs == {}
+
+
+def test_key_error_before_run_opens_releases_nothing():
+    """A malformed event fails before any run exists."""
+    service = _service()
+
+    with patch.object(service, "_get_run") as get_run:
+        with pytest.raises(KeyError):
+            service.emit_event({"run": {}, "job": {}})
+        get_run.assert_not_called()
+
+    assert service._runs == {}
+
+
+def test_release_run_is_a_noop_for_unknown_id():
+    service = _service()
+    service._release_run("never-opened")
+    assert service._runs == {}

--- a/test/unit/lineage/test_wandb_service_run_release.py
+++ b/test/unit/lineage/test_wandb_service_run_release.py
@@ -121,25 +121,54 @@ def test_init_failure_does_not_finish_an_unrelated_global_run():
     assert service._runs == {}
 
 
-def test_init_failure_ignores_a_global_run_with_no_readable_id():
+def _hide_id(run: MagicMock) -> None:
+    """Make the id missing entirely."""
+    del run.id
+
+
+def _break_id(run: MagicMock) -> None:
+    """Make reading the id raise, as a decorated property can.
+
+    Real wandb's ``Run.id`` is a property, so a read can fail with something other
+    than AttributeError — ``getattr(run, "id", None)`` only defaults on the latter.
+    """
+    type(run).id = property(
+        lambda _self: (_ for _ in ()).throw(AssertionError("id unavailable"))
+    )
+
+
+@pytest.mark.parametrize(
+    "make_unreadable", [_hide_id, _break_id], ids=["absent", "raises"]
+)
+def test_init_failure_ignores_a_global_run_with_no_readable_id(make_unreadable):
     """An unreadable id counts as not-ours: releasing the wrong run corrupts it.
 
     Failing to release ours only leaves the id in use until restart, so this is
-    the safer direction to fail in.
+    the safer direction to fail in. Unreadable covers both an id that is absent and
+    one whose read raises; the latter also must not escape, because this read happens
+    inside the init-failure handler ahead of the bare ``raise``, so an error here
+    would replace the init failure that is the real diagnostic.
     """
     service = _service()
-    anonymous = _make_run()
-    del anonymous.id
+    unreadable = _make_run()
+    make_unreadable(unreadable)
 
-    with (
-        patch.object(service, "_init_run", side_effect=RuntimeError("boom")),
-        patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
-    ):
-        wandb_mod.run = anonymous
-        with pytest.raises(RuntimeError):
-            service._get_run("run-1", "job-1")
+    try:
+        with (
+            patch.object(service, "_init_run", side_effect=RuntimeError("boom")),
+            patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
+        ):
+            wandb_mod.run = unreadable
+            # The original init error surfaces, not any error from the id read.
+            with pytest.raises(RuntimeError, match="boom"):
+                service._get_run("run-1", "job-1")
+    finally:
+        # Set on the type by _break_id, so it outlives this instance.
+        if "id" in vars(type(unreadable)):
+            del type(unreadable).id
 
-    anonymous.finish.assert_not_called()
+    unreadable.finish.assert_not_called()
+    assert service._runs == {}
 
 
 def test_init_failure_teardown_error_does_not_mask_original():

--- a/test/unit/lineage/test_wandb_service_run_release.py
+++ b/test/unit/lineage/test_wandb_service_run_release.py
@@ -47,12 +47,15 @@ def _event(event_type: str = "START") -> dict:
     }
 
 
-def _make_run() -> MagicMock:
+def _make_run(run_id: str = "run-1") -> MagicMock:
     run = MagicMock()
     run.settings = SimpleNamespace(mode="online")
     run.tags = []
     run.config = MagicMock()
     run.summary = {}
+    # A real run carries its id, and the init-failure path matches on it to tell
+    # *this* call's partial run from an unrelated one parked on wandb.run.
+    run.id = run_id
     return run
 
 
@@ -93,6 +96,50 @@ def test_init_failure_with_no_partial_run_is_a_clean_reraise():
             service._get_run("run-1", "job-1")
 
     assert service._runs == {}
+
+
+def test_init_failure_does_not_finish_an_unrelated_global_run():
+    """A run on wandb.run that is not ours must be left alone.
+
+    ``wandb.run`` is a module global. The cleanup used to finish whatever sat
+    there with ``exit_code=1``, so a failed init for one id would corrupt an
+    unrelated run that happened to be open — marking a healthy run failed. Only
+    the id we tried to open may be released.
+    """
+    service = _service()
+    stranger = _make_run("someone-elses-run")
+
+    with (
+        patch.object(service, "_init_run", side_effect=RuntimeError("boom")),
+        patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
+    ):
+        wandb_mod.run = stranger
+        with pytest.raises(RuntimeError):
+            service._get_run("run-1", "job-1")
+
+    stranger.finish.assert_not_called()
+    assert service._runs == {}
+
+
+def test_init_failure_ignores_a_global_run_with_no_readable_id():
+    """An unreadable id counts as not-ours: releasing the wrong run corrupts it.
+
+    Failing to release ours only leaves the id in use until restart, so this is
+    the safer direction to fail in.
+    """
+    service = _service()
+    anonymous = _make_run()
+    del anonymous.id
+
+    with (
+        patch.object(service, "_init_run", side_effect=RuntimeError("boom")),
+        patch("gbserver.lineage.wandb_service.wandb") as wandb_mod,
+    ):
+        wandb_mod.run = anonymous
+        with pytest.raises(RuntimeError):
+            service._get_run("run-1", "job-1")
+
+    anonymous.finish.assert_not_called()
 
 
 def test_init_failure_teardown_error_does_not_mask_original():


### PR DESCRIPTION
## Summary

Five related fixes to the wandb lineage recorder:

- **Bound the lineage scan to tracked builds; surface sink query failures.** The scan no longer ranges over untracked builds, and a failing sink query is reported rather than silently treated as "nothing recorded".
- **Drop lineage for a sink-deleted run id without retrying.** A run deleted on the sink side is no longer retried forever.
- **Release wandb runs on lineage failure paths.** Run ids are deterministic (the target uuid) and the watcher retries a failed target with that same id. `wandb.init()` registers a run as in-flight before it can fail, and two paths leaked that registration — a failure inside `init()`, and a failure after the run opened. Because the id is reused, wandb rejected every retry with `run ID <id> is in use`, turning a transient error permanent and blocking the retry mechanism meant to recover from it.
- **Make allowlist retirement stick.** Retirement never took effect (details below).
- **Record builds retired with lineage missing**, so a knowingly-partial build stays auditable.

The third fix adds `_release_run()` (a no-op for an unknown id, so terminal `COMPLETE`/`FAIL` events that already finish and pop are not finished twice) and `_finish_quietly()` (so a failing `finish()` during cleanup never masks the original exception), and extracts `_init_run()` as a seam for the release-then-reraise in `_get_run`.

## Retirement never took effect

`_admit_builds_in_anchored_range` guarded re-admission with `t.uuid not in self._dropped` — a *target* uuid tested against the dropped-*targets* set, which never holds build ids — so the guard could not fire. Retirement also left no trace to test against, discarding from `_allowed_build_ids` and nothing more; since admission's first condition is absence from that same set, a just-retired build matched it immediately and was re-admitted on the very next scan for as long as one of its targets sat inside the anchor. The method's own comment claimed to prevent exactly this.

Fixed by adding `_retired_build_ids`, populated at the retirement site and tested by anchored-range admission. The other admission path needs no change: `_refresh_allowed_builds` skips finished builds, which every retired build is by construction — now noted there, since the reasoning is load-bearing and was undocumented.

## Builds retired with lineage missing

A dropped target subtracts from `pending`, so "confirmed" covered *dropped* as well as *recorded*: a build whose targets were all dropped looked complete while its lineage was absent.

Retiring it is still correct. A run deleted from wandb cannot be regenerated (ids derive from the target and the sink refuses a deleted id), so retaining the build would pin it forever for lineage that can never land — and we do not want incomplete builds in wandb. What was missing is the audit trail: the drop is logged at `ERROR`, but logs rotate and "was this build's lineage complete?" is a question asked long after.

`_build_lineage_is_confirmed` now returns which targets were dropped, and retirement persists them under `LINEAGE_WATCHER_INCOMPLETE_KEY` (`{"builds": {<build_id>: {"target_ids": [...], "retired_at": <ISO>}}}`) so each build's completeness stays queryable. The retirement log line no longer claims lineage is recorded when it is not.

## Scoping the wandb run release

`_get_run`'s init-failure cleanup read the module-global `wandb.run` and finished whatever sat there with `exit_code=1`, so a failed init for one id could mark an unrelated open run as failed. It now matches on `run.id` first; an unreadable id counts as not-ours, since releasing the wrong run corrupts it while failing to release ours only leaves the id in use until restart. `emit_event`'s error path already went through `_release_run`, keyed by `run_id`, and needed no change.

## Test plan

- `test/unit/lineage/` — **139 passed**, including 41 in `test_lineage_watcher.py` and 9 in `test_wandb_service_run_release.py`.
- New coverage: retirement marking a build retired and not re-admitting it; the incomplete-lineage record (written on drop, absent on a clean retirement, accumulating across builds, and never blocking retirement when the kv write fails); an unrelated global run left untouched on init failure, including the unreadable-id case.
- Every new test was checked by **mutation** — reverting the corresponding fix makes it fail, and restoring the fix makes it pass. Removing `stop_at` from the admission call also fails 1 test; stubbing that call to `[]` fails 4, confirming the path is load-bearing for recording rather than only for the allowlist.
- The existing run-release fixture built its leaked run from a bare `MagicMock`, so `.id` auto-returned a `Mock` and never modeled run identity — the very thing the bug ignored. It now carries an id.
- Two tests pin the admission bound, which is `stop_at` rather than `finished_after=UTC_MIN`: history behind the anchor is not admitted, and builds inside it still are. Asserted on the observable effect, so they hold if the bound is expressed another way. (`finished_after=UTC_MIN` reads as "unfiltered" and was twice reported as a full-history walk; it is not.)
- The late-failure behavior was verified empirically against the installed wandb 0.28.2 rather than assumed: `_set_global_run` runs near the end of a successful `init()`, so a late failure leaves the partial run on `wandb.run` (id intact) while an early validation failure leaves `None`. Both branches are handled.
- `black` clean across `src/gbserver/lineage/` and `test/unit/lineage/`.
- `pylint` reports only pre-existing findings.

## Module size

`lineage_watcher.py` sat over `max-module-lines`, so its prose was condensed from 1165 to **exactly 1000 lines**, clearing `too-many-lines`. The anchor mechanism had been explained three times over and the checkpoint twice; the class docstring is now an overview with pointers instead of restating what each method documents at its own site.

No reason was dropped — the SQLite/Postgres offset trap, the checkpoint timestamp form, and the naive/aware `TypeError` all remain. The pass was verified **AST-identical** to the state before it, so no executable line changed.

Two caveats worth stating: the module now sits exactly at the limit, so the next added line trips the warning again — the durable fix is splitting it, which is out of scope here. And `wandb_service.py` was already at exactly 1000 lines, so this PR's 17 added lines put it at 1017 and it now reports `too-many-lines`; no `# pylint: disable` was added to hide it, since nine other modules in `src/` exceed the limit with no exemption.

Generated with [Claude Code](https://claude.com/claude-code)
