### PR TITLE
Add shareable lsf monitor and include in builtin lsf steps so mem:// is supported in lsf

### DIFF
--- a/docs/environments/lsf.md
+++ b/docs/environments/lsf.md
@@ -81,6 +81,25 @@ assetstores:
 The `bsub` launcher takes no launcher-level config — job-submission options come from the step
 `config` section below.
 
+### Referencing the shared LSF monitor
+
+Rather than spell out the artifact rules in every step, reference the shipped LSF monitor
+library — [`builtins/monitors/lsf/monitor.yaml`](../../src/gbserver/builtins/monitors/lsf/monitor.yaml).
+It is a `bsub_monitor` carrying the standard `LLMB_ARTIFACT_*` (both `PATH` and `STATE`) and
+`LLMB_STEP_METADATA_KEY/VALUE` rules, so a step that references it gets artifact capture and
+step-metadata (lineage) events for free:
+
+```yaml
+    monitors:
+      bsub_monitor:
+        ref: space://monitors/lsf
+```
+
+To add step-specific rules (e.g. an `ARTIFACT_PUSHED_EVENT`, or a `WORKLOAD_STATUS_EVENT`)
+without discarding the inherited ones, append them via `extra_event_configs` — see
+[Overriding a referenced monitor](../steps/monitoring-and-artifact-events.md#overriding-a-referenced-monitor).
+The inline form below remains valid when a step needs a bespoke rule set.
+
 ## Step `config` blocks read by Lsf
 
 ```yaml
@@ -144,6 +163,10 @@ assetstores:
 ```
 
 ### `step.yaml`
+
+This example uses the **inline** monitor form to show the `event_configs` schema in context;
+most steps instead `ref: space://monitors/lsf` (see [above](#referencing-the-shared-lsf-monitor))
+and append only what they add.
 
 ```yaml
 name: my-lsf-step

--- a/docs/steps/monitoring-and-artifact-events.md
+++ b/docs/steps/monitoring-and-artifact-events.md
@@ -73,7 +73,7 @@ shipped **monitor library** and referenced by name. A library monitor lives at
 
 `space://monitors/<name>` resolves to the library directory whose `monitor.yaml` holds the
 monitor; a same-named directory under a configuration's own `monitors/` tree overrides the
-built-in. The shipped monitors — `bash`, `docker`, `skypilot` — all carry the standard
+built-in. The shipped monitors — `bash`, `docker`, `skypilot`, `lsf` — all carry the standard
 `LLMB_ARTIFACT_*` artifact rules (both the `PATH` and `STATE` variants below), so a step that
 just references one gets artifact capture for free.
 
@@ -182,9 +182,9 @@ and the rule is identical except it emits `state` instead of `path`:
 
 **Which environments can produce a `mem://` output.** Consuming a `mem://` input works everywhere — the
 transport is host-side and environment-agnostic. Producing one additionally needs the step's monitor to
-carry this STATE rule. The shipped `space://monitors/bash`, `space://monitors/skypilot`, and
-`space://monitors/docker` monitors already include it (referencing one gives it for free); the k8s / lsf
-/ runpod monitors do not yet. To add it to a step whose monitor lacks it, append the rule via
+carry this STATE rule. The shipped `space://monitors/bash`, `space://monitors/skypilot`,
+`space://monitors/docker`, and `space://monitors/lsf` monitors already include it (referencing
+one gives it for free); the k8s / runpod monitors do not yet. To add it to a step whose monitor lacks it, append the rule via
 `extra_event_configs` (see [Overriding a referenced monitor](#overriding-a-referenced-monitor)) or inline
 it. (RunPod's `pod_status_monitor` applies no `event_configs` at all — see below — so it cannot register
 `mem://` outputs by marker.)
@@ -263,6 +263,7 @@ delivers logs**, not a universal best practice — the shipped monitors differ d
 | `bash` (`space://monitors/bash`) | **Yes** (`^LLMB_ARTIFACT_ID:...`) | The bash launcher echoes the command back (`command step start: <cmd>`); anchoring stops the rule from matching that echo. Steps print the real marker at column 0, so the anchor still matches them. |
 | `skypilot` (`space://monitors/skypilot`) | **No** | SkyPilot's *retrieved* job logs prefix stdout lines (e.g. `(worker1, rank=0) …`), so the marker is not at column 0 and a `^` anchor would never match. |
 | `docker` (`space://monitors/docker`) | **No** | Docker streams raw stdout so either works; kept unanchored to match SkyPilot. |
+| `lsf` (`space://monitors/lsf`) | **No** | LSF tails the job's raw stdout log (no worker prefix), so either works; kept unanchored for forward compatibility with future/wrapped LSF log sources. |
 
 Anchoring `space://monitors/skypilot` "for consistency" once caused a real regression — the
 markers stopped matching and the job registered **zero** artifacts. If you author a new monitor,
@@ -271,8 +272,8 @@ anchor only when the environment injects a line you must avoid matching.
 > **Exception — the step-metadata marker is anchored on every monitor.** Unlike the artifact
 > rules above, `LLMB_STEP_METADATA_KEY/VALUE` surfaces in lineage as *authoritative build
 > provenance* (e.g. a byoc step's resolved `commit_hash`), so it must not be injectable by
-> arbitrary mid-stream output from cloned-repo code. Bash and Docker anchor it with a plain
-> `^`; SkyPilot anchors it too but permits only its own `(name, pid=N) ` log prefix before the
+> arbitrary mid-stream output from cloned-repo code. Bash, Docker, and LSF anchor it with a
+> plain `^`; SkyPilot anchors it too but permits only its own `(name, pid=N) ` log prefix before the
 > marker (`^(\([^)]*\)\s+)?LLMB_STEP_METADATA_KEY:...`), so a marker embedded after other text
 > on the line is ignored. Do **not** un-anchor these to match the artifact rules — the trade-off
 > is deliberate. (Caveat: because SkyPilot prefixes every line, a *deliberate* clean-line echo of

--- a/src/gbserver/builtins/monitors/bash/monitor.yaml
+++ b/src/gbserver/builtins/monitors/bash/monitor.yaml
@@ -1,7 +1,7 @@
 # Shared monitor for the `log_monitor` type (Bash environment). Referenced by
 # bash steps via `ref: space://monitors/bash`. Streams every log line as a
-# MESSAGE_EVENT and detects the standard LLMB artifact markers (env:// PATH and
-# mem:// STATE forms) plus the LLMB_STEP_METADATA_KEY/VALUE step-metadata marker.
+# MESSAGE_EVENT and detects the standard LLMB artifact markers (PATH and STATE
+# forms) plus the LLMB_STEP_METADATA_KEY/VALUE step-metadata marker.
 # Steps that emit no markers simply never fire those events.
 type: log_monitor
 config:
@@ -12,10 +12,12 @@ config:
       event_fields:
         - field_name: msg
           field_regex: .*
-    # env:// artifact: a line that BEGINS with
+    # filesystem-path artifact: a line that BEGINS with
     #   LLMB_ARTIFACT_ID:<output> LLMB_ARTIFACT_PATH:<path>
-    # registers <path> as the artifact for the named output. The `^` anchor is
-    # required because the command step echoes the command back ("command step
+    # registers <path> as the artifact for the named output. Consumed by any
+    # filesystem-backed store (file://, hf://, cos://, lh://, env://); the output's
+    # uri scheme in build.yaml picks the handler, not this marker. The `^` anchor
+    # is required because the command step echoes the command back ("command step
     # start: <cmd>"); other steps print the marker at column 0, so the anchor
     # still matches them.
     - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT

--- a/src/gbserver/builtins/monitors/docker/monitor.yaml
+++ b/src/gbserver/builtins/monitors/docker/monitor.yaml
@@ -1,15 +1,18 @@
 # Shared monitor for the `docker_log` type (Docker environment). Referenced by
 # docker steps via `ref: space://monitors/docker`. Detects the standard
-# LLMB env:// artifact marker (with a binding payload) and the
+# LLMB artifact markers (PATH and STATE forms, with a binding payload) and the
 # LLMB_STEP_METADATA_KEY/VALUE step-metadata marker, and streams every other
 # line as a MESSAGE_EVENT.
 type: docker_log
 config:
   event_configs:
-    # env:// artifact: registers <path> for the named output. Unanchored, to
-    # match the skypilot monitor (whose retrieved logs are prefixed). Docker
-    # streams raw stdout so an anchor would also work, but keeping it unanchored
-    # keeps the two consistent; bash anchors because it echoes its own command.
+    # filesystem-path artifact: registers <path> for the named output. Consumed by
+    # any filesystem-backed store (file://, hf://, cos://, lh://, env://); the
+    # output's uri scheme in build.yaml picks the handler, not this marker.
+    # Unanchored, to match the skypilot monitor (whose retrieved logs are
+    # prefixed). Docker streams raw stdout so an anchor would also work, but
+    # keeping it unanchored keeps the two consistent; bash anchors because it
+    # echoes its own command.
     - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
       line_regex: "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_PATH:.*"
       is_json: false

--- a/src/gbserver/builtins/monitors/lsf/monitor.yaml
+++ b/src/gbserver/builtins/monitors/lsf/monitor.yaml
@@ -8,13 +8,12 @@
 #     (LSFBsubMonitor + a live LogFileMonitor tail) has no consumer for these
 #     keys, so shipping them would be inert config. See lsf.py / lsf_bsub_monitor.py.
 #
-#   * Regexes are NOT anchored to the start of line. SkyPilot's retrieved logs
-#     prefix each line with a `(name, pid=N) ` group, so its artifact rules are
-#     unanchored and its metadata rule permits only that prefix. LSF tails the
-#     job's raw stdout log (no worker prefix), but these rules are deliberately
-#     left unanchored anyway for forward compatibility with future/wrapped LSF
-#     log sources. (ANSI is stripped centrally in
-#     Environment.get_events_from_log_line, so no ANSI handling belongs here.)
+#   * The two artifact rules are NOT anchored to the start of line — matching the
+#     skypilot/docker monitors, and kept unanchored for forward compatibility with
+#     future/wrapped LSF log sources. The STEP_METADATA_UPDATE rule, by contrast,
+#     IS anchored with a plain `^` (see the security note below). (ANSI is stripped
+#     centrally in Environment.get_events_from_log_line, so no ANSI handling
+#     belongs here.)
 #
 # Marker convention (shared with the bash/docker/skypilot monitors):
 #   * env:// artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path> registers
@@ -33,11 +32,13 @@
 # referencing step MUST use the reserved `extra_event_configs` key — a plain
 # `event_configs` overlay is rejected because it would drop the base rules below.
 #
-# SECURITY NOTE: The SkyPilot monitor anchors its STEP_METADATA_UPDATE rule so
-# that build-provenance metadata cannot be injected by arbitrary mid-line output
-# from cloned-repo (byoc) code echoing the marker substring. This LSF rule is
-# intentionally left unanchored (see the anchoring note above). If LSF later
-# grows a byoc-style step that runs untrusted code, revisit this rule.
+# SECURITY NOTE: Step metadata surfaces in lineage as authoritative build
+# provenance, so its marker must not be injectable by arbitrary mid-line output
+# from cloned-repo (byoc) code echoing the marker substring. The
+# STEP_METADATA_UPDATE rule is therefore anchored with a plain `^`, as on the
+# bash/docker monitors. LSF tails the job's raw stdout log (no worker prefix), so
+# `^` matches a real emission at column 0 while rejecting an embedded one. Do not
+# un-anchor it to match the artifact rules — the trade-off is deliberate.
 type: bsub_monitor
 config:
   event_configs:
@@ -69,8 +70,10 @@ config:
     # step metadata: merges <value> into the step's StoredStepRun.metadata under
     # <key>. Both fields are top-level, so they are splatted into
     # StepMetadataUpdateEventPayload.
+    # Anchored with a plain `^` — provenance must not be injectable (see security
+    # note in the header).
     - event_type: STEP_METADATA_UPDATE_EVENT
-      line_regex: 'LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*'
+      line_regex: '^LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*'
       event_fields:
         - field_name: metadata_key
           field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"

--- a/src/gbserver/builtins/monitors/lsf/monitor.yaml
+++ b/src/gbserver/builtins/monitors/lsf/monitor.yaml
@@ -16,11 +16,13 @@
 #     belongs here.)
 #
 # Marker convention (shared with the bash/docker/skypilot monitors):
-#   * env:// artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path> registers
-#     <path> for the named output. The artifact event emits a `binding` payload
-#     ({"path": <path>}) that downstream targets dereference as
+#   * filesystem-path artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>
+#     registers <path> for the named output. The artifact event emits a `binding`
+#     payload ({"path": <path>}) that downstream targets dereference as
 #     {{ bindings.<x>.binding.path }}; it enables retry-transparent NEWARTIFACT
-#     deduplication.
+#     deduplication. This form is NOT env://-specific: it is consumed by every
+#     filesystem-backed store — file://, hf://, cos://, lh://, env:// — with the
+#     output's uri scheme in build.yaml (not this marker) selecting the handler.
 #   * mem:// artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_STATE:<value>
 #     registers <value> as the output's `state` (no path normalisation). PATH and
 #     STATE markers are mutually exclusive per line.
@@ -42,7 +44,9 @@
 type: bsub_monitor
 config:
   event_configs:
-    # env:// artifact: registers <path> for the named output.
+    # filesystem-path artifact: registers <path> for the named output. Consumed by
+    # any filesystem-backed store (file://, hf://, cos://, lh://, env://); the
+    # output's uri scheme in build.yaml picks the handler, not this marker.
     - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
       line_regex: "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_PATH:.*"
       event_fields:

--- a/src/gbserver/builtins/monitors/lsf/monitor.yaml
+++ b/src/gbserver/builtins/monitors/lsf/monitor.yaml
@@ -1,0 +1,80 @@
+# Base monitor for the `bsub_monitor` type, shared by all LSF steps. A step
+# references this via `ref: space://monitors/lsf` and overrides only what
+# differs (e.g. appends extra event_configs). Modeled on
+# builtins/monitors/skypilot/monitor.yaml, but adapted for LSF:
+#
+#   * No poll_interval_seconds / log_retrieval keys. Unlike SkyPilot (which
+#     polls job status and retrieves logs on a schedule), the LSF runtime
+#     (LSFBsubMonitor + a live LogFileMonitor tail) has no consumer for these
+#     keys, so shipping them would be inert config. See lsf.py / lsf_bsub_monitor.py.
+#
+#   * Regexes are NOT anchored to the start of line. SkyPilot's retrieved logs
+#     prefix each line with a `(name, pid=N) ` group, so its artifact rules are
+#     unanchored and its metadata rule permits only that prefix. LSF tails the
+#     job's raw stdout log (no worker prefix), but these rules are deliberately
+#     left unanchored anyway for forward compatibility with future/wrapped LSF
+#     log sources. (ANSI is stripped centrally in
+#     Environment.get_events_from_log_line, so no ANSI handling belongs here.)
+#
+# Marker convention (shared with the bash/docker/skypilot monitors):
+#   * env:// artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path> registers
+#     <path> for the named output. The artifact event emits a `binding` payload
+#     ({"path": <path>}) that downstream targets dereference as
+#     {{ bindings.<x>.binding.path }}; it enables retry-transparent NEWARTIFACT
+#     deduplication.
+#   * mem:// artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_STATE:<value>
+#     registers <value> as the output's `state` (no path normalisation). PATH and
+#     STATE markers are mutually exclusive per line.
+#   * step metadata — LLMB_STEP_METADATA_KEY:<key> LLMB_STEP_METADATA_VALUE:<value>
+#     merges <value> into the step's StoredStepRun.metadata under <key> (e.g. a
+#     git commit_hash resolved at runtime), surfacing as build provenance in lineage.
+#
+# To extend the events a step listens for (rather than replace these), a
+# referencing step MUST use the reserved `extra_event_configs` key — a plain
+# `event_configs` overlay is rejected because it would drop the base rules below.
+#
+# SECURITY NOTE: The SkyPilot monitor anchors its STEP_METADATA_UPDATE rule so
+# that build-provenance metadata cannot be injected by arbitrary mid-line output
+# from cloned-repo (byoc) code echoing the marker substring. This LSF rule is
+# intentionally left unanchored (see the anchoring note above). If LSF later
+# grows a byoc-style step that runs untrusted code, revisit this rule.
+type: bsub_monitor
+config:
+  event_configs:
+    # env:// artifact: registers <path> for the named output.
+    - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
+      line_regex: "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_PATH:.*"
+      event_fields:
+        - field_name: binding_id
+          field_regex: "(?<=LLMB_ARTIFACT_ID:)[^ ]+"
+        - field_name: path
+          field_regex: "(?<=LLMB_ARTIFACT_PATH:).*"
+          is_data: true
+        - field_name: binding
+          field_value_template: '{ "path": "{{ fields.data.path }}" }'
+          is_json: true
+    # mem:// artifact: registers <value> as the output's `state`, passed verbatim
+    # to a consumer via {{ bindings.<x>.binding.state }} (no path normalisation).
+    - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
+      line_regex: "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_STATE:.*"
+      event_fields:
+        - field_name: binding_id
+          field_regex: "(?<=LLMB_ARTIFACT_ID:)[^ ]+"
+        - field_name: state
+          field_regex: "(?<=LLMB_ARTIFACT_STATE:).*"
+          is_data: true
+        - field_name: binding
+          field_value_template: '{ "state": "{{ fields.data.state }}" }'
+          is_json: true
+    # step metadata: merges <value> into the step's StoredStepRun.metadata under
+    # <key>. Both fields are top-level, so they are splatted into
+    # StepMetadataUpdateEventPayload.
+    - event_type: STEP_METADATA_UPDATE_EVENT
+      line_regex: 'LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*'
+      event_fields:
+        - field_name: metadata_key
+          field_regex: "(?<=LLMB_STEP_METADATA_KEY:)[^ ]+"
+        - field_name: metadata_value
+          # Trim trailing whitespace/carriage-return (CRLF logs) so it is not
+          # folded into the value; internal spaces are preserved.
+          field_regex: '(?<=LLMB_STEP_METADATA_VALUE:).*?(?=\s*$)'

--- a/src/gbserver/builtins/monitors/lsf/monitor.yaml
+++ b/src/gbserver/builtins/monitors/lsf/monitor.yaml
@@ -9,11 +9,13 @@
 #     keys, so shipping them would be inert config. See lsf.py / lsf_bsub_monitor.py.
 #
 #   * The two artifact rules are NOT anchored to the start of line — matching the
-#     skypilot/docker monitors, and kept unanchored for forward compatibility with
-#     future/wrapped LSF log sources. The STEP_METADATA_UPDATE rule, by contrast,
-#     IS anchored with a plain `^` (see the security note below). (ANSI is stripped
-#     centrally in Environment.get_events_from_log_line, so no ANSI handling
-#     belongs here.)
+#     skypilot/docker monitors, and kept unanchored for backwards compatibility
+#     with artifact markers already emitted mid-line by existing steps/workloads.
+#     The STEP_METADATA_UPDATE rule, by contrast, IS anchored with a plain `^`
+#     (see the security note below): it is a new marker with no legacy emissions
+#     to preserve, so it can require column-0 emission from day one. (ANSI is
+#     stripped centrally in Environment.get_events_from_log_line, so no ANSI
+#     handling belongs here.)
 #
 # Marker convention (shared with the bash/docker/skypilot monitors):
 #   * filesystem-path artifact — LLMB_ARTIFACT_ID:<id> LLMB_ARTIFACT_PATH:<path>
@@ -75,7 +77,10 @@ config:
     # <key>. Both fields are top-level, so they are splatted into
     # StepMetadataUpdateEventPayload.
     # Anchored with a plain `^` — provenance must not be injectable (see security
-    # note in the header).
+    # note in the header). EMISSION CONTRACT: whatever emits this marker must echo
+    # it bare at column 0 (like the artifact lines in llmb_lsf_wrapper.sh), NOT with
+    # the `${LLMB_LSF_JOB_NAME}: ` prefix the wrapper uses for its status/info
+    # lines — a leading prefix would make `^` silently drop the event.
     - event_type: STEP_METADATA_UPDATE_EVENT
       line_regex: '^LLMB_STEP_METADATA_KEY:.* LLMB_STEP_METADATA_VALUE:.*'
       event_fields:

--- a/src/gbserver/builtins/monitors/skypilot/monitor.yaml
+++ b/src/gbserver/builtins/monitors/skypilot/monitor.yaml
@@ -9,7 +9,10 @@
 #
 # The artifact event emits a `binding` payload ({"path": <artifact path>}) — this
 # is what downstream targets dereference as `{{ bindings.<x>.binding.path }}`, and
-# it enables retry-transparent NEWARTIFACT deduplication. Every {{ config.* }}
+# it enables retry-transparent NEWARTIFACT deduplication. This PATH form is NOT
+# env://-specific: it is consumed by every filesystem-backed store — file://,
+# hf://, cos://, lh://, env:// — with the output's uri scheme in build.yaml (not
+# this marker) selecting the handler. Every {{ config.* }}
 # carries a `| default(...)` so a referencing step that omits the key still
 # renders under strict templating.
 #
@@ -28,10 +31,12 @@ config:
   log_retrieval:
     mode: "{{ config.log_retrieval_mode | default('on_completion') }}"
   event_configs:
-    # env:// artifact: registers <path> for the named output. NOT anchored:
-    # SkyPilot's retrieved job logs prefix stdout lines, so the marker is not at
-    # column 0 — a `^` anchor would fail to match. (Contrast bash, which reads
-    # raw stdout and anchors to avoid matching its own command echo.)
+    # filesystem-path artifact: registers <path> for the named output. Consumed by
+    # any filesystem-backed store (file://, hf://, cos://, lh://, env://); the
+    # output's uri scheme in build.yaml picks the handler, not this marker. NOT
+    # anchored: SkyPilot's retrieved job logs prefix stdout lines, so the marker is
+    # not at column 0 — a `^` anchor would fail to match. (Contrast bash, which
+    # reads raw stdout and anchors to avoid matching its own command echo.)
     - event_type: NEWARTIFACT_IN_ENVIRONMENT_EVENT
       line_regex: "LLMB_ARTIFACT_ID:.* LLMB_ARTIFACT_PATH:.*"
       event_fields:

--- a/src/gbserver/builtins/steps/gbstep/step_default.yaml
+++ b/src/gbserver/builtins/steps/gbstep/step_default.yaml
@@ -54,9 +54,12 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        # References the shared LSF monitor library (builtins/monitors/lsf) for the
+        # standard artifact + step-metadata convention, and appends the default
+        # workload-status / validation-data events every gbstep-based LSF step needs.
+        ref: space://monitors/lsf
         config:
-          event_configs:
+          extra_event_configs:
           - event_type: WORKLOAD_STATUS_EVENT
             line_regex: "^LLMB_EVENT_WORKLOAD_STATUS:.+"
             is_json: False

--- a/src/gbserver/builtins/steps/lsf/cosrclone/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/cosrclone/step.yaml
@@ -28,4 +28,6 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        ref: space://monitors/lsf
+        type: bsub_monitor
+        config:
+          event_configs: []

--- a/src/gbserver/builtins/steps/lsf/cosrclone/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/cosrclone/step.yaml
@@ -28,6 +28,4 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
-        config:
-          event_configs: []
+        ref: space://monitors/lsf

--- a/src/gbserver/builtins/steps/lsf/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/hfpull/step.yaml
@@ -27,4 +27,4 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        ref: space://monitors/lsf

--- a/src/gbserver/builtins/steps/lsf/hfpush/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/hfpush/step.yaml
@@ -33,9 +33,9 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        ref: space://monitors/lsf
         config:
-          event_configs:
+          extra_event_configs:
           - event_type: ARTIFACT_PUSHED_EVENT
             line_regex: Pushed HF URI:\s.+
             is_json: false

--- a/src/gbserver/builtins/steps/lsf/lhpull/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/lhpull/step.yaml
@@ -32,4 +32,4 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        ref: space://monitors/lsf

--- a/src/gbserver/builtins/steps/lsf/lhpush/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/lhpush/step.yaml
@@ -36,9 +36,9 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        ref: space://monitors/lsf
         config:
-          event_configs:
+          extra_event_configs:
           - event_type: ARTIFACT_PUSHED_EVENT
             line_regex: Pushed\sURI:\s.+
             is_json: false

--- a/src/gbserver/builtins/steps/lsf/s3pull/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/s3pull/step.yaml
@@ -22,4 +22,4 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        ref: space://monitors/lsf

--- a/src/gbserver/builtins/steps/lsf/s3push/step.yaml
+++ b/src/gbserver/builtins/steps/lsf/s3push/step.yaml
@@ -22,4 +22,4 @@ environment_configs:
         - bsub_monitor
     monitors:
       bsub_monitor:
-        type: bsub_monitor
+        ref: space://monitors/lsf

--- a/test/unit/build/test_resolve_monitor_config.py
+++ b/test/unit/build/test_resolve_monitor_config.py
@@ -435,12 +435,19 @@ class TestBuiltinLsfMonitor:
         assert m_type == "bsub_monitor"
         assert "poll_interval_seconds" not in cfg
         assert "log_retrieval" not in cfg
+        rules = {e["event_type"]: e for e in cfg["event_configs"]}
         event_types = [e["event_type"] for e in cfg["event_configs"]]
         assert event_types == [
             "NEWARTIFACT_IN_ENVIRONMENT_EVENT",  # env:// PATH
             "NEWARTIFACT_IN_ENVIRONMENT_EVENT",  # mem:// STATE
             "STEP_METADATA_UPDATE_EVENT",
         ]
+        # Artifact rules are unanchored (raw-log forward-compat); the provenance
+        # rule is `^`-anchored so it cannot be injected mid-line.
+        assert rules["STEP_METADATA_UPDATE_EVENT"]["line_regex"].startswith("^")
+        for e in cfg["event_configs"]:
+            if e["event_type"] == "NEWARTIFACT_IN_ENVIRONMENT_EVENT":
+                assert not e["line_regex"].startswith("^")
 
     def test_lsf_step_overlay_appends_push_event(
         self: Self, builtin_monitor_space

--- a/test/unit/build/test_resolve_monitor_config.py
+++ b/test/unit/build/test_resolve_monitor_config.py
@@ -395,6 +395,70 @@ class TestResolveMonitorConfig:
             _reset_monitor_file_cache()
 
 
+@pytest.fixture
+def builtin_monitor_space():
+    """Point SpaceURI at the real shipped ``builtins/`` monitor library.
+
+    Unlike ``monitor_library`` (which synthesizes a temp library), this resolves
+    ``space://monitors/<name>`` against the monitor.yaml files actually shipped in
+    the repo, so a content regression in one is caught. Restores prior base URIs.
+    """
+    import gbserver.build.space as space_mod
+
+    builtins = Path(space_mod.__file__).parent.parent / "builtins"
+    prev = getattr(SpaceURI._thread_local, "base_uris", None)
+    prev_secrets = getattr(SpaceURI._thread_local, "space_secrets", None)
+    SpaceURI.set_baseuris(base_uris=[builtins.as_uri()], space_secrets={})
+    _reset_monitor_file_cache()
+    try:
+        yield builtins
+    finally:
+        SpaceURI.set_baseuris(
+            base_uris=prev if prev is not None else ["file:"],
+            space_secrets=prev_secrets or {},
+        )
+        _reset_monitor_file_cache()
+
+
+class TestBuiltinLsfMonitor:
+    """The shipped builtins/monitors/lsf/monitor.yaml resolves as expected."""
+
+    def test_lsf_monitor_resolves_to_bsub_type_and_rules(
+        self: Self, builtin_monitor_space
+    ) -> None:
+        """`ref: space://monitors/lsf` yields the bsub_monitor type with exactly the
+        three standard rules (artifact PATH, artifact STATE, step-metadata) and no
+        inert poll/log_retrieval keys (which have no LSF runtime consumer)."""
+        m_type, cfg = resolve_monitor_config(
+            StepMonitorConfig(ref="space://monitors/lsf")
+        )
+        assert m_type == "bsub_monitor"
+        assert "poll_interval_seconds" not in cfg
+        assert "log_retrieval" not in cfg
+        event_types = [e["event_type"] for e in cfg["event_configs"]]
+        assert event_types == [
+            "NEWARTIFACT_IN_ENVIRONMENT_EVENT",  # env:// PATH
+            "NEWARTIFACT_IN_ENVIRONMENT_EVENT",  # mem:// STATE
+            "STEP_METADATA_UPDATE_EVENT",
+        ]
+
+    def test_lsf_step_overlay_appends_push_event(
+        self: Self, builtin_monitor_space
+    ) -> None:
+        """A step (e.g. lhpush) that refs the LSF monitor and appends its own
+        ARTIFACT_PUSHED_EVENT via extra_event_configs keeps the three base rules."""
+        push = {"event_type": "ARTIFACT_PUSHED_EVENT", "line_regex": r"Pushed\sURI:\s.+"}
+        _, cfg = resolve_monitor_config(
+            StepMonitorConfig(
+                ref="space://monitors/lsf",
+                config={"extra_event_configs": [push]},
+            )
+        )
+        assert len(cfg["event_configs"]) == 4
+        assert cfg["event_configs"][-1] == push
+        assert "extra_event_configs" not in cfg
+
+
 def _env_cfg(monitors: dict) -> StepEnvironmentTypeConfig:
     """Build a StepEnvironmentTypeConfig with the given monitors map."""
     return StepEnvironmentTypeConfig(

--- a/test/unit/build/test_resolve_monitor_config.py
+++ b/test/unit/build/test_resolve_monitor_config.py
@@ -447,7 +447,10 @@ class TestBuiltinLsfMonitor:
     ) -> None:
         """A step (e.g. lhpush) that refs the LSF monitor and appends its own
         ARTIFACT_PUSHED_EVENT via extra_event_configs keeps the three base rules."""
-        push = {"event_type": "ARTIFACT_PUSHED_EVENT", "line_regex": r"Pushed\sURI:\s.+"}
+        push = {
+            "event_type": "ARTIFACT_PUSHED_EVENT",
+            "line_regex": r"Pushed\sURI:\s.+",
+        }
         _, cfg = resolve_monitor_config(
             StepMonitorConfig(
                 ref="space://monitors/lsf",


### PR DESCRIPTION
## Description

The builtin lsf steps (and future lsf steps) can now use the shared lsf monitor.yaml that provides generalized/common support for new artifacts, mem:// uris, and step execution metadata events.

`test/integration/ibm/buildrunner/lsf/test_buildrunner_1step_bluevela.py::TestBuildRunner1StepBlueVela::test_runner`, which uses the modified and bultin `hfpull/push` steps, has been run and passed.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
