### PR TITLE
Resolve sys.stderr dynamically in the console log handler

### DIFF
--- a/src/gbserver/utils/logger.py
+++ b/src/gbserver/utils/logger.py
@@ -116,6 +116,10 @@ class _ConsoleStreamHandler(logging.StreamHandler):
     """
 
     def __init__(self):
+        # Intentionally skip StreamHandler.__init__ (which snapshots a stream
+        # into self.stream) and init only the Handler base, mirroring the stdlib
+        # logging._StderrHandler; the stream property below stays live.
+        # pylint: disable=super-init-not-called,non-parent-init-called
         logging.Handler.__init__(self)
 
     @property

--- a/src/gbserver/utils/logger.py
+++ b/src/gbserver/utils/logger.py
@@ -109,18 +109,18 @@ class _ConsoleStreamHandler(logging.StreamHandler):
     a closed file, producing flaky ``I/O operation on closed file`` failures under
     parallel test runs (issue #315). Resolving ``sys.stderr`` on each access keeps
     the handler on the live stream and never retains a closed one.
+
+    This mirrors the standard library's ``logging._StderrHandler`` (used for
+    ``logging.lastResort``): skip ``StreamHandler.__init__`` so nothing snapshots
+    a stream into ``self.stream``, and expose ``stream`` as a read-only property.
     """
+
+    def __init__(self):
+        logging.Handler.__init__(self)
 
     @property
     def stream(self):
         return sys.stderr
-
-    @stream.setter
-    def stream(self, value):
-        # StreamHandler.__init__/setStream assign self.stream; ignore the
-        # assignment so the handler stays bound to the live sys.stderr rather
-        # than a captured snapshot.
-        pass
 
 
 def configure_logging(
@@ -145,6 +145,10 @@ def configure_logging(
             force=True,
         )
     else:
+        # NOTE: this explicit-format branch lets basicConfig build its own bare
+        # StreamHandler, which still snapshots sys.stderr (the issue #315 hazard).
+        # It is left as-is because no caller passes `format`; the CLI paths that
+        # reconfigure logging under CliRunner all take the `format is None` branch.
         logging.basicConfig(
             format=format,
             level=get_log_level(level),

--- a/src/gbserver/utils/logger.py
+++ b/src/gbserver/utils/logger.py
@@ -12,6 +12,7 @@
 #
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Optional, Self
 
@@ -96,6 +97,32 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+class _ConsoleStreamHandler(logging.StreamHandler):
+    """StreamHandler that resolves ``sys.stderr`` at emit time.
+
+    A bare ``logging.StreamHandler()`` captures whatever ``sys.stderr`` is at
+    construction and holds that reference for the life of the handler. When
+    logging is (re)configured inside ``click.testing.CliRunner.invoke()`` — which
+    swaps ``sys.stdout``/``sys.stderr`` for an in-memory buffer and later
+    closes/garbage-collects it — the handler would pin that transient buffer, and
+    a later cross-boundary write (or CliRunner's own ``getvalue()``) would land on
+    a closed file, producing flaky ``I/O operation on closed file`` failures under
+    parallel test runs (issue #315). Resolving ``sys.stderr`` on each access keeps
+    the handler on the live stream and never retains a closed one.
+    """
+
+    @property
+    def stream(self):
+        return sys.stderr
+
+    @stream.setter
+    def stream(self, value):
+        # StreamHandler.__init__/setStream assign self.stream; ignore the
+        # assignment so the handler stays bound to the live sys.stderr rather
+        # than a captured snapshot.
+        pass
+
+
 def configure_logging(
     level: str = DEFAULT_LOG_LEVEL,
     format: Optional[str] = None,
@@ -107,7 +134,7 @@ def configure_logging(
     if skip_if_already_configured and __LOGGER_CONFIGURED:
         return
     if format is None:
-        handler: logging.Handler = logging.StreamHandler()
+        handler: logging.Handler = _ConsoleStreamHandler()
         if log_file is not None:
             handler = logging.FileHandler(filename=log_file, encoding="utf-8", mode="w")
         handler.setFormatter(CustomFormatter())

--- a/src/gbserver/utils/logger.py
+++ b/src/gbserver/utils/logger.py
@@ -137,29 +137,27 @@ def configure_logging(
     global __LOGGER_CONFIGURED
     if skip_if_already_configured and __LOGGER_CONFIGURED:
         return
-    if format is None:
-        handler: logging.Handler = _ConsoleStreamHandler()
-        if log_file is not None:
-            handler = logging.FileHandler(filename=log_file, encoding="utf-8", mode="w")
-        handler.setFormatter(CustomFormatter())
-        logging.basicConfig(
-            handlers=[handler],
-            level=get_log_level(level),
-            datefmt="%Y-%m-%d %H:%M:%S",
-            force=True,
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    # Always build the handler ourselves so no code path lets basicConfig
+    # construct a bare StreamHandler, which snapshots sys.stderr and reintroduces
+    # the issue #315 flake. The console handler resolves sys.stderr at emit time.
+    if log_file is not None:
+        handler: logging.Handler = logging.FileHandler(
+            filename=log_file, encoding="utf-8", mode="w"
         )
     else:
-        # NOTE: this explicit-format branch lets basicConfig build its own bare
-        # StreamHandler, which still snapshots sys.stderr (the issue #315 hazard).
-        # It is left as-is because no caller passes `format`; the CLI paths that
-        # reconfigure logging under CliRunner all take the `format is None` branch.
-        logging.basicConfig(
-            format=format,
-            level=get_log_level(level),
-            datefmt="%Y-%m-%d %H:%M:%S",
-            filename=log_file,
-            filemode="w",
-        )
+        handler = _ConsoleStreamHandler()
+    handler.setFormatter(
+        logging.Formatter(format, datefmt=datefmt)
+        if format is not None
+        else CustomFormatter()
+    )
+    logging.basicConfig(
+        handlers=[handler],
+        level=get_log_level(level),
+        datefmt=datefmt,
+        force=True,
+    )
     __LOGGER_CONFIGURED = True
     logger = logging.getLogger(__name__)
     logger.info("logging level set to %s", level)

--- a/src/gbserver/utils/logger.py
+++ b/src/gbserver/utils/logger.py
@@ -91,9 +91,12 @@ class CustomFormatter(logging.Formatter):
         logging.CRITICAL: DO_CRITICAL_COLOR + DEFAULT_LOG_FORMAT + DO_RESET,
     }
 
+    def __init__(self, datefmt: Optional[str] = None):
+        super().__init__(datefmt=datefmt)
+
     def format(self, record):
         log_fmt = self.FORMATS.get(record.levelno)
-        formatter = logging.Formatter(log_fmt)
+        formatter = logging.Formatter(log_fmt, datefmt=self.datefmt)
         return formatter.format(record)
 
 
@@ -150,12 +153,11 @@ def configure_logging(
     handler.setFormatter(
         logging.Formatter(format, datefmt=datefmt)
         if format is not None
-        else CustomFormatter()
+        else CustomFormatter(datefmt=datefmt)
     )
     logging.basicConfig(
         handlers=[handler],
         level=get_log_level(level),
-        datefmt=datefmt,
         force=True,
     )
     __LOGGER_CONFIGURED = True

--- a/test/unit/utils/test_logger.py
+++ b/test/unit/utils/test_logger.py
@@ -29,6 +29,7 @@ the *current* ``sys.stderr`` at emit time rather than pin a transient stream.
 import logging
 import sys
 
+import click
 from click.testing import CliRunner
 
 from gbserver.utils import logger as logger_mod
@@ -54,7 +55,9 @@ def test_console_handler_does_not_retain_clirunner_captured_stream():
     isolation exits and the buffer is abandoned. The fix makes the handler track
     the live ``sys.stderr``.
     """
-    saved_handlers = logging.getLogger().handlers[:]
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
     try:
         runner = CliRunner()
         with runner.isolation():
@@ -72,5 +75,32 @@ def test_console_handler_does_not_retain_clirunner_captured_stream():
         assert handler.stream is not captured_stream
         assert handler.stream is sys.stderr
     finally:
-        root = logging.getLogger()
         root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_log_output_is_captured_during_clirunner_invoke():
+    """A record logged during invoke() must still land in ``result.output``.
+
+    Guards against a naive "fix" that pins the handler to ``sys.__stderr__``:
+    that would stop the flaky-close failure but silently break log capture,
+    since CliRunner only redirects ``sys.stdout``/``sys.stderr``.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        logger_mod.configure_logging(level="INFO", skip_if_already_configured=False)
+        log = logging.getLogger("gbserver.test.capture")
+
+        @click.command()
+        def emit():
+            log.warning("captured-during-invoke")
+
+        result = CliRunner().invoke(emit, [])
+
+        assert result.exit_code == 0, result.output
+        assert "captured-during-invoke" in result.output
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)

--- a/test/unit/utils/test_logger.py
+++ b/test/unit/utils/test_logger.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for gbserver.utils.logger stream binding.
+
+Issue #315: a bare ``logging.StreamHandler()`` captures ``sys.stderr`` at
+construction and holds it forever. The ``gbserver`` root group reconfigures
+logging inside ``click.testing.CliRunner.invoke()``, where ``sys.stderr`` is an
+in-memory buffer that CliRunner later closes / garbage-collects. A captured
+reference lets a cross-boundary log write (or CliRunner's own ``getvalue()``)
+land on a closed file, producing flaky ``ValueError: I/O operation on closed
+file`` failures under large parallel test runs. The console handler must resolve
+the *current* ``sys.stderr`` at emit time rather than pin a transient stream.
+"""
+
+import logging
+import sys
+
+from click.testing import CliRunner
+
+from gbserver.utils import logger as logger_mod
+
+
+def _console_handler() -> logging.StreamHandler:
+    """Return the root logger's console StreamHandler (not a FileHandler)."""
+    handlers = [
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+    ]
+    assert handlers, "expected a console StreamHandler on the root logger"
+    return handlers[0]
+
+
+def test_console_handler_does_not_retain_clirunner_captured_stream():
+    """Reconfiguring logging inside a CliRunner isolation must not pin its buffer.
+
+    On the buggy implementation the handler captures ``sys.stderr`` (CliRunner's
+    transient buffer) at construction and keeps pointing at it after the
+    isolation exits and the buffer is abandoned. The fix makes the handler track
+    the live ``sys.stderr``.
+    """
+    saved_handlers = logging.getLogger().handlers[:]
+    try:
+        runner = CliRunner()
+        with runner.isolation():
+            # Mimic the gbserver root group calling configure_logging() while
+            # CliRunner has swapped sys.stderr for its in-memory buffer.
+            logger_mod.configure_logging(skip_if_already_configured=False)
+            captured_stream = sys.stderr
+            handler = _console_handler()
+            # While inside the isolation the handler should target the live
+            # (captured) stream so log output is still capturable.
+            assert handler.stream is captured_stream
+
+        # After the isolation exits, CliRunner has restored sys.stderr and will
+        # close/GC its buffer. The handler must no longer reference it.
+        assert handler.stream is not captured_stream
+        assert handler.stream is sys.stderr
+    finally:
+        root = logging.getLogger()
+        root.handlers[:] = saved_handlers

--- a/test/unit/utils/test_logger.py
+++ b/test/unit/utils/test_logger.py
@@ -30,9 +30,27 @@ import logging
 import sys
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from gbserver.utils import logger as logger_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_logging():
+    """Restore a clean root-logger baseline after each test.
+
+    ``configure_logging`` runs ``basicConfig(force=True)``, which closes and
+    detaches the root logger's existing handlers. Snapshotting the handler
+    objects and reinstating them in teardown (the previous approach) therefore
+    re-attached *closed* handlers to the next test in the same worker -- the
+    exact cross-test stream corruption issue #315 is about. Restore only the
+    level and reconfigure a fresh, live handler instead.
+    """
+    saved_level = logging.getLogger().level
+    yield
+    logger_mod.configure_logging(skip_if_already_configured=False)
+    logging.getLogger().setLevel(saved_level)
 
 
 def _console_handler() -> logging.StreamHandler:
@@ -55,28 +73,21 @@ def test_console_handler_does_not_retain_clirunner_captured_stream():
     isolation exits and the buffer is abandoned. The fix makes the handler track
     the live ``sys.stderr``.
     """
-    root = logging.getLogger()
-    saved_handlers = root.handlers[:]
-    saved_level = root.level
-    try:
-        runner = CliRunner()
-        with runner.isolation():
-            # Mimic the gbserver root group calling configure_logging() while
-            # CliRunner has swapped sys.stderr for its in-memory buffer.
-            logger_mod.configure_logging(skip_if_already_configured=False)
-            captured_stream = sys.stderr
-            handler = _console_handler()
-            # While inside the isolation the handler should target the live
-            # (captured) stream so log output is still capturable.
-            assert handler.stream is captured_stream
+    runner = CliRunner()
+    with runner.isolation():
+        # Mimic the gbserver root group calling configure_logging() while
+        # CliRunner has swapped sys.stderr for its in-memory buffer.
+        logger_mod.configure_logging(skip_if_already_configured=False)
+        captured_stream = sys.stderr
+        handler = _console_handler()
+        # While inside the isolation the handler should target the live
+        # (captured) stream so log output is still capturable.
+        assert handler.stream is captured_stream
 
-        # After the isolation exits, CliRunner has restored sys.stderr and will
-        # close/GC its buffer. The handler must no longer reference it.
-        assert handler.stream is not captured_stream
-        assert handler.stream is sys.stderr
-    finally:
-        root.handlers[:] = saved_handlers
-        root.setLevel(saved_level)
+    # After the isolation exits, CliRunner has restored sys.stderr and will
+    # close/GC its buffer. The handler must no longer reference it.
+    assert handler.stream is not captured_stream
+    assert handler.stream is sys.stderr
 
 
 def test_log_output_is_captured_during_clirunner_invoke():
@@ -86,21 +97,14 @@ def test_log_output_is_captured_during_clirunner_invoke():
     that would stop the flaky-close failure but silently break log capture,
     since CliRunner only redirects ``sys.stdout``/``sys.stderr``.
     """
-    root = logging.getLogger()
-    saved_handlers = root.handlers[:]
-    saved_level = root.level
-    try:
-        logger_mod.configure_logging(level="INFO", skip_if_already_configured=False)
-        log = logging.getLogger("gbserver.test.capture")
+    logger_mod.configure_logging(level="INFO", skip_if_already_configured=False)
+    log = logging.getLogger("gbserver.test.capture")
 
-        @click.command()
-        def emit():
-            log.warning("captured-during-invoke")
+    @click.command()
+    def emit():
+        log.warning("captured-during-invoke")
 
-        result = CliRunner().invoke(emit, [])
+    result = CliRunner().invoke(emit, [])
 
-        assert result.exit_code == 0, result.output
-        assert "captured-during-invoke" in result.output
-    finally:
-        root.handlers[:] = saved_handlers
-        root.setLevel(saved_level)
+    assert result.exit_code == 0, result.output
+    assert "captured-during-invoke" in result.output


### PR DESCRIPTION
## Summary

- `configure_logging()` built a bare `logging.StreamHandler()`, which snapshots `sys.stderr` at construction and holds that reference for the life of the handler.
- The `gbserver` root Click group calls `configure_logging()` in its callback. Under `click.testing.CliRunner.invoke()` (used heavily in tests), `sys.stdout`/`sys.stderr` are swapped for an in-memory buffer that CliRunner later closes / garbage-collects. The handler then pins that transient buffer, so a cross-boundary write — or CliRunner's own `finally: getvalue()` — lands on a closed file and raises `ValueError: I/O operation on closed file`. This surfaced as intermittent failures under large parallel (`pytest -n auto`) runs.
- Fix: a small `_ConsoleStreamHandler(logging.StreamHandler)` whose `stream` is a read-only property returning the current `sys.stderr`, mirroring the stdlib `logging._StderrHandler` (used for `logging.lastResort`). The handler always targets the live stream and never retains a closed one. Log capture during `invoke()` is preserved.

## Root cause detail

Empirically confirmed: closing OR garbage-collecting the `TextIOWrapper` that CliRunner installs as `sys.stdout`/`sys.stderr` closes the underlying `BytesIO`, so a later `getvalue()` raises. The trigger only opens up under heavy parallel worker shutdown, which is why it reproduced in full-tree runs but not in isolation.

## Verification

1. New deterministic regression test `test/unit/utils/test_logger.py` fails on the old code and passes on the fix; a second test locks in that a record logged during `invoke()` still lands in `result.output` (guards against a naive `sys.__stderr__` "fix" that would silently break log capture).
2. Full unit suite: 2366 passed / 15 skipped (`-n auto`).
3. Full-tree parallel repro (`-m "not ibm and not extended" -n auto --dist=loadgroup`), 4 runs: zero flake-induced failures. The `I/O operation on closed file` message count dropped from ~882 (main) to ~292; the residual is non-fatal logging noise emitted at worker/atexit shutdown (engine disposal + SQLAlchemy pool teardown writing to an already-closed stderr) and never fails a test. Silencing that shutdown-time noise is left out of scope.

## Test plan

- [ ] `pytest test/unit/utils/test_logger.py`
- [ ] `pytest test/unit -n auto --dist=loadgroup` (green)
- [ ] Full-tree parallel run shows no `I/O operation on closed file` test failures

## Note

An unrelated, pre-existing flaky test (`TestOpenLineageAPI::test_existing_build_endpoint_still_works`) failed once in `test (3.11)` on this PR's CI but passed on re-run and on `test (3.12)` for the same commit. It is a test-isolation issue independent of this change, tracked separately in #323.

Fixes #315

Generated with [Claude Code](https://claude.com/claude-code)

