### PR TITLE
Render gb build restart status message as rich text

### DIFF
--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -1237,7 +1237,7 @@ def restart_build_cmd(ctx, build_id, format, skip_version_check, quiet):
 ```
 gb build status {restarted_build_id}
 ```"""
-                click.echo(parse_markdown_str(markdown_str))
+                click.echo(f"\n{parse_markdown_str(markdown_str)}")
             if format == "json":
                 click.echo(json.dumps({"build_id": restarted_build_id}))
 

--- a/src/gbcli/commands/command_build.py
+++ b/src/gbcli/commands/command_build.py
@@ -1233,10 +1233,11 @@ def restart_build_cmd(ctx, build_id, format, skip_version_check, quiet):
             details_page = f"{WEB_UI_URL}/builds/{restarted_build_id}"
             if not quiet:
                 click.echo(f"✅ Restarting build {restarted_build_id}: {details_page}")
-                click.echo(f"""To get the build status:
+                markdown_str = f"""To get the build status:
 ```
 gb build status {restarted_build_id}
-```""")
+```"""
+                click.echo(parse_markdown_str(markdown_str))
             if format == "json":
                 click.echo(json.dumps({"build_id": restarted_build_id}))
 


### PR DESCRIPTION
## Summary

- `gb build restart` emitted its "To get the build status" hint via `click.echo` directly, so the markdown code fences displayed as literal ```` ``` ```` text — unlike `gb build start`, which renders the same kind of message as rich text.
- Route the message through `parse_markdown_str()` (the same helper `gb build start` uses at line 805) so the fenced code block renders properly.
- Match the leading-newline spacing of the sibling call site for consistency.

## Test plan

- Run `gb build restart <id>` and confirm the status hint renders as rich text (formatted code block) rather than raw markdown with visible backtick fences.
- Confirm the output now matches the style of `gb build start`.

Generated with [Claude Code](https://claude.com/claude-code)