### PR TITLE
Fix: LSF hfpull/hfpush should not request a GPU

### DIFF
--- a/docs/builds/build-yaml-reference.md
+++ b/docs/builds/build-yaml-reference.md
@@ -225,6 +225,12 @@ floor (values under `launcher_config.resources` override them). GPU/accelerator
 selection and node count are supplied via `launcher_config.resources` on the step
 (e.g. `accelerators: "A100:8"`), not via `num_gpus_per_node`/`num_nodes`.
 
+For **lsf**, an unset `num_gpus_per_node` defaults to **1** GPU, unlike k8s which
+defaults to `0`. A non-GPU step (e.g. a pull/push step) must therefore set
+`num_gpus_per_node: 0` explicitly; otherwise the `bsub` job requests a GPU and
+waits for one to free up instead of being scheduled immediately on the normal
+queue.
+
 Per-environment specifics (k8s `affinity`, skypilot `cluster`/`zone`, lsf
 `queue`, etc.) are documented in the per-type
 [environment pages](../environments/README.md).

--- a/src/gbserver/builtins/steps/lsf/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/hfpull/step.yaml
@@ -18,6 +18,7 @@ config:
       type: ''
   compute_config:
     total_memory_per_node: 10Gi
+    num_gpus_per_node: 0
 environment_configs:
   Lsf:
     launchers:

--- a/src/gbserver/builtins/steps/lsf/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/hfpush/step.yaml
@@ -24,6 +24,7 @@ config:
       resource_group_id: null
   compute_config:
     total_memory_per_node: 10Gi
+    num_gpus_per_node: 0
 environment_configs:
   Lsf:
     launchers:


### PR DESCRIPTION
## Summary

- Add `num_gpus_per_node: 0` to the `compute_config` of the LSF `hfpull` and `hfpush` steps so they no longer request a GPU.
- The LSF `bsub` template (`llmb_lsf_jobsub.sh`) defaults an unset `num_gpus_per_node` to `1`, so these pull/push steps were emitting `-gpu "num=1/task:mode=exclusive_process"` and waiting for a GPU to free up instead of being scheduled immediately on the normal queue. This matches the existing pattern in `lsf/lhpull` / `lsf/lhpush`.
- Document the LSF defaulting behavior in the `compute_config` reference so future non-GPU steps set `num_gpus_per_node: 0` explicitly. This closes the documentation gap between LSF (defaults to 1) and k8s (defaults to 0) that allowed this bug to slip in.

Closes ibm-granite/granite.build#266

## Test plan

- No functional/code change — LSF step config + docs only.
- Verified against the template gate `{%- if num_gpus_per_node > 0 %}` ([llmb_lsf_jobsub.sh:107](https://github.com/ibm-granite/granite.build/blob/main/src/gbserver/builtins/steps/gbstep/lsf_scripts/%7B%7B%20step.name%20%7C%20default(run_metadata.target_name)%20%7D%7D/llmb_lsf_jobsub.sh#L107)): setting `num_gpus_per_node: 0` suppresses the `-gpu` bsub flag entirely, matching `lhpull`/`lhpush`.
- No published copies of these steps exist under `test/steps`, `test-data/steps`, or `configurations/assets`, so no regeneration required.

Generated with [Claude Code](https://claude.com/claude-code)