### PR TITLE
Increase timeout on slurm 1step test to try and get ci nightly action to pass

### DIFF
--- a/test-data/integration/standalone/buildrunner/skypilot_slurm/1step/buildtest.yaml
+++ b/test-data/integration/standalone/buildrunner/skypilot_slurm/1step/buildtest.yaml
@@ -21,4 +21,4 @@ target_expectations:
 # against this YAML's directory.
 space_uri: ../../../../../../configurations/spaces/local
 simulate_step_failure: true
-timeout_minutes: 10 # Seems sufficient on mac running local slurm cluster
+timeout_minutes: 15 # 15 vs 10 for ci in github. 


### PR DESCRIPTION
## Description

The slurm 1 step test is failing [here](https://github.com/ibm-granite/granite.build/actions/runs/32683964446/job/97305502907#step:5:30958) due to timeout.  Let's try and add 50% to the timeout and see if things get better.  Odd that the other slurm tests with this same timeout do not get this problem - for example, [here](https://github.com/ibm-granite/granite.build/actions/runs/32683964446/job/97305502907#step:5:22461).

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`)
- [ ] Code formatted (`make xformat`)
- [ ] Linting passes (`make xcheck`)
- [ ] No IBM-internal references introduced
- [ ] Documentation updated (if applicable)
