### PR TITLE
Fix flaky openlineage test and rework HF mocking so CI never touches HF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,13 +288,14 @@ cicd-pr-test:
 quick-tests-setup:
 	$(MAKE) g4os-skypilot-venv
 
-# Setup does not setup slurm, so the skypilot/slurm tests are skipped 
-# Mock most of HF since the action does not have the HF_TOKEN secret on PRs
+# Setup does not setup slurm, so the skypilot/slurm tests are skipped
+# GBTEST_MODE=mock forces GBTEST_MOCK_HF=true (see test/libgbtest/mock_env.py), so
+# HF is never touched — the action has no HF_TOKEN secret on PRs and we don't want
+# CI flaking on HF rate limits. A test needing real HF opts in via @pytest.mark.live("hf").
 .PHONY: quick-tests
 quick-tests:
 	export GB_ENVIRONMENT=STANDALONE &&			\
-	$(MAKE) GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group \
-		GBTEST_MODE=mock				\
+	$(MAKE) GBTEST_MODE=mock				\
 		PYTEST_MARKERS="not ibm and not extended" 	\
 		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\
 		.test
@@ -318,13 +319,13 @@ extended-tests: check-image-tag-not-dirty
 ibm-quick-tests-setup:
 	$(MAKE) venv
 
-# Mock most of HF since the action does not have the HF_TOKEN secret on PRs
+# GBTEST_MODE=mock forces GBTEST_MOCK_HF=true so HF is never touched (no HF_TOKEN
+# secret on PRs; avoids HF rate-limit flakes).
 # secret_manager tests require IBM_CLOUD_SECRETS_MANAGER_SERVICE_URL env var, which SPS is not providing or so it seems
 .PHONY: ibm-quick-tests
 ibm-quick-tests: check_ibm_sps_api_key
 	export GB_ENVIRONMENT=STAGING &&			\
-	$(MAKE) GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group \
-		GBTEST_MODE=mock				\
+	$(MAKE) GBTEST_MODE=mock				\
 		PYTEST_MARKERS="ibm and not extended" 	\
 		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\
 		.test
@@ -374,16 +375,17 @@ test-merge: check-image-tag-not-dirty
 		PYTEST_TEST_TARGETS="test/unit test/e2e test/integration/ibm"	\
 		.test
 
+# HF_TOKEN is required for STANDALONE live runs. In mock mode HF is mocked
+# (GBTEST_MODE=mock forces GBTEST_MOCK_HF=true), so no token is needed; an
+# explicit GBTEST_MOCK_HF=true also satisfies the check.
 .PHONY: check_hf_token
 check_hf_token:
-	@if [ "$$GB_ENVIRONMENT" = "STANDALONE" -a -z "$$HF_TOKEN" ]; then	\
-	    case ",$(GBTEST_MOCKED_HF_OPS)," in						\
-	        *,push,*|*,all,*) : ;;						\
-	        *)								\
-	            echo "HF_TOKEN env var required in GB_ENVIRONMENT=STANDALONE mode (or add 'push' to GBTEST_MOCKED_HF_OPS to mock HF pushes)";	\
-	            exit 1;							\
-	            ;;								\
-	    esac;								\
+	@mock_hf=$$(echo "$(GBTEST_MOCK_HF)" | tr A-Z a-z);			\
+	if [ "$$GB_ENVIRONMENT" = "STANDALONE" ] && [ -z "$$HF_TOKEN" ]		\
+	    && [ "$(GBTEST_MODE)" != "mock" ] && [ "$$mock_hf" != "true" ];	\
+	then									\
+	    echo "HF_TOKEN env var required in GB_ENVIRONMENT=STANDALONE live mode (use GBTEST_MODE=mock, or set GBTEST_MOCK_HF=true, to mock HF)";	\
+	    exit 1;								\
 	fi
 
 # The main test implementation, called after VENVDIR has been established
@@ -394,7 +396,7 @@ check_hf_token:
 .PHONY: .test
 .test:	check_hf_token
 	source $(VENVDIR)/bin/activate && \
-		export GBTEST_MOCKED_HF_OPS=${GBTEST_MOCKED_HF_OPS} &&	\
+		export GBTEST_MOCK_HF=${GBTEST_MOCK_HF} &&	\
 		export GBTEST_MODE=${GBTEST_MODE} && \
 		export GBSERVER_IMAGE_TAG=${IMAGE_TAG} && \
 		export GBSERVER_SIDECAR_MONITORING_IMAGE_TAG=${SIDECAR_IMAGE_TAG} && \

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ quick-tests-setup:
 	$(MAKE) g4os-skypilot-venv
 
 # Setup does not setup slurm, so the skypilot/slurm tests are skipped
-# GBTEST_MODE=mock forces GBTEST_MOCK_HF=true (see test/libgbtest/mock_env.py), so
+# GBTEST_MODE=mock defaults GBTEST_MOCK_HF=true (see test/libgbtest/mock_env.py), so
 # HF is never touched — the action has no HF_TOKEN secret on PRs and we don't want
 # CI flaking on HF rate limits. A test needing real HF opts in via @pytest.mark.live("hf").
 .PHONY: quick-tests
@@ -319,7 +319,7 @@ extended-tests: check-image-tag-not-dirty
 ibm-quick-tests-setup:
 	$(MAKE) venv
 
-# GBTEST_MODE=mock forces GBTEST_MOCK_HF=true so HF is never touched (no HF_TOKEN
+# GBTEST_MODE=mock defaults GBTEST_MOCK_HF=true so HF is never touched (no HF_TOKEN
 # secret on PRs; avoids HF rate-limit flakes).
 # secret_manager tests require IBM_CLOUD_SECRETS_MANAGER_SERVICE_URL env var, which SPS is not providing or so it seems
 .PHONY: ibm-quick-tests
@@ -375,14 +375,20 @@ test-merge: check-image-tag-not-dirty
 		PYTEST_TEST_TARGETS="test/unit test/e2e test/integration/ibm"	\
 		.test
 
-# HF_TOKEN is required for STANDALONE live runs. In mock mode HF is mocked
-# (GBTEST_MODE=mock forces GBTEST_MOCK_HF=true), so no token is needed; an
-# explicit GBTEST_MOCK_HF=true also satisfies the check.
+# HF_TOKEN is required for STANDALONE live runs. In mock mode HF is mocked by
+# default (GBTEST_MODE=mock defaults GBTEST_MOCK_HF=true), so no token is needed
+# unless that default is explicitly overridden with GBTEST_MOCK_HF=false; an
+# explicit GBTEST_MOCK_HF=true also satisfies the check on its own.
 .PHONY: check_hf_token
 check_hf_token:
 	@mock_hf=$$(echo "$(GBTEST_MOCK_HF)" | tr A-Z a-z);			\
+	mode_mocks_hf=false;							\
+	if [ "$(GBTEST_MODE)" = "mock" ] && [ "$$mock_hf" != "false" ];		\
+	then									\
+	    mode_mocks_hf=true;							\
+	fi;									\
 	if [ "$$GB_ENVIRONMENT" = "STANDALONE" ] && [ -z "$$HF_TOKEN" ]		\
-	    && [ "$(GBTEST_MODE)" != "mock" ] && [ "$$mock_hf" != "true" ];	\
+	    && [ "$$mode_mocks_hf" != "true" ] && [ "$$mock_hf" != "true" ];	\
 	then									\
 	    echo "HF_TOKEN env var required in GB_ENVIRONMENT=STANDALONE live mode (use GBTEST_MODE=mock, or set GBTEST_MOCK_HF=true, to mock HF)";	\
 	    exit 1;								\

--- a/src/gbcommon/types/testing.py
+++ b/src/gbcommon/types/testing.py
@@ -7,13 +7,15 @@
 import os
 from typing import Optional
 
+from gbcommon.types.gbenvconfig import getenv_boolean
+
 _GBTEST_PREFIX = "GBTEST_"
 
 # Controls whether HuggingFace Hub I/O is mocked. Set by tests that lack real
 # (or write) HuggingFace access — e.g. forked-PR CI, which has no HF_TOKEN. It is
-# all-or-nothing: when "true", every HF op (push/pull/exists/delete and
+# all-or-nothing: when truthy, every HF op (push/pull/exists/delete and
 # resource-group resolution) short-circuits before touching the Hub; when
-# unset/false, all ops run for real. Propagated to remote jobs/pods via env var
+# unset/empty/falsy, all ops run for real. Propagated to remote jobs/pods via env var
 # so they mock identically. Read at call time (not import time) so tests can
 # toggle it by setting/unsetting the env var without any patching.
 ENV_VAR_GBTEST_MOCK_HF = f"{_GBTEST_PREFIX}MOCK_HF"
@@ -27,10 +29,18 @@ _HF_MOCK_SAVED: list[Optional[str]] = []
 def is_hf_mocked() -> bool:
     """Return True if HuggingFace Hub I/O should be mocked (all ops).
 
+    A plain boolean read of GBTEST_MOCK_HF using the repo-standard parsing, so
+    "true"/"1"/"yes"/"on" all enable mocking and unset/empty are both False.
+    Defaulting it on under GBTEST_MODE=mock is a separate, deliberate test-init
+    step that writes the resolved value back to the environment (see
+    pytest_sessionstart in test/conftest.py) — this function stays a dumb read so
+    it behaves identically in a dispatched worker or pod, which only ever receives
+    the forwarded env var.
+
     Returns:
-        bool: True when GBTEST_MOCK_HF is set to "true" (case-insensitive).
+        bool: True when GBTEST_MOCK_HF parses as truthy.
     """
-    return os.getenv(ENV_VAR_GBTEST_MOCK_HF, "").lower() == "true"
+    return getenv_boolean(ENV_VAR_GBTEST_MOCK_HF)
 
 
 def enable_hf_mocks() -> None:

--- a/src/gbcommon/types/testing.py
+++ b/src/gbcommon/types/testing.py
@@ -9,91 +9,53 @@ from typing import Optional
 
 _GBTEST_PREFIX = "GBTEST_"
 
-# Controls which HF operations are mocked. Set by tests that lack real (or
-# write) HuggingFace access. The value is a comma-separated, case-insensitive
-# list of op names (see HF_OP_* below); the token "all" mocks everything and an
-# empty/unset value mocks nothing. Propagated to remote jobs/pods via env var so
-# they mock the same ops. Read at call time (not import time) so tests can toggle
-# it by setting/unsetting the env var without any patching.
-#
-# Selective mocking lets forked-PR CI mock the token-requiring ops (push, exists,
-# delete, resource_group) while letting pull run for real against public repos
-# (which download anonymously, no HF_TOKEN needed).
-ENV_VAR_GBTEST_MOCKED_HF_OPS = f"{_GBTEST_PREFIX}MOCKED_HF_OPS"
+# Controls whether HuggingFace Hub I/O is mocked. Set by tests that lack real
+# (or write) HuggingFace access — e.g. forked-PR CI, which has no HF_TOKEN. It is
+# all-or-nothing: when "true", every HF op (push/pull/exists/delete and
+# resource-group resolution) short-circuits before touching the Hub; when
+# unset/false, all ops run for real. Propagated to remote jobs/pods via env var
+# so they mock identically. Read at call time (not import time) so tests can
+# toggle it by setting/unsetting the env var without any patching.
+ENV_VAR_GBTEST_MOCK_HF = f"{_GBTEST_PREFIX}MOCK_HF"
 
-# Canonical HF operation names that can be selectively mocked.
-HF_OP_PULL = "pull"
-HF_OP_PUSH = "push"
-HF_OP_EXISTS = "exists"
-HF_OP_DELETE = "delete"
-HF_OP_RESOURCE_GROUP = "resource_group"
-HF_OPS_ALL = frozenset(
-    {HF_OP_PULL, HF_OP_PUSH, HF_OP_EXISTS, HF_OP_DELETE, HF_OP_RESOURCE_GROUP}
-)
-
-# Sentinel value in GBTEST_MOCKED_HF_OPS meaning "mock every HF op".
-_HF_OPS_ALL_TOKEN = "all"
-
-# Stack of prior GBTEST_MOCKED_HF_OPS values saved by enable_hf_mocks() so that
+# Stack of prior GBTEST_MOCK_HF values saved by enable_hf_mocks() so that
 # disable_hf_mocks() restores the previous value instead of clobbering a
-# suite-level default (e.g. one exported by the Makefile) for sibling tests.
-_HF_OPS_SAVED: list[Optional[str]] = []
+# suite-level default (e.g. one forced by mock mode) for sibling tests.
+_HF_MOCK_SAVED: list[Optional[str]] = []
 
 
-def hf_mocked_ops() -> set[str]:
-    """Parse GBTEST_MOCKED_HF_OPS into the set of HF ops to mock.
-
-    Returns:
-        set[str]: lowercased op names to mock. The token "all" expands to
-        HF_OPS_ALL; an empty/unset env var yields an empty set.
-    """
-    raw = os.getenv(ENV_VAR_GBTEST_MOCKED_HF_OPS, "")
-    ops = {tok.strip().lower() for tok in raw.split(",") if tok.strip()}
-    if _HF_OPS_ALL_TOKEN in ops:
-        return set(HF_OPS_ALL)
-    return ops
-
-
-def is_hf_mocked(op: str) -> bool:
-    """Return True if the given HF op should be mocked.
-
-    Args:
-        op: One of the HF_OP_* operation names (e.g. HF_OP_PULL).
+def is_hf_mocked() -> bool:
+    """Return True if HuggingFace Hub I/O should be mocked (all ops).
 
     Returns:
-        bool: True if ``op`` is listed in GBTEST_MOCKED_HF_OPS (or it lists "all").
+        bool: True when GBTEST_MOCK_HF is set to "true" (case-insensitive).
     """
-    return op.lower() in hf_mocked_ops()
+    return os.getenv(ENV_VAR_GBTEST_MOCK_HF, "").lower() == "true"
 
 
-def enable_hf_mocks(*ops: str) -> None:
-    """Enable mocking of the given HF ops for this process and any remote jobs/pods.
+def enable_hf_mocks() -> None:
+    """Enable HF mocking for this process and any remote jobs/pods.
 
-    Sets GBTEST_MOCKED_HF_OPS in the environment; the previous value is saved and
+    Sets GBTEST_MOCK_HF=true in the environment; the previous value is saved and
     restored by the matching disable_hf_mocks(). Since is_hf_mocked() reads the
     env var at call time, this takes effect immediately without patching, and the
-    env var is forwarded to remote pods so they mock the same ops.
-
-    Args:
-        *ops: HF_OP_* names to mock. Defaults to all ops when none are given.
+    env var is forwarded to remote pods so they mock too.
     """
-    _HF_OPS_SAVED.append(os.environ.get(ENV_VAR_GBTEST_MOCKED_HF_OPS))
-    os.environ[ENV_VAR_GBTEST_MOCKED_HF_OPS] = (
-        ",".join(ops) if ops else _HF_OPS_ALL_TOKEN
-    )
+    _HF_MOCK_SAVED.append(os.environ.get(ENV_VAR_GBTEST_MOCK_HF))
+    os.environ[ENV_VAR_GBTEST_MOCK_HF] = "true"
 
 
 def disable_hf_mocks() -> None:
-    """Restore GBTEST_MOCKED_HF_OPS to the value saved by the matching enable_hf_mocks().
+    """Restore GBTEST_MOCK_HF to the value saved by the matching enable_hf_mocks().
 
     Restores the prior value (or removes the var if there was none), so per-test
     enable/disable does not clobber a suite-level default set outside the test.
     """
-    prior = _HF_OPS_SAVED.pop() if _HF_OPS_SAVED else None
+    prior = _HF_MOCK_SAVED.pop() if _HF_MOCK_SAVED else None
     if prior is None:
-        os.environ.pop(ENV_VAR_GBTEST_MOCKED_HF_OPS, None)
+        os.environ.pop(ENV_VAR_GBTEST_MOCK_HF, None)
     else:
-        os.environ[ENV_VAR_GBTEST_MOCKED_HF_OPS] = prior
+        os.environ[ENV_VAR_GBTEST_MOCK_HF] = prior
 
 
 # Causes the supporting environments that implement step-level retry to inject
@@ -124,7 +86,7 @@ def disable_failure_simulation() -> None:
 
 # The set of all GBTEST_ env var names defined in this module.
 _GBTEST_EXPORTED_ENV_VARS = {
-    ENV_VAR_GBTEST_MOCKED_HF_OPS,
+    ENV_VAR_GBTEST_MOCK_HF,
     ENV_VAR_GBTEST_SIMULATE_FAILURE_SCENARIO,
 }
 

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -36,14 +36,7 @@ from huggingface_hub import (
 )
 
 from gbcommon.types.constants import GB_TEST_STANDALONE_ENVIRONMENT
-from gbcommon.types.testing import (
-    HF_OP_DELETE,
-    HF_OP_EXISTS,
-    HF_OP_PULL,
-    HF_OP_PUSH,
-    HF_OP_RESOURCE_GROUP,
-    is_hf_mocked,
-)
+from gbcommon.types.testing import is_hf_mocked
 from gbcommon.uri.uri import URI
 from gbserver.types.artifact import ArtifactType
 from gbserver.types.constants import GB_ENVIRONMENT
@@ -328,7 +321,7 @@ class HfURI(URI):
         The latter are dangerous here: the resource may actually exist but we
         would still report it missing, so they must be visible in logs.
         """
-        if is_hf_mocked(HF_OP_EXISTS):
+        if is_hf_mocked():
             return True
         repo_id = "<unparsed>"
         try:
@@ -605,8 +598,8 @@ class HfURI(URI):
         so all repo files land directly in *dest*.  For buckets, uses
         ``HfApi.sync_bucket`` to download bucket contents to *dest*.
 
-        Returns ``True`` immediately without network calls when ``pull`` is
-        listed in ``GBTEST_MOCKED_HF_OPS``.
+        Returns ``True`` immediately without network calls when HF mocking is
+        enabled via ``GBTEST_MOCK_HF``.
 
         Token is resolved from ``self.secrets['HF_TOKEN']`` or the ``HF_TOKEN``
         environment variable.  For non-default hosts the ``endpoint`` kwarg is
@@ -619,7 +612,7 @@ class HfURI(URI):
         Returns:
             True if the download succeeded, False on any error.
         """
-        if is_hf_mocked(HF_OP_PULL):
+        if is_hf_mocked():
             return True
         try:
             p = self._parts()
@@ -762,7 +755,7 @@ class HfURI(URI):
         Returns:
             True if deletion succeeded, False on any error.
         """
-        if is_hf_mocked(HF_OP_DELETE):
+        if is_hf_mocked():
             return True
         p = self._parts()
         try:
@@ -898,7 +891,7 @@ class HfURI(URI):
             ValueError: If any of the provided inputs disagree, or if name/space
                 resolution fails.
         """
-        if is_hf_mocked(HF_OP_RESOURCE_GROUP):
+        if is_hf_mocked():
             # When this op is mocked there is no live Hub to query; skip the
             # resource-group lookup (which would hit the /resource-groups list
             # endpoint and require a token) and keep any explicit id, else None.
@@ -1138,7 +1131,7 @@ class HfURI(URI):
                 resulting empty commit, leaving the push a silent no-op).
             Exception: Any error from the HuggingFace Hub API is re-raised.
         """
-        if is_hf_mocked(HF_OP_PUSH):
+        if is_hf_mocked():
             return
         p = self._parts()
         repo_id = f"{p.owner}/{p.repo}"

--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -19,8 +19,10 @@ HF_TYPE='{{ hfp.hf.type }}'
 
 # Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
 # gbcommon.types.testing.is_hf_mocked. Forwarded as a worker env var.
+# Keep this identical to the other hfpull/hfpush step scripts (lsf + skypilot):
+# the `case` form is portable across bash and sh so the four copies can't drift.
 hf_mocked() {
-    [[ "${GBTEST_MOCK_HF:-}" == [Tt][Rr][Uu][Ee] ]]
+    case "${GBTEST_MOCK_HF:-}" in [Tt][Rr][Uu][Ee]) return 0 ;; *) return 1 ;; esac
 }
 if hf_mocked; then
     echo "[GBTEST_MOCK_HF] mocking hfpull — skipping real download"

--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -17,16 +17,13 @@ HF_REPO='{{ hfp.owner }}/{{ hfp.repo }}'
 HF_REVISION='{{ hfp.revision }}'
 HF_TYPE='{{ hfp.hf.type }}'
 
-# Mocked iff the op (or "all") is listed in GBTEST_MOCKED_HF_OPS;
-# tolerant of spaces/case to match gbcommon.types.testing.hf_mocked_ops.
+# Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
+# gbcommon.types.testing.is_hf_mocked. Forwarded as a worker env var.
 hf_mocked() {
-    local ops=",${GBTEST_MOCKED_HF_OPS:-},"
-    ops=${ops// /}
-    ops=${ops,,}
-    case "$ops" in *,"$1",*|*,all,*) return 0 ;; *) return 1 ;; esac
+    [[ "${GBTEST_MOCK_HF:-}" == [Tt][Rr][Uu][Ee] ]]
 }
-if hf_mocked pull; then
-    echo "[GBTEST_MOCKED_HF_OPS] mocking hfpull — skipping real download"
+if hf_mocked; then
+    echo "[GBTEST_MOCK_HF] mocking hfpull — skipping real download"
     mkdir -p "${HF_DEST}"
     echo mock > "${HF_DEST}/.gbtest_mock_hfpull"
     echo "Pulled HF URI: ${HF_URI} to path ${HF_DEST}"

--- a/src/gbserver/builtins/steps/lsf/hfpush/lsf_scripts/hfpush/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpush/lsf_scripts/hfpush/command.sh
@@ -24,8 +24,10 @@ BINDING_ID='{{ hfp.binding_id }}'
 
 # Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
 # gbcommon.types.testing.is_hf_mocked. Forwarded as a worker env var.
+# Keep this identical to the other hfpull/hfpush step scripts (lsf + skypilot):
+# the `case` form is portable across bash and sh so the four copies can't drift.
 hf_mocked() {
-    [[ "${GBTEST_MOCK_HF:-}" == [Tt][Rr][Uu][Ee] ]]
+    case "${GBTEST_MOCK_HF:-}" in [Tt][Rr][Uu][Ee]) return 0 ;; *) return 1 ;; esac
 }
 if hf_mocked; then
     echo "[GBTEST_MOCK_HF] mocking hfpush — skipping create_repo and upload"

--- a/src/gbserver/builtins/steps/lsf/hfpush/lsf_scripts/hfpush/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpush/lsf_scripts/hfpush/command.sh
@@ -22,16 +22,13 @@ HF_TYPE='{{ hfp.hf.type }}'
 HF_RESOURCE_GROUP_ID='{{ hfp.hf.resource_group_id }}'
 BINDING_ID='{{ hfp.binding_id }}'
 
-# Mocked iff the op (or "all") is listed in GBTEST_MOCKED_HF_OPS;
-# tolerant of spaces/case to match gbcommon.types.testing.hf_mocked_ops.
+# Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
+# gbcommon.types.testing.is_hf_mocked. Forwarded as a worker env var.
 hf_mocked() {
-    local ops=",${GBTEST_MOCKED_HF_OPS:-},"
-    ops=${ops// /}
-    ops=${ops,,}
-    case "$ops" in *,"$1",*|*,all,*) return 0 ;; *) return 1 ;; esac
+    [[ "${GBTEST_MOCK_HF:-}" == [Tt][Rr][Uu][Ee] ]]
 }
-if hf_mocked push; then
-    echo "[GBTEST_MOCKED_HF_OPS] mocking hfpush — skipping create_repo and upload"
+if hf_mocked; then
+    echo "[GBTEST_MOCK_HF] mocking hfpush — skipping create_repo and upload"
     echo "Pushed HF URI: ${HF_URI} for binding ${BINDING_ID}"
     echo 'hfpush end'
     exit 0

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -45,6 +45,9 @@ environment_configs:
 
             # Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
             # gbcommon.types.testing.is_hf_mocked. Forwarded as a worker env var.
+            # Keep identical to the other hfpull/hfpush step scripts (lsf + skypilot);
+            # skypilot embeds this inline (no shared file on the worker), so the copies
+            # are kept byte-identical to prevent behavioral drift.
             hf_mocked() {
                 case "${GBTEST_MOCK_HF:-}" in [Tt][Rr][Uu][Ee]) return 0 ;; *) return 1 ;; esac
             }

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -43,16 +43,13 @@ environment_configs:
             HF_REVISION='{{ config.hfpull_config.revision }}'
             HF_TYPE='{{ config.hfpull_config.hf.type }}'
 
-            # Mocked iff the op (or "all") is listed in GBTEST_MOCKED_HF_OPS;
-            # tolerant of spaces/case to match gbcommon.types.testing.hf_mocked_ops.
+            # Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
+            # gbcommon.types.testing.is_hf_mocked. Forwarded as a worker env var.
             hf_mocked() {
-                local ops=",${GBTEST_MOCKED_HF_OPS:-},"
-                ops=${ops// /}
-                ops=${ops,,}
-                case "$ops" in *,"$1",*|*,all,*) return 0 ;; *) return 1 ;; esac
+                case "${GBTEST_MOCK_HF:-}" in [Tt][Rr][Uu][Ee]) return 0 ;; *) return 1 ;; esac
             }
-            if hf_mocked pull; then
-                echo "[GBTEST_MOCKED_HF_OPS] mocking hfpull — skipping real download"
+            if hf_mocked; then
+                echo "[GBTEST_MOCK_HF] mocking hfpull — skipping real download"
                 mkdir -p "${HF_DEST}"
                 echo mock > "${HF_DEST}/.gbtest_mock_hfpull"
                 echo "Pulled HF URI: ${HF_URI} to path ${HF_DEST}"

--- a/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
@@ -57,18 +57,15 @@ environment_configs:
             export HF_SOURCE
             BINDING_ID='{{ config.hfpush_config.binding_id }}'
 
-            # Mocked iff the op (or "all") is listed in GBTEST_MOCKED_HF_OPS;
-            # tolerant of spaces/case to match gbcommon.types.testing.hf_mocked_ops.
-            # GBTEST_MOCKED_HF_OPS arrives as a worker env var (sky.Task envs),
-            # not via hfpush_config — it is test-harness state, not a push param.
+            # Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching
+            # gbcommon.types.testing.is_hf_mocked. GBTEST_MOCK_HF arrives as a
+            # worker env var (sky.Task envs), not via hfpush_config — it is
+            # test-harness state, not a push param.
             hf_mocked() {
-                local ops=",${GBTEST_MOCKED_HF_OPS:-},"
-                ops=${ops// /}
-                ops=${ops,,}
-                case "$ops" in *,"$1",*|*,all,*) return 0 ;; *) return 1 ;; esac
+                case "${GBTEST_MOCK_HF:-}" in [Tt][Rr][Uu][Ee]) return 0 ;; *) return 1 ;; esac
             }
-            if hf_mocked push; then
-                echo "[GBTEST_MOCKED_HF_OPS] mocking hfpush — skipping create_repo and upload"
+            if hf_mocked; then
+                echo "[GBTEST_MOCK_HF] mocking hfpush — skipping create_repo and upload"
                 echo "Pushed HF URI: ${HF_URI} for binding ${BINDING_ID}"
                 echo 'hfpush end'
                 exit 0

--- a/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpush/step.yaml
@@ -61,6 +61,9 @@ environment_configs:
             # gbcommon.types.testing.is_hf_mocked. GBTEST_MOCK_HF arrives as a
             # worker env var (sky.Task envs), not via hfpush_config — it is
             # test-harness state, not a push param.
+            # Keep identical to the other hfpull/hfpush step scripts (lsf + skypilot);
+            # skypilot embeds this inline (no shared file on the worker), so the copies
+            # are kept byte-identical to prevent behavioral drift.
             hf_mocked() {
                 case "${GBTEST_MOCK_HF:-}" in [Tt][Rr][Uu][Ee]) return 0 ;; *) return 1 ;; esac
             }

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -926,7 +926,7 @@ class Environment(ABC):
         every environment gets, regardless of launcher:
 
         1. The ``GBTEST_`` test-control vars currently set in the server's own
-           environment (e.g. GBTEST_MOCKED_HF_OPS), forwarded so a step running
+           environment (e.g. GBTEST_MOCK_HF), forwarded so a step running
            in a detached env — remote pod/job, container, or the clean-env bash
            subprocess — mocks the same HF ops the server would.
         2. The run_metadata-derived standard vars (currently GB_BUILD_ID; see

--- a/src/gbserver/storage/singleton_storage.py
+++ b/src/gbserver/storage/singleton_storage.py
@@ -110,6 +110,17 @@ def get_storage_factory() -> StorageFactory:
     return __STORAGE_FACTORY
 
 
+def reset_admin_storage() -> None:
+    """Clear the cached singleton so the next get_admin_storage() rebuilds it.
+
+    A test that swaps in prefixed storage (or tears down its backing db) clears
+    this on teardown; otherwise the next get_admin_storage() reuses the stale
+    singleton, which points at tables that are now gone.
+    """
+    global __STORAGE
+    __STORAGE = None
+
+
 def get_admin_storage() -> SingletonAdminStorage:
     """Get the tuple of storage instances that the REST apis should be using.
 

--- a/src/gbserver/storage/storage.py
+++ b/src/gbserver/storage/storage.py
@@ -718,8 +718,12 @@ class BaseItemStorage(IItemStorage[BASE_ITEM_TYPE], Generic[BASE_ITEM_TYPE]):
             not self._does_table_exist()
         ):  # Try and avoid needlessly creating the table only to delete it, seen in setup/teardown of tests.
             # Table is gone: reset the flag even here, so the get_by_*() guards
-            # don't trust a stale "initialized" and query a dropped table.
-            self.__is_storage_initialized = False
+            # don't trust a stale "initialized" and query a dropped table. Held
+            # under the same lock as the reset below, so both writes to the flag
+            # are guarded identically (no schema work happens on this path, so
+            # the lock is uncontended here).
+            with self.__storage_modification_lock:
+                self.__is_storage_initialized = False
             self.logger.debug(f"Done deleting table: table does not exist.")
             return
 

--- a/src/gbserver/storage/storage.py
+++ b/src/gbserver/storage/storage.py
@@ -717,6 +717,9 @@ class BaseItemStorage(IItemStorage[BASE_ITEM_TYPE], Generic[BASE_ITEM_TYPE]):
         if (
             not self._does_table_exist()
         ):  # Try and avoid needlessly creating the table only to delete it, seen in setup/teardown of tests.
+            # Table is gone: reset the flag even here, so the get_by_*() guards
+            # don't trust a stale "initialized" and query a dropped table.
+            self.__is_storage_initialized = False
             self.logger.debug(f"Done deleting table: table does not exist.")
             return
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -818,6 +818,11 @@ def _hf_mock(request):
         try:
             yield
         finally:
+            # Restore exactly the entry state: always clear first (in case the
+            # test body set the var), then put back the prior value if there was
+            # one. Guards against leaking GBTEST_MOCK_HF into later tests in the
+            # same worker when it was unset on entry (e.g. a GBTEST_LIVE_HF run).
+            os.environ.pop("GBTEST_MOCK_HF", None)
             if prior is not None:
                 os.environ["GBTEST_MOCK_HF"] = prior
     else:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -332,6 +332,13 @@ def pytest_sessionstart(session):
             os.environ[key] = value
         for key, value in MOCK_ENV_DEFAULTS.items():
             os.environ.setdefault(key, value)
+        # A whole-run live-HF opt-in (GBTEST_LIVE_HF=true) lifts the forced HF
+        # mock so the entire mock-mode run can exercise real HuggingFace. Per-test
+        # opt-in is handled by the _hf_mock fixture via @pytest.mark.live("hf").
+        from libgbtest.mode import is_live
+
+        if is_live("hf"):
+            os.environ.pop("GBTEST_MOCK_HF", None)
         logger.info(
             "Mock mode: applied placeholder env vars. "
             "Set GBTEST_MODE=live or per-service GBTEST_LIVE_<SERVICE>=true for real connections."
@@ -797,13 +804,23 @@ def _mock_kubernetes(request):
 
 
 @pytest.fixture(autouse=True)
-def _mock_huggingface(request):
-    """In mock mode, patch HuggingFace Hub downloads."""
-    if should_use_live(request, "hf"):
-        yield
-        return
+def _hf_mock(request):
+    """Bridge the ``live("hf")`` marker to the GBTEST_MOCK_HF guard.
 
-    with patch("huggingface_hub.snapshot_download", return_value="/tmp/fake-model"):
+    In mock mode GBTEST_MOCK_HF=true is forced at session start, so every HF op
+    (push/pull/exists/delete) short-circuits in HfURI without touching the Hub —
+    no per-test setup needed. A test marked ``@pytest.mark.live("hf")`` (or a run
+    with GBTEST_LIVE_HF=true) exercises real HF instead, so lift the guard for its
+    duration and restore it afterwards.
+    """
+    if should_use_live(request, "hf"):
+        prior = os.environ.pop("GBTEST_MOCK_HF", None)
+        try:
+            yield
+        finally:
+            if prior is not None:
+                os.environ["GBTEST_MOCK_HF"] = prior
+    else:
         yield
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -326,25 +326,44 @@ def pytest_sessionstart(session):
 
     if test_mode != "live":
         # Mock mode: apply placeholder env vars so modules can import safely
-        from libgbtest.mock_env import (
-            MOCK_ENV_DEFAULTS,
-            MOCK_ENV_FORCED,
-            MOCK_ENV_MOCK_DEFAULTS,
-        )
+        from libgbtest.mock_env import MOCK_ENV_DEFAULTS, MOCK_ENV_FORCED
+
+        from gbcommon.types.gbenvconfig import getenv_boolean
+        from gbcommon.types.testing import ENV_VAR_GBTEST_MOCK_HF
 
         for key, value in MOCK_ENV_FORCED.items():
             os.environ[key] = value
-        # Mocking switches default on in mock mode but stay overridable, so an
-        # explicit GBTEST_MOCK_HF=false in the environment survives.
-        for key, value in MOCK_ENV_MOCK_DEFAULTS.items():
-            os.environ.setdefault(key, value)
         for key, value in MOCK_ENV_DEFAULTS.items():
             os.environ.setdefault(key, value)
+
+        # HF mocking: mock mode turns it on, then an explicit setting overrides.
+        #
+        # (1) GBTEST_MODE=mock defaults HF mocking ON. This is a deliberate
+        #     test-initialization step, not a property of the var itself —
+        #     is_hf_mocked() stays a plain boolean read where unset and empty are
+        #     both False.
+        # (2) An explicitly set, non-blank GBTEST_MOCK_HF then wins, parsed with
+        #     the repo-standard getenv_boolean, so GBTEST_MOCK_HF=false opts out
+        #     of the default and GBTEST_MOCK_HF=1/yes/on opt in.
+        #
+        # Blank is deliberately treated as "no choice made", not as an opt-out:
+        # `make .test` exports `GBTEST_MOCK_HF=${GBTEST_MOCK_HF}` unconditionally,
+        # which leaves the var present-but-empty when no caller set it. Reading
+        # that as false silently un-mocked HF for all of CI (PR #314 review).
+        #
+        # The resolved value is written back to the environment so every consumer
+        # sees the same normalized "true"/"false": in-process is_hf_mocked(), and
+        # dispatched jobs/pods, which receive only the forwarded env var and
+        # re-read it in a separate process (their shell guards match on "true").
+        mock_hf = True
+        if os.environ.get(ENV_VAR_GBTEST_MOCK_HF, "").strip():
+            mock_hf = getenv_boolean(ENV_VAR_GBTEST_MOCK_HF, mock_hf)
         # A whole-run live-HF opt-in (GBTEST_LIVE_HF=true) lifts the HF mock so
         # the entire mock-mode run can exercise real HuggingFace. Per-test opt-in
         # is handled by the _hf_mock fixture via @pytest.mark.live("hf").
         if os.environ.get("GBTEST_LIVE_HF", "").lower() == "true":
-            os.environ.pop("GBTEST_MOCK_HF", None)
+            mock_hf = False
+        os.environ[ENV_VAR_GBTEST_MOCK_HF] = "true" if mock_hf else "false"
         logger.info(
             "Mock mode: applied placeholder env vars. "
             "Set GBTEST_MODE=live or per-service GBTEST_LIVE_<SERVICE>=true for real connections."
@@ -827,11 +846,13 @@ def _wants_live_hf(request) -> bool:
 def _hf_mock(request):
     """Bridge the ``live("hf")`` marker to the GBTEST_MOCK_HF guard.
 
-    In mock mode GBTEST_MOCK_HF=true is set at session start (overridable), so
-    every HF op (push/pull/exists/delete) short-circuits in HfURI without touching
-    the Hub — no per-test setup needed. A test marked ``@pytest.mark.live("hf")``
-    (or a run with GBTEST_LIVE_HF=true) exercises real HF instead, so lift the
-    guard for its duration and restore it afterwards.
+    In mock mode pytest_sessionstart resolves GBTEST_MOCK_HF to "true" by default
+    (an explicit non-blank value overrides), so every HF op (push/pull/exists/
+    delete) short-circuits in HfURI without touching the Hub — no per-test setup
+    needed. A test marked ``@pytest.mark.live("hf")`` exercises real HF instead,
+    so lift the guard for its duration and restore it afterwards. (A whole-run
+    GBTEST_LIVE_HF=true is already resolved to "false" at session start; popping
+    the var here is equivalent, since unset also reads as not-mocked.)
 
     This is the single gate for HF mocking: it is marker-aware at function, class
     and module scope, so no test base class should re-gate it (a second gate in

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -326,18 +326,24 @@ def pytest_sessionstart(session):
 
     if test_mode != "live":
         # Mock mode: apply placeholder env vars so modules can import safely
-        from libgbtest.mock_env import MOCK_ENV_DEFAULTS, MOCK_ENV_FORCED
+        from libgbtest.mock_env import (
+            MOCK_ENV_DEFAULTS,
+            MOCK_ENV_FORCED,
+            MOCK_ENV_MOCK_DEFAULTS,
+        )
 
         for key, value in MOCK_ENV_FORCED.items():
             os.environ[key] = value
+        # Mocking switches default on in mock mode but stay overridable, so an
+        # explicit GBTEST_MOCK_HF=false in the environment survives.
+        for key, value in MOCK_ENV_MOCK_DEFAULTS.items():
+            os.environ.setdefault(key, value)
         for key, value in MOCK_ENV_DEFAULTS.items():
             os.environ.setdefault(key, value)
-        # A whole-run live-HF opt-in (GBTEST_LIVE_HF=true) lifts the forced HF
-        # mock so the entire mock-mode run can exercise real HuggingFace. Per-test
-        # opt-in is handled by the _hf_mock fixture via @pytest.mark.live("hf").
-        from libgbtest.mode import is_live
-
-        if is_live("hf"):
+        # A whole-run live-HF opt-in (GBTEST_LIVE_HF=true) lifts the HF mock so
+        # the entire mock-mode run can exercise real HuggingFace. Per-test opt-in
+        # is handled by the _hf_mock fixture via @pytest.mark.live("hf").
+        if os.environ.get("GBTEST_LIVE_HF", "").lower() == "true":
             os.environ.pop("GBTEST_MOCK_HF", None)
         logger.info(
             "Mock mode: applied placeholder env vars. "
@@ -803,17 +809,35 @@ def _mock_kubernetes(request):
 # ---------------------------------------------------------------------------
 
 
+def _wants_live_hf(request) -> bool:
+    """True if this test opted in to real HF via marker or GBTEST_LIVE_HF.
+
+    Deliberately narrower than ``should_use_live(request, "hf")``, which also
+    returns True for the whole run when GBTEST_MODE=live. GBTEST_MOCK_HF is an
+    independent axis from GBTEST_MODE, so live mode alone must not strip an
+    explicit GBTEST_MOCK_HF=true — only an HF-specific opt-in does.
+    """
+    for mark in request.node.iter_markers("live"):
+        if "hf" in mark.args:
+            return True
+    return os.environ.get("GBTEST_LIVE_HF", "").lower() == "true"
+
+
 @pytest.fixture(autouse=True)
 def _hf_mock(request):
     """Bridge the ``live("hf")`` marker to the GBTEST_MOCK_HF guard.
 
-    In mock mode GBTEST_MOCK_HF=true is forced at session start, so every HF op
-    (push/pull/exists/delete) short-circuits in HfURI without touching the Hub —
-    no per-test setup needed. A test marked ``@pytest.mark.live("hf")`` (or a run
-    with GBTEST_LIVE_HF=true) exercises real HF instead, so lift the guard for its
-    duration and restore it afterwards.
+    In mock mode GBTEST_MOCK_HF=true is set at session start (overridable), so
+    every HF op (push/pull/exists/delete) short-circuits in HfURI without touching
+    the Hub — no per-test setup needed. A test marked ``@pytest.mark.live("hf")``
+    (or a run with GBTEST_LIVE_HF=true) exercises real HF instead, so lift the
+    guard for its duration and restore it afterwards.
+
+    This is the single gate for HF mocking: it is marker-aware at function, class
+    and module scope, so no test base class should re-gate it (a second gate in
+    setup_method would re-set the var after this fixture lifted it — see #314).
     """
-    if should_use_live(request, "hf"):
+    if _wants_live_hf(request):
         prior = os.environ.pop("GBTEST_MOCK_HF", None)
         try:
             yield

--- a/test/e2e/standalone/test_build_runner_cli.py
+++ b/test/e2e/standalone/test_build_runner_cli.py
@@ -51,6 +51,7 @@ from typing import Optional
 import pytest
 from libgbtest.utils import AbstractSingletonStorageUsingTest
 
+from gbserver.storage.singleton_storage import reset_admin_storage
 from gbserver.storage.sql.engine_cache import get_singleton_engine_cache
 from gbserver.storage.sqlite.storage_factory import SqliteStorageFactory
 from gbserver.storage.storage_factory import StorageFactory
@@ -156,6 +157,8 @@ class TestBuildRunnerCliSignals(AbstractSingletonStorageUsingTest):
         """
         get_singleton_engine_cache().dispose_all()
         self.storage = None
+        # Don't leave a singleton pointing at the temp db we're about to delete.
+        reset_admin_storage()
         if self._prev_gb_home is None:
             os.environ.pop("GB_HOME_DIR", None)
         else:

--- a/test/e2e/standalone/test_standalone_environments_e2e.py
+++ b/test/e2e/standalone/test_standalone_environments_e2e.py
@@ -238,12 +238,14 @@ class TestStandaloneEnvironmentsE2E:
 
     # -- Inference tests (model download + run) --
 
+    @pytest.mark.live("hf")
     def test_bash_inference(self):
         """Bash environment: download a small model and run inference."""
         with patch.dict(os.environ, _STANDALONE_ENV):
             _run_build("bash-inference.yaml", timeout=600)
 
     @skipif_no_docker
+    @pytest.mark.live("hf")
     def test_docker_inference(self):
         """Docker environment: download a small model and run inference."""
         with patch.dict(os.environ, _STANDALONE_ENV):
@@ -269,6 +271,7 @@ class TestStandaloneEnvironmentsE2E:
     # -- TRL fine-tuning tests --
 
     @skipif_no_ml
+    @pytest.mark.live("hf")
     def test_bash_trl_finetune(self):
         """Bash environment: TRL fine-tuning with a small model."""
         with patch.dict(os.environ, _STANDALONE_ENV):
@@ -276,6 +279,7 @@ class TestStandaloneEnvironmentsE2E:
 
     @skipif_no_docker
     @skipif_no_ml
+    @pytest.mark.live("hf")
     def test_docker_trl_finetune(self):
         """Docker environment: TRL fine-tuning with a small model."""
         _build_test_docker_image()
@@ -285,6 +289,7 @@ class TestStandaloneEnvironmentsE2E:
     # -- unitxt evaluation tests --
 
     @skipif_no_ml
+    @pytest.mark.live("hf")
     def test_bash_unitxt_eval(self):
         """Bash environment: unitxt evaluation with a small model."""
         with patch.dict(os.environ, _STANDALONE_ENV):
@@ -292,6 +297,7 @@ class TestStandaloneEnvironmentsE2E:
 
     @skipif_no_docker
     @skipif_no_ml
+    @pytest.mark.live("hf")
     def test_docker_unitxt_eval(self):
         """Docker environment: unitxt evaluation with a small model."""
         _build_test_docker_image()

--- a/test/libgbtest/buildrunner/buildtest.py
+++ b/test/libgbtest/buildrunner/buildtest.py
@@ -44,7 +44,7 @@ from libgbtest.constants import (
     GBTEST_USER_NAME,
     failed_build_assert_message,
 )
-from libgbtest.mode import is_mock_mode
+from libgbtest.mode import is_live, is_mock_mode
 from libgbtest.utils import (
     AbstractSingletonStorageUsingPreloadedSpaceTest,
     is_pytest_running_parallel,
@@ -349,7 +349,10 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
     def setup_method(self: Self, method):
         # breakpoint()
         # Only use real HF calls in live mode; mock artifact ops otherwise.
-        if is_mock_mode():
+        # is_live("hf") also covers the per-service opt-in (GBTEST_LIVE_HF=true),
+        # which conftest honors by lifting GBTEST_MOCK_HF at session start — so
+        # re-mocking here would silently override that opt-in.
+        if is_mock_mode() and not is_live("hf"):
             self._enable_artifact_mocks()
 
         self.class_tested = None
@@ -372,7 +375,10 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
         super().setup_method(method)
 
     def teardown_method(self: Self, method):
-        if is_mock_mode():
+        # Must mirror setup_method's condition exactly: disable_hf_mocks() pops
+        # the stack entry enable_hf_mocks() pushed, so an asymmetric guard would
+        # pop an entry it never pushed.
+        if is_mock_mode() and not is_live("hf"):
             self._disable_artifact_mocks()
 
         if GBTEST_SKIP_BUILD_TEARDOWN:

--- a/test/libgbtest/buildrunner/buildtest.py
+++ b/test/libgbtest/buildrunner/buildtest.py
@@ -44,7 +44,6 @@ from libgbtest.constants import (
     GBTEST_USER_NAME,
     failed_build_assert_message,
 )
-from libgbtest.mode import is_live, is_mock_mode
 from libgbtest.utils import (
     AbstractSingletonStorageUsingPreloadedSpaceTest,
     is_pytest_running_parallel,
@@ -53,9 +52,7 @@ from pydantic import BaseModel, field_validator
 
 from gbcommon.types.testing import (
     disable_failure_simulation,
-    disable_hf_mocks,
     enable_failure_simulation,
-    enable_hf_mocks,
 )
 from gbcommon.uri.uri import URI
 from gbserver.buildrunner.buildrunner import BuildRunner
@@ -348,13 +345,11 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
 
     def setup_method(self: Self, method):
         # breakpoint()
-        # Only use real HF calls in live mode; mock artifact ops otherwise.
-        # is_live("hf") also covers the per-service opt-in (GBTEST_LIVE_HF=true),
-        # which conftest honors by lifting GBTEST_MOCK_HF at session start — so
-        # re-mocking here would silently override that opt-in.
-        if is_mock_mode() and not is_live("hf"):
-            self._enable_artifact_mocks()
-
+        # HF mocking is handled entirely by the autouse `_hf_mock` fixture in
+        # test/conftest.py, which is marker-aware and so honors
+        # @pytest.mark.live("hf") at function, class and module scope. Gating it
+        # here too would re-set GBTEST_MOCK_HF after the fixture lifted it,
+        # force-mocking a live("hf") build test; see PR #314 review.
         self.class_tested = None
         run_locally = getattr(self, "run_locally", False)
         logger.info(f"Test to be run locally: {run_locally}")
@@ -375,12 +370,6 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
         super().setup_method(method)
 
     def teardown_method(self: Self, method):
-        # Must mirror setup_method's condition exactly: disable_hf_mocks() pops
-        # the stack entry enable_hf_mocks() pushed, so an asymmetric guard would
-        # pop an entry it never pushed.
-        if is_mock_mode() and not is_live("hf"):
-            self._disable_artifact_mocks()
-
         if GBTEST_SKIP_BUILD_TEARDOWN:
             logger.warning("skipping the teardown of the test build!")
             return
@@ -420,15 +409,6 @@ class AbstractBuildTest(AbstractSingletonStorageUsingPreloadedSpaceTest):
 
         # And now do the super cleanups
         return super().teardown_method(method)
-
-    def _enable_artifact_mocks(self) -> None:
-        """Enable push/pull/exists/delete mocking for this process and remote jobs/pods
-        and the input/output URIs used in the build.  Currently onl hf://."""
-        enable_hf_mocks()
-
-    def _disable_artifact_mocks(self) -> None:
-        """Disable artifact mocking."""
-        disable_hf_mocks()
 
     def _failed_build_msg(self: Self, build_id: str, message: str) -> str:
         """Format an assertion message with the build ID for easier debugging."""

--- a/test/libgbtest/mock_env.py
+++ b/test/libgbtest/mock_env.py
@@ -6,9 +6,6 @@ MOCK_ENV_FORCED: Always set in mock mode (override any existing env vars).
     These are the variables that control whether external calls happen — they
     must be forced to prevent a developer's shell env from defeating mock mode.
 
-MOCK_ENV_MOCK_DEFAULTS: Mocking switches that default on in mock mode but stay
-    overridable — an explicit value in the environment wins.
-
 MOCK_ENV_DEFAULTS: Only set if not already present (setdefault semantics).
     These provide safe placeholders for variables read at import time.
 """
@@ -22,19 +19,13 @@ MOCK_ENV_FORCED = {
     "WANDB_MODE": "disabled",
 }
 
-# Default-on in mock mode, but overridable — GBTEST_MOCK_HF is an independent
-# axis from GBTEST_MODE, not a consequence of it, so an explicit value in the
-# environment wins (setdefault semantics).
-#
-# GBTEST_MOCK_HF makes mock mode never touch real HuggingFace (push/pull/
-# exists/delete), so CI can't flake on HF rate limits or spend token quota.
-# It is forwarded to dispatched worker jobs/pods (see get_exported_gbtest_env_vars)
-# so they mock too. A single test can still exercise real HF via
-# @pytest.mark.live("hf"), which the _hf_mock fixture honors by lifting the var;
-# a whole run can opt out with GBTEST_MOCK_HF=false or GBTEST_LIVE_HF=true.
-MOCK_ENV_MOCK_DEFAULTS = {
-    "GBTEST_MOCK_HF": "true",
-}
+# NOTE: GBTEST_MOCK_HF is deliberately NOT listed here. It needs three-way
+# precedence (mock-mode default, then an explicit non-blank override, then the
+# GBTEST_LIVE_HF opt-out) and the resolved value written back to the environment
+# for dispatched workers, which neither the forced nor the setdefault pass can
+# express — a blank value from `make .test` would read as an opt-out under
+# setdefault and silently un-mock HF for all of CI. It is resolved explicitly in
+# pytest_sessionstart (test/conftest.py); see PR #314.
 
 # Set only if not already present — safe placeholder values.
 MOCK_ENV_DEFAULTS = {

--- a/test/libgbtest/mock_env.py
+++ b/test/libgbtest/mock_env.py
@@ -6,24 +6,34 @@ MOCK_ENV_FORCED: Always set in mock mode (override any existing env vars).
     These are the variables that control whether external calls happen — they
     must be forced to prevent a developer's shell env from defeating mock mode.
 
+MOCK_ENV_MOCK_DEFAULTS: Mocking switches that default on in mock mode but stay
+    overridable — an explicit value in the environment wins.
+
 MOCK_ENV_DEFAULTS: Only set if not already present (setdefault semantics).
     These provide safe placeholders for variables read at import time.
 """
 
 # Force-set in mock mode — these prevent external connections regardless
 # of what's in the developer's shell environment.
+MOCK_ENV_FORCED = {
+    "GBSERVER_AUTH_MODE": "apikey",
+    "GBTEST_HAS_COMPUTE_CLUSTER_ACCESS": "False",
+    "GBTEST_HAS_GB_CLUSTER_ACCESS": "False",
+    "WANDB_MODE": "disabled",
+}
+
+# Default-on in mock mode, but overridable — GBTEST_MOCK_HF is an independent
+# axis from GBTEST_MODE, not a consequence of it, so an explicit value in the
+# environment wins (setdefault semantics).
 #
 # GBTEST_MOCK_HF makes mock mode never touch real HuggingFace (push/pull/
 # exists/delete), so CI can't flake on HF rate limits or spend token quota.
 # It is forwarded to dispatched worker jobs/pods (see get_exported_gbtest_env_vars)
 # so they mock too. A single test can still exercise real HF via
-# @pytest.mark.live("hf"), which the _hf_mock fixture honors by lifting the var.
-MOCK_ENV_FORCED = {
-    "GBSERVER_AUTH_MODE": "apikey",
-    "GBTEST_HAS_COMPUTE_CLUSTER_ACCESS": "False",
-    "GBTEST_HAS_GB_CLUSTER_ACCESS": "False",
+# @pytest.mark.live("hf"), which the _hf_mock fixture honors by lifting the var;
+# a whole run can opt out with GBTEST_MOCK_HF=false or GBTEST_LIVE_HF=true.
+MOCK_ENV_MOCK_DEFAULTS = {
     "GBTEST_MOCK_HF": "true",
-    "WANDB_MODE": "disabled",
 }
 
 # Set only if not already present — safe placeholder values.

--- a/test/libgbtest/mock_env.py
+++ b/test/libgbtest/mock_env.py
@@ -12,10 +12,17 @@ MOCK_ENV_DEFAULTS: Only set if not already present (setdefault semantics).
 
 # Force-set in mock mode — these prevent external connections regardless
 # of what's in the developer's shell environment.
+#
+# GBTEST_MOCK_HF makes mock mode never touch real HuggingFace (push/pull/
+# exists/delete), so CI can't flake on HF rate limits or spend token quota.
+# It is forwarded to dispatched worker jobs/pods (see get_exported_gbtest_env_vars)
+# so they mock too. A single test can still exercise real HF via
+# @pytest.mark.live("hf"), which the _hf_mock fixture honors by lifting the var.
 MOCK_ENV_FORCED = {
     "GBSERVER_AUTH_MODE": "apikey",
     "GBTEST_HAS_COMPUTE_CLUSTER_ACCESS": "False",
     "GBTEST_HAS_GB_CLUSTER_ACCESS": "False",
+    "GBTEST_MOCK_HF": "true",
     "WANDB_MODE": "disabled",
 }
 

--- a/test/libgbtest/utils.py
+++ b/test/libgbtest/utils.py
@@ -211,6 +211,9 @@ class AbstractSingletonStorageUsingTest(AbstractReadonlySingletonStorageUsingTes
     def teardown_method(self, method):
         self._clear_storage()
         self.storage = None
+        # Don't leave this test's prefixed storage as the global singleton for
+        # the next test that calls get_admin_storage().
+        singleton_storage.reset_admin_storage()
 
     # def get_testing_artifact_registry(self) -> LhArtifactRegistry:
     #     """Get the singleton instance of artifact registration storage that is cleaned before and after test_*() methods.  """

--- a/test/unit/environment/test_launch_env_vars.py
+++ b/test/unit/environment/test_launch_env_vars.py
@@ -54,7 +54,7 @@ class TestBaseStandardEnv:
     @pytest.fixture(autouse=True)
     def _no_gbtest(self, monkeypatch):
         """Isolate the run_metadata-derived set from any GBTEST_ vars the test
-        environment may export (e.g. a suite-level GBTEST_MOCKED_HF_OPS)."""
+        environment may export (e.g. a suite-level GBTEST_MOCK_HF)."""
         monkeypatch.setattr(
             environment_module, "get_exported_gbtest_env_vars", lambda: {}
         )
@@ -92,10 +92,10 @@ class TestBaseGbtestForwarding:
         monkeypatch.setattr(
             environment_module,
             "get_exported_gbtest_env_vars",
-            lambda: {"GBTEST_MOCKED_HF_OPS": "push"},
+            lambda: {"GBTEST_MOCK_HF": "true"},
         )
         assert _base_env_vars({"build_id": "b1"}) == {
-            "GBTEST_MOCKED_HF_OPS": "push",
+            "GBTEST_MOCK_HF": "true",
             "GB_BUILD_ID": "b1",
         }
 
@@ -176,12 +176,12 @@ class TestDockerOverride:
         monkeypatch.setattr(
             environment_module,
             "get_exported_gbtest_env_vars",
-            lambda: {"GBTEST_MOCKED_HF_OPS": "all"},
+            lambda: {"GBTEST_MOCK_HF": "true"},
         )
         env = self._docker().get_launch_env_vars(
             run_metadata=RUN_META, launch_id="lid", container_name="c"
         )
-        assert env["GBTEST_MOCKED_HF_OPS"] == "all"
+        assert env["GBTEST_MOCK_HF"] == "true"
 
 
 class TestRunpodOverride:
@@ -343,11 +343,11 @@ class TestK8sOverride:
         monkeypatch.setattr(
             environment_module,
             "get_exported_gbtest_env_vars",
-            lambda: {"GB_BUILD_ID": "from-gbtest", "GBTEST_MOCKED_HF_OPS": "1"},
+            lambda: {"GB_BUILD_ID": "from-gbtest", "GBTEST_MOCK_HF": "true"},
         )
         env = self._k8s().get_launch_env_vars(run_metadata=RUN_META)
         assert env["GB_BUILD_ID"] == "real-build"
-        assert env["GBTEST_MOCKED_HF_OPS"] == "1"
+        assert env["GBTEST_MOCK_HF"] == "true"
 
 
 class TestAddGbAliases:

--- a/test/unit/gbtypes/test_hf_mock_resolution.py
+++ b/test/unit/gbtypes/test_hf_mock_resolution.py
@@ -1,0 +1,142 @@
+"""Regression tests for how GBTEST_MOCK_HF is resolved at session start.
+
+These run pytest in a subprocess because the behavior under test lives in
+``pytest_sessionstart`` (test/conftest.py) — it has already run by the time an
+in-process test body executes, so it cannot be re-exercised from inside the
+current session.
+
+The case that motivated these: `make .test` runs
+``export GBTEST_MOCK_HF=${GBTEST_MOCK_HF}`` unconditionally, so when no caller
+sets the variable the child sees it *present but empty*. Resolving that as
+"false" silently un-mocked HuggingFace for the whole of CI (PR #314 review).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Body of the throwaway test the subprocess runs: print the resolved state so the
+# parent can assert on it.
+_PROBE = textwrap.dedent("""
+    from gbcommon.types.testing import is_hf_mocked
+
+
+    def test_probe():
+        print(f"RESOLVED:{is_hf_mocked()}")
+    """)
+
+
+def _resolved_is_hf_mocked(tmp_path, env_overrides: dict[str, str | None]) -> bool:
+    """Run a probe test in a subprocess and return its is_hf_mocked() result.
+
+    The probe must live inside the repo's test tree, not in tmp_path: the
+    resolution under test happens in test/conftest.py, which only applies to
+    files collected beneath it.
+
+    Args:
+        tmp_path: unused for the probe location; kept for a unique file name.
+        env_overrides: env vars to set; a None value removes the variable.
+    """
+    probe_dir = _repo_root() / "test" / "unit" / "gbtypes" / "_probe"
+    probe_dir.mkdir(parents=True, exist_ok=True)
+    (probe_dir / "__init__.py").write_text("")
+    probe = probe_dir / f"test_probe_{abs(hash(tmp_path.name)) % 10**8}.py"
+    probe.write_text(_PROBE)
+
+    env = dict(os.environ)
+    env["GB_ENVIRONMENT"] = "STANDALONE"
+    for key, value in env_overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(probe),
+            "-q",
+            "-s",
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            "no:randomly",
+            "--no-cov",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(_repo_root()),
+        env=env,
+        check=False,
+    )
+    try:
+        # The marker may be prefixed by pytest's own progress output (the test
+        # node id), so search anywhere in the line rather than only at the start.
+        markers = [
+            line.split("RESOLVED:", 1)[1]
+            for line in result.stdout.splitlines()
+            if "RESOLVED:" in line
+        ]
+        assert (
+            markers
+        ), f"probe did not report a result.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        return markers[0].strip().split()[0] == "True"
+    finally:
+        probe.unlink(missing_ok=True)
+        # Leave no scratch behind: drop the package dir once the last probe in it
+        # is gone, so a test run doesn't litter the source tree with untracked
+        # files. shutil.rmtree covers the __pycache__ the subprocess created.
+        if not any(probe_dir.glob("test_probe_*.py")):
+            shutil.rmtree(probe_dir, ignore_errors=True)
+
+
+def _repo_root():
+    from pathlib import Path
+
+    return Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "mock_hf,expected,because",
+    [
+        # The `make .test` shape: exported but empty. Must NOT read as an opt-out.
+        ("", True, "blank is 'no choice made', so the mock-mode default applies"),
+        (None, True, "unset in mock mode defaults to mocked"),
+        ("true", True, "explicit true"),
+        ("1", True, "repo-standard boolean parsing accepts 1"),
+        ("yes", True, "repo-standard boolean parsing accepts yes"),
+        ("false", False, "explicit false opts out of the mock-mode default"),
+        ("no", False, "repo-standard boolean parsing accepts no"),
+    ],
+)
+def test_mock_mode_hf_resolution(tmp_path, mock_hf, expected, because):
+    """GBTEST_MODE=mock mocks HF by default; an explicit non-blank value wins."""
+    got = _resolved_is_hf_mocked(
+        tmp_path,
+        {"GBTEST_MODE": "mock", "GBTEST_MOCK_HF": mock_hf, "GBTEST_LIVE_HF": None},
+    )
+    assert got is expected, f"GBTEST_MOCK_HF={mock_hf!r}: {because}"
+
+
+def test_live_mode_honors_explicit_mock_hf(tmp_path):
+    """GBTEST_MOCK_HF is an independent axis: it mocks HF even under live mode."""
+    got = _resolved_is_hf_mocked(
+        tmp_path,
+        {"GBTEST_MODE": "live", "GBTEST_MOCK_HF": "true", "GBTEST_LIVE_HF": None},
+    )
+    assert got is True
+
+
+def test_live_hf_opt_in_lifts_the_mock(tmp_path):
+    """A whole-run GBTEST_LIVE_HF=true opt-in beats the mock-mode default."""
+    got = _resolved_is_hf_mocked(
+        tmp_path,
+        {"GBTEST_MODE": "mock", "GBTEST_MOCK_HF": None, "GBTEST_LIVE_HF": "true"},
+    )
+    assert got is False

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -24,8 +24,7 @@ import pytest
 from pydantic import BaseModel
 
 from gbcommon.types.testing import (
-    ENV_VAR_GBTEST_MOCKED_HF_OPS,
-    HF_OP_PUSH,
+    ENV_VAR_GBTEST_MOCK_HF,
     disable_hf_mocks,
     enable_hf_mocks,
 )
@@ -51,11 +50,11 @@ def _disable_hf_op_mocking(monkeypatch):
 
     These unit tests exercise the *real* HfURI methods (pull/push/exists/delete
     and resource-group resolution) against a mocked HfApi / snapshot_download.
-    A suite-level GBTEST_MOCKED_HF_OPS (e.g. exported by ``make quick-tests``)
-    would otherwise short-circuit those methods before they call the mocked Hub,
-    so clear it here; monkeypatch restores the prior value after each test.
+    A suite-level GBTEST_MOCK_HF (forced true in mock mode) would otherwise
+    short-circuit those methods before they call the mocked Hub, so clear it
+    here; monkeypatch restores the prior value after each test.
     """
-    monkeypatch.delenv(ENV_VAR_GBTEST_MOCKED_HF_OPS, raising=False)
+    monkeypatch.delenv(ENV_VAR_GBTEST_MOCK_HF, raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -526,14 +525,21 @@ class TestHfURIPartsUnit:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.live("hf")
 def test_pull_downloads_tiny_public_model(tmp_path):
     """Download a tiny public model from huggingface.co and verify files land in dest.
 
     Uses hf-internal-testing/tiny-random-bert — a minimal fixture model
     maintained by HuggingFace specifically for CI/testing (< 1 MB).
-    No token is required; the repo is public.
-    Skipped automatically if the Hub is unreachable.
+    No token is required; the repo is public. Marked ``live("hf")`` because it
+    verifies real downloaded files, which is meaningless when HF is mocked — so
+    it never runs in the mock/CI suite. Skipped when HF is not live or the Hub
+    is unreachable.
     """
+    from libgbtest.mode import is_live
+
+    if not is_live("hf"):
+        pytest.skip("HF not live — skipping real pull integration test")
 
     uri = HfURI.from_parts(
         owner="hf-internal-testing",
@@ -557,17 +563,25 @@ def test_pull_downloads_tiny_public_model(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.live("hf")
 def test_push_uploads_file_to_huggingface(tmp_path):
     """Upload a small file to a temporary HF repo and verify it lands there.
 
-    Requires HF_TOKEN to be set with write access to the authenticated user's
-    namespace.  The test creates a throwaway repo, pushes one file, asserts
-    it appears in the repo's file listing, then deletes the repo.
-    Skipped automatically when HF_TOKEN is absent or the Hub is unreachable.
+    Marked ``live("hf")`` because it does a real push and then asserts the file
+    exists on the Hub — that verification is meaningless (and would fail) when
+    HF is mocked, so it never runs in the mock/CI suite. It also requires
+    HF_TOKEN with write access to the authenticated user's namespace. The test
+    creates a throwaway repo, pushes one file, asserts it appears in the repo's
+    file listing, then deletes the repo. Skipped automatically when HF is not
+    live, HF_TOKEN is absent, or the Hub is unreachable.
     """
     import os
 
     from huggingface_hub import HfApi
+    from libgbtest.mode import is_live
+
+    if not is_live("hf"):
+        pytest.skip("HF not live — skipping real push integration test")
 
     token = os.getenv("HF_TOKEN")
     if not token:
@@ -1198,12 +1212,12 @@ class TestHfURIPushErrorVisibility:
         assert "403" in caplog.text
 
     def test_mocked_push_short_circuits(self, tmp_path):
-        """With the op mocked, push() returns without touching HfApi."""
+        """With HF mocked, push() returns without touching HfApi."""
         src = tmp_path / "f.bin"
         src.write_bytes(b"data")
         uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.DATASET)
 
-        enable_hf_mocks(HF_OP_PUSH)
+        enable_hf_mocks()
         try:
             with patch("gbcommon.uri.hf.HfApi") as MockApi:
                 uri.push(src)

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -525,16 +525,15 @@ class TestHfURIPartsUnit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.live("hf")
 def test_pull_downloads_tiny_public_model(tmp_path):
     """Download a tiny public model from huggingface.co and verify files land in dest.
 
     Uses hf-internal-testing/tiny-random-bert — a minimal fixture model
     maintained by HuggingFace specifically for CI/testing (< 1 MB).
-    No token is required; the repo is public. Marked ``live("hf")`` because it
-    verifies real downloaded files, which is meaningless when HF is mocked — so
-    it never runs in the mock/CI suite. Skipped when HF is not live or the Hub
-    is unreachable.
+    No token is required; the repo is public. This is a pure HF-API integration
+    test (it verifies real downloaded files), so it runs only under a live-HF
+    run (GBTEST_LIVE_HF=true or GBTEST_MODE=live) and is skipped otherwise —
+    it belongs to the extended/live suite, not mock CI.
     """
     from libgbtest.mode import is_live
 
@@ -563,17 +562,16 @@ def test_pull_downloads_tiny_public_model(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.live("hf")
 def test_push_uploads_file_to_huggingface(tmp_path):
     """Upload a small file to a temporary HF repo and verify it lands there.
 
-    Marked ``live("hf")`` because it does a real push and then asserts the file
-    exists on the Hub — that verification is meaningless (and would fail) when
-    HF is mocked, so it never runs in the mock/CI suite. It also requires
-    HF_TOKEN with write access to the authenticated user's namespace. The test
-    creates a throwaway repo, pushes one file, asserts it appears in the repo's
-    file listing, then deletes the repo. Skipped automatically when HF is not
-    live, HF_TOKEN is absent, or the Hub is unreachable.
+    This is a pure HF-API integration test: it does a real push and then asserts
+    the file exists on the Hub, which is meaningless (and would fail) when HF is
+    mocked. It runs only under a live-HF run (GBTEST_LIVE_HF=true or
+    GBTEST_MODE=live) and requires HF_TOKEN with write access to the
+    authenticated user's namespace; otherwise it is skipped. It creates a
+    throwaway repo, pushes one file, asserts it appears in the repo's file
+    listing, then deletes the repo. Belongs to the extended/live suite.
     """
     import os
 


### PR DESCRIPTION
## Summary

Two independent changes that make CI more reliable and faster.

### 1. Fix the flaky openlineage test (admin-storage singleton reset + isolation)

`test/integration/standalone/lineage/test_openlineage_service.py::TestOpenLineageAPI::test_existing_build_endpoint_still_works` intermittently failed with `sqlite3.OperationalError: no such table: <prefix>_gb_builds`, and the run showed a ~72s duration for a test whose real cost is ~0.01s.

**Root cause.** `get_admin_storage()` caches a module-level singleton per worker process. Tests that install prefixed storage via `set_storage_prefix()` — and especially `TestBuildRunnerCliSignals`, whose teardown deletes its whole temp sqlite db — never reset that global singleton. A later, unrelated test in the same worker whose REST endpoint calls `get_admin_storage()` (here `GET /lineage/build/<uuid>`) reused the stale singleton, still pointing at the torn-down prefixed tables. The read then hit a missing table, and the read path's `@retry` (10 attempts, exponential backoff up to 30s) turned one missing-table error into ~72s of backoff before failing — that's both the flake and the duration blowup.

**Fix.**
- Add `singleton_storage.reset_admin_storage()` to clear the cached singleton so the next `get_admin_storage()` rebuilds.
- Call it from the base storage-test teardown (`AbstractSingletonStorageUsingTest`) and the CLI test's custom teardown, so prefixed-storage tests restore a clean singleton.
- `storage.delete_table()` also resets `__is_storage_initialized` on the table-already-gone early return, so the `get_by_uuid`/`get_by_where` guards don't trust a stale "initialized" flag (defensive; not the primary cause).

Reproduced and confirmed: running the two files together
```
pytest test/e2e/standalone/test_build_runner_cli.py \
       test/integration/standalone/lineage/test_openlineage_service.py
```
went from **1 failed in ~112s** to **22 passed in ~26s**.

### 2. Rework the HF mock mechanism so CI never *writes* to HuggingFace

CI intermittently failed on transient HuggingFace errors (rate limits, 5xx) and spent HF token quota on operations that aren't CI's job to test. The rate-limit/quota/token exposure is on the **write/admin** side (create-repo, upload, delete, resource-group lookup), so those are what CI must never perform. Live HF integration stays in the nightly extended tests.

**Rework.**
- Collapse the multi-op `GBTEST_MOCKED_HF_OPS` list to a single all-or-nothing boolean `GBTEST_MOCK_HF`, and make it **default-on in mock mode** (forced via `MOCK_ENV_FORCED`) — so `GBTEST_MODE=mock` mocks every HF op with no per-test setup. This removes the per-op parsing complexity (net fewer lines) and keeps `src/` clean: `src` reads one clearly test-named boolean instead of a bespoke op-list mini-language.
- Extend the mocking across the HfURI-based flows, closing the gaps:
  - Forward `GBTEST_` vars from the `bash` and `docker` environments to the dispatched step child (parity with skypilot/lsf/k8s), so standalone workers honor mocking too — closes a latent real-push path.
  - Update the `hfpush`/`hfpull` builtin step scripts (lsf, skypilot) to honor the boolean.
  - Scope note: the guard covers `HfURI` operations and the step scripts that run them. The `gb artifact upload/download` CLI path uses a separate `HFRegistry` client that is not yet guarded (no mock-mode test exercises it today); tracked as a follow-up (#326).
- Escape hatches for real HF: whole-run `GBTEST_LIVE_HF=true`, or per-test `@pytest.mark.live("hf")` (handled by the `_hf_mock` fixture, which is marker-aware via `should_use_live`). The pure HF-API integration tests in `test_hf.py` gate on `is_live("hf")` and skip outside a live-HF run — they belong to the extended/live suite, not mock CI.
- Simplify the Makefile: `quick-tests`/`ibm-quick-tests` no longer pass the op list; `check_hf_token` keys off mock mode instead of the op list.

#### Deliberate exception: real *public* HF pulls stay live for the standalone e2e tests

`GBTEST_MOCK_HF=true` mocks **all** HF ops, but the standalone-environment e2e tests (`test_standalone_environments_e2e.py`: bash/docker inference, TRL fine-tune, unitxt eval) take a **public** HF model as a build input (e.g. `hf:///ibm-granite/granite-4.0-350m`). Mocking the pull would leave the model absent and the workload would exit 1. These tests are therefore marked `@pytest.mark.live("hf")`, which lifts the guard for their duration so the model pull runs **for real**.

This is safe and intentional:
- **Public models download without a token** — the token/rate-limit/quota exposure that motivates this PR is on the *write* side, not tokenless public reads. (This restores the pre-existing behavior: the old suite mocked `push,exists,delete,resource_group` but deliberately left `pull` real.)
- These tests **only read** from HF — none of their builds push an HF output (outputs are empty or `file:` paths), so lifting the whole guard does not let CI write to HF.

**Tradeoff (decision for this PR: keep it active).** Marking these `live("hf")` means CI still performs a real (tokenless) model download on every run, which reintroduces a small amount of HF read traffic and latency. The alternative — mocking the pull and skipping these tests in CI — was considered and rejected for this PR, because the download feeds a *real inference / fine-tune / eval workload* whose end-to-end success is the actual thing under test. We accept the per-run pull to keep that coverage.

**Guidance for adding future `live("hf")` tests.** Reserve the marker for tests where the HF artifact is a **means to a downstream test purpose** (e.g. pull a model, then run and validate inference on it). Do **not** mark a test `live("hf")` when the HF operation *is* the thing being tested (e.g. "download a public HF dataset and assert the download succeeded") — that only exercises the HF API itself, adds live-service flakiness/quota cost to CI, and belongs in the nightly extended/live suite instead.

Net effect: CI never *writes* to HF (no rate-limit flakes, no token quota spent on writes), while the handful of e2e workload tests that need a real public model still get one.

### How `GBTEST_MOCK_HF` resolves (and a naming wart deferred to a follow-up)

`GBTEST_MODE=mock` mocks HF **by default**; an explicitly set, non-blank `GBTEST_MOCK_HF` then overrides that. Resolution happens once in `pytest_sessionstart`, which writes the result back to the environment as `"true"`/`"false"` so every consumer agrees — the in-process read *and* dispatched jobs/pods, which receive only the forwarded env var and re-read it in a separate process.

A blank value counts as "no choice made", not as an opt-out. That matters because `make .test` runs `export GBTEST_MOCK_HF=${GBTEST_MOCK_HF}` unconditionally and the variable has no Makefile default, so the child sees it *present but empty*. An earlier revision of this PR used `os.environ.setdefault()`, which is a no-op on an existing key — that left HF live for all of CI. Fixed, with `test/unit/gbtypes/test_hf_mock_resolution.py` covering the present-but-empty shape specifically.

`is_hf_mocked()` uses the repo-standard `getenv_boolean()`, so unset/empty are False and `1`/`yes`/`on` enable mocking rather than being silently ignored.

**Deferred: `GBTEST_MOCK_HF` and `GBTEST_LIVE_HF` are confusingly named and should converge.** Both are now `GBTEST_`-prefixed HF booleans expressing opposite sides of one question, which reads as two competing knobs. They are genuinely different mechanisms:

| | `GBTEST_MOCK_HF` | `GBTEST_LIVE_HF` |
|---|---|---|
| read by | `HfURI` in `src/`, plus the four hfpull/hfpush step scripts | `test/libgbtest/mode.py` (`is_live`, `should_use_live`) |
| crosses to remote pods | yes (forwarded, re-read there) | no |
| origin | HF-specific mocking switch | `hf`'s slot in the generic `GBTEST_LIVE_<SERVICE>` family |
| polarity | two-way (can force mocking on in live mode) | escalate-only (`=false` is ignored under `GBTEST_MODE=live`) |

Note this collision predates the PR in substance — `GBTEST_LIVE_HF` was already resolvable (`hf` is in `mode.py`'s `SERVICES`) and the mocking switch already existed as `GBTEST_MOCKED_HF_OPS`. What this PR changed is renaming the latter into the former's namespace and shape, which is what makes them look redundant.

Converging them is **deliberately out of scope here**, because every option costs more than it saves in this PR:
- **Collapse onto `GBTEST_LIVE_HF`** — it is never forwarded to workers, and `mode.py` lives in `test/`, which `src/` cannot import (a pod ships `src/` only). It also cannot express "mock HF during a live run", since `=false` is ignored in live mode. That combination is first-class today (`check_hf_token`, `.test`).
- **Collapse onto `GBTEST_MOCK_HF`** — makes `hf` the only one of eight services with no `GBTEST_LIVE_<SERVICE>` opt-in, and breaks the two skip-gates in `test_hf.py`.
- **Rename to `GB_MOCK_HF`** (product namespace, where the code lives) — clean, and touches no files this PR doesn't already touch, but puts a test-only switch in the `GB_` product-config family, where it could read as a supported deployment flag.

Any of these also means inverting polarity in `src/` and in four step scripts (one embedded inline in a jinja `step.yaml`), where a single missed copy silently pushes to the real Hub. Worth doing separately, with the pod paths tested in isolation, rather than on top of a PR that already carries a fixed CI regression.

## Test plan

- `GBTEST_MODE=mock pytest test/unit/uri/test_hf.py` — no HF network; unit tests pass; the two pure HF-API integration tests skip.
- `GBTEST_MODE=mock GBTEST_LIVE_HF=true` + a real `HF_TOKEN` — the `is_live("hf")`-gated integration tests run against real HF.
- The standalone e2e inference tests pull the public model for real under `GBTEST_MOCK_HF=true` (via the `live("hf")` marker) and run the workload; verified the child launch env no longer carries `GBTEST_MOCK_HF` for a marked test.
- The openlineage repro pair above — green and fast.
- Storage suite (`test/unit/storage`, `test/e2e/standalone/test_build_runner_cli.py`) and the lineage file under xdist — green, confirming the teardown change has no regressions.
- `isort --profile black`, `black`, `pylint`, `mypy` on the changed files — clean (the two pre-existing pylint findings on `storage.py:100` and `conftest.py:190` also reproduce on `main`).

Generated with [Claude Code](https://claude.com/claude-code)


