### PR TITLE
fix(skypilot): builtin command-step file_mounts resolve vs workdir

### DIFF
--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -50,6 +50,11 @@ else:
 
 _DEFAULT_POLL_INTERVAL_SECONDS = 300
 
+# URI of the built-in ``command`` step. Its inline relative file_mounts sources
+# are authored relative to the gbserver working dir (repo root) rather than the
+# per-run staging dir, since it ships no step assets into that staging dir.
+BUILTIN_COMMAND_STEP_URI = "space://steps/command"
+
 
 def _require_skypilot():
     """Raise a clear error if the sky SDK is not installed.
@@ -442,6 +447,7 @@ def _build_skypilot_mounts(
     file_mounts_raw: dict,
     asset_dir: Union[Path, str, None],
     build_workdir: Optional[str] = None,
+    source_base_dir: Union[Path, str, None] = None,
 ) -> Tuple[Dict, Dict]:
     """Split a raw ``file_mounts`` mapping into file mounts and storage mounts.
 
@@ -457,9 +463,16 @@ def _build_skypilot_mounts(
     :param asset_dir: ``targetsteprun_asset_dir`` used to resolve relative sources.
     :param build_workdir: per-run workdir for relative-destination remap, or
         ``None`` to leave destinations unchanged.
+    :param source_base_dir: base dir for resolving relative *sources*; when
+        ``None`` (the default) it falls back to ``asset_dir``. The built-in
+        command step passes the gbserver working dir here.
     :returns: a ``(file_mounts, storage_mounts)`` tuple of dicts, either of which
         may be empty.
     """
+    # Relative SOURCES resolve against source_base_dir when provided (the built-in
+    # command step passes the gbserver working dir); otherwise against asset_dir
+    # (custom file:// steps — unchanged). Destinations are unaffected.
+    source_base = source_base_dir if source_base_dir is not None else asset_dir
     file_mounts: Dict[str, str] = {}
     storage_mounts: Dict[str, Any] = {}
     for raw_path, mount_val in file_mounts_raw.items():
@@ -479,11 +492,13 @@ def _build_skypilot_mounts(
                     storage_kwargs["source"] = source
             else:  # local path: resolve relative to the step.yaml dir
                 storage_kwargs["source"] = _resolve_local_mount_source(
-                    source, asset_dir
+                    source, source_base
                 )
             storage_mounts[mount_path] = sky.Storage(**storage_kwargs)
         else:
-            file_mounts[mount_path] = _resolve_local_mount_source(mount_val, asset_dir)
+            file_mounts[mount_path] = _resolve_local_mount_source(
+                mount_val, source_base
+            )
     return file_mounts, storage_mounts
 
 
@@ -1077,17 +1092,30 @@ class Skypilot(Environment):
             # path; the fork's backend wrap-exemption keeps these shared-root
             # destinations un-wrapped. Relative local sources resolve against
             # targetsteprun_asset_dir (the dir holding the rendered step.yaml +
-            # siblings). See _build_skypilot_mounts / _resolve_local_mount_source.
+            # siblings) for custom file:// steps; the built-in command step
+            # instead resolves them against the gbserver working dir (see the
+            # source_base_dir selection below). See _build_skypilot_mounts /
+            # _resolve_local_mount_source.
             file_mounts_raw = launcher_config.get("file_mounts") or config.get(
                 "file_mounts"
             )
             file_mounts: Dict[str, str] = {}
             storage_mounts: Dict[str, Any] = {}
             if file_mounts_raw:
+                # The built-in command step ships no step assets into the per-run
+                # staging dir, so its inline relative file_mounts sources are
+                # authored relative to the gbserver working dir (repo root).
+                # Custom file:// steps keep resolving against the staging dir.
+                source_base_dir = (
+                    Path.cwd()
+                    if run_metadata.get("targetstep_uri") == BUILTIN_COMMAND_STEP_URI
+                    else None
+                )
                 file_mounts, storage_mounts = _build_skypilot_mounts(
                     file_mounts_raw,
                     targetsteprun_asset_dir,
                     build_workdir,
+                    source_base_dir=source_base_dir,
                 )
 
             # The prefix always leads with `set -eu` (fail fast). When a per-run

--- a/test/unit/environment/test_skypilot.py
+++ b/test/unit/environment/test_skypilot.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -175,6 +176,19 @@ class TestBuildSkypilotMounts:
                 source_base_dir=None,
             )
         assert file_mounts == {"/remote/in": "/work/run1/scripts/run.sh"}
+
+    def test_escaping_source_rejected_with_source_base_dir(self):
+        """A '..'-escaping source is rejected even when source_base_dir is set."""
+        from gbserver.environment.skypilot import _build_skypilot_mounts
+
+        with patch("gbserver.environment.skypilot.sky", MagicMock()):
+            with pytest.raises(ValueError, match="escape"):
+                _build_skypilot_mounts(
+                    {"/remote/in": "../secret"},
+                    "/work/run1",
+                    None,
+                    source_base_dir="/repo",
+                )
 
 
 class TestRemapRelativeDest:
@@ -418,8 +432,6 @@ class TestLaunchSkypilot:
         """For the built-in command step, a relative file_mounts SOURCE resolves
         against the gbserver working dir (cwd), not targetsteprun_asset_dir."""
         monkeypatch.chdir(tmp_path)
-        from pathlib import Path
-
         cwd = str(Path.cwd())  # normalize macOS /private symlink after chdir
         mock_sky = MagicMock()
         mock_sky.Resources = MagicMock(return_value=MagicMock())

--- a/test/unit/environment/test_skypilot.py
+++ b/test/unit/environment/test_skypilot.py
@@ -149,6 +149,33 @@ class TestBuildSkypilotMounts:
             )
         assert file_mounts == {"/proj/gbtest/builds/b1/payload": "/work/run1/payload"}
 
+    def test_source_base_dir_overrides_asset_dir_for_sources(self):
+        """When source_base_dir is given, relative SOURCES resolve against it
+        (not asset_dir); destinations still use asset_dir/build_workdir."""
+        from gbserver.environment.skypilot import _build_skypilot_mounts
+
+        with patch("gbserver.environment.skypilot.sky", MagicMock()):
+            file_mounts, _ = _build_skypilot_mounts(
+                {"/remote/in": "samples/data/x"},
+                "/work/run1",
+                None,
+                source_base_dir="/repo",
+            )
+        assert file_mounts == {"/remote/in": "/repo/samples/data/x"}
+
+    def test_source_base_dir_none_falls_back_to_asset_dir(self):
+        """source_base_dir=None keeps today's behavior (resolve vs asset_dir)."""
+        from gbserver.environment.skypilot import _build_skypilot_mounts
+
+        with patch("gbserver.environment.skypilot.sky", MagicMock()):
+            file_mounts, _ = _build_skypilot_mounts(
+                {"/remote/in": "scripts/run.sh"},
+                "/work/run1",
+                None,
+                source_base_dir=None,
+            )
+        assert file_mounts == {"/remote/in": "/work/run1/scripts/run.sh"}
+
 
 class TestRemapRelativeDest:
     """_remap_relative_dest: only relative dsts move under the build workdir."""
@@ -382,6 +409,44 @@ class TestLaunchSkypilot:
         assert (
             skypilot_env._launch_kwargs[launch_id]["targetsteprun_asset_dir"]
             == "/work/run-xyz"
+        )
+
+    @pytest.mark.asyncio
+    async def test_launch_builtin_command_step_resolves_source_against_cwd(
+        self, skypilot_env, monkeypatch, tmp_path
+    ):
+        """For the built-in command step, a relative file_mounts SOURCE resolves
+        against the gbserver working dir (cwd), not targetsteprun_asset_dir."""
+        monkeypatch.chdir(tmp_path)
+        from pathlib import Path
+
+        cwd = str(Path.cwd())  # normalize macOS /private symlink after chdir
+        mock_sky = MagicMock()
+        mock_sky.Resources = MagicMock(return_value=MagicMock())
+        task = MagicMock()
+        mock_sky.Task = MagicMock(return_value=task)
+        mock_sky.launch = MagicMock(return_value="req-cmd")
+        mock_sky.stream_and_get = MagicMock(return_value=(9, MagicMock()))
+
+        with (
+            patch("gbserver.environment.skypilot.sky", mock_sky),
+            patch("gbserver.environment.skypilot.HAS_SKYPILOT", True),
+        ):
+            launch_id = "test-launch-cmd"
+            skypilot_env._get_launch_ready_event(launch_id)
+            await skypilot_env.launch_skypilot(
+                launch_id=launch_id,
+                targetsteprun_asset_dir="/work/run-xyz",
+                launcher_config={
+                    "run": "echo hi",
+                    "file_mounts": {"/remote/in": "samples/data/x"},
+                },
+                config={},
+                run_metadata={"targetstep_uri": "space://steps/command"},
+            )
+
+        task.set_file_mounts.assert_called_once_with(
+            {"/remote/in": f"{cwd}/samples/data/x"}
         )
 
     async def _launch_and_capture_resources(


### PR DESCRIPTION
## Summary

- The built-in `command` step now resolves **relative** inline `file_mounts` *sources* against the **gbserver working directory** (repo root), so committed fixtures/templates can reference repo files with repo-relative paths.
- Custom `file://` steps are unchanged (they still resolve relative sources against their per-run staging/asset dir).
- Scope: the Skypilot launcher only (covers all four Skypilot endpoints: slurm / kubernetes / aws / lsf-via-skypilot).

## Why

`_resolve_local_mount_source` joins a relative source onto `targetsteprun_asset_dir` (the per-run staging dir). Custom steps copy their files into that dir, so step-relative sources work; the built-in `command` step ships no repo files in, so a repo-relative source like `samples/data/...` resolves to a non-existent path and staging fails with `File mount source '…/gbserverworkspace/…/samples/data/…' does not exist locally` — before any compute is provisioned. This resolution is uniform across the in-process test harness and the REST path, so relative repo-paths never worked for the command step; only absolute sources did.

Closes #294.

## Changes

- `src/gbserver/environment/skypilot.py`
  - `_build_skypilot_mounts` gains an optional `source_base_dir` (defaults to today's `asset_dir`, so custom steps are byte-identical); both source resolutions use it.
  - Launch call site passes `Path.cwd()` as `source_base_dir` iff `run_metadata["targetstep_uri"] == "space://steps/command"` (new `BUILTIN_COMMAND_STEP_URI` constant), else `None`.
  - The `~`-rejection and `..`-escape guards are preserved (now measured from `source_base_dir`).
- `test/unit/environment/test_skypilot.py`: unit tests for the override, the `None` fallback, the escape guard against `source_base_dir`, and a launch-level test proving the command step resolves against cwd. Existing tests unchanged and passing.

## Test plan

- [x] `pytest test/unit/environment/test_skypilot.py` — 115 passed
- [ ] After merge, #276 rebases on this; run the DPK `dpk-tokenize-1step` fixture (relative sources) through the harness to confirm it clears staging, plus one real EC2 run (single instance, `/tmp`, no S3).

## Notes

- Follow-ups (non-blocking, out of scope here): promote the `space://steps/command` URI to a shared constant; consider anchoring the working dir at server startup rather than sampling `Path.cwd()` at launch.

## Downstream dependency (please land this first)

This is a prerequisite for the DPK test work — the relative `file_mounts` source
resolution is endpoint-independent (client-side, pre-launch), so those fixtures fail at
staging on **every** SkyPilot endpoint until this merges:

- **#276** (DPK skypilot tests): its `dpk-tokenize-1step` (real-EC2) fixture uses
  repo-relative sources and can't go green without this fix.
- **Planned skypilot/slurm smoke** (local 2-target `env://` handoff): same relative
  sources, same dependency.

Suggested order: **merge this → rebase #276 → trim #276 to {aws 1-step + slurm 2-target}
→ both smokes go green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


