### PR TITLE
Plugin discovery: unify key derivation, wire auth providers, resilience strategies, and CLI commands

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -73,17 +73,26 @@ listed base class and provide the listed key.
 |---|---|---|
 | `gbserver.uri_handlers` | `gbcommon.uri.uri.URI` | the scheme(s) returned by `get_supported_schemes()` |
 | `gbserver.asset_stores` | `gbserver.asset.assetstore.Assetstore` | the URI class(es) returned by `get_supported_uri_classes()` |
-| `gbserver.environments` | `gbserver.environment.environment.Environment` | the **entry-point name** (registered under both `name.lower()` and the name exactly as declared) |
-| `gbserver.secret_managers` | `SpaceSecretManager` **or** `UserSecretManager` | the **entry-point name** (lowercased). One group feeds both families; each class is routed to the family whose base class it subclasses |
+| `gbserver.environments` | `gbserver.environment.environment.Environment` | the **entry-point name** (the environment `type`) |
+| `gbserver.secret_managers` | `SpaceSecretManager` **or** `UserSecretManager` | the **entry-point name** (the secret-manager `type`). One group feeds both families; each class is routed to the family whose base class it subclasses |
+| `gbserver.auth_providers` | `gbserver.api.auth_providers.AuthProvider` | the **entry-point name** (the provider name, matching `provider_name`) |
+| `gbserver.resilience_strategies` | `gbserver.resilience.retry_handler.RetryStrategy` | the **entry-point name** (the strategy config `type`) |
 
-For the URI and asset-store groups the entry-point *name* is cosmetic — the registration key comes from
-the class's own method, so name your entry point whatever reads well. For the environment and
-secret-manager groups the entry-point *name* is the registration key.
+There are exactly two key-derivation shapes, and every group uses one of them:
 
-> **Name-keyed groups are case-normalized.** Environments register under both `name.lower()` and the
-> entry-point name exactly as you declared it; secret managers under `name.lower()`. Because the declared
-> name is preserved verbatim, an entry-point name with internal capitals (e.g. `AWSBatch`) is reachable
-> both as `awsbatch` and as `AWSBatch`, so a build referencing `type: AWSBatch` resolves as written.
+- **Name-keyed** (`gbserver.environments`, `gbserver.secret_managers`, `gbserver.auth_providers`,
+  `gbserver.resilience_strategies`): the entry-point *name* — which you own as the plugin author — is the
+  registration key, following the standard entry-point convention. Choose the name a user will write in
+  config to select your implementation.
+- **Capability-keyed** (`gbserver.uri_handlers`, `gbserver.asset_stores`): the class advertises its key(s)
+  by answering a method, because one class legitimately owns several keys (a URI handler serving both
+  `git` and `git+ssh`) and the resolver dispatches by that capability rather than by a chosen name. Here
+  the entry-point *name* is cosmetic — name it whatever reads well.
+
+> **Name-keyed groups are case-normalized.** A name-keyed plugin registers under both `name.lower()` and
+> the entry-point name exactly as you declared it. Because the declared name is preserved verbatim, an
+> entry-point name with internal capitals (e.g. `AWSBatch`) is reachable both as `awsbatch` and as
+> `AWSBatch`, so a build referencing `type: AWSBatch` resolves as written.
 
 ## Reserved groups (wired in later releases)
 
@@ -93,8 +102,6 @@ separately.
 
 | Group | Purpose |
 |---|---|
-| `gbserver.auth_providers` | Additional authentication providers (`AuthProvider` subclasses) |
-| `gbserver.resilience_strategies` | Additional retry / resilience strategies (`RetryStrategy` subclasses) |
 | `gbserver.builtin_steps` | Additional built-in step directories contributed as step search roots |
 | `gbcli.plugins` | Additional `gbcli` subcommands (a module exposing a `cli` click command) |
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -75,7 +75,7 @@ listed base class and provide the listed key.
 | `gbserver.asset_stores` | a `gbserver.asset.assetstore.Assetstore` subclass | the URI class(es) returned by `get_supported_uri_classes()` |
 | `gbserver.environments` | a `gbserver.environment.environment.Environment` subclass | the **entry-point name** (the environment `type`) |
 | `gbserver.secret_managers` | a `SpaceSecretManager` **or** `UserSecretManager` subclass | the **entry-point name** (the secret-manager `type`). One group feeds both families; each class is routed to the family whose base class it subclasses |
-| `gbserver.auth_providers` | a `gbserver.api.auth_providers.AuthProvider` subclass | the **entry-point name** (the provider name, matching `provider_name`) |
+| `gbserver.auth_providers` | a `gbserver.api.auth_providers.AuthProvider` subclass | the **entry-point name** (the provider name; independent of the class's `provider_name`) |
 | `gbserver.resilience_strategies` | a `gbserver.resilience.retry_handler.RetryStrategy` subclass | the **entry-point name** (the strategy config `type`) |
 | `gbcli.plugins` | a `click.Command` / `click.Group` object | the **entry-point name** (the `gb` subcommand name) |
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -69,25 +69,30 @@ lives in exactly one place. A subsystem constructs a registrar with its own regi
 These subsystems discover plugins today. Declare a class in the listed group; the class must subclass the
 listed base class and provide the listed key.
 
-| Group | Base class | Key derivation |
+| Group | Declares | Key derivation |
 |---|---|---|
-| `gbserver.uri_handlers` | `gbcommon.uri.uri.URI` | the scheme(s) returned by `get_supported_schemes()` |
-| `gbserver.asset_stores` | `gbserver.asset.assetstore.Assetstore` | the URI class(es) returned by `get_supported_uri_classes()` |
-| `gbserver.environments` | `gbserver.environment.environment.Environment` | the **entry-point name** (the environment `type`) |
-| `gbserver.secret_managers` | `SpaceSecretManager` **or** `UserSecretManager` | the **entry-point name** (the secret-manager `type`). One group feeds both families; each class is routed to the family whose base class it subclasses |
-| `gbserver.auth_providers` | `gbserver.api.auth_providers.AuthProvider` | the **entry-point name** (the provider name, matching `provider_name`) |
-| `gbserver.resilience_strategies` | `gbserver.resilience.retry_handler.RetryStrategy` | the **entry-point name** (the strategy config `type`) |
+| `gbserver.uri_handlers` | a `gbcommon.uri.uri.URI` subclass | the scheme(s) returned by `get_supported_schemes()` |
+| `gbserver.asset_stores` | a `gbserver.asset.assetstore.Assetstore` subclass | the URI class(es) returned by `get_supported_uri_classes()` |
+| `gbserver.environments` | a `gbserver.environment.environment.Environment` subclass | the **entry-point name** (the environment `type`) |
+| `gbserver.secret_managers` | a `SpaceSecretManager` **or** `UserSecretManager` subclass | the **entry-point name** (the secret-manager `type`). One group feeds both families; each class is routed to the family whose base class it subclasses |
+| `gbserver.auth_providers` | a `gbserver.api.auth_providers.AuthProvider` subclass | the **entry-point name** (the provider name, matching `provider_name`) |
+| `gbserver.resilience_strategies` | a `gbserver.resilience.retry_handler.RetryStrategy` subclass | the **entry-point name** (the strategy config `type`) |
+| `gbcli.plugins` | a `click.Command` / `click.Group` object | the **entry-point name** (the `gb` subcommand name) |
 
 There are exactly two key-derivation shapes, and every group uses one of them:
 
 - **Name-keyed** (`gbserver.environments`, `gbserver.secret_managers`, `gbserver.auth_providers`,
-  `gbserver.resilience_strategies`): the entry-point *name* — which you own as the plugin author — is the
-  registration key, following the standard entry-point convention. Choose the name a user will write in
-  config to select your implementation.
+  `gbserver.resilience_strategies`, `gbcli.plugins`): the entry-point *name* — which you own as the plugin
+  author — is the registration key, following the standard entry-point convention. Choose the name a user
+  will write in config (or type as a `gb` subcommand) to select your implementation.
 - **Capability-keyed** (`gbserver.uri_handlers`, `gbserver.asset_stores`): the class advertises its key(s)
   by answering a method, because one class legitimately owns several keys (a URI handler serving both
   `git` and `git+ssh`) and the resolver dispatches by that capability rather than by a chosen name. Here
   the entry-point *name* is cosmetic — name it whatever reads well.
+
+Most groups declare a **class** (a subclass of the listed base). `gbcli.plugins` is the exception: its
+entry point resolves directly to a `click` command **object**, since a `gb` subcommand is a command
+instance, not a class. Core-wins still applies — a plugin cannot shadow a built-in `gb` subcommand.
 
 > **Name-keyed groups are case-normalized.** A name-keyed plugin registers under both `name.lower()` and
 > the entry-point name exactly as you declared it. Because the declared name is preserved verbatim, an
@@ -103,7 +108,6 @@ separately.
 | Group | Purpose |
 |---|---|
 | `gbserver.builtin_steps` | Additional built-in step directories contributed as step search roots |
-| `gbcli.plugins` | Additional `gbcli` subcommands (a module exposing a `cli` click command) |
 
 The canonical list of group-name constants is
 [`src/gbcommon/plugins.py`](../../src/gbcommon/plugins.py) — import the constants from there rather than

--- a/src/gbcli/cli.py
+++ b/src/gbcli/cli.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any
+from typing import Any, Callable, Dict, Union
 
 import click
 
@@ -8,6 +8,10 @@ from gbcli.utils.gbconstants import GB_ENVIRONMENT_DEFAULT, gb_environment
 from gbserver.utils.logger import configure_logging
 
 CONTEXT_SETTINGS = dict(auto_envvar_prefix="GBCLI")
+
+# A registry value: either a lazy thunk that imports and returns an in-tree
+# command, or a plugin's already-loaded click command object.
+CommandSource = Union[Callable[[], click.BaseCommand], click.BaseCommand]
 
 
 class Environment:
@@ -35,7 +39,41 @@ hidden_names = [
 ]
 
 
+def _intree_command_loader(name: str) -> Callable[[], click.BaseCommand]:
+    """Build a thunk that imports the in-tree ``command_<name>`` module's ``cli``.
+
+    Registered as the registry *value* so building the registry only records the
+    command name — the (potentially heavy) command module is imported lazily, on
+    first resolution in ``get_command``, exactly as before.
+    """
+
+    def load() -> click.BaseCommand:
+        return __import__(f"gbcli.commands.command_{name}", None, None, ["cli"]).cli
+
+    return load
+
+
+def _resolve_command(value: "CommandSource") -> click.BaseCommand:
+    """Return the click command for a registry value.
+
+    In-tree values are lazy thunks (``() -> command``) that import their module
+    on demand; plugin values are the already-loaded command object. A command is
+    itself callable, so discriminate on type rather than callability.
+    """
+    if isinstance(value, click.BaseCommand):
+        return value
+    return value()
+
+
 class GraniteBuildCLI(click.Group):
+    # Subcommand name -> its command *source*. Both the in-tree
+    # ``command_<name>.py`` scan and any ``gbcli.plugins`` entry points are filed
+    # here through the shared PluginRegistrar (core-wins), like the other
+    # pluggable subsystems. An in-tree source is a lazy thunk (so building the
+    # registry never imports a command module); a plugin source is the loaded
+    # ``click`` command object. ``_resolve_command`` normalizes both to a command.
+    command_types: Dict[str, "CommandSource"] = {}
+
     def __init__(
         self,
         **attrs: Any,
@@ -49,39 +87,65 @@ class GraniteBuildCLI(click.Group):
         configureGBWorkingEnv()
         configure_logging(level="WARNING")
 
+    @classmethod
+    def _load_commands(cls) -> None:
+        """(Re)build ``command_types`` from the in-tree modules and any plugins.
+
+        Keys are discovered by scanning the ``commands`` directory (so dropping
+        in a ``command_<name>.py`` still adds a command with no wiring) and by
+        enumerating the ``gbcli.plugins`` entry-point group. Uses the shared
+        reset-and-rebuild contract; a plugin can only *add* a command, never
+        shadow a built-in (core-wins).
+        """
+        from gbcommon.plugins import (
+            GROUP_CLI_PLUGINS,
+            PluginRegistrar,
+            keys_by_name,
+            rebuild_registry,
+        )
+
+        registrar = PluginRegistrar(cls.command_types, "CLI command", keys_by_name)
+
+        def populate() -> None:
+            for filename in os.listdir(command_folder):
+                if (
+                    filename.endswith(".py")
+                    and filename.startswith("command_")
+                    and filename not in hidden_commands
+                ):
+                    name = filename[8:-3]
+                    registrar.add(_intree_command_loader(name), name)
+            # Plugin commands resolve directly to a click command object; wrap
+            # each in a thunk so every registry value is uniformly ``() -> cmd``.
+            registrar.discover_objects(GROUP_CLI_PLUGINS)
+
+        rebuild_registry(cls.command_types, populate)
+
     def list_commands(self, ctx):
-        rv = []
-        for filename in os.listdir(command_folder):
-            if (
-                filename.endswith(".py")
-                and filename.startswith("command_")
-                and filename not in hidden_commands
-            ):
-                rv.append(filename[8:-3])
-        rv.sort()
-        return rv
+        self._load_commands()
+        # A plugin could file a name that collides with a hidden built-in; keep
+        # list_commands and get_command consistent by hiding it in both.
+        return sorted(n for n in self.command_types if n not in hidden_names)
 
     def get_command(self, ctx, name):
+        self._load_commands()
+        if name in hidden_names:
+            return None
+        loader = self.command_types.get(name)
+        if loader is None:
+            return None
+        env = gb_environment()
+        if env != GB_ENVIRONMENT_DEFAULT:
+            click.echo(f"Warning: GB_ENVIRONMENT is set to {env}", err=True)
         try:
-            env = gb_environment()
-            if env != GB_ENVIRONMENT_DEFAULT:
-                click.echo(f"Warning: GB_ENVIRONMENT is set to {env}", err=True)
-            if name in hidden_names:
-                return
-            mod = __import__(f"gbcli.commands.command_{name}", None, None, ["cli"])
+            return _resolve_command(loader)
         except ImportError as e:
-            invalid_command = str(e).startswith(
-                "No module named 'gbcli.commands.command_"
-            )
-            if invalid_command:
-                return
             message = (
                 f"❌ Some dependencies required by the command '{name}' may be missing."
                 + f"\nPlease reinstall the 'gb' CLI.\nDetails: {e}"
             )
             click.echo(message=message, err=True)
             sys.exit(1)
-        return mod.cli
 
 
 @click.command(cls=GraniteBuildCLI, context_settings=CONTEXT_SETTINGS)

--- a/src/gbcli/cli.py
+++ b/src/gbcli/cli.py
@@ -53,6 +53,25 @@ def _intree_command_loader(name: str) -> Callable[[], click.Command]:
     return load
 
 
+_gb_environment_warned = False
+
+
+def _warn_gb_environment_once() -> None:
+    """Warn (at most once per process) when GB_ENVIRONMENT is non-default.
+
+    click calls ``get_command`` repeatedly while rendering a single invocation
+    (once per listed command for ``--help``), so warning inline there would
+    print the same line a dozen times; gate it on a module-level flag.
+    """
+    global _gb_environment_warned
+    if _gb_environment_warned:
+        return
+    env = gb_environment()
+    if env != GB_ENVIRONMENT_DEFAULT:
+        click.echo(f"Warning: GB_ENVIRONMENT is set to {env}", err=True)
+    _gb_environment_warned = True
+
+
 def _resolve_command(value: "CommandSource") -> click.Command:
     """Return the click command for a registry value.
 
@@ -88,7 +107,7 @@ class GraniteBuildCLI(click.Group):
         configure_logging(level="WARNING")
 
     @classmethod
-    def _load_commands(cls) -> None:
+    def _load_commands(cls, force: bool = False) -> None:
         """(Re)build ``command_types`` from the in-tree modules and any plugins.
 
         Keys are discovered by scanning the ``commands`` directory (so dropping
@@ -96,7 +115,15 @@ class GraniteBuildCLI(click.Group):
         enumerating the ``gbcli.plugins`` entry-point group. Uses the shared
         reset-and-rebuild contract; a plugin can only *add* a command, never
         shadow a built-in (core-wins).
+
+        A **no-op once the registry is populated** so the repeated
+        ``get_command`` / ``list_commands`` calls click makes while rendering a
+        single invocation don't each re-scan the directory; pass ``force=True``
+        to rebuild (tests). The command set is fixed for the life of a ``gb``
+        process, so building once is correct.
         """
+        if cls.command_types and not force:
+            return
         from gbcommon.plugins import (
             GROUP_CLI_PLUGINS,
             PluginRegistrar,
@@ -117,8 +144,14 @@ class GraniteBuildCLI(click.Group):
                     registrar.add(_intree_command_loader(name), name)
             # Plugin commands resolve directly to a click command object (not a
             # thunk); the registry therefore holds a mix of thunks (in-tree) and
-            # command objects (plugins), which _resolve_command normalizes.
-            registrar.discover_objects(GROUP_CLI_PLUGINS)
+            # command objects (plugins), which _resolve_command normalizes. The
+            # predicate rejects an entry point that points at something other than
+            # a click command, so _resolve_command never mistakes a non-command
+            # for a thunk and calls it.
+            registrar.discover_objects(
+                GROUP_CLI_PLUGINS,
+                predicate=lambda obj: isinstance(obj, click.Command),
+            )
 
         rebuild_registry(cls.command_types, populate)
 
@@ -139,9 +172,7 @@ class GraniteBuildCLI(click.Group):
         loader = self.command_types.get(name)
         if loader is None:
             return None
-        env = gb_environment()
-        if env != GB_ENVIRONMENT_DEFAULT:
-            click.echo(f"Warning: GB_ENVIRONMENT is set to {env}", err=True)
+        _warn_gb_environment_once()
         try:
             return _resolve_command(loader)
         except ImportError as e:

--- a/src/gbcli/cli.py
+++ b/src/gbcli/cli.py
@@ -167,7 +167,10 @@ class GraniteBuildCLI(click.Group):
 
     def get_command(self, ctx, name):
         self._load_commands()
-        if name in hidden_names:
+        # Match hidden names case-insensitively: keys_by_name files a plugin
+        # under both its verbatim and lowercase forms, so a case-sensitive check
+        # would let `gb Dataset` slip past the `dataset` guard.
+        if name.lower() in hidden_names:
             return None
         loader = self.command_types.get(name)
         if loader is None:

--- a/src/gbcli/cli.py
+++ b/src/gbcli/cli.py
@@ -11,7 +11,7 @@ CONTEXT_SETTINGS = dict(auto_envvar_prefix="GBCLI")
 
 # A registry value: either a lazy thunk that imports and returns an in-tree
 # command, or a plugin's already-loaded click command object.
-CommandSource = Union[Callable[[], click.BaseCommand], click.BaseCommand]
+CommandSource = Union[Callable[[], click.Command], click.Command]
 
 
 class Environment:
@@ -39,7 +39,7 @@ hidden_names = [
 ]
 
 
-def _intree_command_loader(name: str) -> Callable[[], click.BaseCommand]:
+def _intree_command_loader(name: str) -> Callable[[], click.Command]:
     """Build a thunk that imports the in-tree ``command_<name>`` module's ``cli``.
 
     Registered as the registry *value* so building the registry only records the
@@ -47,20 +47,20 @@ def _intree_command_loader(name: str) -> Callable[[], click.BaseCommand]:
     first resolution in ``get_command``, exactly as before.
     """
 
-    def load() -> click.BaseCommand:
+    def load() -> click.Command:
         return __import__(f"gbcli.commands.command_{name}", None, None, ["cli"]).cli
 
     return load
 
 
-def _resolve_command(value: "CommandSource") -> click.BaseCommand:
+def _resolve_command(value: "CommandSource") -> click.Command:
     """Return the click command for a registry value.
 
     In-tree values are lazy thunks (``() -> command``) that import their module
     on demand; plugin values are the already-loaded command object. A command is
     itself callable, so discriminate on type rather than callability.
     """
-    if isinstance(value, click.BaseCommand):
+    if isinstance(value, click.Command):
         return value
     return value()
 
@@ -115,17 +115,22 @@ class GraniteBuildCLI(click.Group):
                 ):
                     name = filename[8:-3]
                     registrar.add(_intree_command_loader(name), name)
-            # Plugin commands resolve directly to a click command object; wrap
-            # each in a thunk so every registry value is uniformly ``() -> cmd``.
+            # Plugin commands resolve directly to a click command object (not a
+            # thunk); the registry therefore holds a mix of thunks (in-tree) and
+            # command objects (plugins), which _resolve_command normalizes.
             registrar.discover_objects(GROUP_CLI_PLUGINS)
 
         rebuild_registry(cls.command_types, populate)
 
     def list_commands(self, ctx):
         self._load_commands()
-        # A plugin could file a name that collides with a hidden built-in; keep
-        # list_commands and get_command consistent by hiding it in both.
-        return sorted(n for n in self.command_types if n not in hidden_names)
+        # command_types may hold a name under both its lowercase and verbatim
+        # forms (keys_by_name files both, e.g. a plugin command `MyCmd` under
+        # `mycmd` and `MyCmd`), so list each command once under its canonical
+        # lowercase name. Both keys still resolve in get_command. Also hide any
+        # name shadowing a hidden built-in, to stay consistent with get_command.
+        names = {n.lower() for n in self.command_types}
+        return sorted(n for n in names if n not in hidden_names)
 
     def get_command(self, ctx, name):
         self._load_commands()

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -277,7 +277,9 @@ class PluginRegistrar:
                     e,
                 )
 
-    def discover_objects(self, group: str) -> None:
+    def discover_objects(
+        self, group: str, predicate: Optional[Callable[[Any], bool]] = None
+    ) -> None:
         """Run an entry-point plugin pass for ``group`` where the value is an object.
 
         The counterpart to :meth:`discover` for subsystems whose registry value
@@ -286,8 +288,25 @@ class PluginRegistrar:
         each loaded object through :meth:`add` under the entry-point ``name`` and
         applies the same core-wins rule and per-entry guard as :meth:`discover`.
         Use it with a name-deriving ``keys_of`` (e.g. :func:`keys_by_name`).
+
+        ``predicate`` optionally validates each loaded object before it is filed.
+        An object that fails it is skipped with a WARNING — the object-valued
+        analogue of :func:`iter_entry_point_classes`' subclass check, so a plugin
+        that points its entry point at the wrong kind of object (e.g. a function
+        where a ``click`` command is required) is rejected rather than filed and
+        mis-handled downstream.
         """
         for name, obj in iter_entry_point_objects(group):
+            if predicate is not None and not predicate(obj):
+                logger.warning(
+                    "Ignoring plugin entry point %s=%s (group %s): "
+                    "not a valid %s implementation",
+                    name,
+                    _value_label(obj),
+                    group,
+                    self.label,
+                )
+                continue
             try:
                 self.add(obj, name)
             except Exception as e:

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -314,9 +314,15 @@ def _value_label(value: Any) -> Any:
 
     Values are usually classes (``__name__``), but some subsystems file other
     objects — a ``click`` command has ``name`` instead, and a thunk may have
-    neither — so fall back through both before ``repr``.
+    neither — so fall back through both before ``repr``. Uses ``is not None``
+    rather than truthiness so a present-but-empty label (e.g. ``name=""``) is
+    kept as-is instead of being treated as missing.
     """
-    return getattr(value, "__name__", None) or getattr(value, "name", None) or value
+    for attr in ("__name__", "name"):
+        label = getattr(value, attr, None)
+        if label is not None:
+            return label
+    return value
 
 
 def rebuild_registry(

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -36,7 +36,17 @@ loaders already use.
 
 from collections.abc import Hashable
 from importlib.metadata import EntryPoint, entry_points
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Type,
+)
 
 from gbserver.utils.logger import get_logger
 
@@ -196,11 +206,16 @@ class PluginRegistrar:
 
     def __init__(
         self,
-        registry: Dict[Hashable, Type],
+        registry: MutableMapping[Any, Type],
         label: str,
         keys_of: KeysOf,
     ) -> None:
         """``registry`` is the subsystem's own dict; mutated in place.
+
+        Typed ``MutableMapping[Any, Type]`` rather than ``Dict[Hashable, Type]``
+        so a subsystem can pass its own concretely-keyed registry (e.g.
+        ``Dict[str, Type]`` or the asset store's ``Dict[type, Type]``) without a
+        variance error — ``dict`` is invariant in its key type.
 
         ``label`` names the key in log messages (e.g. ``"URI scheme"``).
         ``keys_of(cls, name)`` yields the registry keys ``cls`` belongs under.
@@ -272,13 +287,59 @@ def _key_label(key: Hashable) -> Any:
     return getattr(key, "__name__", key)
 
 
+def rebuild_registry(
+    registry: MutableMapping[Any, Any], populate: Callable[[], None]
+) -> None:
+    """Clear ``registry`` in place, then repopulate it via ``populate``.
+
+    The single reset-and-rebuild contract shared by every subsystem loader, so
+    the reload-safety fix does not have to be re-derived per subsystem.
+
+    The clear is **in place** (``dict.clear()``), never a rebind to a fresh
+    ``{}``: the registries are long-lived ``ClassVar`` dicts and callers may hold
+    a reference to the dict object, so rebinding would strand those references on
+    the old, now-stale dict.
+
+    Rebuilding from scratch (rather than adding on top of whatever is already
+    there) is what makes a loader idempotent and reload-safe. Without it, a
+    re-run after ``importlib.reload`` of a subsystem module leaves the registry
+    pointing at the pre-reload class: the reloaded module defines a *new* class
+    object, but :meth:`PluginRegistrar.add`'s core-wins guard
+    (``existing is not cls``) sees the key already bound to the stale class and
+    refuses to replace it. Clearing first lets the in-tree scan re-file the
+    current classes, and the plugin ``discover`` pass then adds on top with
+    core-wins protecting the freshly-registered built-ins.
+
+    ``populate`` does the subsystem's in-tree scan (``registrar.add(...)``)
+    followed by its ``registrar.discover(group, base_class)`` plugin pass.
+    """
+    registry.clear()
+    populate()
+
+
 # ---------------------------------------------------------------------------
-# Ready-made ``keys_of`` callbacks for the common key-derivation shapes.
+# Ready-made ``keys_of`` callbacks — the two supported key-derivation shapes.
 #
-# A subsystem picks one of these when constructing its PluginRegistrar instead
-# of re-spelling the same lambda. They cover the two ways a key is derived:
-# from the discovered *name* (module name in-tree / entry-point name), or by
-# asking the class itself via one of its methods.
+# There are exactly two ways a subsystem derives a registry key, and every
+# subsystem uses one of them:
+#
+# * ``keys_by_name`` — the key **is the name** (the module name in-tree, the
+#   entry-point name for a plugin). This is the industry-standard entry-point
+#   convention (cf. the Python packaging guide and OpenStack stevedore, where
+#   the entry-point name, owned by the plugin author, is the lookup key). Use it
+#   whenever an implementation is selected by a name a user writes in config
+#   (environment ``type``, secret-manager ``type``, auth provider, retry
+#   strategy ``type``).
+#
+# * ``keys_from_method`` — the class **advertises its capability keys** by
+#   answering a method. Use it when the key is a capability the class dispatches
+#   on rather than a chosen name, and one class may own several keys: URI
+#   handlers key on the scheme(s) they serve (``git``, ``git+ssh``) and asset
+#   stores on the URI class(es) they back. The resolver looks up by that
+#   capability, not by plugin name, so name-as-key does not apply here.
+#
+# A subsystem picks one when constructing its PluginRegistrar instead of
+# re-spelling the same lambda.
 # ---------------------------------------------------------------------------
 
 
@@ -289,21 +350,22 @@ def _require_name(name: Optional[str]) -> str:
     return name
 
 
-def keys_by_name_lower(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
-    """Key = the name, lowercased. (secret managers)"""
-    return (_require_name(name).lower(),)
+def keys_by_name(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
+    """Keys = the name lowercased *and* the name exactly as declared.
 
-
-def keys_by_name_cased(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
-    """Keys = the name lowercased *and* the name exactly as declared. (environments)
-
-    The declared name is preserved verbatim so a plugin's own casing stays
-    reachable: an entry point ``AWSBatch`` registers under both ``awsbatch`` and
-    ``AWSBatch``, so a build referencing ``type: AWSBatch`` resolves. (An earlier
-    version used ``str.capitalize()``, which lowercases every character after the
-    first and left internal capitals unreachable.) In-tree names are already a
-    single ``str.capitalize()`` (module ``k8s`` -> ``K8s``), so this keeps the
+    The canonical name-as-key helper for every name-keyed subsystem (secret
+    managers, environments, auth providers, retry strategies). The declared name
+    is preserved verbatim so a plugin's own casing stays reachable: an entry
+    point ``AWSBatch`` registers under both ``awsbatch`` and ``AWSBatch``, so a
+    build referencing ``type: AWSBatch`` resolves. (An earlier version used
+    ``str.capitalize()``, which lowercases every character after the first and
+    left internal capitals unreachable.) In-tree names are already a single
+    ``str.capitalize()`` (module ``k8s`` -> ``K8s``), so this keeps the
     historical ``{k8s, K8s}`` keys unchanged while no longer mangling plugins.
+
+    Filing both the lowercased and verbatim forms is a superset of a
+    lowercase-only key: a caller that lowercases before lookup is unaffected,
+    and one that passes the declared casing now also resolves.
     """
     resolved = _require_name(name)
     lowered = resolved.lower()
@@ -312,7 +374,7 @@ def keys_by_name_cased(_cls: Type, name: Optional[str]) -> Iterable[Hashable]:
 
 
 def keys_from_method(method_name: str) -> KeysOf:
-    """Build a ``keys_of`` that asks the class for its keys via ``method_name``.
+    """Build a ``keys_of`` that asks the class for its capability keys via ``method_name``.
 
     Used when the registration keys come from the class rather than its name —
     e.g. ``get_supported_schemes`` (URI) or ``get_supported_uri_classes``

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -227,14 +227,33 @@ class PluginRegistrar:
     def add(self, cls: Type, name: Optional[str] = None) -> None:
         """Register ``cls`` under each of its keys, honoring core-wins.
 
+        Collision is decided **once for the whole class**, not per key: if *any*
+        of its keys is already bound to a different value, the entire
+        registration is refused. ``keys_by_name`` files one class under several
+        key strings (a lowercase alias plus the verbatim name), so a per-key
+        check would let a plugin whose lowercase key collides with a built-in
+        still slip in under its case-variant key (e.g. built-in ``build`` +
+        plugin ``Build``) — shadowing the built-in under a different case and
+        defeating core-wins. All-or-nothing closes that hole.
+
         A class that yields *no* keys (e.g. a discovered handler that forgot to
         override its key method and inherits the base ``[]``) is filed nowhere
         and would silently never resolve; warn so its author gets a diagnostic
         rather than a handler that is quietly ignored at runtime.
         """
-        produced_key = False
-        for key in self.keys_of(cls, name):
-            produced_key = True
+        keys = list(self.keys_of(cls, name))
+        if not keys:
+            logger.warning(
+                "%s: %s produced no keys and was not registered; "
+                "check that its key derivation is implemented",
+                self.label,
+                _value_label(cls),
+            )
+            return
+
+        # Core wins: if any key is already owned by a different value, refuse the
+        # whole registration so the newcomer can't shadow it under a sibling key.
+        for key in keys:
             existing = self.registry.get(key)
             if existing is not None and existing is not cls:
                 logger.warning(
@@ -244,15 +263,10 @@ class PluginRegistrar:
                     _value_label(existing),
                     _value_label(cls),
                 )
-                continue
+                return
+
+        for key in keys:
             self.registry[key] = cls
-        if not produced_key:
-            logger.warning(
-                "%s: %s produced no keys and was not registered; "
-                "check that its key derivation is implemented",
-                self.label,
-                _value_label(cls),
-            )
 
     def discover(self, group: str, base_class: Type) -> None:
         """Run the entry-point plugin pass for ``group`` into this registry.

--- a/src/gbcommon/plugins.py
+++ b/src/gbcommon/plugins.py
@@ -241,8 +241,8 @@ class PluginRegistrar:
                     "%s %r already registered to %s; ignoring %s",
                     self.label,
                     _key_label(key),
-                    existing.__name__,
-                    cls.__name__,
+                    _value_label(existing),
+                    _value_label(cls),
                 )
                 continue
             self.registry[key] = cls
@@ -251,7 +251,7 @@ class PluginRegistrar:
                 "%s: %s produced no keys and was not registered; "
                 "check that its key derivation is implemented",
                 self.label,
-                getattr(cls, "__name__", cls),
+                _value_label(cls),
             )
 
     def discover(self, group: str, base_class: Type) -> None:
@@ -272,7 +272,29 @@ class PluginRegistrar:
                 logger.error(
                     "Error registering plugin %s=%s (group %s): %s",
                     name,
-                    getattr(cls, "__name__", cls),
+                    _value_label(cls),
+                    group,
+                    e,
+                )
+
+    def discover_objects(self, group: str) -> None:
+        """Run an entry-point plugin pass for ``group`` where the value is an object.
+
+        The counterpart to :meth:`discover` for subsystems whose registry value
+        is not a class subclassing a common base but an object keyed by name —
+        the CLI, for instance, registers ``click`` command objects. It routes
+        each loaded object through :meth:`add` under the entry-point ``name`` and
+        applies the same core-wins rule and per-entry guard as :meth:`discover`.
+        Use it with a name-deriving ``keys_of`` (e.g. :func:`keys_by_name`).
+        """
+        for name, obj in iter_entry_point_objects(group):
+            try:
+                self.add(obj, name)
+            except Exception as e:
+                logger.error(
+                    "Error registering plugin %s=%s (group %s): %s",
+                    name,
+                    _value_label(obj),
                     group,
                     e,
                 )
@@ -285,6 +307,16 @@ def _key_label(key: Hashable) -> Any:
     URI *class*; show its name rather than its ``repr``.
     """
     return getattr(key, "__name__", key)
+
+
+def _value_label(value: Any) -> Any:
+    """Human-readable form of a registry *value* for log messages.
+
+    Values are usually classes (``__name__``), but some subsystems file other
+    objects — a ``click`` command has ``name`` instead, and a thunk may have
+    neither — so fall back through both before ``repr``.
+    """
+    return getattr(value, "__name__", None) or getattr(value, "name", None) or value
 
 
 def rebuild_registry(

--- a/src/gbcommon/uri/uri.py
+++ b/src/gbcommon/uri/uri.py
@@ -88,26 +88,19 @@ class URI(ABC):
     def _load_urihandlers() -> None:
         """Discover and register every URI handler, rebuilding the registry.
 
-        Rebuilds ``URI.uri_handler_classes`` from scratch on each call: the
-        registry is cleared first so the method is idempotent and reload-safe.
-        Without the clear, the ``PluginRegistrar`` core-wins guard would keep a
-        stale prior registration and refuse to replace it — so a re-run after
-        ``importlib.reload(gbcommon.uri.<scheme>)`` (as the test conftest does)
-        would leave the registry pointing at the pre-reload class, distinct from
-        the module's current one. The in-tree scan repopulates built-ins with
-        their current classes; the plugin ``discover`` pass then adds external
-        handlers, with core-wins still protecting the freshly-registered
+        Rebuilds ``URI.uri_handler_classes`` from scratch on each call via the
+        shared :func:`~gbcommon.plugins.rebuild_registry` contract, so the method
+        is idempotent and reload-safe: the in-tree scan repopulates built-ins
+        with their current classes and the plugin ``discover`` pass adds external
+        handlers on top, with core-wins protecting the freshly-registered
         built-ins.
         """
         from gbcommon.plugins import (
             GROUP_URI_HANDLERS,
             PluginRegistrar,
             keys_from_method,
+            rebuild_registry,
         )
-
-        # Rebuild from scratch (in place, preserving any held reference to the
-        # dict) so a reload's new classes win over stale registrations.
-        URI.uri_handler_classes.clear()
 
         # Files each URI handler under the scheme(s) it advertises. Both the
         # in-tree scan and the plugin pass register through this one registrar.
@@ -118,43 +111,46 @@ class URI(ABC):
         )
         package_dir = os.path.dirname(__file__)
 
-        for filename in os.listdir(package_dir):
-            if (
-                filename.endswith(".py")
-                and filename != "__init__.py"
-                and filename != "utils.py"
-                and filename != os.path.basename(__file__)
-            ):
-                urihandler_modulename = filename[:-3]
-                urihandler_name = urihandler_modulename.capitalize() + "URI"
-                try:
-                    module = importlib.import_module(
-                        f".{urihandler_modulename}", package="gbcommon.uri"
-                    )
-                    if hasattr(module, urihandler_name):
-                        handler_class = getattr(module, urihandler_name)
-                        if isinstance(handler_class, type) and issubclass(
-                            handler_class, URI
-                        ):
-                            registrar.add(handler_class)
+        def populate() -> None:
+            for filename in os.listdir(package_dir):
+                if (
+                    filename.endswith(".py")
+                    and filename != "__init__.py"
+                    and filename != "utils.py"
+                    and filename != os.path.basename(__file__)
+                ):
+                    urihandler_modulename = filename[:-3]
+                    urihandler_name = urihandler_modulename.capitalize() + "URI"
+                    try:
+                        module = importlib.import_module(
+                            f".{urihandler_modulename}", package="gbcommon.uri"
+                        )
+                        if hasattr(module, urihandler_name):
+                            handler_class = getattr(module, urihandler_name)
+                            if isinstance(handler_class, type) and issubclass(
+                                handler_class, URI
+                            ):
+                                registrar.add(handler_class)
+                            else:
+                                logger.error(
+                                    f"Ignoring {urihandler_name} since it is not a subclass or URI class"
+                                )
                         else:
                             logger.error(
-                                f"Ignoring {urihandler_name} since it is not a subclass or URI class"
+                                f"Module {urihandler_modulename} does not contain expected uri_hander class {urihandler_name}."
                             )
-                    else:
+                    except ImportError as e:
+                        logger.error(f"Error importing module {urihandler_name}: {e}")
+                    except Exception as e:
                         logger.error(
-                            f"Module {urihandler_modulename} does not contain expected uri_hander class {urihandler_name}."
+                            f"Error loading uri handler from {urihandler_name}: {e}"
                         )
-                except ImportError as e:
-                    logger.error(f"Error importing module {urihandler_name}: {e}")
-                except Exception as e:
-                    logger.error(
-                        f"Error loading uri handler from {urihandler_name}: {e}"
-                    )
 
-        # Discover URI handlers shipped by separately-installed plugin packages.
-        # Runs after the in-tree scan so the core-wins rule protects built-ins.
-        registrar.discover(GROUP_URI_HANDLERS, URI)
+            # Discover URI handlers shipped by separately-installed plugin packages.
+            # Runs after the in-tree scan so the core-wins rule protects built-ins.
+            registrar.discover(GROUP_URI_HANDLERS, URI)
+
+        rebuild_registry(URI.uri_handler_classes, populate)
 
     @classmethod
     def get_uri_class(

--- a/src/gbserver/api/auth_providers.py
+++ b/src/gbserver/api/auth_providers.py
@@ -254,36 +254,102 @@ class IBMidAuthProvider(AuthProvider):
 
 # ---------------------------------------------------------------------------
 # Provider registry
+#
+# ``provider_types`` maps a provider name to its class. Both the in-tree
+# built-ins and any entry-point plugins (group ``gbserver.auth_providers``) are
+# filed through the shared ``PluginRegistrar`` under the ``keys_by_name`` rule,
+# exactly like the other name-keyed subsystems. The registry drives the *class
+# lookup*; ordering and per-provider construction stay in ``build_provider_list``
+# (see below), because an ``auth_mode`` selects an ordered *set* of providers and
+# some (IBMid) need constructor arguments.
 # ---------------------------------------------------------------------------
 
+# Provider name -> class. Populated by ``_load_auth_providers`` (in-tree scan +
+# entry-point plugin pass), keyed under both lowercased and verbatim names.
+provider_types: dict = {}
 
-def build_provider_list(auth_mode: str) -> List[AuthProvider]:
-    """Build the list of active providers based on *auth_mode*.
+# The built-in providers, registered by their public name. Kept as an explicit
+# list rather than a directory scan: both live in this module.
+_BUILTIN_PROVIDERS = [
+    ("github", GitHubAuthProvider),
+    ("ibmid", IBMidAuthProvider),
+]
 
-    Provider order matters: JWT-based providers are checked first so that
-    ``identify_token`` can distinguish token formats before falling through
-    to the opaque-token provider (GitHub).
+# auth_mode -> ordered provider names. Order matters: JWT-based providers are
+# listed first so ``identify_token`` can claim JWT-shaped tokens before the
+# opaque-token provider (GitHub) sees them. Ordering lives here, never in
+# ``provider_types`` iteration order, so registration order carries no auth
+# semantics.
+_AUTH_MODES = {
+    "github": ["github"],
+    "ibmid": ["ibmid"],
+    "multi": ["ibmid", "github"],
+}
+
+
+def _load_auth_providers() -> None:
+    """(Re)build ``provider_types`` from the built-ins and any plugins.
+
+    Uses the shared reset-and-rebuild contract, so the registry is reload-safe
+    and a plugin can only *add* a provider, never shadow a built-in (core-wins).
     """
-    from gbserver.types.constants import (
-        GBSERVER_IBMID_CLIENT_ID,
-        GBSERVER_IBMID_ISSUER,
-        GBSERVER_IBMID_JWKS_URI,
+    from gbcommon.plugins import (
+        GROUP_AUTH_PROVIDERS,
+        PluginRegistrar,
+        keys_by_name,
+        rebuild_registry,
     )
 
-    def _make_ibmid():
-        return IBMidAuthProvider(
+    registrar = PluginRegistrar(provider_types, "Auth provider", keys_by_name)
+
+    def populate() -> None:
+        for name, cls in _BUILTIN_PROVIDERS:
+            registrar.add(cls, name)
+        registrar.discover(GROUP_AUTH_PROVIDERS, AuthProvider)
+
+    rebuild_registry(provider_types, populate)
+
+
+def _make_provider(name: str) -> AuthProvider:
+    """Instantiate the registered provider *name*, supplying its constructor args.
+
+    Construction is kept out of the registry (which holds classes): IBMid needs
+    its issuer/JWKS/client-id from configuration, and other providers may need
+    their own arguments. Plugin providers with no special arguments construct
+    with defaults.
+    """
+    cls = provider_types[name]
+    if name == "ibmid":
+        from gbserver.types.constants import (
+            GBSERVER_IBMID_CLIENT_ID,
+            GBSERVER_IBMID_ISSUER,
+            GBSERVER_IBMID_JWKS_URI,
+        )
+
+        return cls(
             issuer=GBSERVER_IBMID_ISSUER,
             jwks_uri=GBSERVER_IBMID_JWKS_URI,
             client_id=GBSERVER_IBMID_CLIENT_ID,
         )
+    return cls()
 
-    if auth_mode == "github":
-        return [GitHubAuthProvider()]
-    if auth_mode == "ibmid":
-        return [_make_ibmid()]
-    if auth_mode == "multi":
-        return [_make_ibmid(), GitHubAuthProvider()]
 
-    # Unknown mode – default to GitHub for backward compatibility
-    logger.warning("Unknown GBSERVER_AUTH_MODE '%s', falling back to github", auth_mode)
-    return [GitHubAuthProvider()]
+def build_provider_list(auth_mode: str) -> List[AuthProvider]:
+    """Build the ordered list of active providers for *auth_mode*.
+
+    Provider order matters: JWT-based providers are checked first so that
+    ``identify_token`` can distinguish token formats before falling through
+    to the opaque-token provider (GitHub). The ordering comes from
+    :data:`_AUTH_MODES`; the class for each name comes from the registry.
+    """
+    _load_auth_providers()
+
+    names = _AUTH_MODES.get(auth_mode)
+    if names is None:
+        # Unknown mode – default to GitHub for backward compatibility.
+        logger.warning(
+            "Unknown GBSERVER_AUTH_MODE '%s', falling back to github", auth_mode
+        )
+        names = ["github"]
+
+    return [_make_provider(name) for name in names]

--- a/src/gbserver/api/auth_providers.py
+++ b/src/gbserver/api/auth_providers.py
@@ -338,22 +338,24 @@ def _make_provider(name: str) -> Optional[AuthProvider]:
     if cls is None:
         logger.warning("Auth provider '%s' is not registered; skipping", name)
         return None
-    if name == "ibmid":
-        from gbserver.types.constants import (
-            GBSERVER_IBMID_CLIENT_ID,
-            GBSERVER_IBMID_ISSUER,
-            GBSERVER_IBMID_JWKS_URI,
-        )
-
-        return cls(
-            issuer=GBSERVER_IBMID_ISSUER,
-            jwks_uri=GBSERVER_IBMID_JWKS_URI,
-            client_id=GBSERVER_IBMID_CLIENT_ID,
-        )
-    # Other providers construct with no args. A provider needing constructor
-    # args has no arg source here yet (only the built-in modes are selectable),
-    # so degrade gracefully rather than raise on the request path.
+    # Construction can fail (e.g. IBMid's PyJWKClient with a misconfigured JWKS
+    # URI); degrade gracefully rather than raise on the request path, matching
+    # the None-on-missing contract above.
     try:
+        if name == "ibmid":
+            from gbserver.types.constants import (
+                GBSERVER_IBMID_CLIENT_ID,
+                GBSERVER_IBMID_ISSUER,
+                GBSERVER_IBMID_JWKS_URI,
+            )
+
+            return cls(
+                issuer=GBSERVER_IBMID_ISSUER,
+                jwks_uri=GBSERVER_IBMID_JWKS_URI,
+                client_id=GBSERVER_IBMID_CLIENT_ID,
+            )
+        # Other providers construct with no args. A provider needing constructor
+        # args has no arg source here yet (only the built-in modes are selectable).
         return cls()
     except Exception as e:
         logger.warning("Could not construct auth provider '%s': %s", name, e)

--- a/src/gbserver/api/auth_providers.py
+++ b/src/gbserver/api/auth_providers.py
@@ -280,6 +280,13 @@ _BUILTIN_PROVIDERS = [
 # opaque-token provider (GitHub) sees them. Ordering lives here, never in
 # ``provider_types`` iteration order, so registration order carries no auth
 # semantics.
+#
+# NOTE: this map is intentionally hardcoded to the built-in modes for now. A
+# plugin AuthProvider is discovered into ``provider_types`` but is not yet
+# selectable, because no ``auth_mode`` references it. Making plugin providers
+# reachable (e.g. letting GBSERVER_AUTH_MODE name providers directly) is a
+# deliberate follow-up; the registry lookup below is already provider-name
+# driven, so that extension needs no change here.
 _AUTH_MODES = {
     "github": ["github"],
     "ibmid": ["ibmid"],
@@ -310,15 +317,21 @@ def _load_auth_providers() -> None:
     rebuild_registry(provider_types, populate)
 
 
-def _make_provider(name: str) -> AuthProvider:
+def _make_provider(name: str) -> Optional[AuthProvider]:
     """Instantiate the registered provider *name*, supplying its constructor args.
 
     Construction is kept out of the registry (which holds classes): IBMid needs
     its issuer/JWKS/client-id from configuration, and other providers may need
     their own arguments. Plugin providers with no special arguments construct
     with defaults.
+
+    Returns ``None`` (with a warning) if *name* is not in the registry, so a
+    misconfigured mode degrades gracefully rather than raising mid-request.
     """
-    cls = provider_types[name]
+    cls = provider_types.get(name)
+    if cls is None:
+        logger.warning("Auth provider '%s' is not registered; skipping", name)
+        return None
     if name == "ibmid":
         from gbserver.types.constants import (
             GBSERVER_IBMID_CLIENT_ID,
@@ -352,4 +365,12 @@ def build_provider_list(auth_mode: str) -> List[AuthProvider]:
         )
         names = ["github"]
 
-    return [_make_provider(name) for name in names]
+    providers = [p for p in (_make_provider(name) for name in names) if p is not None]
+    if not providers:
+        # Every configured name was unregistered; fall back so auth still works.
+        logger.warning(
+            "No auth providers could be built for mode '%s'; falling back to github",
+            auth_mode,
+        )
+        providers = [GitHubAuthProvider()]
+    return providers

--- a/src/gbserver/api/auth_providers.py
+++ b/src/gbserver/api/auth_providers.py
@@ -294,12 +294,18 @@ _AUTH_MODES = {
 }
 
 
-def _load_auth_providers() -> None:
+def _load_auth_providers(force: bool = False) -> None:
     """(Re)build ``provider_types`` from the built-ins and any plugins.
 
-    Uses the shared reset-and-rebuild contract, so the registry is reload-safe
+    ``build_provider_list`` is on the per-request auth path, so this is a
+    **no-op once the registry is populated** — the built-ins and the installed
+    plugin set do not change under a running server. Pass ``force=True`` to
+    rebuild anyway (tests that reload modules). When it does (re)build it goes
+    through the shared reset-and-rebuild contract, so the registry is reload-safe
     and a plugin can only *add* a provider, never shadow a built-in (core-wins).
     """
+    if provider_types and not force:
+        return
     from gbcommon.plugins import (
         GROUP_AUTH_PROVIDERS,
         PluginRegistrar,

--- a/src/gbserver/api/auth_providers.py
+++ b/src/gbserver/api/auth_providers.py
@@ -350,7 +350,14 @@ def _make_provider(name: str) -> Optional[AuthProvider]:
             jwks_uri=GBSERVER_IBMID_JWKS_URI,
             client_id=GBSERVER_IBMID_CLIENT_ID,
         )
-    return cls()
+    # Other providers construct with no args. A provider needing constructor
+    # args has no arg source here yet (only the built-in modes are selectable),
+    # so degrade gracefully rather than raise on the request path.
+    try:
+        return cls()
+    except Exception as e:
+        logger.warning("Could not construct auth provider '%s': %s", name, e)
+        return None
 
 
 def build_provider_list(auth_mode: str) -> List[AuthProvider]:

--- a/src/gbserver/asset/assetstore.py
+++ b/src/gbserver/asset/assetstore.py
@@ -132,15 +132,18 @@ class Assetstore(ABC):
         return assetstore
 
     @classmethod
-    def _load_assetstore_types(cls):
-        """Discover and register every asset store, rebuilding the registry.
+    def _load_assetstore_types(cls, force: bool = False):
+        """Discover and register every asset store.
 
-        Rebuilds ``cls.assetstore_types`` from scratch on each call via the
-        shared :func:`~gbcommon.plugins.rebuild_registry` contract, so the method
-        is idempotent and reload-safe (see that helper for why clearing first
-        matters). Invoked once at package import; the entry-point group is cached
-        so re-running is cheap.
+        A **no-op once the registry is populated** (the built-in and installed
+        plugin set is fixed for the process); pass ``force=True`` to rebuild
+        (tests that reload modules). When it does (re)build it goes through the
+        shared :func:`~gbcommon.plugins.rebuild_registry` contract, so it is
+        reload-safe (see that helper for why clearing first matters). This keeps
+        the loader's cheap-path guard consistent with the secret-manager loader.
         """
+        if cls.assetstore_types and not force:
+            return
         from gbcommon.plugins import (
             GROUP_ASSET_STORES,
             PluginRegistrar,

--- a/src/gbserver/asset/assetstore.py
+++ b/src/gbserver/asset/assetstore.py
@@ -133,12 +133,19 @@ class Assetstore(ABC):
 
     @classmethod
     def _load_assetstore_types(cls):
-        if len(cls.assetstore_types) != 0:
-            return
+        """Discover and register every asset store, rebuilding the registry.
+
+        Rebuilds ``cls.assetstore_types`` from scratch on each call via the
+        shared :func:`~gbcommon.plugins.rebuild_registry` contract, so the method
+        is idempotent and reload-safe (see that helper for why clearing first
+        matters). Invoked once at package import; the entry-point group is cached
+        so re-running is cheap.
+        """
         from gbcommon.plugins import (
             GROUP_ASSET_STORES,
             PluginRegistrar,
             keys_from_method,
+            rebuild_registry,
         )
 
         # Files each asset store under the URI class(es) it supports. Both the
@@ -150,45 +157,48 @@ class Assetstore(ABC):
         )
         package_dir = os.path.dirname(__file__)
 
-        for filename in os.listdir(package_dir):
-            if (
-                filename.endswith(".py")
-                and filename != "__init__.py"
-                and filename != "asset.py"
-                and filename != os.path.basename(__file__)
-            ):
-                assetstore_module_name = filename[:-3]
-                assetstore_classname = assetstore_module_name.capitalize()
-                try:
-                    module = importlib.import_module(
-                        f".{assetstore_module_name}", package="gbserver.asset"
-                    )
-                    if hasattr(module, assetstore_classname):
-                        handler_class = getattr(module, assetstore_classname)
-                        if isinstance(handler_class, type) and issubclass(
-                            handler_class, cls
-                        ):
-                            registrar.add(handler_class)
+        def populate() -> None:
+            for filename in os.listdir(package_dir):
+                if (
+                    filename.endswith(".py")
+                    and filename != "__init__.py"
+                    and filename != "asset.py"
+                    and filename != os.path.basename(__file__)
+                ):
+                    assetstore_module_name = filename[:-3]
+                    assetstore_classname = assetstore_module_name.capitalize()
+                    try:
+                        module = importlib.import_module(
+                            f".{assetstore_module_name}", package="gbserver.asset"
+                        )
+                        if hasattr(module, assetstore_classname):
+                            handler_class = getattr(module, assetstore_classname)
+                            if isinstance(handler_class, type) and issubclass(
+                                handler_class, cls
+                            ):
+                                registrar.add(handler_class)
+                            else:
+                                logger.error(
+                                    f"Ignoring {assetstore_classname} since it is not a subclass of AssetStore class"
+                                )
                         else:
                             logger.error(
-                                f"Ignoring {assetstore_classname} since it is not a subclass of AssetStore class"
+                                f"Module {assetstore_module_name} does not contain expected AssetStore type class {assetstore_classname}."
                             )
-                    else:
+                    except ImportError as e:
                         logger.error(
-                            f"Module {assetstore_module_name} does not contain expected AssetStore type class {assetstore_classname}."
+                            f"Error importing module {assetstore_module_name}: {e}"
                         )
-                except ImportError as e:
-                    logger.error(
-                        f"Error importing module {assetstore_module_name}: {e}"
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Error loading AssetStore type from {assetstore_classname}: {e}"
-                    )
+                    except Exception as e:
+                        logger.error(
+                            f"Error loading AssetStore type from {assetstore_classname}: {e}"
+                        )
 
-        # Discover asset stores shipped by separately-installed plugin packages.
-        # Runs after the in-tree scan so the core-wins rule protects built-ins.
-        registrar.discover(GROUP_ASSET_STORES, cls)
+            # Discover asset stores shipped by separately-installed plugin packages.
+            # Runs after the in-tree scan so the core-wins rule protects built-ins.
+            registrar.discover(GROUP_ASSET_STORES, cls)
+
+        rebuild_registry(cls.assetstore_types, populate)
 
     @classmethod
     @abstractmethod

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -1373,68 +1373,79 @@ class Environment(ABC):
 
     @classmethod
     def _load_environment_types(cls: Type[Self]) -> None:
+        """Discover and register every environment type, rebuilding the registry.
+
+        Rebuilds ``cls.environment_types`` from scratch on each call via the
+        shared :func:`~gbcommon.plugins.rebuild_registry` contract, so the method
+        is idempotent and reload-safe (see that helper for why clearing first
+        matters).
+        """
         from gbcommon.plugins import (
             GROUP_ENVIRONMENTS,
             PluginRegistrar,
-            keys_by_name_cased,
+            keys_by_name,
+            rebuild_registry,
         )
 
         # Files each environment under both cased forms of its name (module name
         # in-tree, entry-point name for plugins), mirroring the historical
         # behavior. Both passes register through this one registrar.
         registrar = PluginRegistrar(
-            cls.environment_types, "Environment type", keys_by_name_cased
+            cls.environment_types, "Environment type", keys_by_name
         )
         package_dir = os.path.dirname(__file__)
 
-        for filename in os.listdir(package_dir):
-            if (
-                filename.endswith(".py")
-                and filename != "__init__.py"
-                and filename != "environment_sync.py"
-                and filename != os.path.basename(__file__)
-            ):
-                environment_type_modulename = filename[:-3]
-                environment_type_name = environment_type_modulename.capitalize()
-                try:
-                    module = importlib.import_module(
-                        f".{environment_type_modulename}",
-                        package="gbserver.environment",
-                    )
-                    if hasattr(module, environment_type_name):
-                        handler_class = getattr(module, environment_type_name)
-                        if isinstance(handler_class, type) and issubclass(
-                            handler_class, cls
-                        ):
-                            registrar.add(handler_class, environment_type_name)
+        def populate() -> None:
+            for filename in os.listdir(package_dir):
+                if (
+                    filename.endswith(".py")
+                    and filename != "__init__.py"
+                    and filename != "environment_sync.py"
+                    and filename != os.path.basename(__file__)
+                ):
+                    environment_type_modulename = filename[:-3]
+                    environment_type_name = environment_type_modulename.capitalize()
+                    try:
+                        module = importlib.import_module(
+                            f".{environment_type_modulename}",
+                            package="gbserver.environment",
+                        )
+                        if hasattr(module, environment_type_name):
+                            handler_class = getattr(module, environment_type_name)
+                            if isinstance(handler_class, type) and issubclass(
+                                handler_class, cls
+                            ):
+                                registrar.add(handler_class, environment_type_name)
+                            else:
+                                logger.warning(
+                                    "Ignoring %s since it is not a subclass of Environment class",
+                                    environment_type_name,
+                                )
                         else:
                             logger.warning(
-                                "Ignoring %s since it is not a subclass of Environment class",
+                                "Module %s does not contain expected environment type class %s",
+                                environment_type_modulename,
                                 environment_type_name,
                             )
-                    else:
-                        logger.warning(
-                            "Module %s does not contain expected environment type class %s",
-                            environment_type_modulename,
+                    except ImportError as e:
+                        logger.debug(
+                            "Optional environment module %s not available: %s",
                             environment_type_name,
+                            e,
                         )
-                except ImportError as e:
-                    logger.debug(
-                        "Optional environment module %s not available: %s",
-                        environment_type_name,
-                        e,
-                    )
-                except Exception as e:
-                    logger.error(
-                        "Error loading Environment type from %s: %s",
-                        environment_type_name,
-                        e,
-                    )
+                    except Exception as e:
+                        logger.error(
+                            "Error loading Environment type from %s: %s",
+                            environment_type_name,
+                            e,
+                        )
 
-        # Discover environments shipped by separately-installed plugin packages.
-        # Runs after the in-tree scan so the core-wins rule protects built-ins.
-        # The entry-point *name* is the type key (e.g. ``k8s``).
-        registrar.discover(GROUP_ENVIRONMENTS, cls)
+            # Discover environments shipped by separately-installed plugin packages.
+            # Runs after the in-tree scan so the core-wins rule protects built-ins.
+            # The entry-point *name* is the type key (e.g. ``k8s``).
+            registrar.discover(GROUP_ENVIRONMENTS, cls)
+
+        rebuild_registry(cls.environment_types, populate)
 
     async def _read_stream_and_create_event_all(
         self: Self,

--- a/src/gbserver/resilience/retry_handler.py
+++ b/src/gbserver/resilience/retry_handler.py
@@ -37,7 +37,7 @@ import asyncio
 import json
 import re
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional, Self, Set
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Self, Set, Type
 
 from gbserver.types.buildevent import (
     BuildEvent,
@@ -89,10 +89,7 @@ def build_retry_strategies_from_config(
         ]
     """
     from gbserver.resilience.strategies import (
-        AnyFailureRetryStrategy,
-        AsperaRetryStrategy,
         FileNotFoundRetryStrategy,
-        LsfTransientErrorRetryStrategy,
         NCCLErrorRetryStrategy,
         PodEvictionRetryStrategy,
         UnhealthyInsufficientPodsRetryStrategy,
@@ -114,17 +111,11 @@ def build_retry_strategies_from_config(
             FileNotFoundRetryStrategy(),
         ]
 
-    # Build strategies from config
+    # Build strategies from config. The registry maps a config ``type`` string to
+    # its class (built-ins plus any entry-point plugins); it is rebuilt cheaply
+    # via the shared plugin-discovery contract.
+    RetryStrategy._load_retry_strategies()
     strategies = []
-    strategy_map = {
-        "UnhealthyInsufficientPods": UnhealthyInsufficientPodsRetryStrategy,
-        "PodEviction": PodEvictionRetryStrategy,
-        "NCCLError": NCCLErrorRetryStrategy,
-        "FileNotFound": FileNotFoundRetryStrategy,
-        "LsfTransientError": LsfTransientErrorRetryStrategy,
-        "AsperaFailure": AsperaRetryStrategy,
-        "AnyFailure": AnyFailureRetryStrategy,
-    }
 
     for strategy_config in config:
         strategy_type = strategy_config.get("type")
@@ -134,7 +125,7 @@ def build_retry_strategies_from_config(
             )
             continue
 
-        strategy_class = strategy_map.get(strategy_type)
+        strategy_class = RetryStrategy.strategy_types.get(strategy_type)
         if not strategy_class:
             logger.warning("Unknown strategy type '%s', skipping", strategy_type)
             continue
@@ -192,6 +183,40 @@ class RetryStrategy(ABC):
 
     # Whether this strategy accepts object_types parameter in __init__
     accepts_object_types: bool = True
+
+    # config ``type`` string -> strategy class. Populated by
+    # ``_load_retry_strategies`` (in-tree built-ins + entry-point plugins), keyed
+    # under both the verbatim config type and its lowercase alias. The registry
+    # drives the *class lookup*; construction (``cls(**params)``) stays in
+    # ``build_retry_strategies_from_config``.
+    strategy_types: ClassVar[Dict[str, Type["RetryStrategy"]]] = {}
+
+    @classmethod
+    def _load_retry_strategies(cls) -> None:
+        """(Re)build ``strategy_types`` from the built-ins and any plugins.
+
+        Uses the shared reset-and-rebuild contract, so the registry is
+        reload-safe and a plugin can only *add* a strategy type, never shadow a
+        built-in (core-wins).
+        """
+        from gbcommon.plugins import (
+            GROUP_RESILIENCE_STRATEGIES,
+            PluginRegistrar,
+            keys_by_name,
+            rebuild_registry,
+        )
+        from gbserver.resilience.strategies import BUILTIN_STRATEGIES
+
+        registrar = PluginRegistrar(
+            RetryStrategy.strategy_types, "Retry strategy type", keys_by_name
+        )
+
+        def populate() -> None:
+            for type_name, strategy_class in BUILTIN_STRATEGIES.items():
+                registrar.add(strategy_class, type_name)
+            registrar.discover(GROUP_RESILIENCE_STRATEGIES, RetryStrategy)
+
+        rebuild_registry(RetryStrategy.strategy_types, populate)
 
     @abstractmethod
     def should_retry(

--- a/src/gbserver/resilience/retry_handler.py
+++ b/src/gbserver/resilience/retry_handler.py
@@ -192,13 +192,16 @@ class RetryStrategy(ABC):
     strategy_types: ClassVar[Dict[str, Type["RetryStrategy"]]] = {}
 
     @classmethod
-    def _load_retry_strategies(cls) -> None:
+    def _load_retry_strategies(cls, force: bool = False) -> None:
         """(Re)build ``strategy_types`` from the built-ins and any plugins.
 
-        Uses the shared reset-and-rebuild contract, so the registry is
-        reload-safe and a plugin can only *add* a strategy type, never shadow a
-        built-in (core-wins).
+        No-op once populated (``build_retry_strategies_from_config`` runs
+        per-launch), matching the sibling loaders; ``force=True`` rebuilds. The
+        rebuild goes through the shared contract, so the registry is reload-safe
+        and a plugin can only *add* a type, never shadow a built-in (core-wins).
         """
+        if cls.strategy_types and not force:
+            return
         from gbcommon.plugins import (
             GROUP_RESILIENCE_STRATEGIES,
             PluginRegistrar,

--- a/src/gbserver/resilience/strategies/__init__.py
+++ b/src/gbserver/resilience/strategies/__init__.py
@@ -41,4 +41,24 @@ __all__ = [
     "PodEvictionRetryStrategy",
     "UnhealthyInsufficientPodsRetryStrategy",
     "AsperaRetryStrategy",
+    "BUILTIN_STRATEGIES",
 ]
+
+# The in-tree registration source: config ``type`` string -> strategy class.
+#
+# This is a curated, static list rather than a directory scan because the
+# config ``type`` (the public, user-facing name) deliberately differs from both
+# the class name and the module name (e.g. ``UnhealthyInsufficientPods`` ->
+# ``UnhealthyInsufficientPodsRetryStrategy`` in ``unhealthy_insufficient_pods``),
+# so a filename-derived key would be wrong. The retry-handler loader files each
+# of these through the shared ``PluginRegistrar`` and then folds in any
+# entry-point plugins (group ``gbserver.resilience_strategies``).
+BUILTIN_STRATEGIES = {
+    "UnhealthyInsufficientPods": UnhealthyInsufficientPodsRetryStrategy,
+    "PodEviction": PodEvictionRetryStrategy,
+    "NCCLError": NCCLErrorRetryStrategy,
+    "FileNotFound": FileNotFoundRetryStrategy,
+    "LsfTransientError": LsfTransientErrorRetryStrategy,
+    "AsperaFailure": AsperaRetryStrategy,
+    "AnyFailure": AnyFailureRetryStrategy,
+}

--- a/src/gbserver/utils/secretmanager_discovery.py
+++ b/src/gbserver/utils/secretmanager_discovery.py
@@ -37,6 +37,7 @@ def discover_secret_managers(
     package_name: str,
     base_class: Type,
     registry: Dict[str, Type],
+    force: bool = False,
 ) -> None:
     """Populate ``registry`` with ``key -> subclass`` for one secret-manager package.
 
@@ -45,16 +46,23 @@ def discover_secret_managers(
     name does not end in the lowercased base-class name (e.g. ``factory.py``) and the
     base module itself are skipped, so helper modules are never mistaken for backends.
 
-    No-op if ``registry`` is already populated.
+    Unlike the other subsystem loaders (which run once at package import), this is
+    also called on an API request path (``gbserver.api.secrets``) that resolves a
+    space's secret manager. To keep that path cheap it is a **no-op once the
+    registry is populated**; pass ``force=True`` to rebuild anyway (for tests that
+    reload modules). When it does (re)build, it goes through the shared
+    :func:`~gbcommon.plugins.rebuild_registry` contract so the reload-safe
+    clear-in-place semantics are identical to the other subsystems.
     """
-    if len(registry) != 0:
+    if len(registry) != 0 and not force:
         return
     # Import locally to avoid a hard import-time dependency and keep parity with
     # the other subsystems, which import the registrar lazily too.
     from gbcommon.plugins import (
         GROUP_SECRET_MANAGERS,
         PluginRegistrar,
-        keys_by_name_lower,
+        keys_by_name,
+        rebuild_registry,
     )
 
     package_dir = os.path.dirname(package_file)
@@ -62,48 +70,58 @@ def discover_secret_managers(
     suffix = base_name.lower()  # e.g. "usersecretmanager"
     self_module = os.path.basename(package_file)
 
-    # Key = the discovered name lowercased (module <key> prefix in-tree,
-    # entry-point name for plugins). Both passes register through this registrar.
-    registrar = PluginRegistrar(registry, f"{base_name} key", keys_by_name_lower)
+    # Key = the discovered name (module <key> prefix in-tree, entry-point name for
+    # plugins), filed lowercased plus verbatim. Both passes register through this
+    # registrar.
+    registrar = PluginRegistrar(registry, f"{base_name} key", keys_by_name)
 
-    for filename in os.listdir(package_dir):
-        if not filename.endswith(".py"):
-            continue
-        if filename in ("__init__.py", self_module):
-            continue
-        module_name = filename[:-3]
-        # Only "<key><base_name>.py" modules are backends; skip helpers (factory.py).
-        if not module_name.lower().endswith(suffix) or len(module_name) <= len(suffix):
-            continue
-        key_name = module_name[: -len(base_name)].lower()
-        type_name = key_name.capitalize() + base_name
-        try:
-            module = importlib.import_module(f".{module_name}", package=package_name)
-            if not hasattr(module, type_name):
-                logger.error(
-                    "Module %s does not contain expected type class %s",
-                    module_name,
-                    type_name,
-                )
+    def populate() -> None:
+        for filename in os.listdir(package_dir):
+            if not filename.endswith(".py"):
                 continue
-            handler_class = getattr(module, type_name)
-            if isinstance(handler_class, type) and issubclass(
-                handler_class, base_class
+            if filename in ("__init__.py", self_module):
+                continue
+            module_name = filename[:-3]
+            # Only "<key><base_name>.py" modules are backends; skip helpers (factory.py).
+            if not module_name.lower().endswith(suffix) or len(module_name) <= len(
+                suffix
             ):
-                registrar.add(handler_class, key_name)
-            else:
-                logger.error(
-                    "Ignoring %s since it is not a subclass of %s",
-                    type_name,
-                    base_name,
+                continue
+            key_name = module_name[: -len(base_name)].lower()
+            type_name = key_name.capitalize() + base_name
+            try:
+                module = importlib.import_module(
+                    f".{module_name}", package=package_name
                 )
-        except ImportError as e:
-            logger.error("Error importing module %s: %s", type_name, e)
-        except Exception as e:
-            logger.error("Error loading secret manager type from %s: %s", type_name, e)
+                if not hasattr(module, type_name):
+                    logger.error(
+                        "Module %s does not contain expected type class %s",
+                        module_name,
+                        type_name,
+                    )
+                    continue
+                handler_class = getattr(module, type_name)
+                if isinstance(handler_class, type) and issubclass(
+                    handler_class, base_class
+                ):
+                    registrar.add(handler_class, key_name)
+                else:
+                    logger.error(
+                        "Ignoring %s since it is not a subclass of %s",
+                        type_name,
+                        base_name,
+                    )
+            except ImportError as e:
+                logger.error("Error importing module %s: %s", type_name, e)
+            except Exception as e:
+                logger.error(
+                    "Error loading secret manager type from %s: %s", type_name, e
+                )
 
-    # Discover secret managers shipped by separately-installed plugin packages.
-    # Runs after the in-tree scan so the core-wins rule protects built-ins. The
-    # one group feeds both the Space and User families — the ``issubclass``
-    # filter in ``discover`` routes each class to the family it belongs to.
-    registrar.discover(GROUP_SECRET_MANAGERS, base_class)
+        # Discover secret managers shipped by separately-installed plugin packages.
+        # Runs after the in-tree scan so the core-wins rule protects built-ins. The
+        # one group feeds both the Space and User families — the ``issubclass``
+        # filter in ``discover`` routes each class to the family it belongs to.
+        registrar.discover(GROUP_SECRET_MANAGERS, base_class)
+
+    rebuild_registry(registry, populate)

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -815,3 +815,103 @@ def test_retry_strategy_plugin_collision_core_wins(
     RetryStrategy._load_retry_strategies()
     assert RetryStrategy.strategy_types["AnyFailure"] is not ShadowStrategy
     assert "already registered" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# PluginRegistrar.discover_objects (object-valued registries, e.g. the CLI)
+# ---------------------------------------------------------------------------
+
+
+def test_registrar_discover_objects_files_by_name(monkeypatch):
+    """discover_objects routes loaded objects (not classes) through add()."""
+    marker = object()
+    eps = _make_entry_points(monkeypatch, {"thing": ("thing", marker)})
+    _patch_entry_points(monkeypatch, {"g": eps})
+
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "thing", plugins.keys_by_name)
+    registrar.discover_objects("g")
+    assert reg["thing"] is marker
+
+
+def test_registrar_add_non_class_value_and_collision(caplog):
+    """add() files a non-class value and logs a collision without needing __name__."""
+    first = object()
+    second = object()
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "thing", plugins.keys_by_name)
+    registrar.add(first, "x")
+    registrar.add(second, "x")  # collision: core (first) wins
+    assert reg["x"] is first
+    assert "already registered" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_command_registry_snapshot():
+    from gbcli.cli import GraniteBuildCLI
+
+    saved = dict(GraniteBuildCLI.command_types)
+    yield GraniteBuildCLI
+    GraniteBuildCLI.command_types.clear()
+    GraniteBuildCLI.command_types.update(saved)
+
+
+def test_cli_plugin_command_registered_by_name(
+    monkeypatch, cli_command_registry_snapshot
+):
+    """A plugin command is filed under its entry-point name and resolves to its
+    click command object."""
+    import click
+
+    @click.command("dummy")
+    def dummy_cmd():
+        pass
+
+    eps = _make_entry_points(monkeypatch, {"dummy": ("dummy_cmd", dummy_cmd)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_CLI_PLUGINS: eps})
+
+    cli_command_registry_snapshot._load_commands()
+    assert "dummy" in cli_command_registry_snapshot.command_types
+    # get_command resolves the registered value to the click command object.
+    resolved = cli_command_registry_snapshot().get_command(None, "dummy")
+    assert resolved is dummy_cmd
+
+
+def test_cli_plugin_collision_core_wins(
+    monkeypatch, caplog, cli_command_registry_snapshot
+):
+    """A plugin cannot shadow an in-tree command (core-wins).
+
+    Asserts against the classmethod loader / registry directly rather than
+    constructing ``GraniteBuildCLI`` (whose __init__ reconfigures logging, which
+    would detach the handler caplog relies on)."""
+    import click
+
+    @click.command("build")
+    def shadow_build():
+        pass
+
+    eps = _make_entry_points(monkeypatch, {"build": ("shadow_build", shadow_build)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_CLI_PLUGINS: eps})
+
+    cli_command_registry_snapshot._load_commands()
+    # The in-tree build loader was registered first, so the plugin is refused.
+    assert cli_command_registry_snapshot.command_types["build"] is not shadow_build
+    assert "already registered" in caplog.text
+
+
+def test_cli_noop_when_no_plugins(monkeypatch, cli_command_registry_snapshot):
+    """With no plugin installed, only in-tree commands are listed."""
+    _patch_entry_points(monkeypatch, {})
+    cli_command_registry_snapshot._load_commands()
+    names = sorted(
+        n for n in cli_command_registry_snapshot.command_types if n != "dataset"
+    )
+    assert "build" in names
+    assert "version" in names
+    assert "dataset" not in names  # hidden built-in stays hidden

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -671,3 +671,83 @@ def test_secret_manager_loader_force_rebuilds(monkeypatch):
     assert id(registry) == identity
     assert "local" in registry
     assert registry["local"] is not StaleSM
+
+
+# ---------------------------------------------------------------------------
+# Auth providers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_provider_registry_snapshot():
+    from gbserver.api import auth_providers
+
+    saved = dict(auth_providers.provider_types)
+    yield auth_providers
+    auth_providers.provider_types.clear()
+    auth_providers.provider_types.update(saved)
+
+
+def test_auth_provider_plugin_registered_by_name(
+    monkeypatch, auth_provider_registry_snapshot
+):
+    """A plugin provider is filed under its entry-point name (lower + verbatim)."""
+    from gbserver.api.auth_providers import AuthProvider
+
+    class DummyProvider(AuthProvider):
+        @property
+        def provider_name(self):
+            return "dummy"
+
+        def identify_token(self, token):
+            return False
+
+        def validate_token(self, token):
+            return (None, "nope")
+
+    eps = _make_entry_points(monkeypatch, {"dummy": ("DummyProvider", DummyProvider)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_AUTH_PROVIDERS: eps})
+
+    auth_provider_registry_snapshot._load_auth_providers()
+    assert auth_provider_registry_snapshot.provider_types["dummy"] is DummyProvider
+
+
+def test_auth_provider_plugin_collision_core_wins(
+    monkeypatch, caplog, auth_provider_registry_snapshot
+):
+    """A plugin cannot shadow a built-in provider (core-wins)."""
+    from gbserver.api.auth_providers import AuthProvider
+
+    class ShadowGitHub(AuthProvider):
+        @property
+        def provider_name(self):
+            return "github"
+
+        def identify_token(self, token):
+            return False
+
+        def validate_token(self, token):
+            return (None, "nope")
+
+    eps = _make_entry_points(monkeypatch, {"github": ("ShadowGitHub", ShadowGitHub)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_AUTH_PROVIDERS: eps})
+
+    auth_provider_registry_snapshot._load_auth_providers()
+    # The in-tree GitHubAuthProvider was registered first, so the plugin is refused.
+    assert auth_provider_registry_snapshot.provider_types["github"].__name__ == (
+        "GitHubAuthProvider"
+    )
+    assert "already registered" in caplog.text
+
+
+def test_auth_provider_build_list_multi_order(
+    monkeypatch, auth_provider_registry_snapshot
+):
+    """build_provider_list preserves the JWT-before-opaque order for 'multi'."""
+    monkeypatch.setenv("GBSERVER_IBMID_CLIENT_ID", "test-id")
+    _patch_entry_points(monkeypatch, {})
+
+    providers = auth_provider_registry_snapshot.build_provider_list("multi")
+    assert [p.provider_name for p in providers] == ["ibmid", "github"]
+
+

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -764,6 +764,9 @@ def retry_strategy_registry_snapshot():
     from gbserver.resilience.retry_handler import RetryStrategy
 
     saved = dict(RetryStrategy.strategy_types)
+    # Start empty so the (load-once-guarded) loader rebuilds under the test's
+    # patched entry points, then restore on teardown.
+    RetryStrategy.strategy_types.clear()
     yield RetryStrategy
     RetryStrategy.strategy_types.clear()
     RetryStrategy.strategy_types.update(saved)
@@ -944,6 +947,31 @@ def test_cli_mixed_case_plugin_listed_once(monkeypatch, cli_command_registry_sna
     assert "MyCmd" not in listed  # not shown twice under the verbatim key
     assert cli.get_command(None, "MyCmd") is mycmd
     assert cli.get_command(None, "mycmd") is mycmd
+
+
+def test_cli_hidden_name_blocked_case_insensitively(
+    monkeypatch, cli_command_registry_snapshot
+):
+    """A plugin claiming a hidden built-in's name is blocked in either case.
+
+    `command_dataset.py` is skipped by the in-tree scan, so a plugin can file
+    `Dataset` under both `dataset` and `Dataset`. get_command must refuse both,
+    not just the lowercase form, so the hidden guard can't be bypassed by case.
+    """
+    import click
+
+    @click.command("Dataset")
+    def shadow_dataset():
+        pass
+
+    eps = _make_entry_points(
+        monkeypatch, {"Dataset": ("shadow_dataset", shadow_dataset)}
+    )
+    _patch_entry_points(monkeypatch, {plugins.GROUP_CLI_PLUGINS: eps})
+
+    cli = cli_command_registry_snapshot()
+    assert cli.get_command(None, "Dataset") is None
+    assert cli.get_command(None, "dataset") is None
 
 
 def test_auth_build_list_skips_unregistered_name(

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -188,6 +188,21 @@ def test_registrar_core_wins_on_collision(caplog):
     assert "already registered" in caplog.text
 
 
+def test_registrar_core_wins_is_all_or_nothing_across_keys(caplog):
+    """A collision on any one key refuses the whole registration.
+
+    With keys_by_name a class is filed under both a lowercase alias and its
+    verbatim name. A newcomer colliding on the lowercase key must not still slip
+    in under its case-variant key (built-in `build` vs plugin `Build`), which
+    would shadow the built-in under a different case and defeat core-wins.
+    """
+    reg = {"build": _Good}  # built-in, filed under its lowercase key
+    registrar = plugins.PluginRegistrar(reg, "thing", plugins.keys_by_name)
+    registrar.add(_NotSubclass, "Build")  # keys: {"build", "Build"}
+    assert reg == {"build": _Good}  # newcomer filed under neither key
+    assert "already registered" in caplog.text
+
+
 def test_registrar_reregister_same_class_is_quiet(caplog):
     reg: dict = {}
     registrar = plugins.PluginRegistrar(reg, "thing", keys_of=lambda cls, name: [name])
@@ -912,6 +927,32 @@ def test_cli_plugin_collision_core_wins(
     # The in-tree build loader was registered first, so the plugin is refused.
     assert cli_command_registry_snapshot.command_types["build"] is not shadow_build
     assert "already registered" in caplog.text
+
+
+def test_cli_plugin_case_variant_cannot_shadow_builtin(
+    monkeypatch, cli_command_registry_snapshot
+):
+    """A case-variant plugin name cannot shadow an in-tree command either.
+
+    The in-tree `build` is keyed under `build`; a plugin `Build` collides on that
+    key and, with all-or-nothing core-wins, is filed under neither `build` nor
+    `Build`. So `gb Build` must not resolve to the plugin — the exact bypass
+    a per-key collision check would have allowed.
+    """
+    import click
+
+    @click.command("Build")
+    def shadow_build():
+        pass
+
+    eps = _make_entry_points(monkeypatch, {"Build": ("shadow_build", shadow_build)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_CLI_PLUGINS: eps})
+
+    # (The collision WARNING is asserted by the registrar-level test;
+    # constructing GraniteBuildCLI reconfigures logging and detaches caplog.)
+    cli = cli_command_registry_snapshot()
+    assert "Build" not in cli.command_types
+    assert cli.get_command(None, "Build") is not shadow_build
 
 
 def test_cli_noop_when_no_plugins(monkeypatch, cli_command_registry_snapshot):

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -502,9 +502,9 @@ def test_assetstore_plugin_collision_core_wins(
     eps = _make_entry_points(monkeypatch, {"shadow": ("ShadowStore", ShadowStore)})
     _patch_entry_points(monkeypatch, {plugins.GROUP_ASSET_STORES: eps})
 
-    # The loader rebuilds the registry from scratch each call (clear + in-tree
-    # scan + plugin pass), so no manual clear is needed to re-exercise it.
-    Assetstore._load_assetstore_types()
+    # force=True re-exercises the loader (clear + in-tree scan + plugin pass)
+    # even though the registry is already populated from import.
+    Assetstore._load_assetstore_types(force=True)
     assert Assetstore.assetstore_types[HfURI] is core_hf_store
     assert "already registered" in caplog.text
 
@@ -614,9 +614,9 @@ def test_environment_loader_rebuilds_registry(monkeypatch, env_registry_snapshot
     assert "stale-key" not in Environment.environment_types
 
 
-def test_assetstore_loader_rebuilds_registry(monkeypatch, assetstore_registry_snapshot):
-    """The assetstore loader rebuilds from scratch each call (was a len()-guarded
-    no-op before), so a stale entry left in the registry is dropped."""
+def test_assetstore_loader_force_rebuilds(monkeypatch, assetstore_registry_snapshot):
+    """A forced rebuild clears in place, so a stale entry left in the populated
+    registry is dropped and the in-tree class re-filed (reload-safe)."""
     from gbcommon.uri.hf import HfURI
     from gbserver.asset.assetstore import Assetstore
 
@@ -630,7 +630,7 @@ def test_assetstore_loader_rebuilds_registry(monkeypatch, assetstore_registry_sn
     _patch_entry_points(monkeypatch, {})
     Assetstore.assetstore_types[HfURI] = StaleStore
 
-    Assetstore._load_assetstore_types()
+    Assetstore._load_assetstore_types(force=True)
 
     # The in-tree scan re-files HfURI's real core store, replacing the stale one.
     assert Assetstore.assetstore_types[HfURI] is core_hf_store
@@ -683,6 +683,9 @@ def auth_provider_registry_snapshot():
     from gbserver.api import auth_providers
 
     saved = dict(auth_providers.provider_types)
+    # Start empty so the (load-once-guarded) loader rebuilds under the test's
+    # patched entry points, then restore the real registry on teardown.
+    auth_providers.provider_types.clear()
     yield auth_providers
     auth_providers.provider_types.clear()
     auth_providers.provider_types.update(saved)
@@ -856,6 +859,9 @@ def cli_command_registry_snapshot():
     from gbcli.cli import GraniteBuildCLI
 
     saved = dict(GraniteBuildCLI.command_types)
+    # Start empty so the (load-once-guarded) loader rebuilds under the test's
+    # patched entry points, then restore on teardown.
+    GraniteBuildCLI.command_types.clear()
     yield GraniteBuildCLI
     GraniteBuildCLI.command_types.clear()
     GraniteBuildCLI.command_types.update(saved)
@@ -952,3 +958,33 @@ def test_auth_build_list_skips_unregistered_name(
     # Falls back to github rather than raising KeyError mid-request.
     providers = ap.build_provider_list("broken")
     assert [p.provider_name for p in providers] == ["github"]
+
+
+def test_cli_non_command_plugin_rejected(
+    monkeypatch, caplog, cli_command_registry_snapshot
+):
+    """A gbcli.plugins entry point that is not a click command is skipped with a
+    warning, never filed (so _resolve_command can't later invoke it)."""
+
+    def not_a_command():
+        return "should-never-be-invoked"
+
+    eps = _make_entry_points(monkeypatch, {"weird": ("not_a_command", not_a_command)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_CLI_PLUGINS: eps})
+
+    cli_command_registry_snapshot._load_commands(force=True)
+    assert "weird" not in cli_command_registry_snapshot.command_types
+    assert "not a valid" in caplog.text
+
+
+def test_discover_objects_predicate_skips_and_warns(monkeypatch, caplog):
+    """discover_objects filters out objects failing the predicate, with a warning."""
+    good, bad = object(), object()
+    eps = _make_entry_points(monkeypatch, {"good": ("good", good), "bad": ("bad", bad)})
+    _patch_entry_points(monkeypatch, {"g": eps})
+
+    reg: dict = {}
+    registrar = plugins.PluginRegistrar(reg, "thing", plugins.keys_by_name)
+    registrar.discover_objects("g", predicate=lambda o: o is good)
+    assert reg == {"good": good}
+    assert "not a valid" in caplog.text

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -915,3 +915,40 @@ def test_cli_noop_when_no_plugins(monkeypatch, cli_command_registry_snapshot):
     assert "build" in names
     assert "version" in names
     assert "dataset" not in names  # hidden built-in stays hidden
+
+
+def test_cli_mixed_case_plugin_listed_once(monkeypatch, cli_command_registry_snapshot):
+    """A mixed-case plugin command name is filed under both cases but listed once.
+
+    keys_by_name files `MyCmd` under both `mycmd` and `MyCmd`; list_commands must
+    show a single canonical entry, while get_command still resolves either form.
+    """
+    import click
+
+    @click.command("MyCmd")
+    def mycmd():
+        pass
+
+    eps = _make_entry_points(monkeypatch, {"MyCmd": ("mycmd", mycmd)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_CLI_PLUGINS: eps})
+
+    cli = cli_command_registry_snapshot()
+    listed = cli.list_commands(None)
+    assert listed.count("mycmd") == 1
+    assert "MyCmd" not in listed  # not shown twice under the verbatim key
+    assert cli.get_command(None, "MyCmd") is mycmd
+    assert cli.get_command(None, "mycmd") is mycmd
+
+
+def test_auth_build_list_skips_unregistered_name(
+    monkeypatch, auth_provider_registry_snapshot
+):
+    """A mode naming an unregistered provider degrades gracefully, not KeyError."""
+    _patch_entry_points(monkeypatch, {})
+    ap = auth_provider_registry_snapshot
+    # Force a mode that references a name absent from the registry.
+    monkeypatch.setitem(ap._AUTH_MODES, "broken", ["nonexistent"])
+
+    # Falls back to github rather than raising KeyError mid-request.
+    providers = ap.build_provider_list("broken")
+    assert [p.provider_name for p in providers] == ["github"]

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -751,3 +751,67 @@ def test_auth_provider_build_list_multi_order(
     assert [p.provider_name for p in providers] == ["ibmid", "github"]
 
 
+# ---------------------------------------------------------------------------
+# Resilience strategies
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def retry_strategy_registry_snapshot():
+    from gbserver.resilience.retry_handler import RetryStrategy
+
+    saved = dict(RetryStrategy.strategy_types)
+    yield RetryStrategy
+    RetryStrategy.strategy_types.clear()
+    RetryStrategy.strategy_types.update(saved)
+
+
+def test_retry_strategy_plugin_registered_by_name(
+    monkeypatch, retry_strategy_registry_snapshot
+):
+    """A plugin strategy is discovered and looked up by its config ``type`` name."""
+    from gbserver.resilience.retry_handler import RetryStrategy
+
+    class DummyStrategy(RetryStrategy):
+        def should_retry(self, event):
+            return False
+
+    eps = _make_entry_points(monkeypatch, {"Dummy": ("DummyStrategy", DummyStrategy)})
+    _patch_entry_points(monkeypatch, {plugins.GROUP_RESILIENCE_STRATEGIES: eps})
+
+    RetryStrategy._load_retry_strategies()
+    # Reachable under the verbatim config type and its lowercase alias.
+    assert RetryStrategy.strategy_types["Dummy"] is DummyStrategy
+    assert RetryStrategy.strategy_types["dummy"] is DummyStrategy
+
+
+def test_retry_strategy_builtin_types_present(
+    monkeypatch, retry_strategy_registry_snapshot
+):
+    """The in-tree config types are registered under their verbatim names."""
+    from gbserver.resilience.retry_handler import RetryStrategy
+
+    _patch_entry_points(monkeypatch, {})
+    RetryStrategy._load_retry_strategies()
+    assert "UnhealthyInsufficientPods" in RetryStrategy.strategy_types
+    assert "AnyFailure" in RetryStrategy.strategy_types
+
+
+def test_retry_strategy_plugin_collision_core_wins(
+    monkeypatch, caplog, retry_strategy_registry_snapshot
+):
+    """A plugin cannot shadow a built-in strategy type (core-wins)."""
+    from gbserver.resilience.retry_handler import RetryStrategy
+
+    class ShadowStrategy(RetryStrategy):
+        def should_retry(self, event):
+            return False
+
+    eps = _make_entry_points(
+        monkeypatch, {"AnyFailure": ("ShadowStrategy", ShadowStrategy)}
+    )
+    _patch_entry_points(monkeypatch, {plugins.GROUP_RESILIENCE_STRATEGIES: eps})
+
+    RetryStrategy._load_retry_strategies()
+    assert RetryStrategy.strategy_types["AnyFailure"] is not ShadowStrategy
+    assert "already registered" in caplog.text

--- a/test/unit/plugins/test_entry_point_discovery.py
+++ b/test/unit/plugins/test_entry_point_discovery.py
@@ -198,15 +198,15 @@ def test_registrar_reregister_same_class_is_quiet(caplog):
 
 
 def test_keys_of_helpers():
-    assert list(plugins.keys_by_name_lower(_Good, "Foo")) == ["foo"]
-    # An in-tree name is already capitalized (module k8s -> "K8s"), giving the
-    # historical {lower, cased} pair.
-    assert list(plugins.keys_by_name_cased(_Good, "K8s")) == ["k8s", "K8s"]
+    # The single canonical name-as-key helper: {lower, verbatim}, deduped.
+    # An in-tree name is already capitalized (module k8s -> "K8s").
+    assert list(plugins.keys_by_name(_Good, "K8s")) == ["k8s", "K8s"]
     # An already-lowercase name files exactly one key, not a duplicate pair.
-    assert list(plugins.keys_by_name_cased(_Good, "foo")) == ["foo"]
+    assert list(plugins.keys_by_name(_Good, "foo")) == ["foo"]
+    assert list(plugins.keys_by_name(_Good, "Foo")) == ["foo", "Foo"]
     # A plugin's internal capitals survive verbatim so `type: AWSBatch` resolves
     # (the old str.capitalize() would have mangled this to "Awsbatch").
-    assert list(plugins.keys_by_name_cased(_Good, "AWSBatch")) == [
+    assert list(plugins.keys_by_name(_Good, "AWSBatch")) == [
         "awsbatch",
         "AWSBatch",
     ]
@@ -447,22 +447,27 @@ def test_environment_plugin_lowercase_name_single_key(
 def test_environment_plugin_collision_core_wins(
     monkeypatch, caplog, env_registry_snapshot
 ):
+    """A plugin declaring an existing built-in's key cannot shadow it.
+
+    The loader rebuilds the registry from scratch each call (in-tree scan first,
+    plugin ``discover`` last), so we let the plugin collide with a genuine
+    in-tree environment. ``bash`` is the one built-in guaranteed present under
+    any dependency set (the local executor has no optional dependency), so the
+    test stays hermetic in standalone CI without pre-seeding — which the rebuild
+    would clear anyway.
+    """
     from gbserver.environment.environment import Environment
 
-    # Seed a known core type ourselves rather than depending on a specific
-    # built-in (e.g. "k8s" is only registered when its optional dependency is
-    # installed, which is not the case in the standalone CI env). This keeps the
-    # test hermetic under any dependency set and under parallel execution.
-    CoreEnv = type("CoreEnv", (Environment,), {})
-    Environment.environment_types["seeded"] = CoreEnv
-    Environment.environment_types["Seeded"] = CoreEnv
+    class ShadowBash(Environment):
+        pass
 
-    ShadowEnv = type("ShadowEnv", (Environment,), {})
-    eps = _make_entry_points(monkeypatch, {"seeded": ("ShadowEnv", ShadowEnv)})
+    eps = _make_entry_points(monkeypatch, {"bash": ("ShadowBash", ShadowBash)})
     _patch_entry_points(monkeypatch, {plugins.GROUP_ENVIRONMENTS: eps})
 
     Environment._load_environment_types()
-    assert Environment.environment_types["seeded"] is CoreEnv  # core kept
+    # The in-tree Bash class was registered first, so the plugin is refused.
+    assert Environment.environment_types["bash"] is not ShadowBash
+    assert Environment.environment_types["bash"].__name__ == "Bash"
     assert "already registered" in caplog.text
 
 
@@ -497,9 +502,8 @@ def test_assetstore_plugin_collision_core_wins(
     eps = _make_entry_points(monkeypatch, {"shadow": ("ShadowStore", ShadowStore)})
     _patch_entry_points(monkeypatch, {plugins.GROUP_ASSET_STORES: eps})
 
-    # Force the loader past its len-guard by clearing, then re-populating via
-    # the in-tree pass + the plugin pass in a single call.
-    Assetstore.assetstore_types.clear()
+    # The loader rebuilds the registry from scratch each call (clear + in-tree
+    # scan + plugin pass), so no manual clear is needed to re-exercise it.
     Assetstore._load_assetstore_types()
     assert Assetstore.assetstore_types[HfURI] is core_hf_store
     assert "already registered" in caplog.text
@@ -560,3 +564,110 @@ def test_secret_manager_plugin_routed_by_base_class(monkeypatch):
     )
     # The Space-family dummy is filtered out of the User-family registry.
     assert "dummy" not in registry
+
+
+# ---------------------------------------------------------------------------
+# Shared reset/rebuild lifecycle: rebuild_registry
+#
+# The four loaders above route their reset through this one contract. These
+# tests pin the contract itself and its reload-safety for each newly-converted
+# loader (URI's is test_uri_loader_rebuilds_registry above).
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_registry_clears_in_place():
+    """The registry is cleared IN PLACE (not rebound) and refilled by populate.
+
+    In place matters: callers (and ClassVar consumers) may hold a reference to
+    the dict object, so the same object must survive the rebuild.
+    """
+    registry = {"stale": object()}
+    identity = id(registry)
+    marker = object()
+
+    def populate():
+        registry["fresh"] = marker
+
+    plugins.rebuild_registry(registry, populate)
+
+    assert id(registry) == identity  # same object, not rebound
+    assert "stale" not in registry  # cleared
+    assert registry["fresh"] is marker  # repopulated
+
+
+def test_environment_loader_rebuilds_registry(monkeypatch, env_registry_snapshot):
+    """A stale registration is replaced by the loader's fresh in-tree class,
+    rather than kept by the core-wins guard (the PR #289 class of bug — the
+    environment loader previously never cleared)."""
+    from gbserver.environment.environment import Environment
+
+    class StaleEnv(Environment):
+        pass
+
+    _patch_entry_points(monkeypatch, {})
+    Environment.environment_types["stale-key"] = StaleEnv
+
+    Environment._load_environment_types()
+
+    # The stale key is gone (the loader rebuilt from scratch), and a real
+    # in-tree environment resolves to the module's current class.
+    assert "stale-key" not in Environment.environment_types
+
+
+def test_assetstore_loader_rebuilds_registry(monkeypatch, assetstore_registry_snapshot):
+    """The assetstore loader rebuilds from scratch each call (was a len()-guarded
+    no-op before), so a stale entry left in the registry is dropped."""
+    from gbcommon.uri.hf import HfURI
+    from gbserver.asset.assetstore import Assetstore
+
+    core_hf_store = Assetstore.assetstore_types[HfURI]
+
+    class StaleStore(Assetstore):
+        @classmethod
+        def get_supported_uri_classes(cls):
+            return [HfURI]
+
+    _patch_entry_points(monkeypatch, {})
+    Assetstore.assetstore_types[HfURI] = StaleStore
+
+    Assetstore._load_assetstore_types()
+
+    # The in-tree scan re-files HfURI's real core store, replacing the stale one.
+    assert Assetstore.assetstore_types[HfURI] is core_hf_store
+
+
+def test_secret_manager_loader_force_rebuilds(monkeypatch):
+    """The secret-manager loader keeps a populated-registry no-op for the API hot
+    path, but force=True rebuilds in place — replacing a stale entry."""
+    from gbserver.spacesecretmanager import spacesecretmanager as sm_module
+    from gbserver.spacesecretmanager.spacesecretmanager import SpaceSecretManager
+    from gbserver.utils import secretmanager_discovery
+
+    class StaleSM(SpaceSecretManager):
+        pass
+
+    _patch_entry_points(monkeypatch, {})
+    registry: dict = {"local": StaleSM}
+
+    # Without force, an already-populated registry is left untouched (hot path).
+    secretmanager_discovery.discover_secret_managers(
+        package_file=sm_module.__file__,
+        package_name="gbserver.spacesecretmanager",
+        base_class=SpaceSecretManager,
+        registry=registry,
+    )
+    assert registry["local"] is StaleSM  # no-op, stale entry kept
+
+    # With force, the registry is rebuilt in place: the stale "local" is replaced
+    # by the real in-tree class and the same dict object is reused.
+    identity = id(registry)
+    secretmanager_discovery.discover_secret_managers(
+        package_file=sm_module.__file__,
+        package_name="gbserver.spacesecretmanager",
+        base_class=SpaceSecretManager,
+        registry=registry,
+        force=True,
+    )
+    assert id(registry) == identity
+    assert "local" in registry
+    assert registry["local"] is not StaleSM


### PR DESCRIPTION
## Summary

Continues the plugin foundation (entry-point discovery) by covering three more subsystems and pushing for consistency across the ones already wired.

- **Unify key derivation.** Collapse the three ad-hoc key helpers into two clearly-named shapes documented as the plugin contract:
  - `keys_by_name` — the entry-point name is the key (filed under both lowercased and verbatim forms). This is the standard entry-point convention; it replaces `keys_by_name_lower` and `keys_by_name_cased` (a superset of both, so name-keyed lookups stay backward-compatible).
  - `keys_from_method` — kept and documented as the "capability keys" path for URI handlers and asset stores, where a class advertises its key(s) by answering a method rather than being keyed by a chosen name (see "Why URI handlers and asset stores keep `keys_from_method`" below).
- **Shared registry rebuild contract.** Add `rebuild_registry`, a single clear-in-place-and-repopulate primitive that every loader now routes through, so reload-safety is not re-derived per subsystem. This also fixes two latent inconsistencies (the environment loader never cleared; the asset-store and secret-manager loaders early-returned once populated). The secret-manager loader keeps a populated no-op guard because it is also invoked on an API request path, and gains a `force` flag for tests.
- **Auth providers** (`gbserver.auth_providers`): a `provider_types` registry populated through the registrar; `build_provider_list` becomes registry-driven, with ordering in an explicit mode map and per-provider construction in a small factory. The registry is built once per process (a load-once guard, since `build_provider_list` is on the per-request auth path), with a `force=` rebuild for tests. Behavior with no plugin installed is unchanged.
- **Resilience strategies** (`gbserver.resilience_strategies`): a `strategy_types` registry keyed by the config `type`; built-in types seeded via a static map (the config type deliberately differs from class/module names). `accepts_object_types` handling and `cls(**params)` construction are unchanged.
- **CLI commands** (`gbcli.plugins`): `GraniteBuildCLI` keeps a `command_types` registry, filled by the in-tree `command_*.py` scan plus entry-point plugins. Discovery stays dynamic and lazy — the registry value is a *source* (an in-tree thunk that imports its module only when the command is resolved, or a plugin's loaded `click` command), so building/listing commands never imports a command module. The registry is built once per process (a load-once guard, since `click` calls `get_command`/`list_commands` repeatedly while rendering a single invocation). The CLI is the one object-valued subsystem, so it uses a new `PluginRegistrar.discover_objects` pass alongside the class-based `discover`; a predicate rejects an entry point that points at a non-`click.Command` object so it is never filed (and never invoked in place of a command).
- Docs: move auth providers, resilience strategies, and CLI commands from the reserved to the supported table; document the two key-derivation shapes. Only `gbserver.builtin_steps` remains reserved (deferred to avoid conflicts with other in-flight work).

All changes are additive: with no plugin installed, every registry populates exactly as before.

## Why URI handlers and asset stores keep `keys_from_method`

The consistency push converges the *name-keyed* subsystems onto one helper, but URI handlers and asset stores are deliberately left on `keys_from_method` this round because their key is a **capability the class has**, not a name someone picks — and `keys_by_name` cannot express it:

- **One class owns several keys.** `keys_by_name` derives keys from a *single* entry-point name, but a URI handler routinely serves multiple schemes: today `GitURI` → `git+git` / `git+https` / `git+ssh`, `CosURI` → `cos` / `s3`, `SpaceURI` → `gb` / `space`. There is no single name to file these under; the class enumerates them via `get_supported_schemes()`.
- **The key is dictated by the data, not chosen by the author.** Resolution is `uri_handler_classes[parsed_uri.scheme]` — the scheme comes from the URI string a user writes (`git+ssh://…`), so the lookup key must equal the scheme the handler parses, which is unrelated to what the plugin author would name the handler. `keys_by_name` would force the plugin name and the lookup key to be the same string and break the moment a handler serves a scheme that differs from its name (or serves several).
- **Asset-store keys aren't even strings.** That registry is `Dict[type[URI], type[Assetstore]]` — e.g. `{GitURI: Gitstore, CosURI: Cosstore, …}`, looked up by `assetstore_types[type(uri)]`. `get_supported_uri_classes()` returns URI *classes*; `keys_by_name` only produces string keys, so it structurally can't key this registry.

So `keys_from_method` is not leftover cruft — it encodes a genuinely different registration model (dispatch-by-capability vs. select-by-name). Collapsing it into `keys_by_name` would either break multi-scheme handlers and the class-keyed asset-store registry, or force plugin authors to declare one entry point per scheme and rename handlers to match schemes. The two shapes are the honest end state, not a transitional split; the single `keys_from_method(method_name)` helper already abstracts over both capability registries (string schemes and URI-class keys) without needing to split further. (Built-in steps, still reserved, are a *third* shape again — a filesystem search path — reinforcing that one helper per model is the right factoring.)

## Out of scope

**Built-in steps (`gbserver.builtin_steps`) are intentionally excluded from this PR** and remain reserved. That subsystem is not a class/name registry — it resolves steps through a filesystem base-URI search path (`SpaceURI`), so wiring it means contributing extra base URIs rather than registering into a registry, a distinct mechanism from the ones here. It is also being touched by other in-flight work, and deferring it keeps this PR conflict-free. It is planned as a follow-up.

## Test plan

- New unit coverage in `test/unit/plugins/test_entry_point_discovery.py`: the `rebuild_registry` contract and per-loader reload-safety; the converged `keys_by_name`; `PluginRegistrar.discover_objects` (including its predicate filter); and plugin discovery + core-wins collision for auth providers, resilience strategies, and CLI commands (including the mixed-case CLI listing, the unregistered-auth-name fallback, and rejection of a non-`click.Command` CLI plugin).
- Existing auth (`test/unit/api/test_auth_providers.py`) and CLI (`test/unit/gbcli`) suites pass unchanged, confirming behavior is preserved.
- `black`, `isort --profile black`, `pylint`, and `mypy --disable-error-code=import-untyped` clean on the changed files.

Generated with [Claude Code](https://claude.com/claude-code)


