### PR TITLE
Fix lineage never recorded for a build first seen without targets; add lineage-init

### DIFF
--- a/src/gbserver/commands/command_lineage_init.py
+++ b/src/gbserver/commands/command_lineage_init.py
@@ -28,6 +28,7 @@ deliberately.
 """
 
 import json
+from typing import Optional
 
 import click
 
@@ -162,7 +163,7 @@ def _clear_dropped_targets(storage) -> None:
 @pass_environment
 def cli(
     ctx: CliEnvironment,
-    build_id: str,
+    build_id: Optional[str],
     force: bool,
     clear_dropped_targets: bool,
     show: bool,

--- a/src/gbserver/commands/command_lineage_init.py
+++ b/src/gbserver/commands/command_lineage_init.py
@@ -150,12 +150,11 @@ def cli(
             click.echo(f"{LINEAGE_WATCHER_DROPPED_KEY}: no targets dropped.")
         return
 
-    if clear_dropped_targets:
+    if clear_dropped_targets and build_id is None:
+        # Clearing alone is a complete operation: the checkpoint is untouched
+        # and the watcher retries the targets on its next scan.
         _clear_dropped_targets(storage)
-        if build_id is None:
-            # Clearing alone is a complete operation: the checkpoint is untouched
-            # and the watcher retries the targets on its next scan.
-            return
+        return
 
     if build_id is None:
         raise click.ClickException(
@@ -177,6 +176,12 @@ def cli(
         wrote = seed_if_absent(storage, build_id, force=force)
     except LineageSeedError as exc:
         raise click.ClickException(str(exc)) from exc
+
+    # Clear only after the seed lands. The two writes are separate kv_pairs calls
+    # with no shared transaction, so clearing first meant a failed seed still
+    # wiped the durable drop set -- a "failed" run that silently mutated state.
+    if clear_dropped_targets:
+        _clear_dropped_targets(storage)
 
     value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_CHECKPOINT_KEY)
     if wrote:

--- a/src/gbserver/commands/command_lineage_init.py
+++ b/src/gbserver/commands/command_lineage_init.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Place the lineage checkpoint without starting the watcher.
+
+``lineage-watch --base-build-id`` already seeds the checkpoint, but it then runs
+the watcher forever, so initializing a fresh environment meant starting it and
+killing it once the key appeared. That works, but it records lineage for however
+long it happened to run -- an unclear amount of work on an environment being set
+up, and awkward to script.
+
+This command does the seeding half only: resolve the anchor, write
+``gb_kv_pairs``, exit. The watcher then starts clean, from a mark someone chose
+deliberately.
+"""
+
+import json
+
+import click
+
+from gbserver.lineage.lineage_reconciler import (
+    LINEAGE_WATCHER_CHECKPOINT_KEY,
+    LINEAGE_WATCHER_DROPPED_KEY,
+)
+from gbserver.lineage.lineage_seeding import LineageSeedError, seed_if_absent
+from gbserver.storage.singleton_storage import get_admin_storage
+from gbserver.types.context import CliEnvironment, pass_environment
+from gbserver.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _clear_dropped_targets(storage) -> None:
+    """Empty the durable dropped-*target* set so those targets are retried.
+
+    Writes an empty list rather than deleting the key, so the shape stays what
+    ``LineageWatcher._load_dropped`` expects on its next start.
+
+    A running watcher does NOT see this immediately: ``_dropped`` is loaded once in
+    ``start()``, not per scan (unlike the checkpoint, which is re-read every scan).
+    So this takes effect on the watcher's next restart, and the caller is told so
+    rather than left to wonder why the targets are still skipped.
+    """
+    existing = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
+    target_ids = (existing or {}).get("target_ids", [])
+    if not target_ids:
+        click.echo(f"{LINEAGE_WATCHER_DROPPED_KEY}: nothing to clear.")
+        return
+    storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []})
+    click.echo(
+        f"Cleared {len(target_ids)} dropped target(s) from "
+        f"{LINEAGE_WATCHER_DROPPED_KEY}: {', '.join(sorted(target_ids))}. "
+        "Restart the lineage watcher for this to take effect -- it loads the drop "
+        "set once at start(), not on every scan."
+    )
+
+
+@click.command()
+@click.option(
+    "--build-id",
+    required=False,
+    default=None,
+    type=str,
+    metavar="from-latest|all|BUILD_ID",
+    help=(
+        "Anchor to seed: 'from-latest' starts at the most recent build, 'all' "
+        "walks the full history (expensive first scan), any other value is "
+        "treated as a build id. The anchor is the build itself: it and every "
+        "build created after it are processed, so the anchored build is recorded "
+        "whole."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Replace an existing checkpoint instead of keeping it. Moving the anchor "
+        "back re-drives lineage already recorded; moving it forward skips lineage "
+        "for good."
+    ),
+)
+@click.option(
+    "--clear-dropped-targets",
+    is_flag=True,
+    default=False,
+    help=(
+        "Clear the set of TARGET ids the watcher permanently gave up on (after "
+        "exhausting its record attempts) so they are retried. Requires a watcher "
+        "restart to take effect: the drop set is loaded once at start(), unlike "
+        "the checkpoint, which is re-read every scan. Moving the anchor back does "
+        "NOT clear them, which is why this exists -- the drop decision is durable "
+        "on purpose, and a dropped target is otherwise skipped forever. Only "
+        "useful once whatever made recording fail is fixed."
+    ),
+)
+@click.option(
+    "--show",
+    is_flag=True,
+    default=False,
+    help=(
+        "Print the current checkpoint and dropped-target set, then exit without "
+        "writing anything."
+    ),
+)
+@pass_environment
+def cli(
+    ctx: CliEnvironment,
+    build_id: str,
+    force: bool,
+    clear_dropped_targets: bool,
+    show: bool,
+) -> None:
+    """Seed the lineage checkpoint (gb_kv_pairs) without running the watcher."""
+    storage = get_admin_storage()
+
+    if show:
+        existing = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_CHECKPOINT_KEY)
+        if existing is None:
+            click.echo(
+                f"No lineage checkpoint under {LINEAGE_WATCHER_CHECKPOINT_KEY}. "
+                "The watcher records nothing until one is seeded."
+            )
+        else:
+            click.echo(f"{LINEAGE_WATCHER_CHECKPOINT_KEY} = {json.dumps(existing)}")
+        # Report the drop set too: a dropped target is skipped on every scan, so an
+        # operator asking "why is this target's lineage missing?" needs to see it
+        # next to the checkpoint rather than querying gb_kv_pairs by hand.
+        dropped = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
+        target_ids = (dropped or {}).get("target_ids", [])
+        if target_ids:
+            click.echo(
+                f"{LINEAGE_WATCHER_DROPPED_KEY}: {len(target_ids)} target(s) "
+                f"permanently skipped: {', '.join(sorted(target_ids))}"
+            )
+        else:
+            click.echo(f"{LINEAGE_WATCHER_DROPPED_KEY}: no targets dropped.")
+        return
+
+    if clear_dropped_targets:
+        _clear_dropped_targets(storage)
+        if build_id is None:
+            # Clearing alone is a complete operation: the checkpoint is untouched
+            # and the watcher retries the targets on its next scan.
+            return
+
+    if build_id is None:
+        raise click.ClickException(
+            "Nothing to do: pass --build-id to seed the checkpoint, "
+            "--clear-dropped-targets to retry dropped targets, or --show to "
+            "inspect the current state."
+        )
+
+    if not build_id.strip():
+        # Same reason lineage-watch rejects this: an empty string passes click's
+        # required check but resolves to no anchor, so the operator would believe a
+        # checkpoint was placed when none was.
+        raise click.ClickException(
+            "--build-id was given an empty value; pass 'from-latest', 'all', or a "
+            "build id."
+        )
+
+    try:
+        wrote = seed_if_absent(storage, build_id, force=force)
+    except LineageSeedError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_CHECKPOINT_KEY)
+    if wrote:
+        click.echo(f"Seeded {LINEAGE_WATCHER_CHECKPOINT_KEY} = {json.dumps(value)}")
+    else:
+        # Not an error: seed-if-absent is the safe default, and re-running this
+        # command on an initialized environment should be a no-op rather than a
+        # failure.
+        click.echo(
+            f"{LINEAGE_WATCHER_CHECKPOINT_KEY} already set to {json.dumps(value)}; "
+            "kept it. Pass --force to replace it."
+        )

--- a/src/gbserver/commands/command_lineage_init.py
+++ b/src/gbserver/commands/command_lineage_init.py
@@ -43,29 +43,74 @@ from gbserver.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+def _read_dropped_target_ids(storage) -> list:
+    """Read the durable drop set's target ids, rejecting an unusable shape clearly.
+
+    ``get_value`` returns whatever is in ``gb_kv_pairs``, so a hand-corrupted row
+    (a string, a list) would otherwise fail on ``.get`` with a bare AttributeError
+    traceback. ``--show`` is exactly the command an operator reaches for when they
+    suspect the state is malformed, so it has to report that rather than crash on it.
+    """
+    value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
+    if not value:
+        return []
+    if not isinstance(value, dict):
+        raise click.ClickException(
+            f"{LINEAGE_WATCHER_DROPPED_KEY} holds {type(value).__name__}, not an "
+            f"object: {value!r}. Expected {{'target_ids': [...]}}; fix or delete the "
+            "row in gb_kv_pairs."
+        )
+    target_ids = value.get("target_ids", [])
+    if not isinstance(target_ids, list):
+        raise click.ClickException(
+            f"{LINEAGE_WATCHER_DROPPED_KEY} has a non-list 'target_ids' "
+            f"({type(target_ids).__name__}): {target_ids!r}. Fix or delete the row "
+            "in gb_kv_pairs."
+        )
+    # Element types matter, not just the container: both callers ``sorted()`` and
+    # ``join()`` these, which raise TypeError on a mixed or non-string list. Letting
+    # that through would defeat the whole point of this helper.
+    bad = [t for t in target_ids if not isinstance(t, str)]
+    if bad:
+        raise click.ClickException(
+            f"{LINEAGE_WATCHER_DROPPED_KEY} has non-string target id(s) in "
+            f"'target_ids': {bad!r}. Expected a list of uuid strings; fix or delete "
+            "the row in gb_kv_pairs."
+        )
+    return target_ids
+
+
 def _clear_dropped_targets(storage) -> None:
     """Empty the durable dropped-*target* set so those targets are retried.
 
     Writes an empty list rather than deleting the key, so the shape stays what
     ``LineageWatcher._load_dropped`` expects on its next start.
 
-    A running watcher does NOT see this immediately: ``_dropped`` is loaded once in
-    ``start()``, not per scan (unlike the checkpoint, which is re-read every scan).
-    So this takes effect on the watcher's next restart, and the caller is told so
-    rather than left to wonder why the targets are still skipped.
+    Stop the watcher before calling this. ``_dropped`` is loaded once in ``start()``,
+    not per scan (unlike the checkpoint, which is re-read every scan), and
+    ``_persist_dropped`` writes the whole in-memory set. So a running watcher not
+    only misses the clear -- the next target it drops persists its stale full set,
+    resurrecting every id cleared here, and a later restart reloads them. Clearing
+    is only durable while the watcher is down.
     """
-    existing = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
-    target_ids = (existing or {}).get("target_ids", [])
+    target_ids = _read_dropped_target_ids(storage)
     if not target_ids:
         click.echo(f"{LINEAGE_WATCHER_DROPPED_KEY}: nothing to clear.")
         return
-    storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []})
-    click.echo(
+    # Format before writing. These two lines used to be the other way round, so any
+    # formatting error (a non-string id reaching sorted()/join()) exited non-zero
+    # having already wiped the durable set -- the same mutate-on-failure bug the
+    # deferred clear in cli() exists to avoid. Building the string first keeps the
+    # write the last thing that can happen.
+    summary = (
         f"Cleared {len(target_ids)} dropped target(s) from "
         f"{LINEAGE_WATCHER_DROPPED_KEY}: {', '.join(sorted(target_ids))}. "
-        "Restart the lineage watcher for this to take effect -- it loads the drop "
-        "set once at start(), not on every scan."
+        "This only sticks while the watcher is stopped: a running watcher loads the "
+        "drop set once at start() and rewrites its whole in-memory set on the next "
+        "drop, which would restore what was just cleared."
     )
+    storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []})
+    click.echo(summary)
 
 
 @click.command()
@@ -99,9 +144,10 @@ def _clear_dropped_targets(storage) -> None:
     default=False,
     help=(
         "Clear the set of TARGET ids the watcher permanently gave up on (after "
-        "exhausting its record attempts) so they are retried. Requires a watcher "
-        "restart to take effect: the drop set is loaded once at start(), unlike "
-        "the checkpoint, which is re-read every scan. Moving the anchor back does "
+        "exhausting its record attempts) so they are retried. Stop the watcher "
+        "first: it loads the drop set once at start() (unlike the checkpoint, "
+        "re-read every scan) and rewrites the whole set on its next drop, which "
+        "would restore what was cleared. Moving the anchor back does "
         "NOT clear them, which is why this exists -- the drop decision is durable "
         "on purpose, and a dropped target is otherwise skipped forever. Only "
         "useful once whatever made recording fail is fixed."
@@ -139,8 +185,7 @@ def cli(
         # Report the drop set too: a dropped target is skipped on every scan, so an
         # operator asking "why is this target's lineage missing?" needs to see it
         # next to the checkpoint rather than querying gb_kv_pairs by hand.
-        dropped = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
-        target_ids = (dropped or {}).get("target_ids", [])
+        target_ids = _read_dropped_target_ids(storage)
         if target_ids:
             click.echo(
                 f"{LINEAGE_WATCHER_DROPPED_KEY}: {len(target_ids)} target(s) "
@@ -151,8 +196,9 @@ def cli(
         return
 
     if clear_dropped_targets and build_id is None:
-        # Clearing alone is a complete operation: the checkpoint is untouched
-        # and the watcher retries the targets on its next scan.
+        # Clearing alone is a complete operation: the checkpoint is untouched, and
+        # the watcher retries the targets once it is (re)started -- it reads the drop
+        # set only in start(), so a running watcher would not pick this up.
         _clear_dropped_targets(storage)
         return
 

--- a/src/gbserver/commands/command_lineage_init.py
+++ b/src/gbserver/commands/command_lineage_init.py
@@ -133,9 +133,10 @@ def _clear_dropped_targets(storage) -> None:
     is_flag=True,
     default=False,
     help=(
-        "Replace an existing checkpoint instead of keeping it. Moving the anchor "
-        "back re-drives lineage already recorded; moving it forward skips lineage "
-        "for good."
+        "Replace an existing checkpoint instead of keeping it. Requires --build-id: "
+        "it qualifies a seed and does nothing on its own. Moving the anchor back "
+        "re-drives lineage already recorded; moving it forward skips lineage for "
+        "good."
     ),
 )
 @click.option(
@@ -159,7 +160,9 @@ def _clear_dropped_targets(storage) -> None:
     default=False,
     help=(
         "Print the current checkpoint and dropped-target set, then exit without "
-        "writing anything."
+        "writing anything. Must be passed alone: combining it with --build-id, "
+        "--force or --clear-dropped-targets is an error rather than a silently "
+        "ignored write."
     ),
 )
 @pass_environment
@@ -173,13 +176,43 @@ def cli(
     """Seed the lineage checkpoint (gb_kv_pairs) without running the watcher."""
     storage = get_admin_storage()
 
+    if show and (clear_dropped_targets or build_id is not None or force):
+        # --show returned early, so a write flag passed alongside it was silently
+        # ignored and the command still exited 0 -- an operator or setup script
+        # reasonably reads that as "shown and done", while the targets stay skipped
+        # forever. Reject rather than guess an order, as lineage-watch does for its
+        # two mutually exclusive anchors.
+        conflicting = ", ".join(
+            flag
+            for flag, given in (
+                ("--build-id", build_id is not None),
+                ("--force", force),
+                ("--clear-dropped-targets", clear_dropped_targets),
+            )
+            if given
+        )
+        raise click.ClickException(
+            f"--show is read-only and cannot be combined with {conflicting}; run "
+            "them as separate commands."
+        )
+
     if show:
         existing = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_CHECKPOINT_KEY)
-        if existing is None:
-            click.echo(
-                f"No lineage checkpoint under {LINEAGE_WATCHER_CHECKPOINT_KEY}. "
-                "The watcher records nothing until one is seeded."
-            )
+        # `not existing`, not `is None`: _read_checkpoint_value treats an empty value
+        # as absent and records nothing, so testing identity here would report a {}
+        # row as a seeded checkpoint -- disagreeing with the watcher in exactly the
+        # case --show exists to diagnose.
+        if not existing:
+            if existing is None:
+                detail = f"No lineage checkpoint under {LINEAGE_WATCHER_CHECKPOINT_KEY}"
+            else:
+                # Distinguish "never seeded" from "seeded with something unusable":
+                # both record nothing, but only the second needs the row cleaned up.
+                detail = (
+                    f"No usable lineage checkpoint under "
+                    f"{LINEAGE_WATCHER_CHECKPOINT_KEY} (value: {json.dumps(existing)})"
+                )
+            click.echo(f"{detail}. The watcher records nothing until one is seeded.")
         else:
             click.echo(f"{LINEAGE_WATCHER_CHECKPOINT_KEY} = {json.dumps(existing)}")
         # Report the drop set too: a dropped target is skipped on every scan, so an
@@ -194,6 +227,15 @@ def cli(
         else:
             click.echo(f"{LINEAGE_WATCHER_DROPPED_KEY}: no targets dropped.")
         return
+
+    if force and build_id is None:
+        # --force only qualifies a seed (replace-if-present), so alone or with just
+        # --clear-dropped-targets it has nothing to act on. Saying so names the flag
+        # the operator actually typed, instead of letting it fall through to a
+        # "Nothing to do" message that lists every flag except that one.
+        raise click.ClickException(
+            "--force only applies when seeding; pass --build-id with it, or drop it."
+        )
 
     if clear_dropped_targets and build_id is None:
         # Clearing alone is a complete operation: the checkpoint is untouched, and

--- a/src/gbserver/commands/command_lineage_init.py
+++ b/src/gbserver/commands/command_lineage_init.py
@@ -86,12 +86,10 @@ def _clear_dropped_targets(storage) -> None:
     Writes an empty list rather than deleting the key, so the shape stays what
     ``LineageWatcher._load_dropped`` expects on its next start.
 
-    Stop the watcher before calling this. ``_dropped`` is loaded once in ``start()``,
-    not per scan (unlike the checkpoint, which is re-read every scan), and
-    ``_persist_dropped`` writes the whole in-memory set. So a running watcher not
-    only misses the clear -- the next target it drops persists its stale full set,
-    resurrecting every id cleared here, and a later restart reloads them. Clearing
-    is only durable while the watcher is down.
+    A running watcher picks this up on its next scan: ``_load_dropped`` re-reads the
+    row every scan (like the checkpoint) and treats it as authoritative, so no
+    restart is needed and the clear cannot be undone by the watcher rewriting a stale
+    in-memory set.
     """
     target_ids = _read_dropped_target_ids(storage)
     if not target_ids:
@@ -105,9 +103,7 @@ def _clear_dropped_targets(storage) -> None:
     summary = (
         f"Cleared {len(target_ids)} dropped target(s) from "
         f"{LINEAGE_WATCHER_DROPPED_KEY}: {', '.join(sorted(target_ids))}. "
-        "This only sticks while the watcher is stopped: a running watcher loads the "
-        "drop set once at start() and rewrites its whole in-memory set on the next "
-        "drop, which would restore what was just cleared."
+        "A running watcher retries them on its next scan; no restart needed."
     )
     storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []})
     click.echo(summary)
@@ -145,11 +141,9 @@ def _clear_dropped_targets(storage) -> None:
     default=False,
     help=(
         "Clear the set of TARGET ids the watcher permanently gave up on (after "
-        "exhausting its record attempts) so they are retried. Stop the watcher "
-        "first: it loads the drop set once at start() (unlike the checkpoint, "
-        "re-read every scan) and rewrites the whole set on its next drop, which "
-        "would restore what was cleared. Moving the anchor back does "
-        "NOT clear them, which is why this exists -- the drop decision is durable "
+        "exhausting its record attempts) so they are retried. A running watcher "
+        "picks this up on its next scan, no restart needed. Moving the anchor back "
+        "does NOT clear them, which is why this exists -- the drop decision is durable "
         "on purpose, and a dropped target is otherwise skipped forever. Only "
         "useful once whatever made recording fail is fixed."
     ),
@@ -238,9 +232,8 @@ def cli(
         )
 
     if clear_dropped_targets and build_id is None:
-        # Clearing alone is a complete operation: the checkpoint is untouched, and
-        # the watcher retries the targets once it is (re)started -- it reads the drop
-        # set only in start(), so a running watcher would not pick this up.
+        # Clearing alone is a complete operation: the checkpoint is untouched, and a
+        # running watcher retries the targets on its next scan.
         _clear_dropped_targets(storage)
         return
 

--- a/src/gbserver/lineage/lineage_reconciler.py
+++ b/src/gbserver/lineage/lineage_reconciler.py
@@ -509,19 +509,22 @@ class ReconcileResult:
             can classify it as permanent or transient.
         dropped: Targets skipped because they are in the caller's permanent-drop
             set. Present so the caller can log the resulting known gap.
-        had_no_targets: The build had no recordable target at all this pass. It is
-            reported ``all_confirmed`` so the checkpoint can still pass a finished
-            build that genuinely produces no lineage, but the confirmation rests on
-            an *empty* set -- the sink was never asked anything. The caller must not
-            cache that as "this build is done, stop re-reading its targets".
+        sink_unqueried: ``all_confirmed`` was reached without asking the sink
+            anything -- ``filter_unrecorded`` was never called, because there was no
+            candidate to ask about. Two passes end that way: no recordable target at
+            all, and every recordable target in the caller's permanent-drop set. Both
+            are reported ``all_confirmed`` so the checkpoint can still pass a finished
+            build, but the confirmation rests on an *empty* candidate set rather than
+            a sink answer. The caller must not cache that as "this build is done,
+            stop re-reading its targets" while the build can still gain one.
 
             The build row and its target rows are separate, non-transactional
             writes, and a scan lands at an arbitrary point between them: a build
-            read while still RUNNING has no target rows yet. Its targets are
-            persisted before it reaches SUCCESS (buildrunner drains one FIFO with a
-            single consumer, and finalize_build_status commits children before the
-            parent), so they are there on a later scan -- but only if the caller
-            still looks.
+            read while still RUNNING has no target rows yet, or only ones that
+            happen to be dropped. Its targets are persisted before it reaches
+            SUCCESS (buildrunner drains one FIFO with a single consumer, and
+            finalize_build_status commits children before the parent), so they are
+            there on a later scan -- but only if the caller still looks.
     """
 
     newly_recorded: int = 0
@@ -529,7 +532,7 @@ class ReconcileResult:
     dedup_query_failed: bool = False
     query_failure: Optional[Exception] = None
     dropped: set[str] = field(default_factory=set)
-    had_no_targets: bool = False
+    sink_unqueried: bool = False
 
 
 def reconcile_build(
@@ -579,13 +582,13 @@ def reconcile_build(
         # No recordable target: nothing to write and nothing outstanding, so the
         # build is trivially confirmed and the checkpoint may pass it.
         #
-        # Flagged as empty, though, because this confirmation is not a sink answer:
+        # Flagged unqueried, though, because this confirmation is not a sink answer:
         # with no target to ask about, filter_unrecorded was never called. A build
         # read while still RUNNING lands here (its target rows are written before it
         # reaches SUCCESS, but this scan ran before that). If the caller caches this
         # as complete, its finished-and-complete skip gate stops re-reading the
         # targets and the lineage is never recorded.
-        return ReconcileResult(all_confirmed=True, had_no_targets=True)
+        return ReconcileResult(all_confirmed=True, sink_unqueried=True)
 
     skipped = {t.uuid for t in targets if t.uuid in dropped}
     candidates = {t.uuid for t in targets if t.uuid not in dropped}
@@ -593,7 +596,14 @@ def reconcile_build(
         # Every target is permanently dropped. Confirmed *with a known gap*: the
         # alternative is pinning the checkpoint forever behind targets that will
         # never record, which is what the durable dropped set exists to prevent.
-        return ReconcileResult(all_confirmed=True, dropped=skipped)
+        #
+        # Unqueried for the same reason as the no-target case above: every target
+        # was filtered out of `candidates`, so filter_unrecorded was never called
+        # and this confirmation is not a sink answer either. A RUNNING build whose
+        # only targets so far happen to all be dropped lands here, and the ones
+        # written between this scan and its terminal status are still to come --
+        # so the caller must not cache it as done while it can still gain them.
+        return ReconcileResult(all_confirmed=True, dropped=skipped, sink_unqueried=True)
 
     # Expected run count per candidate, so ``filter_unrecorded`` can tell a
     # fully-recorded target from one whose runs were only partially emitted by a

--- a/src/gbserver/lineage/lineage_reconciler.py
+++ b/src/gbserver/lineage/lineage_reconciler.py
@@ -509,6 +509,19 @@ class ReconcileResult:
             can classify it as permanent or transient.
         dropped: Targets skipped because they are in the caller's permanent-drop
             set. Present so the caller can log the resulting known gap.
+        had_no_targets: The build had no recordable target at all this pass. It is
+            reported ``all_confirmed`` so the checkpoint can still pass a finished
+            build that genuinely produces no lineage, but the confirmation rests on
+            an *empty* set -- the sink was never asked anything. The caller must not
+            cache that as "this build is done, stop re-reading its targets".
+
+            The build row and its target rows are separate, non-transactional
+            writes, and a scan lands at an arbitrary point between them: a build
+            read while still RUNNING has no target rows yet. Its targets are
+            persisted before it reaches SUCCESS (buildrunner drains one FIFO with a
+            single consumer, and finalize_build_status commits children before the
+            parent), so they are there on a later scan -- but only if the caller
+            still looks.
     """
 
     newly_recorded: int = 0
@@ -516,6 +529,7 @@ class ReconcileResult:
     dedup_query_failed: bool = False
     query_failure: Optional[Exception] = None
     dropped: set[str] = field(default_factory=set)
+    had_no_targets: bool = False
 
 
 def reconcile_build(
@@ -564,7 +578,14 @@ def reconcile_build(
     if not targets:
         # No recordable target: nothing to write and nothing outstanding, so the
         # build is trivially confirmed and the checkpoint may pass it.
-        return ReconcileResult(all_confirmed=True)
+        #
+        # Flagged as empty, though, because this confirmation is not a sink answer:
+        # with no target to ask about, filter_unrecorded was never called. A build
+        # read while still RUNNING lands here (its target rows are written before it
+        # reaches SUCCESS, but this scan ran before that). If the caller caches this
+        # as complete, its finished-and-complete skip gate stops re-reading the
+        # targets and the lineage is never recorded.
+        return ReconcileResult(all_confirmed=True, had_no_targets=True)
 
     skipped = {t.uuid for t in targets if t.uuid in dropped}
     candidates = {t.uuid for t in targets if t.uuid not in dropped}

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -113,6 +113,13 @@ class LineageWatcher:
         # unrecorded lineage: an in-memory-only drop set would let a dropped target
         # return after a restart and block the checkpoint forever.
         self._dropped: set[str] = set()
+        # Drops this process decided but could not persist (_persist_dropped is
+        # non-raising, so a kv failure leaves the decision in memory only). Tracked
+        # separately because _load_dropped re-reads the durable row every scan and
+        # takes it as authoritative: without this, an unpersisted drop would be
+        # dropped from the set on the next scan and the target re-recorded forever,
+        # while a *persisted* id must follow the row so an operator's clear lands.
+        self._dropped_unpersisted: set[str] = set()
         # target_uuid -> attempts so far, for targets to retry on a later scan.
         self._failed_attempts: dict[str, int] = {}
         # Builds whose lineage the sink has confirmed complete this process. Two
@@ -145,8 +152,12 @@ class LineageWatcher:
 
         self._store = get_lineage_store()
         storage = get_admin_storage()
-        # Load the durable drop set before the first scan, so a target already
-        # given up on stays skipped instead of blocking the checkpoint again.
+        # Load the durable drop set up front so a target already given up on stays
+        # skipped from the first scan. _reconcile re-reads it every scan too; this
+        # only makes the state correct before the thread is running, and resets it
+        # when start() runs again on an instance a previous stop() left populated.
+        self._dropped = set()
+        self._dropped_unpersisted = set()
         self._load_dropped(storage)
         self.worker_thread = threading.Thread(
             target=self._run, name="lineage-watcher", daemon=True
@@ -155,7 +166,7 @@ class LineageWatcher:
         logger.info("LineageWatcher started")
 
     def _load_dropped(self, storage: SingletonAdminStorage) -> None:
-        """Load the durable set of permanently-given-up-on target uuids.
+        """Re-read the durable set of permanently-given-up-on target uuids.
 
         A dropped target is one that failed ``_MAX_RECORD_ATTEMPTS`` times; the
         decision to stop trying is permanent, so it must outlive the process.
@@ -164,55 +175,66 @@ class LineageWatcher:
         exhaust its attempts again, and repeat every restart — wedging all newer
         lineage behind it.
 
-        A read failure or an unusable shape is logged and treated as an empty set:
-        raising here would abort ``start()`` and leave the watcher not running at
-        all, which records nothing rather than slightly too much. Empty is not
-        harmless though -- it is exactly the wedge described above -- so it is
-        logged at ERROR with the offending value, not swallowed. The row is left as
-        it is for an operator to inspect; the next ``_persist_dropped`` overwrites
-        it, which is why the value goes in the log while it still exists.
+        Called before every scan, not once in ``start()``, for the same reason the
+        checkpoint is: the row is the single source of truth, so an operator who
+        clears it with ``lineage-init --clear-dropped-targets`` has the targets
+        retried on the next scan instead of having to restart the service. Loading
+        once also made the clear *unsafe* rather than merely slow -- the next drop
+        persisted the whole stale in-memory set, restoring every id just cleared.
+
+        The row is authoritative, plus any drop this process could not persist. A
+        plain union would never let a clear through (the cleared ids are still in
+        memory); a plain assignment would resurrect a drop whose persist failed
+        (``_persist_dropped`` is deliberately non-raising), re-recording a hopeless
+        target every scan. Taking the row and adding back only
+        ``_dropped_unpersisted`` gets both: the clear lands, the unpersisted drop
+        survives.
+
+        A read failure or an unusable shape is logged and leaves the in-memory set
+        as it is: raising would abort ``start()`` (no watcher at all) or, per scan,
+        kill the loop. Keeping the current set is the conservative direction -- it
+        skips what this process already knows is hopeless rather than retrying it --
+        and it is logged at ERROR with the offending value, not swallowed. The row is
+        left for an operator to inspect; the next ``_persist_dropped`` overwrites it,
+        which is why the value goes in the log while it still exists.
         """
         try:
             value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
         except Exception:
-            # Clear explicitly rather than just returning: start() can run again on a
-            # live instance after stop(), where _dropped still holds the previous
-            # set, and the log below would then be describing a state we had not set.
-            self._dropped = set()
             logger.exception(
-                "Failed to read the lineage drop set from %s; starting with an "
-                "empty set. Targets already given up on will be retried and may "
-                "exhaust their attempts again.",
+                "Failed to read the lineage drop set from %s; keeping the current "
+                "in-memory set (%d target(s)) for this scan.",
                 LINEAGE_WATCHER_DROPPED_KEY,
+                len(self._dropped),
             )
             return
 
-        if not value:
-            return
+        if value is None:
+            # No row at all: never seeded, or cleared by deleting it rather than
+            # emptying it. Treated the same as an empty set -- honouring that is the
+            # point of re-reading -- while unpersisted drops are added back below.
+            value = {}
 
         target_ids = value.get("target_ids", []) if isinstance(value, dict) else None
         # Element types matter as much as the container's: a mixed list loads fine
         # here but makes ``_persist_dropped``'s sorted() raise on the next drop, and
         # that unwinds through reconcile_build (on_error is called outside its
-        # try/except) into _run, failing every scan forever. Empty is the fallback
-        # this guard is for; a wedged watcher is not.
+        # try/except) into _run, failing every scan forever.
         if isinstance(target_ids, list) and not all(
             isinstance(t, str) for t in target_ids
         ):
             target_ids = None
         if not isinstance(target_ids, list):
-            self._dropped = set()
             logger.error(
-                "Lineage drop set under %s is unusable (%r); starting with an empty "
-                "set. Expected {'target_ids': [...]}. Targets already given up on "
-                "will be retried and may exhaust their attempts again, holding the "
-                "checkpoint behind them.",
+                "Lineage drop set under %s is unusable (%r); keeping the current "
+                "in-memory set (%d target(s)). Expected {'target_ids': [...]}.",
                 LINEAGE_WATCHER_DROPPED_KEY,
                 value,
+                len(self._dropped),
             )
             return
 
-        self._dropped = set(target_ids)
+        self._dropped = set(target_ids) | self._dropped_unpersisted
 
     def _persist_dropped(self, storage: SingletonAdminStorage) -> None:
         """Persist the drop set so the decision survives a restart.
@@ -222,18 +244,27 @@ class LineageWatcher:
         exception here would unwind into ``_run`` and fail the whole scan -- and then
         every later scan the same way. Losing durability for one drop only costs a
         re-attempt after a restart; losing the scan loop stops all lineage.
+
+        On failure the set is remembered in ``_dropped_unpersisted`` so the next
+        ``_load_dropped`` -- which treats the durable row as authoritative -- adds it
+        back instead of resurrecting the target. A success clears that, handing those
+        ids over to the row, where an operator's clear can then reach them.
         """
         try:
             storage.kv_pair_storage.set_value(
                 LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": sorted(self._dropped)}
             )
         except Exception:
+            self._dropped_unpersisted |= self._dropped
             logger.exception(
                 "Failed to persist the lineage drop set to %s; the in-memory set "
                 "still applies for this process, but the drop decision will not "
                 "survive a restart.",
                 LINEAGE_WATCHER_DROPPED_KEY,
             )
+            return
+
+        self._dropped_unpersisted.clear()
 
     def _run(self) -> None:
         """Main monitoring loop (runs in daemon thread).
@@ -309,6 +340,10 @@ class LineageWatcher:
         logger.info("Lineage scan: reading checkpoint and builds...")
 
         storage = get_admin_storage()
+        # Re-read the drop set every scan, like the checkpoint below: it is the
+        # single source of truth, so `lineage-init --clear-dropped-targets` retries
+        # those targets on the next scan rather than requiring a service restart.
+        self._load_dropped(storage)
         checkpoint = self._read_checkpoint(storage)
         if checkpoint is None:
             # No checkpoint: recording is off until seeded. Return before selecting

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -163,16 +163,77 @@ class LineageWatcher:
         checkpoint (which never advances past a build with unrecorded lineage),
         exhaust its attempts again, and repeat every restart — wedging all newer
         lineage behind it.
+
+        A read failure or an unusable shape is logged and treated as an empty set:
+        raising here would abort ``start()`` and leave the watcher not running at
+        all, which records nothing rather than slightly too much. Empty is not
+        harmless though -- it is exactly the wedge described above -- so it is
+        logged at ERROR with the offending value, not swallowed. The row is left as
+        it is for an operator to inspect; the next ``_persist_dropped`` overwrites
+        it, which is why the value goes in the log while it still exists.
         """
-        value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
-        if value:
-            self._dropped = set(value.get("target_ids", []))
+        try:
+            value = storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
+        except Exception:
+            # Clear explicitly rather than just returning: start() can run again on a
+            # live instance after stop(), where _dropped still holds the previous
+            # set, and the log below would then be describing a state we had not set.
+            self._dropped = set()
+            logger.exception(
+                "Failed to read the lineage drop set from %s; starting with an "
+                "empty set. Targets already given up on will be retried and may "
+                "exhaust their attempts again.",
+                LINEAGE_WATCHER_DROPPED_KEY,
+            )
+            return
+
+        if not value:
+            return
+
+        target_ids = value.get("target_ids", []) if isinstance(value, dict) else None
+        # Element types matter as much as the container's: a mixed list loads fine
+        # here but makes ``_persist_dropped``'s sorted() raise on the next drop, and
+        # that unwinds through reconcile_build (on_error is called outside its
+        # try/except) into _run, failing every scan forever. Empty is the fallback
+        # this guard is for; a wedged watcher is not.
+        if isinstance(target_ids, list) and not all(
+            isinstance(t, str) for t in target_ids
+        ):
+            target_ids = None
+        if not isinstance(target_ids, list):
+            self._dropped = set()
+            logger.error(
+                "Lineage drop set under %s is unusable (%r); starting with an empty "
+                "set. Expected {'target_ids': [...]}. Targets already given up on "
+                "will be retried and may exhaust their attempts again, holding the "
+                "checkpoint behind them.",
+                LINEAGE_WATCHER_DROPPED_KEY,
+                value,
+            )
+            return
+
+        self._dropped = set(target_ids)
 
     def _persist_dropped(self, storage: SingletonAdminStorage) -> None:
-        """Persist the drop set so the decision survives a restart."""
-        storage.kv_pair_storage.set_value(
-            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": sorted(self._dropped)}
-        )
+        """Persist the drop set so the decision survives a restart.
+
+        Never raises. ``_on_record_error`` calls this from inside ``reconcile_build``,
+        where ``on_error`` runs outside the try/except guarding the record call, so an
+        exception here would unwind into ``_run`` and fail the whole scan -- and then
+        every later scan the same way. Losing durability for one drop only costs a
+        re-attempt after a restart; losing the scan loop stops all lineage.
+        """
+        try:
+            storage.kv_pair_storage.set_value(
+                LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": sorted(self._dropped)}
+            )
+        except Exception:
+            logger.exception(
+                "Failed to persist the lineage drop set to %s; the in-memory set "
+                "still applies for this process, but the drop decision will not "
+                "survive a restart.",
+                LINEAGE_WATCHER_DROPPED_KEY,
+            )
 
     def _run(self) -> None:
         """Main monitoring loop (runs in daemon thread).

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -450,8 +450,10 @@ class LineageWatcher:
         anchor_index = next(
             (i for i, b in enumerate(builds) if b.uuid == anchor_build_id), None
         )
-        anchor = builds[anchor_index] if anchor_index is not None else None
-        if anchor is None:
+        # Branch on the index rather than on a separate `anchor is None` check: the
+        # two are equivalent at runtime, but narrowing the index here is what lets
+        # the successor slice below use it as an int without a second guard.
+        if anchor_index is None:
             # No anchor row to gate on. Two very different reasons:
             #
             # The backfill sentinel names no build by construction, so it is never
@@ -466,6 +468,7 @@ class LineageWatcher:
             if anchor_build_id != BACKFILL_BUILD_ID:
                 return False
             return self._write_checkpoint(storage, builds[0])
+        anchor = builds[anchor_index]
         # The gate: the mark may leave the anchor only once the anchor can no
         # longer gain lineage and everything it has is in the sink. A running
         # anchor, or one whose targets failed to record, holds the mark — stepping

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -472,13 +472,15 @@ class LineageWatcher:
                 )
 
             if result.all_confirmed and (
-                not result.had_no_targets or build.status.is_finished()
+                not result.sink_unqueried or build.status.is_finished()
             ):
                 self._complete_builds.add(build.uuid)
             else:
-                # An empty pass is cached only once the build is finished, and the
-                # build state is what separates the two reasons a pass can come back
-                # empty.
+                # A confirmation the sink was never asked for is cached only once the
+                # build is finished, and the build state is what separates the two
+                # reasons such a pass can come back with an empty candidate set.
+                # Either reason reaches here: no target rows at all, or target rows
+                # that are all in the durable drop set.
                 #
                 # Still RUNNING: the targets do not exist *yet*. The build row and
                 # its target rows are separate, non-transactional writes, so a scan

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -375,9 +375,17 @@ class LineageWatcher:
                     ", ".join(sorted(result.dropped)),
                 )
 
-            if result.all_confirmed:
+            if result.all_confirmed and not result.had_no_targets:
                 self._complete_builds.add(build.uuid)
             else:
+                # An empty pass is deliberately NOT cached, even though it reports
+                # all_confirmed so the checkpoint can pass a finished build with no
+                # lineage of its own. Caching it would set the skip gate below on a
+                # build whose targets do not exist yet: a build selected while
+                # RUNNING has none, and when it finishes and its targets appear the
+                # gate ("cached complete AND finished") would skip re-reading them
+                # forever. Only a restart cleared this set, which is exactly how the
+                # bug surfaced -- the lineage recorded only after a service restart.
                 self._complete_builds.discard(build.uuid)
 
         advanced = self._advance_checkpoint(storage, anchor_build_id, builds)

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -454,13 +454,23 @@ class LineageWatcher:
                 # how the bug surfaced (lineage recorded only after a service
                 # restart).
                 #
-                # Finished: the build will never gain a target, so the emptiness is
-                # final and the confirmation is honest -- it is cached above. It has
-                # to be: _advance_checkpoint requires the anchor in this set, so
+                # Finished: the emptiness is treated as final and cached above. It
+                # has to be: _advance_checkpoint requires the anchor in this set, so
                 # discarding a finished build here would wedge the mark on it
                 # forever and block every newer build's lineage behind it. That
                 # includes every FAILED build, which select_builds_from_checkpoint
                 # does not filter out and which therefore does become an anchor.
+                #
+                # "Finished" is very nearly "will never gain a target", but not
+                # quite: finalize_build_status (buildrunner/build_utils.py) re-runs
+                # entity finalization precisely because targets can be stored
+                # concurrently with a previous finalization call -- a target row can
+                # still appear after the build row reads terminal. When that happens
+                # the skip gate below never re-reads this build, and the checkpoint
+                # advances past it, losing that lineage until a restart. That is the
+                # accepted side of the trade: the alternative wedges the mark on
+                # every finished build with no recordable targets, which is the
+                # common case, not the race.
                 self._complete_builds.discard(build.uuid)
 
         advanced = self._advance_checkpoint(storage, anchor_build_id, builds)

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -498,16 +498,39 @@ class LineageWatcher:
                 # includes every FAILED build, which select_builds_from_checkpoint
                 # does not filter out and which therefore does become an anchor.
                 #
-                # "Finished" is very nearly "will never gain a target", but not
-                # quite: finalize_build_status (buildrunner/build_utils.py) re-runs
-                # entity finalization precisely because targets can be stored
-                # concurrently with a previous finalization call -- a target row can
-                # still appear after the build row reads terminal. When that happens
-                # the skip gate below never re-reads this build, and the checkpoint
-                # advances past it, losing that lineage until a restart. That is the
-                # accepted side of the trade: the alternative wedges the mark on
-                # every finished build with no recordable targets, which is the
-                # common case, not the race.
+                # "Finished" is very nearly "will never gain a *recordable* target",
+                # and the gap is narrower than the bare build/target write ordering
+                # suggests. Two things close most of it:
+                #
+                #   - finalize_build_status (buildrunner/build_utils.py) finalizes
+                #     targets before it writes the build's terminal status, and
+                #     writes that status only when the build is not already
+                #     finished. So on the ordinary path the targets are committed
+                #     first, by construction rather than by luck.
+                #   - select_recordable_targets asks for status==SUCCESS with a
+                #     non-NULL finished_at, so a merely-present row is not enough to
+                #     lose. Notably the re-run entity finalization does NOT
+                #     manufacture one: _finalize_target_or_step_status leaves a
+                #     PENDING target PENDING when the build succeeded (it logs a
+                #     warning and treats it as a platform bug), so it never
+                #     back-fills a target into SUCCESS behind us.
+                #
+                # What remains is a genuine target event -- carrying its own SUCCESS
+                # and finished_at -- drained from the buildrunner's FIFO after a
+                # terminal status was written from *outside* that flow: an external
+                # cancel, or a concurrent stop_and_fail() landing on a cached
+                # StoredBuild status (see the skip gate's note on that stale
+                # window). When that happens the skip gate never re-reads this build
+                # and the checkpoint advances past it, losing that lineage until a
+                # restart clears this in-memory set.
+                #
+                # That is the accepted side of the trade, and the asymmetry is what
+                # settles it: the loss is rare and bounded by process lifetime,
+                # while the alternative wedges the mark on every finished build with
+                # no recordable targets -- the common case, not the race. If it ever
+                # needs closing, the cheap fix lives here (age out this set, or
+                # withhold caching when the terminal status did not come from the
+                # runner) rather than in a status re-read next to the target insert.
                 self._complete_builds.discard(build.uuid)
 
         advanced = self._advance_checkpoint(storage, anchor_build_id, builds)

--- a/src/gbserver/lineage/lineage_watcher.py
+++ b/src/gbserver/lineage/lineage_watcher.py
@@ -375,17 +375,31 @@ class LineageWatcher:
                     ", ".join(sorted(result.dropped)),
                 )
 
-            if result.all_confirmed and not result.had_no_targets:
+            if result.all_confirmed and (
+                not result.had_no_targets or build.status.is_finished()
+            ):
                 self._complete_builds.add(build.uuid)
             else:
-                # An empty pass is deliberately NOT cached, even though it reports
-                # all_confirmed so the checkpoint can pass a finished build with no
-                # lineage of its own. Caching it would set the skip gate below on a
-                # build whose targets do not exist yet: a build selected while
-                # RUNNING has none, and when it finishes and its targets appear the
-                # gate ("cached complete AND finished") would skip re-reading them
-                # forever. Only a restart cleared this set, which is exactly how the
-                # bug surfaced -- the lineage recorded only after a service restart.
+                # An empty pass is cached only once the build is finished, and the
+                # build state is what separates the two reasons a pass can come back
+                # empty.
+                #
+                # Still RUNNING: the targets do not exist *yet*. The build row and
+                # its target rows are separate, non-transactional writes, so a scan
+                # lands between them and reads none. Caching that would arm the skip
+                # gate below ("cached complete AND finished") on a build whose
+                # targets appear moments later, and it would then skip re-reading
+                # them forever -- only a restart cleared this set, which is exactly
+                # how the bug surfaced (lineage recorded only after a service
+                # restart).
+                #
+                # Finished: the build will never gain a target, so the emptiness is
+                # final and the confirmation is honest -- it is cached above. It has
+                # to be: _advance_checkpoint requires the anchor in this set, so
+                # discarding a finished build here would wedge the mark on it
+                # forever and block every newer build's lineage behind it. That
+                # includes every FAILED build, which select_builds_from_checkpoint
+                # does not filter out and which therefore does become an anchor.
                 self._complete_builds.discard(build.uuid)
 
         advanced = self._advance_checkpoint(storage, anchor_build_id, builds)

--- a/test/unit/lineage/test_lineage_init_command.py
+++ b/test/unit/lineage/test_lineage_init_command.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``gbserver lineage-init``: seed the checkpoint without running the watcher.
+
+The point of the command is what it does *not* do -- it must never construct a
+LineageWatcher, because the whole reason it exists is that seeding via
+``lineage-watch --base-build-id`` also starts recording for as long as the
+operator leaves the process up.
+
+All assert against ``result.output`` (combined stdout+stderr): CliRunner mixes the
+streams by default on Click 8.1.x, where accessing ``result.stderr`` raises.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gbserver.commands import command_lineage_init
+from gbserver.lineage.lineage_reconciler import (
+    LINEAGE_WATCHER_CHECKPOINT_KEY,
+    LINEAGE_WATCHER_DROPPED_KEY,
+)
+from gbserver.lineage.lineage_seeding import LineageSeedError
+
+MODULE = "gbserver.commands.command_lineage_init"
+
+_CHECKPOINT = {
+    "build_id": "b-1",
+    "created_time": "2026-01-01T00:00:00+00:00",
+    "version": 2,
+}
+
+
+@pytest.mark.live("storage", "lineage")
+class TestLineageInitCommand:
+    """Seeding, idempotency and the read-only ``--show`` path."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_storage(self):
+        self.storage = MagicMock()
+        self._stored: dict = {}
+        self.storage.kv_pair_storage.get_value.side_effect = self._stored.get
+        with patch(f"{MODULE}.get_admin_storage", return_value=self.storage):
+            yield
+
+    def _run(self, *args):
+        return CliRunner().invoke(command_lineage_init.cli, list(args))
+
+    def test_seeding_writes_the_checkpoint_and_never_starts_a_watcher(self):
+        """The command seeds and exits; recording is left to the deployed watcher.
+
+        This is the whole reason the command exists, so it is pinned explicitly:
+        seeding through ``lineage-watch --base-build-id`` also runs the watcher,
+        which records for however long the operator leaves the process up.
+        """
+        self._stored.clear()
+        with patch(f"{MODULE}.seed_if_absent", return_value=True) as seed:
+            self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+            result = self._run("--build-id", "from-latest")
+
+        assert result.exit_code == 0, result.output
+        seed.assert_called_once_with(self.storage, "from-latest", force=False)
+        assert "Seeded" in result.output
+        assert "b-1" in result.output, "the operator must see the anchor it landed on"
+
+    def test_an_already_seeded_environment_is_a_no_op_not_a_failure(self):
+        """Re-running on an initialized environment must exit 0 and change nothing.
+
+        Seed-if-absent is the safe default and the command is expected to be run
+        from setup scripts, so a second run has to be harmless rather than an
+        error someone has to special-case.
+        """
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+        with patch(f"{MODULE}.seed_if_absent", return_value=False):
+            result = self._run("--build-id", "from-latest")
+
+        assert result.exit_code == 0, result.output
+        assert "already set" in result.output
+        assert "--force" in result.output, "say how to override it"
+
+    def test_show_reports_the_current_checkpoint_without_writing(self):
+        """``--show`` is read-only: it must not call the seeding path at all."""
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+        with patch(f"{MODULE}.seed_if_absent") as seed:
+            result = self._run("--build-id", "from-latest", "--show")
+
+        assert result.exit_code == 0, result.output
+        assert "b-1" in result.output
+        seed.assert_not_called()
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    def test_show_says_so_when_nothing_is_seeded_yet(self):
+        """The unseeded state is the one an operator is diagnosing; name it."""
+        self._stored.clear()
+        result = self._run("--build-id", "from-latest", "--show")
+
+        assert result.exit_code == 0, result.output
+        assert "No lineage checkpoint" in result.output
+        assert "records nothing" in result.output
+
+    def test_force_is_passed_through(self):
+        """``--force`` must reach seed_if_absent, not be silently dropped."""
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+        with patch(f"{MODULE}.seed_if_absent", return_value=True) as seed:
+            result = self._run("--build-id", "b-2", "--force")
+
+        assert result.exit_code == 0, result.output
+        seed.assert_called_once_with(self.storage, "b-2", force=True)
+
+    def test_an_empty_anchor_is_rejected(self):
+        """An empty string passes click's required check but resolves to no anchor.
+
+        Same guard as lineage-watch: without it the command reports success while
+        leaving the environment unseeded, which is the confusing failure the whole
+        command is meant to remove.
+        """
+        with patch(f"{MODULE}.seed_if_absent") as seed:
+            result = self._run("--build-id", "   ")
+
+        assert result.exit_code != 0
+        assert "empty value" in result.output
+        seed.assert_not_called()
+
+    def test_clear_dropped_targets_empties_the_durable_set(self):
+        """The drop set is written empty, not deleted.
+
+        ``LineageWatcher._load_dropped`` reads ``value.get("target_ids", [])``, so
+        keeping the shape is what makes the cleared state readable on its next
+        start rather than a missing key it has to tolerate.
+        """
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-1", "t-2"]}
+        result = self._run("--clear-dropped-targets")
+
+        assert result.exit_code == 0, result.output
+        self.storage.kv_pair_storage.set_value.assert_called_once_with(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []}
+        )
+        assert "t-1" in result.output and "t-2" in result.output
+        assert "Restart" in result.output, (
+            "the drop set is loaded once at start(), so a running watcher keeps "
+            "skipping these targets until restarted -- the operator must be told"
+        )
+
+    def test_clearing_dropped_targets_leaves_the_checkpoint_alone(self):
+        """Clearing is a complete operation on its own; --build-id stays optional."""
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-1"]}
+        with patch(f"{MODULE}.seed_if_absent") as seed:
+            result = self._run("--clear-dropped-targets")
+
+        assert result.exit_code == 0, result.output
+        seed.assert_not_called(), "no anchor was requested, so none may be written"
+
+    def test_clearing_an_empty_drop_set_is_a_no_op(self):
+        """Nothing to clear must not write, so a scripted run stays harmless."""
+        self._stored.clear()
+        result = self._run("--clear-dropped-targets")
+
+        assert result.exit_code == 0, result.output
+        assert "nothing to clear" in result.output
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    def test_clear_and_seed_compose_in_one_invocation(self):
+        """Both flags together: clear the drop set AND move the anchor."""
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-1"]}
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+        with patch(f"{MODULE}.seed_if_absent", return_value=True) as seed:
+            result = self._run(
+                "--build-id", "b-2", "--force", "--clear-dropped-targets"
+            )
+
+        assert result.exit_code == 0, result.output
+        seed.assert_called_once_with(self.storage, "b-2", force=True)
+        assert "Cleared 1 dropped target" in result.output
+
+    def test_show_reports_dropped_targets(self):
+        """A dropped target is skipped every scan; --show must surface it."""
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-9"]}
+        result = self._run("--show")
+
+        assert result.exit_code == 0, result.output
+        assert "t-9" in result.output
+        assert "permanently skipped" in result.output
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    def test_no_flags_at_all_is_an_error_not_a_silent_no_op(self):
+        """Bare invocation must say what to pass, not exit 0 having done nothing."""
+        result = self._run()
+
+        assert result.exit_code != 0
+        assert "Nothing to do" in result.output
+
+    def test_an_unresolvable_anchor_fails_cleanly(self):
+        """A bad build id must surface as a CLI error, not a traceback."""
+        with patch(
+            f"{MODULE}.seed_if_absent",
+            side_effect=LineageSeedError("No build with a creation time found"),
+        ):
+            result = self._run("--build-id", "nope")
+
+        assert result.exit_code != 0
+        assert "No build with a creation time found" in result.output

--- a/test/unit/lineage/test_lineage_init_command.py
+++ b/test/unit/lineage/test_lineage_init_command.py
@@ -187,6 +187,24 @@ class TestLineageInitCommand:
         seed.assert_called_once_with(self.storage, "b-2", force=True)
         assert "Cleared 1 dropped target" in result.output
 
+    def test_a_failed_seed_leaves_the_drop_set_intact(self):
+        """A non-zero exit must not have mutated durable state.
+
+        The clear and the seed are separate kv_pairs writes with no shared
+        transaction, so clearing first meant a failed seed still wiped the drop
+        set -- targets silently un-dropped by a run that reported failure, with
+        nothing to roll it back. Clearing happens only after the seed lands.
+        """
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-1"]}
+        with patch(
+            f"{MODULE}.seed_if_absent", side_effect=LineageSeedError("no such build")
+        ):
+            result = self._run("--build-id", "b-nope", "--clear-dropped-targets")
+
+        assert result.exit_code != 0
+        assert "no such build" in result.output
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
     def test_show_reports_dropped_targets(self):
         """A dropped target is skipped every scan; --show must surface it."""
         self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT

--- a/test/unit/lineage/test_lineage_init_command.py
+++ b/test/unit/lineage/test_lineage_init_command.py
@@ -155,10 +155,9 @@ class TestLineageInitCommand:
             LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []}
         )
         assert "t-1" in result.output and "t-2" in result.output
-        assert "stopped" in result.output, (
-            "a running watcher loads the drop set once at start() and rewrites the "
-            "whole set on its next drop, restoring what was just cleared -- the "
-            "operator must be told to stop it first, not merely to restart later"
+        assert "next scan" in result.output, (
+            "the watcher re-reads the drop set every scan, so the operator should be "
+            "told the clear applies without a restart"
         )
 
     @pytest.mark.parametrize(

--- a/test/unit/lineage/test_lineage_init_command.py
+++ b/test/unit/lineage/test_lineage_init_command.py
@@ -151,10 +151,59 @@ class TestLineageInitCommand:
             LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []}
         )
         assert "t-1" in result.output and "t-2" in result.output
-        assert "Restart" in result.output, (
-            "the drop set is loaded once at start(), so a running watcher keeps "
-            "skipping these targets until restarted -- the operator must be told"
+        assert "stopped" in result.output, (
+            "a running watcher loads the drop set once at start() and rewrites the "
+            "whole set on its next drop, restoring what was just cleared -- the "
+            "operator must be told to stop it first, not merely to restart later"
         )
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "oops",
+            ["t-1"],
+            7,
+            {"target_ids": "t-1"},
+            # Mixed and non-string elements pass a container-only shape check but
+            # blow up in sorted()/join() -- and for --clear-dropped-targets that
+            # used to happen *after* the row was wiped.
+            {"target_ids": ["t-1", 7]},
+            {"target_ids": [1, 2]},
+            {"target_ids": [None]},
+        ],
+    )
+    @pytest.mark.parametrize("flag", ["--show", "--clear-dropped-targets"])
+    def test_a_malformed_drop_set_is_reported_not_a_traceback(self, bad_value, flag):
+        """A corrupt drop set exits as a ClickException, never an uncaught error.
+
+        ``--show`` is what an operator runs when they suspect the state is broken,
+        so crashing on the bad state it exists to report is the wrong failure mode.
+        Asserting on SystemExit (what Click raises for a ClickException) rather than
+        merely "not AttributeError" is deliberate: the first version of this guard
+        checked the container shape only, and a mixed list still died in sorted().
+        """
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = bad_value
+        result = self._run(flag)
+
+        assert result.exit_code != 0
+        assert isinstance(result.exception, SystemExit), result.exception
+        assert LINEAGE_WATCHER_DROPPED_KEY in result.output
+        assert "gb_kv_pairs" in result.output
+        # The row must survive: a clear that fails must not have wiped it first.
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    def test_a_non_list_target_ids_is_reported_not_a_traceback(self):
+        """The right shape with a wrong inner type is caught too.
+
+        ``{"target_ids": "t-1"}`` survives the dict check but would silently
+        iterate as characters, clearing a set the operator never saw listed.
+        """
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": "t-1"}
+        result = self._run("--show")
+
+        assert result.exit_code != 0
+        assert "target_ids" in result.output
+        self.storage.kv_pair_storage.set_value.assert_not_called()
 
     def test_clearing_dropped_targets_leaves_the_checkpoint_alone(self):
         """Clearing is a complete operation on its own; --build-id stays optional."""
@@ -163,7 +212,9 @@ class TestLineageInitCommand:
             result = self._run("--clear-dropped-targets")
 
         assert result.exit_code == 0, result.output
-        seed.assert_not_called(), "no anchor was requested, so none may be written"
+        # Plain call, not `assert x, "msg"` -- that parses as a tuple and the message
+        # can never surface. assert_not_called() raises on its own.
+        seed.assert_not_called()
 
     def test_clearing_an_empty_drop_set_is_a_no_op(self):
         """Nothing to clear must not write, so a scripted run stays harmless."""

--- a/test/unit/lineage/test_lineage_init_command.py
+++ b/test/unit/lineage/test_lineage_init_command.py
@@ -94,10 +94,14 @@ class TestLineageInitCommand:
         assert "--force" in result.output, "say how to override it"
 
     def test_show_reports_the_current_checkpoint_without_writing(self):
-        """``--show`` is read-only: it must not call the seeding path at all."""
+        """``--show`` is read-only: it must not call the seeding path at all.
+
+        Called alone -- passing --build-id alongside it is now rejected outright
+        rather than silently ignored (see test_show_must_be_called_alone).
+        """
         self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
         with patch(f"{MODULE}.seed_if_absent") as seed:
-            result = self._run("--build-id", "from-latest", "--show")
+            result = self._run("--show")
 
         assert result.exit_code == 0, result.output
         assert "b-1" in result.output
@@ -107,7 +111,7 @@ class TestLineageInitCommand:
     def test_show_says_so_when_nothing_is_seeded_yet(self):
         """The unseeded state is the one an operator is diagnosing; name it."""
         self._stored.clear()
-        result = self._run("--build-id", "from-latest", "--show")
+        result = self._run("--show")
 
         assert result.exit_code == 0, result.output
         assert "No lineage checkpoint" in result.output
@@ -203,6 +207,75 @@ class TestLineageInitCommand:
 
         assert result.exit_code != 0
         assert "target_ids" in result.output
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "extra_args",
+        [
+            ["--clear-dropped-targets"],
+            ["--build-id", "b-1"],
+            ["--force", "--build-id", "b-1"],
+            ["--force"],
+            ["--clear-dropped-targets", "--build-id", "b-1"],
+        ],
+    )
+    def test_show_must_be_called_alone(self, extra_args):
+        """``--show`` is read-only, so a write flag beside it is an error.
+
+        It used to return early and exit 0 with the write silently dropped, which an
+        operator or setup script reads as "shown and done" while the state is
+        unchanged. The message names the offending flag rather than guessing an order.
+        """
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-1"]}
+        with patch(f"{MODULE}.seed_if_absent") as seed:
+            result = self._run("--show", *extra_args)
+
+        assert result.exit_code != 0
+        assert "--show is read-only" in result.output
+        for flag in (a for a in extra_args if a.startswith("--")):
+            assert flag in result.output, f"{flag} was not named in: {result.output}"
+        seed.assert_not_called()
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    def test_show_alone_still_works(self):
+        """The guard must not break the read-only path it protects."""
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = _CHECKPOINT
+        result = self._run("--show")
+
+        assert result.exit_code == 0, result.output
+        assert "b-1" in result.output
+        self.storage.kv_pair_storage.set_value.assert_not_called()
+
+    @pytest.mark.parametrize("stored", [{}, [], ""])
+    def test_show_reports_an_empty_checkpoint_as_unusable(self, stored):
+        """An empty value records nothing, so --show must not call it seeded.
+
+        ``_read_checkpoint_value`` tests ``if not value``, so reporting presence with
+        ``is None`` here would disagree with the watcher in the one case the flag
+        exists to diagnose.
+        """
+        self._stored[LINEAGE_WATCHER_CHECKPOINT_KEY] = stored
+        result = self._run("--show")
+
+        assert result.exit_code == 0, result.output
+        assert "No usable lineage checkpoint" in result.output
+        assert "records nothing until one is seeded" in result.output
+
+    @pytest.mark.parametrize(
+        "args", [["--force"], ["--force", "--clear-dropped-targets"]]
+    )
+    def test_force_without_a_build_id_names_force(self, args):
+        """--force only qualifies a seed, so alone it must say so.
+
+        It previously fell through to "Nothing to do", which lists every other flag
+        but never the one the operator actually typed.
+        """
+        self._stored[LINEAGE_WATCHER_DROPPED_KEY] = {"target_ids": ["t-1"]}
+        result = self._run(*args)
+
+        assert result.exit_code != 0
+        assert "--force only applies when seeding" in result.output
+        # The clear must not have happened either: --force was rejected first.
         self.storage.kv_pair_storage.set_value.assert_not_called()
 
     def test_clearing_dropped_targets_leaves_the_checkpoint_alone(self):

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -685,6 +685,65 @@ class TestLineageWatcher:
 
         assert {target_id for _build_id, target_id in store.calls} == {"t-a"}
 
+    def test_running_build_with_only_dropped_targets_is_not_cached_as_complete(self):
+        """The sibling of the bug above, on the all-targets-dropped path.
+
+        A RUNNING build whose only targets so far are all in the durable drop set
+        also confirms without a sink answer: every target is filtered out of
+        `candidates`, so filter_unrecorded is never called. That pass used to report
+        all_confirmed without flagging itself unqueried, so it was cached complete
+        and the skip gate ("cached complete AND finished") then swallowed the
+        non-dropped target that arrived before the build finished -- the same
+        restart-only recovery as the empty case.
+        """
+        watcher, store = self._make_watcher()
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": ["t-dropped"]}
+        )
+        self._builds = [_build("A", _BASE, Status.RUNNING)]
+        self._targets = [_target("A", "t-dropped")]
+        self._seed("A", _BASE)
+
+        watcher._reconcile()
+        assert store.calls == [], "the only target is permanently dropped"
+        assert "A" not in watcher._complete_builds, (
+            "an all-dropped pass on a RUNNING build asked the sink nothing, so it "
+            "must not arm the skip gate against targets still to come"
+        )
+
+        # A gains a target that is *not* dropped, then finishes: the next scan must
+        # re-read its targets rather than skip the build.
+        self._builds = [_build("A", _BASE, Status.SUCCESS)]
+        self._targets = [_target("A", "t-dropped"), _target("A", "t-live")]
+
+        watcher._reconcile()
+
+        assert {target_id for _build_id, target_id in store.calls} == {"t-live"}
+
+    def test_finished_build_with_only_dropped_targets_is_cached_as_complete(self):
+        """The other half: a *finished* all-dropped build must still be cached.
+
+        _advance_checkpoint requires the anchor in _complete_builds, so refusing to
+        cache this build pins the mark on it forever and blocks every newer build's
+        lineage -- exactly what the durable drop set exists to prevent. Flagging the
+        pass unqueried must not cost that.
+        """
+        watcher, _store = self._make_watcher()
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": ["t-dropped"]}
+        )
+        self._builds = [
+            _build("A", _BASE, Status.SUCCESS),
+            _build("B", _BASE + timedelta(minutes=1), Status.SUCCESS),
+        ]
+        self._targets = [_target("A", "t-dropped"), _target("B", "t-b")]
+        self._seed("A", _BASE)
+
+        watcher._reconcile()
+
+        assert "A" in watcher._complete_builds
+        assert self._checkpoint_build() == "B", "the mark must not wedge on A"
+
     # ---- fail-closed dedup ------------------------------------------------
 
     def test_dedup_failure_aborts_the_pass_and_records_nothing(self):

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -869,6 +869,114 @@ class TestLineageWatcher:
 
         assert "t-1" in fresh._dropped
 
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "oops",
+            ["t-1"],
+            7,
+            {"target_ids": "t-1"},
+            {"target_ids": 3},
+            # These pass a container-only check but make _persist_dropped's sorted()
+            # raise on the next drop, which unwinds into _run and fails every scan.
+            {"target_ids": ["t-1", 7]},
+            {"target_ids": [1, 2]},
+            {"target_ids": [None]},
+        ],
+    )
+    def test_an_unusable_drop_set_starts_empty_instead_of_raising(self, bad_value):
+        """A corrupt row must not abort start(): a dead watcher records nothing.
+
+        Empty is the only readable fallback, but it is the wedge the drop set
+        exists to prevent, so it is logged at ERROR rather than swallowed.
+        """
+        self.storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, bad_value)
+
+        fresh = LineageWatcher()
+        fresh._store = _StubStore()
+        fresh._load_dropped(self.storage)
+
+        assert fresh._dropped == set()
+
+    def test_an_unusable_drop_set_is_left_on_disk_for_inspection(self):
+        """Loading never rewrites the bad row -- the operator still needs to see it."""
+        self.storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, "oops")
+
+        fresh = LineageWatcher()
+        fresh._store = _StubStore()
+        fresh._load_dropped(self.storage)
+
+        assert (
+            self.storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
+            == "oops"
+        )
+
+    def test_persisting_after_a_corrupt_load_does_not_raise(self):
+        """The load fallback must leave a persistable set, or the watcher wedges.
+
+        A mixed list loaded as-is makes ``_persist_dropped``'s sorted() raise on the
+        next drop; ``on_error`` runs outside ``reconcile_build``'s try/except, so that
+        unwinds into ``_run`` and fails every scan from then on -- worse than the
+        empty-set fallback the guard chooses.
+        """
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": ["t-1", 7]}
+        )
+
+        fresh = LineageWatcher()
+        fresh._store = _StubStore()
+        fresh._load_dropped(self.storage)
+        fresh._dropped.add("t-2")
+        fresh._persist_dropped(self.storage)
+
+        assert self.storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY) == {
+            "target_ids": ["t-2"]
+        }
+
+    def test_a_failing_persist_never_escapes_to_abort_the_scan(self):
+        """Durability is best-effort; the scan loop is not.
+
+        ``_on_record_error`` persists from inside ``reconcile_build``, so a raise here
+        would kill the iteration and every one after it.
+        """
+        storage = MagicMock()
+        storage.kv_pair_storage.set_value.side_effect = RuntimeError("kv down")
+
+        fresh = LineageWatcher()
+        fresh._store = _StubStore()
+        fresh._dropped = {"t-1"}
+        fresh._persist_dropped(storage)
+
+        assert fresh._dropped == {"t-1"}
+
+    def test_a_failing_drop_set_read_starts_empty_instead_of_raising(self):
+        """A storage error is treated the same as a corrupt shape."""
+        storage = MagicMock()
+        storage.kv_pair_storage.get_value.side_effect = RuntimeError("kv down")
+
+        fresh = LineageWatcher()
+        fresh._store = _StubStore()
+        fresh._load_dropped(storage)
+
+        assert fresh._dropped == set()
+
+    @pytest.mark.parametrize("bad_value", ["oops", {"target_ids": ["t-9", 7]}])
+    def test_reloading_over_a_stale_set_clears_it(self, bad_value):
+        """A failed reload must not silently keep the previous set.
+
+        ``start()`` can run again on a live instance after ``stop()``, where
+        ``_dropped`` still holds the old set -- so the "starting with an empty set"
+        log has to describe what actually happened.
+        """
+        self.storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, bad_value)
+
+        fresh = LineageWatcher()
+        fresh._store = _StubStore()
+        fresh._dropped = {"stale-1"}
+        fresh._load_dropped(self.storage)
+
+        assert fresh._dropped == set()
+
     # ---- checkpoint value handling ---------------------------------------
 
     def test_backfill_anchor_records_everything(self):

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -854,6 +854,87 @@ class TestLineageWatcher:
         assert "t-a" in watcher._dropped
         assert self._checkpoint_build() == "A"
 
+    def test_clearing_the_row_retries_the_target_without_a_restart(self):
+        """The point of re-reading every scan: `lineage-init --clear` needs no restart.
+
+        Previously _dropped was loaded once in start(), so a cleared row was invisible
+        to a live watcher -- and worse, the next drop persisted the whole stale set,
+        undoing the operator's clear.
+        """
+        watcher, store = self._make_watcher(fail={"t-1"})
+        self._builds = [_build("A", _BASE, Status.SUCCESS)]
+        self._targets = [_target("A", "t-1")]
+        self._seed("A", _BASE)
+        for _ in range(LineageWatcher._MAX_RECORD_ATTEMPTS):
+            watcher._reconcile()
+        assert "t-1" in watcher._dropped
+
+        # What the CLI writes, on the same live instance.
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []}
+        )
+        store._fail = set()
+        watcher._reconcile()
+
+        assert "t-1" not in watcher._dropped, "the clear must take effect on this scan"
+        assert "t-1" in store._recorded, "the target must actually be retried"
+
+    def test_the_watcher_does_not_undo_a_clear_on_its_next_drop(self):
+        """A later drop must persist only what is still dropped, not a stale set."""
+        watcher, store = self._make_watcher(fail={"t-1", "t-2"})
+        self._builds = [_build("A", _BASE, Status.SUCCESS)]
+        self._targets = [_target("A", "t-1"), _target("A", "t-2")]
+        self._seed("A", _BASE)
+        for _ in range(LineageWatcher._MAX_RECORD_ATTEMPTS):
+            watcher._reconcile()
+        assert watcher._dropped == {"t-1", "t-2"}
+
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []}
+        )
+        # t-2 keeps failing and gets re-dropped; t-1 must not come back with it.
+        store._fail = {"t-2"}
+        for _ in range(LineageWatcher._MAX_RECORD_ATTEMPTS + 1):
+            watcher._reconcile()
+
+        persisted = self.storage.kv_pair_storage.get_value(LINEAGE_WATCHER_DROPPED_KEY)
+        assert "t-1" not in persisted["target_ids"], "the clear was undone"
+
+    def test_an_unpersisted_drop_survives_the_next_scans_reload(self):
+        """A drop whose persist failed must not be resurrected by the reload.
+
+        _persist_dropped is non-raising, so the decision can exist only in memory;
+        treating the row as authoritative without adding those back would re-record a
+        hopeless target on every scan.
+        """
+        watcher, _store = self._make_watcher()
+        watcher._dropped = {"t-9"}
+        failing = MagicMock()
+        failing.kv_pair_storage.set_value.side_effect = RuntimeError("kv down")
+        watcher._persist_dropped(failing)
+        assert watcher._dropped_unpersisted == {"t-9"}
+
+        # The durable row never got it, but the reload must not drop it.
+        watcher._load_dropped(self.storage)
+
+        assert "t-9" in watcher._dropped
+
+    def test_a_successful_persist_hands_ids_over_to_the_row(self):
+        """After a good persist the ids live in the row, so a clear can reach them."""
+        watcher, _store = self._make_watcher()
+        watcher._dropped = {"t-9"}
+        watcher._dropped_unpersisted = {"t-9"}
+        watcher._persist_dropped(self.storage)
+
+        assert watcher._dropped_unpersisted == set()
+
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": []}
+        )
+        watcher._load_dropped(self.storage)
+
+        assert watcher._dropped == set(), "a persisted id must follow the row"
+
     def test_dropped_target_survives_a_restart(self):
         """The drop decision is durable, so a restart does not resurrect it."""
         watcher, _store = self._make_watcher(fail={"t-1"})
@@ -961,21 +1042,46 @@ class TestLineageWatcher:
         assert fresh._dropped == set()
 
     @pytest.mark.parametrize("bad_value", ["oops", {"target_ids": ["t-9", 7]}])
-    def test_reloading_over_a_stale_set_clears_it(self, bad_value):
-        """A failed reload must not silently keep the previous set.
+    def test_an_unusable_row_keeps_the_current_set(self, bad_value):
+        """A bad row must not retry what this process knows is hopeless.
 
-        ``start()`` can run again on a live instance after ``stop()``, where
-        ``_dropped`` still holds the old set -- so the "starting with an empty set"
-        log has to describe what actually happened.
+        _load_dropped now runs every scan, so "clear on failure" would re-record a
+        dropped target on every pass for as long as the row stays corrupt. Keeping
+        the in-memory set is the conservative direction.
         """
         self.storage.kv_pair_storage.set_value(LINEAGE_WATCHER_DROPPED_KEY, bad_value)
 
         fresh = LineageWatcher()
         fresh._store = _StubStore()
-        fresh._dropped = {"stale-1"}
+        fresh._dropped = {"t-known"}
         fresh._load_dropped(self.storage)
 
-        assert fresh._dropped == set()
+        assert fresh._dropped == {"t-known"}
+
+    def test_starting_resets_a_set_left_by_a_previous_run(self):
+        """start() re-reads from scratch, so a stale instance does not leak state."""
+        self.storage.kv_pair_storage.set_value(
+            LINEAGE_WATCHER_DROPPED_KEY, {"target_ids": ["t-row"]}
+        )
+
+        fresh = LineageWatcher()
+        fresh._dropped = {"t-stale"}
+        fresh._dropped_unpersisted = {"t-stale"}
+        with (
+            patch(
+                "gbserver.lineage.lineage_watcher.get_lineage_store",
+                return_value=_StubStore(),
+            ),
+            patch(
+                "gbserver.lineage.lineage_watcher.get_admin_storage",
+                return_value=self.storage,
+            ),
+            patch.object(LineageWatcher, "_run"),
+        ):
+            fresh.start()
+            fresh.stop_event.set()
+
+        assert fresh._dropped == {"t-row"}, "the stale set must not survive start()"
 
     # ---- checkpoint value handling ---------------------------------------
 

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -346,6 +346,47 @@ class TestLineageWatcher:
         watcher._reconcile()
         assert self._checkpoint_build() == "B"
 
+    def test_targets_appearing_after_an_empty_scan_are_still_recorded(self):
+        """A build scanned while it had no targets must be re-read once it has them.
+
+        The real sequence from production: the watcher selects a build that is still
+        RUNNING and has no gb_targets rows yet. That pass has nothing to record, so
+        it reports all_confirmed -- a finished build with genuinely no lineage must
+        not pin the checkpoint. But the confirmation rests on an empty set; the sink
+        was never asked about anything.
+
+        Caching that as complete is the bug: the skip gate is "cached complete AND
+        finished", and when the build then succeeds and its target appears, both
+        halves hold and the build is skipped without ever re-reading its targets.
+        The lineage was recorded only after a service restart, which is the one
+        thing that clears the in-memory set.
+        """
+        watcher, store = self._make_watcher()
+        build = _build("B1", _BASE, Status.RUNNING)
+        self._builds = [build]
+        self._targets = []
+        self._seed("B1", _BASE)
+
+        watcher._reconcile()
+        assert store.calls == [], "nothing to record while the build has no targets"
+        assert "B1" not in watcher._complete_builds, (
+            "an empty pass must not be cached as complete: the sink was never asked "
+            "about any target, so there is nothing to skip re-reading later"
+        )
+
+        # By the time the build reads SUCCESS its target rows are already persisted
+        # (buildrunner finalizes children before the parent), so a later scan sees
+        # both -- provided the build was not cached as complete by the empty pass.
+        build.status = Status.SUCCESS
+        self._targets = [_target("B1", "t-b1")]
+
+        watcher._reconcile()
+        recorded = {target_id for _build_id, target_id in store.calls}
+        assert recorded == {"t-b1"}, (
+            "the target that appeared after the empty scan must be recorded without "
+            "needing a restart to clear the completed-build cache"
+        )
+
     def test_checkpoint_never_steps_off_a_non_finished_build(self):
         """The mark never leaves a running build, never jumping past it to C.
 

--- a/test/unit/lineage/test_lineage_watcher.py
+++ b/test/unit/lineage/test_lineage_watcher.py
@@ -613,6 +613,78 @@ class TestLineageWatcher:
 
         assert self._checkpoint_build() == "B"
 
+    def test_finished_no_target_anchor_does_not_wedge_the_checkpoint(self):
+        """The anchor itself has no targets: the mark must still step off it.
+
+        The previous test seeds an anchor that *has* a target, so the advance is
+        gated on a build that gets cached either way -- the no-target build is
+        only the destination and never the anchor. Here the empty build is the
+        anchor, which is the case that wedges: it is finished, so it will never
+        gain a target, but _advance_checkpoint requires the anchor in
+        _complete_builds. Refusing to cache it pins the mark on it forever and
+        blocks every newer build's lineage behind it.
+        """
+        watcher, store = self._make_watcher()
+        self._builds = [
+            _build("A", _BASE, Status.SUCCESS),
+            _build("B", _BASE + timedelta(minutes=1), Status.SUCCESS),
+        ]
+        self._targets = [_target("B", "t-b")]
+        self._seed("A", _BASE)
+
+        # Two scans: the first advances off the empty anchor A, the second must
+        # then advance off B. A single scan passes even when wedged, because the
+        # first pass is the one that reads A while it is still the anchor.
+        watcher._reconcile()
+        assert self._checkpoint_build() == "B", "the mark wedged on empty anchor A"
+
+        watcher._reconcile()
+
+        assert {target_id for _build_id, target_id in store.calls} == {"t-b"}
+
+    def test_failed_anchor_with_no_targets_does_not_wedge_the_checkpoint(self):
+        """A FAILED build is the common shape of a finished build with no lineage.
+
+        ``select_builds_from_checkpoint`` has no status filter, so a FAILED build
+        does become an anchor -- and it records nothing by definition. If that
+        wedged the mark, one failed build would stop lineage for the platform.
+        """
+        watcher, _store = self._make_watcher()
+        self._builds = [
+            _build("A", _BASE, Status.FAILED),
+            _build("B", _BASE + timedelta(minutes=1), Status.SUCCESS),
+        ]
+        self._targets = [_target("B", "t-b")]
+        self._seed("A", _BASE)
+
+        watcher._reconcile()
+
+        assert self._checkpoint_build() == "B"
+
+    def test_running_build_with_no_targets_is_not_cached_as_complete(self):
+        """The original bug: an empty pass on a RUNNING build must not be cached.
+
+        Caching it arms the skip gate ("cached complete AND finished") on a build
+        whose targets are written moments later, so they are never re-read and the
+        lineage appears only after a restart. Finished-and-empty is cached;
+        running-and-empty is not, and the build state is the whole distinction.
+        """
+        watcher, store = self._make_watcher()
+        self._builds = [_build("A", _BASE, Status.RUNNING)]
+        self._targets = []
+        self._seed("A", _BASE)
+
+        watcher._reconcile()
+        assert "A" not in watcher._complete_builds
+
+        # A finishes and its targets land: the next scan must re-read them.
+        self._builds = [_build("A", _BASE, Status.SUCCESS)]
+        self._targets = [_target("A", "t-a")]
+
+        watcher._reconcile()
+
+        assert {target_id for _build_id, target_id in store.calls} == {"t-a"}
+
     # ---- fail-closed dedup ------------------------------------------------
 
     def test_dedup_failure_aborts_the_pass_and_records_nothing(self):


### PR DESCRIPTION
## The bug

A build read while still `RUNNING` has no `gb_targets` rows yet — the build row and
its target rows are separate, non-transactional writes, and a 30s scan lands at an
arbitrary point between them. That pass has nothing to record, so `reconcile_build`
reported `all_confirmed` (correct in itself: a finished build with genuinely no
lineage must not pin the checkpoint). But the watcher cached it in
`_complete_builds`, and the skip gate is "cached complete AND finished":

```python
if build.uuid in self._complete_builds and build.status.is_finished():
    continue
```

Once the build reached SUCCESS — with its targets by then persisted, since
buildrunner drains one FIFO with a single consumer and `finalize_build_status`
commits children before the parent — both halves held, so the build was skipped
without its targets ever being re-read.

**The lineage was recorded only after a service restart**, which is the one thing
that clears the in-memory set. Reported from DEV; reproduced in a unit test.

### Fix

The confirmation was never a sink answer: with no target to ask about,
`filter_unrecorded` was never called. Flag the empty pass as `had_no_targets` and
refuse to cache it. `all_confirmed` still holds, so the checkpoint can pass a
finished build that produces no lineage of its own, but the build stays eligible
for a re-read.

Both halves of the skip gate are load-bearing and stay: `is_finished()` says the
build can gain no new target, while `_complete_builds` says its existing lineage is
in the sink. A SUCCESS build whose targets were never written — a scan that crashed
mid-pass, an aborted dedup query — must still be re-read, which is why the
checkpoint build is re-selected every scan.

The regression test fails on the old code (the build is cached after the empty scan)
and passes with the fix.

## New: `gbserver lineage-init`

The watcher records nothing until `gb_kv_pairs` holds a checkpoint, and the only way
to place one was `lineage-watch --base-build-id`, which seeds and then runs the
watcher forever. Initializing an environment therefore meant starting the watcher
and killing it once the key appeared — it works, but it records lineage for however
long the process happened to live, which is an unclear amount of work on an
environment still being set up and awkward to script.

```shell
# seed and exit                        -> no pod restart needed
gbserver lineage-init --build-id from-latest

# read-only: checkpoint + drop set     -> no pod restart needed (writes nothing)
gbserver lineage-init --show

# replace an existing mark             -> no pod restart needed
gbserver lineage-init --build-id <uuid> --force

# retry permanently-dropped targets    -> POD RESTART REQUIRED
gbserver lineage-init --clear-dropped-targets
```

Why only the last one needs a restart: `_reconcile` re-reads the **checkpoint** from
storage on every scan, so anything that moves the anchor takes effect within one
interval (30s default) in the running process. The **drop set** is different —
`_load_dropped` runs once in `start()`, not per scan, so a cleared drop set is not
seen until the watcher restarts. The command prints this in its output rather than
leaving the operator to wonder why the targets are still skipped.

Verified in-process for all three no-restart cases, including a `--force` that moves
the anchor *backwards*, which correctly re-drives the older build's lineage on the
next scan of the same process.

- **No `LineageWatcher` is ever constructed**, which a test pins explicitly.
- Seed-if-absent is the default, so a second run is a no-op that exits 0 rather than
  an error a setup script has to special-case.
- `--clear-dropped-targets` empties the durable set of **target** ids the watcher
  gave up on after exhausting its record attempts. Moving the anchor back does *not*
  clear them — the drop decision is deliberately durable, so a dropped target is
  otherwise skipped on every scan forever with no supported way to bring it back.
- `--show` reports both the checkpoint and the drop set, which is the state an
  operator asking "why is this target's lineage missing?" previously had to query
  `gb_kv_pairs` by hand to see.
- `--build-id` is optional because clearing is a complete operation on its own; a
  bare invocation with no flags errors instead of silently doing nothing.

## Also

Narrow `_advance_checkpoint` on the anchor *index* instead of on a separate
`anchor is None` check. The two are equivalent at runtime, but the successor slice
(`builds[anchor_index + 1:]`) read the index after a guard on a different variable,
which mypy flagged as `int | None`. No behaviour change.

## Testing

- `pytest test/unit/lineage/` — 160 passed
- `pylint src/gbserver/lineage/lineage_watcher.py` — 10.00/10
- `mypy` — 0 errors in both changed lineage files and the new command (the 15
  remaining repo-wide errors are pre-existing in `myghapi.py`, `filesystem.py`,
  `uri.py`, `space_user_storage.py`)
- The new command exercised against a real standalone sqlite DB, where `--show`
  surfaced an actually-dropped target that had been silently skipped on every scan.
