### PR TITLE
Step usage doc fixes in byoc and eval steps

### DIFF
--- a/configurations/assets/environments/skypilot/steps/byoc/README.md
+++ b/configurations/assets/environments/skypilot/steps/byoc/README.md
@@ -7,12 +7,8 @@ the bare launcher node — no custom image is built for this step.
 
 > **Developing or testing this step?** See `steps/byoc/skypilot/README.md` in the
 > granite.build repository for how the step is generated, tested, and published —
-> including the environment variables the SkyPilot **aws** integration test requires.
-> Those (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`) are only the
-> test **skip gate**; a real build gets its AWS creds from the space **secret manager**
-> via the `GB_AWS_ACCESS_KEY_ID` / `GB_AWS_SECRET_ACCESS_KEY` secret names declared in
-> the AWS `environment.yaml` (materialized into a `gb-skypilot` profile). See
-> `docs/environments/skypilot-aws.md` in the granite.build repository.
+> including the environment variables the SkyPilot **aws** integration test requires
+> (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`).
 
 ## Referencing the step
 
@@ -102,22 +98,39 @@ Use relative paths from there; when you need an absolute path — e.g. for an
 
 ## Example build.yaml
 
-This example wires **two inputs** (one direct `uri:`, one `binding:` to an upstream
-target's output) and **two outputs** (one of which receives two artifacts via repeated
-markers). The `command` reads each input via `{{ bindings.<name>.binding.path }}` and
-registers each artifact via a marker line:
+This example declares **two byoc targets**: an upstream `pretrain` producer whose
+`model` output the downstream `run` target binds to. `run` wires **two inputs** (one
+direct `uri:`, one `binding:` to `pretrain`'s output) and **two outputs** (one of which
+receives two artifacts via repeated markers). The `command` reads each input via
+`{{ bindings.<name>.binding.path }}` and registers each artifact via a marker line:
 
 ```yaml
 granite.build:
   name: byoc-example
   version: 0.0.1
   targets:
+    pretrain:
+      environment_uri: space://environments/skypilot/aws
+      outputs:
+        model:
+          uri: lh://prod/myspace/models/shared/byoc-pretrain-{{ run_metadata.targetsteprun_id | short_hash }}/1
+      steps:
+        - step_uri: space://steps/byoc
+          config:
+            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
+            byoc_config:
+              image: "python:3.12-slim"
+              repo: "https://github.com/org/repo"
+              command: >-
+                cd code;
+                python pretrain.py --out-dir "$(pwd)/out";
+                echo "LLMB_ARTIFACT_ID:model LLMB_ARTIFACT_PATH:$(pwd)/out/model.ckpt"
     run:
       environment_uri: space://environments/skypilot/aws
       inputs:
         dataset:
           uri: hf:///datasets/org/my-dataset
-        upstream_model:
+        init_model:
           binding: pretrain.model   # <upstream-target>.<output-id>
       outputs:
         checkpoints:
@@ -138,7 +151,7 @@ granite.build:
                 cd code;
                 python main.py
                 --dataset "{{ bindings.dataset.binding.path }}"
-                --init-model "{{ bindings.upstream_model.binding.path }}"
+                --init-model "{{ bindings.init_model.binding.path }}"
                 --out-dir "$(pwd)/out";
                 echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-1.ckpt";
                 echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-2.ckpt";

--- a/configurations/assets/environments/skypilot/steps/byoc/README.md
+++ b/configurations/assets/environments/skypilot/steps/byoc/README.md
@@ -113,7 +113,7 @@ granite.build:
       environment_uri: space://environments/skypilot/aws
       outputs:
         model:
-          uri: lh://prod/myspace/models/shared/byoc-pretrain-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/my-org/byoc-pretrain-{{ run_metadata.targetsteprun_id | short_hash }}
       steps:
         - step_uri: space://steps/byoc
           config:
@@ -134,9 +134,9 @@ granite.build:
           binding: pretrain.model   # <upstream-target>.<output-id>
       outputs:
         checkpoints:
-          uri: lh://prod/myspace/models/shared/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/my-org/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}
         report:
-          uri: lh://prod/myspace/reports/shared/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/datasets/my-org/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}
       steps:
         - step_uri: space://steps/byoc
           config:

--- a/steps/byoc/skypilot/USAGE.md
+++ b/steps/byoc/skypilot/USAGE.md
@@ -98,22 +98,39 @@ Use relative paths from there; when you need an absolute path — e.g. for an
 
 ## Example build.yaml
 
-This example wires **two inputs** (one direct `uri:`, one `binding:` to an upstream
-target's output) and **two outputs** (one of which receives two artifacts via repeated
-markers). The `command` reads each input via `{{ bindings.<name>.binding.path }}` and
-registers each artifact via a marker line:
+This example declares **two byoc targets**: an upstream `pretrain` producer whose
+`model` output the downstream `run` target binds to. `run` wires **two inputs** (one
+direct `uri:`, one `binding:` to `pretrain`'s output) and **two outputs** (one of which
+receives two artifacts via repeated markers). The `command` reads each input via
+`{{ bindings.<name>.binding.path }}` and registers each artifact via a marker line:
 
 ```yaml
 granite.build:
   name: byoc-example
   version: 0.0.1
   targets:
+    pretrain:
+      environment_uri: space://environments/skypilot/aws
+      outputs:
+        model:
+          uri: lh://prod/myspace/models/shared/byoc-pretrain-{{ run_metadata.targetsteprun_id | short_hash }}/1
+      steps:
+        - step_uri: space://steps/byoc
+          config:
+            compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
+            byoc_config:
+              image: "python:3.12-slim"
+              repo: "https://github.com/org/repo"
+              command: >-
+                cd code;
+                python pretrain.py --out-dir "$(pwd)/out";
+                echo "LLMB_ARTIFACT_ID:model LLMB_ARTIFACT_PATH:$(pwd)/out/model.ckpt"
     run:
       environment_uri: space://environments/skypilot/aws
       inputs:
         dataset:
           uri: hf:///datasets/org/my-dataset
-        upstream_model:
+        init_model:
           binding: pretrain.model   # <upstream-target>.<output-id>
       outputs:
         checkpoints:
@@ -134,7 +151,7 @@ granite.build:
                 cd code;
                 python main.py
                 --dataset "{{ bindings.dataset.binding.path }}"
-                --init-model "{{ bindings.upstream_model.binding.path }}"
+                --init-model "{{ bindings.init_model.binding.path }}"
                 --out-dir "$(pwd)/out";
                 echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-1.ckpt";
                 echo "LLMB_ARTIFACT_ID:checkpoints LLMB_ARTIFACT_PATH:$(pwd)/out/epoch-2.ckpt";

--- a/steps/byoc/skypilot/USAGE.md
+++ b/steps/byoc/skypilot/USAGE.md
@@ -113,7 +113,7 @@ granite.build:
       environment_uri: space://environments/skypilot/aws
       outputs:
         model:
-          uri: lh://prod/myspace/models/shared/byoc-pretrain-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/my-org/byoc-pretrain-{{ run_metadata.targetsteprun_id | short_hash }}
       steps:
         - step_uri: space://steps/byoc
           config:
@@ -134,9 +134,9 @@ granite.build:
           binding: pretrain.model   # <upstream-target>.<output-id>
       outputs:
         checkpoints:
-          uri: lh://prod/myspace/models/shared/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/my-org/byoc-out-{{ run_metadata.targetsteprun_id | short_hash }}
         report:
-          uri: lh://prod/myspace/reports/shared/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/datasets/my-org/byoc-report-{{ run_metadata.targetsteprun_id | short_hash }}
       steps:
         - step_uri: space://steps/byoc
           config:

--- a/steps/eval/skypilot/USAGE.md
+++ b/steps/eval/skypilot/USAGE.md
@@ -49,21 +49,25 @@ All fields live under the step's `config.eval_config` and are templated into the
 
 | Field | Type | Required | Purpose |
 |---|---|---|---|
-| `model_path` | string | **required** | Model to evaluate (path or hub id). Passed as `--model-path`. |
+| `model_path` | string | **required** | Model to evaluate. Passed as `--model-path`. Usually set from a bound `model` input via Jinja — `"{{ bindings.model.binding.path }}"` — so the resolved artifact path is templated in before `run`; a literal path or hub id also works. |
 | `tasks` | string | optional (default empty ⇒ a `placeholder` task) | Comma-separated benchmark/task names. Passed as `--tasks`. |
 | `output_dir` | string | optional (default `output`) | Directory the results file is written into; `results.json` is created here. Passed as `--output-dir`. |
 | `per_device_eval_batch_size` | int | optional (default `8`) | Per-device eval batch size. Passed as `--batch-size`. |
 
 ## Inputs and outputs
 
-- **Inputs** — the exemplar takes the model to evaluate as the `model_path`
-  *config* string rather than a bound artifact input, so it declares no target
-  `inputs:`. (To consume a resolved artifact instead, add a target input and
-  reference its path in the `run` block.)
+- **Inputs** — the model to evaluate is a target `inputs.model` artifact. Its
+  resolved filesystem path is templated into `eval_config.model_path` via
+  `"{{ bindings.model.binding.path }}"` (`step.config` values are Jinja-rendered
+  with `bindings.*` in scope before `run`), so no change to the step is needed to
+  consume it. The input can be a direct `uri:` (e.g. `hf:///models/<org>/<repo>`)
+  or a `binding:` to an upstream target's model output. A literal path or hub id
+  in `model_path` also works if you prefer not to declare an input.
 - **Outputs** — declared on the step as `outputs.optional.results` (`type:
   dataset`), a single file at `<output_dir>/results.json`. It is registered by the
   `run:` block (see [Who emits the artifact line?](#who-emits-the-artifact-line)),
-  not by `eval.sh`. Bind a matching `outputs.results` on the target to persist it.
+  not by `eval.sh`. Bind a matching `outputs.results` on the target — with an
+  `hf://` dataset `uri` to persist it to the Hub, as in the example below.
 
 ## Working directory and paths
 
@@ -80,15 +84,20 @@ granite.build:
   targets:
     evaluate:
       environment_uri: space://environments/skypilot/aws
+      inputs:
+        model:
+          uri: hf:///models/ibm-granite/granite-4.0-h-350m
       outputs:
         results:
-          uri: lh://prod/myspace/datasets/shared/eval-{{ run_metadata.targetsteprun_id | short_hash }}/1
+          uri: hf://huggingface.co/datasets/my-org/eval-{{ run_metadata.targetsteprun_id | short_hash }}
       steps:
         - step_uri: space://steps/eval
           config:
             compute_config: { num_nodes: 1, num_gpus_per_node: 1 }
             eval_config:
-              model_path: "ibm-granite/granite-4.0-h-350m"
+              # The model to evaluate is the target's `model` input; its resolved
+              # filesystem path is templated into model_path before `run`.
+              model_path: "{{ bindings.model.binding.path }}"
               tasks: "hellaswag,arc_easy"
               output_dir: "output"
               per_device_eval_batch_size: 8


### PR DESCRIPTION
## Description

The USAGE.md (which show up as the README.md after step publishing) had incorrect/invalid build.yaml examples.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
