### PR TITLE
Make _load_urihandlers idempotent to fix a test failure

### DIFF
--- a/src/gbcommon/uri/uri.py
+++ b/src/gbcommon/uri/uri.py
@@ -86,11 +86,28 @@ class URI(ABC):
 
     @staticmethod
     def _load_urihandlers() -> None:
+        """Discover and register every URI handler, rebuilding the registry.
+
+        Rebuilds ``URI.uri_handler_classes`` from scratch on each call: the
+        registry is cleared first so the method is idempotent and reload-safe.
+        Without the clear, the ``PluginRegistrar`` core-wins guard would keep a
+        stale prior registration and refuse to replace it — so a re-run after
+        ``importlib.reload(gbcommon.uri.<scheme>)`` (as the test conftest does)
+        would leave the registry pointing at the pre-reload class, distinct from
+        the module's current one. The in-tree scan repopulates built-ins with
+        their current classes; the plugin ``discover`` pass then adds external
+        handlers, with core-wins still protecting the freshly-registered
+        built-ins.
+        """
         from gbcommon.plugins import (
             GROUP_URI_HANDLERS,
             PluginRegistrar,
             keys_from_method,
         )
+
+        # Rebuild from scratch (in place, preserving any held reference to the
+        # dict) so a reload's new classes win over stale registrations.
+        URI.uri_handler_classes.clear()
 
         # Files each URI handler under the scheme(s) it advertises. Both the
         # in-tree scan and the plugin pass register through this one registrar.

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -362,6 +362,38 @@ def test_uri_noop_when_no_plugins(monkeypatch, uri_registry_snapshot):
     assert URI.uri_handler_classes == baseline
 
 
+def test_uri_loader_rebuilds_registry(monkeypatch, uri_registry_snapshot):
+    """The loader rebuilds the registry from scratch on every run: a stale entry
+    left over from a prior registration is replaced by the module's current
+    class, not kept by the core-wins guard.
+
+    This guards the reload path the test conftest relies on. After
+    ``importlib.reload(gbcommon.uri.git)`` the module's ``GitURI`` is a brand-new
+    class object; re-running ``_load_urihandlers`` must register that new object.
+    A loader that reused the registry would hit core-wins and keep the
+    pre-reload class, so ``URI.get_uri`` would hand back instances whose class
+    differs from ``gbcommon.uri.git.GitURI`` — defeating any ``monkeypatch`` that
+    targets the module attribute (the exact regression behind the git-base
+    resolver test cloning for real instead of using its patched clone).
+    """
+    import gbcommon.uri.git
+    from gbcommon.uri.uri import URI
+
+    # A distinct class standing in for a stale pre-reload registration.
+    class StaleGitURI(gbcommon.uri.git.GitURI):
+        pass
+
+    _patch_entry_points(monkeypatch, {})
+    schemes = gbcommon.uri.git.GitURI.get_supported_schemes()
+    for scheme in schemes:
+        URI.uri_handler_classes[scheme] = StaleGitURI
+
+    URI._load_urihandlers()
+
+    for scheme in schemes:
+        assert URI.uri_handler_classes[scheme] is gbcommon.uri.git.GitURI
+
+
 # ---------------------------------------------------------------------------
 # Environment loader
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Description

test/unit/uri/test_space_uri_resolver.py::TestGitBaseUri tests were all failing.  Fix is to have_load_urihandlers() now clears the registry at the start, rebuilding it from scratch each run. This makes it idempotent and reload-safe; the in-tree scan repopulates built-ins with their current classes, and the plugin discover pass still adds external handlers with core-wins protecting the freshly-registered built-ins.


Brief description of what this PR does and why.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
