### PR TITLE
Make cancelled builds cancel quickly in skypilot and k8s

### DIFF
--- a/src/gbserver/build/buildrun.py
+++ b/src/gbserver/build/buildrun.py
@@ -696,9 +696,44 @@ class BuildRun(Run):
         logger.info("BuildRun._cleanup start")
         self_entity = self.entity
         assert isinstance(self_entity, Build)
+        # On cancellation, abort any still-running target/step run tasks before
+        # tearing down. They are created detached (asyncio.create_task) so
+        # build_run.cancel() — which cancels only the BuildRun task — never
+        # reaches them; without this they run their environment launch (e.g.
+        # SkyPilot provisioning) to completion, and target.teardown() blocks on
+        # the launch-done barrier for the full provisioning time. On the success
+        # path these tasks are already done, so this is a no-op.
+        await self._cancel_inflight_run_tasks()
         teardown_tasks: set[Task] = set()
         for target in self_entity.targets.values():
             teardown_tasks.add(asyncio.create_task(target.teardown()))
         if len(teardown_tasks) > 0:
             await asyncio.wait(teardown_tasks)
         logger.info("BuildRun._cleanup end")
+
+    async def _cancel_inflight_run_tasks(self: Self) -> None:
+        """Cancel and drain any still-running target/step run tasks.
+
+        The per-target/step run tasks are created detached (``asyncio.create_task``
+        in ``__dispatch_target``/``_run_targets_of_build``), so cancelling the
+        BuildRun task does not propagate to them. During a build cancellation this
+        leaves them blocked in the environment launch (e.g. an uninterruptible
+        ``sky.stream_and_get`` provisioning call). Cancelling them here propagates
+        ``CancelledError`` down to that launch so it aborts promptly (SkyPilot
+        request api_cancel + partial-cluster teardown) instead of provisioning a
+        cluster only to tear it down.
+
+        Awaiting the cancelled tasks lets each run's own cleanup (e.g. ``sky.down``)
+        complete before the build finishes, so clusters are not leaked. Uses
+        ``return_exceptions=True`` so the expected ``CancelledError``/``RunFailed``
+        results do not mask each other.
+        """
+        inflight = [t for t in self.tasks if not t.done()]
+        if not inflight:
+            return
+        logger.info(
+            "BuildRun._cleanup cancelling %d in-flight run task(s)", len(inflight)
+        )
+        for t in inflight:
+            t.cancel()
+        await asyncio.gather(*inflight, return_exceptions=True)

--- a/src/gbserver/build/buildrun.py
+++ b/src/gbserver/build/buildrun.py
@@ -54,6 +54,14 @@ from gbserver.utils.utils import get_uuid, short_alphanumeric_lower_hash
 # Matches {{ target_hash }} with any surrounding whitespace.
 _TARGET_HASH_RE = re.compile(r"\{\{\s*target_hash\s*\}\}")
 
+# Upper bound (seconds) for draining cancelled in-flight run tasks in _cleanup.
+# Generous: a child's cleanup chain can include sky.down, helm uninstall backoff
+# (~70s) and RayCluster deletion, all of which we want to let finish normally.
+# The bound only exists so a wedged cleanup (e.g. a hung sky.down) cannot block
+# the CANCELLED transition indefinitely — stragglers are left to finish in the
+# background, mirroring Environment._drain_thread_future.
+_INFLIGHT_CANCEL_DRAIN_TIMEOUT = 300.0
+
 logger = get_logger(__name__)
 
 
@@ -723,10 +731,13 @@ class BuildRun(Run):
         request api_cancel + partial-cluster teardown) instead of provisioning a
         cluster only to tear it down.
 
-        Awaiting the cancelled tasks lets each run's own cleanup (e.g. ``sky.down``)
-        complete before the build finishes, so clusters are not leaked. Uses
-        ``return_exceptions=True`` so the expected ``CancelledError``/``RunFailed``
-        results do not mask each other.
+        Draining the cancelled tasks lets each run's own cleanup (e.g. ``sky.down``)
+        complete before the build finishes, so clusters are not leaked. The drain
+        is *bounded* (``_INFLIGHT_CANCEL_DRAIN_TIMEOUT``): this runs ahead of
+        teardown in ``_cleanup``, so a wedged child cleanup (a hung ``sky.down``,
+        an endless helm backoff) would otherwise block the CANCELLED transition
+        indefinitely. ``asyncio.wait`` does not kill the tasks on timeout, so any
+        straggler keeps running in the background while the build proceeds.
         """
         inflight = [t for t in self.tasks if not t.done()]
         if not inflight:
@@ -736,4 +747,19 @@ class BuildRun(Run):
         )
         for t in inflight:
             t.cancel()
-        await asyncio.gather(*inflight, return_exceptions=True)
+        _, pending = await asyncio.wait(
+            inflight, timeout=_INFLIGHT_CANCEL_DRAIN_TIMEOUT
+        )
+        if pending:
+            logger.warning(
+                "BuildRun._cleanup: %d in-flight run task(s) did not drain within "
+                "%ss after cancel; proceeding with teardown",
+                len(pending),
+                _INFLIGHT_CANCEL_DRAIN_TIMEOUT,
+            )
+            # Consume each straggler's eventual result so it is not later logged
+            # as an unretrieved task exception when it finally completes.
+            for t in pending:
+                t.add_done_callback(
+                    lambda f: None if f.cancelled() else f.exception()
+                )

--- a/src/gbserver/build/buildrun.py
+++ b/src/gbserver/build/buildrun.py
@@ -754,9 +754,19 @@ class BuildRun(Run):
         logger.info("BuildRun._cleanup cancelling %d in-flight task(s)", len(inflight))
         for t in inflight:
             t.cancel()
-        _, pending = await asyncio.wait(
+        done, pending = await asyncio.wait(
             inflight, timeout=_INFLIGHT_CANCEL_DRAIN_TIMEOUT
         )
+        # Consume each drained task's result. A child may finish carrying a real
+        # exception (Run.run raises RunFailed; TargetRun._run re-raises ValueError)
+        # rather than CancelledError; the previous gather(return_exceptions=True)
+        # retrieved those implicitly, but asyncio.wait does not — without this the
+        # exception is logged as an unretrieved task exception when the task is
+        # GC'd. Skip cancelled tasks: .exception() would re-raise their
+        # CancelledError, and a cancelled task never triggers that warning anyway.
+        for t in done:
+            if not t.cancelled():
+                t.exception()
         if pending:
             logger.warning(
                 "BuildRun._cleanup: %d in-flight task(s) did not drain within "

--- a/src/gbserver/build/buildrun.py
+++ b/src/gbserver/build/buildrun.py
@@ -751,9 +751,7 @@ class BuildRun(Run):
         inflight = [t for t in self.tasks if not t.done()]
         if not inflight:
             return
-        logger.info(
-            "BuildRun._cleanup cancelling %d in-flight task(s)", len(inflight)
-        )
+        logger.info("BuildRun._cleanup cancelling %d in-flight task(s)", len(inflight))
         for t in inflight:
             t.cancel()
         _, pending = await asyncio.wait(
@@ -769,6 +767,4 @@ class BuildRun(Run):
             # Consume each straggler's eventual result so it is not later logged
             # as an unretrieved task exception when it finally completes.
             for t in pending:
-                t.add_done_callback(
-                    lambda f: None if f.cancelled() else f.exception()
-                )
+                t.add_done_callback(lambda f: None if f.cancelled() else f.exception())

--- a/src/gbserver/build/buildrun.py
+++ b/src/gbserver/build/buildrun.py
@@ -704,14 +704,14 @@ class BuildRun(Run):
         logger.info("BuildRun._cleanup start")
         self_entity = self.entity
         assert isinstance(self_entity, Build)
-        # On cancellation, abort any still-running target/step run tasks before
+        # On cancellation, abort any still-running detached run tasks before
         # tearing down. They are created detached (asyncio.create_task) so
         # build_run.cancel() — which cancels only the BuildRun task — never
         # reaches them; without this they run their environment launch (e.g.
         # SkyPilot provisioning) to completion, and target.teardown() blocks on
         # the launch-done barrier for the full provisioning time. On the success
         # path these tasks are already done, so this is a no-op.
-        await self._cancel_inflight_run_tasks()
+        await self._cancel_inflight_tasks()
         teardown_tasks: set[Task] = set()
         for target in self_entity.targets.values():
             teardown_tasks.add(asyncio.create_task(target.teardown()))
@@ -719,17 +719,26 @@ class BuildRun(Run):
             await asyncio.wait(teardown_tasks)
         logger.info("BuildRun._cleanup end")
 
-    async def _cancel_inflight_run_tasks(self: Self) -> None:
-        """Cancel and drain any still-running target/step run tasks.
+    async def _cancel_inflight_tasks(self: Self) -> None:
+        """Cancel and drain any still-running tasks tracked in ``self.tasks``.
 
-        The per-target/step run tasks are created detached (``asyncio.create_task``
-        in ``__dispatch_target``/``_run_targets_of_build``), so cancelling the
-        BuildRun task does not propagate to them. During a build cancellation this
-        leaves them blocked in the environment launch (e.g. an uninterruptible
-        ``sky.stream_and_get`` provisioning call). Cancelling them here propagates
-        ``CancelledError`` down to that launch so it aborts promptly (SkyPilot
-        request api_cancel + partial-cluster teardown) instead of provisioning a
-        cluster only to tear it down.
+        ``self.tasks`` holds two kinds of task and this cancels *both*:
+
+        * The detached ``TargetRun`` coroutine tasks (untagged), created via
+          ``asyncio.create_task`` in ``__dispatch_target``/
+          ``_run_targets_of_build``. Cancelling the BuildRun task does not
+          propagate to them, so during a build cancellation they stay blocked in
+          the environment launch (e.g. an uninterruptible ``sky.stream_and_get``
+          provisioning call). Cancelling them here propagates ``CancelledError``
+          down to that launch so it aborts promptly (SkyPilot request api_cancel
+          + partial-cluster teardown) instead of provisioning a cluster only to
+          tear it down.
+        * The tagged ``_process_event`` tasks, which do artifact registration and
+          DB writes. Cancelling one mid-flight is acceptable on the cancel path:
+          asyncio delivers ``CancelledError`` only at an ``await`` boundary, not
+          mid-statement, and the build is being torn down regardless. They are
+          cancelled+drained here (rather than filtered out) so they are not left
+          as orphaned pending tasks.
 
         Draining the cancelled tasks lets each run's own cleanup (e.g. ``sky.down``)
         complete before the build finishes, so clusters are not leaked. The drain
@@ -743,7 +752,7 @@ class BuildRun(Run):
         if not inflight:
             return
         logger.info(
-            "BuildRun._cleanup cancelling %d in-flight run task(s)", len(inflight)
+            "BuildRun._cleanup cancelling %d in-flight task(s)", len(inflight)
         )
         for t in inflight:
             t.cancel()
@@ -752,7 +761,7 @@ class BuildRun(Run):
         )
         if pending:
             logger.warning(
-                "BuildRun._cleanup: %d in-flight run task(s) did not drain within "
+                "BuildRun._cleanup: %d in-flight task(s) did not drain within "
                 "%ss after cancel; proceeding with teardown",
                 len(pending),
                 _INFLIGHT_CANCEL_DRAIN_TIMEOUT,

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -987,7 +987,7 @@ class Environment(ABC):
         IDEMPOTENCY CONTRACT: every concrete ``cleanup_*`` implementation MUST
         be idempotent and must tolerate a resource that was never created or is
         already gone. Build cancellation now propagates promptly (see
-        ``BuildRun._cancel_inflight_run_tasks``), so a cleanup can fire *before*
+        ``BuildRun._cancel_inflight_tasks``), so a cleanup can fire *before*
         the matching launch has recorded its backing resource, *during*
         provisioning, or *after* the resource is already torn down. Treat
         "resource does not exist" as success — do NOT raise or retry-storm on

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -983,6 +983,19 @@ class Environment(ABC):
         TaskGroup) so that it survives cancellation of the caller's scope.
         This ensures destructive cleanup (e.g. sky.down) actually runs during
         build cancellation.
+
+        IDEMPOTENCY CONTRACT: every concrete ``cleanup_*`` implementation MUST
+        be idempotent and must tolerate a resource that was never created or is
+        already gone. Build cancellation now propagates promptly (see
+        ``BuildRun._cancel_inflight_run_tasks``), so a cleanup can fire *before*
+        the matching launch has recorded its backing resource, *during*
+        provisioning, or *after* the resource is already torn down. Treat
+        "resource does not exist" as success — do NOT raise or retry-storm on
+        it. Examples: k8s treats helm's "release: not found" as done rather than
+        retrying at backoff; SkyPilot cancels by a deterministic name because
+        its launch_id->resource map is only populated after provisioning
+        returns. When the launch_id->resource bookkeeping may be empty on the
+        cancel path, tear down by the deterministic resource name instead.
         """
         assert launch_type
         assert launch_id
@@ -1137,7 +1150,16 @@ class Environment(ABC):
         self.__teardown_started_events.pop(setup_id, None)
 
     def teardown(self: Self, type: str, setup_id: str, **kwargs) -> Task:
-        """Teardown the setup from the environment."""
+        """Teardown the setup from the environment.
+
+        IDEMPOTENCY CONTRACT: every concrete ``teardown_*`` implementation MUST
+        be idempotent and must tolerate a setup that was never fully created or
+        is already gone. Because build cancellation now propagates promptly, a
+        teardown can run after a setup was only partially provisioned (or after
+        a cleanup already removed the resource). Treat "resource does not exist"
+        as success — do NOT raise or retry-storm on it. See the ``cleanup``
+        docstring above for the same contract on the per-launch path.
+        """
 
         async def teardown_helper():
             logger.debug("Sync waiting on setup done")

--- a/src/gbserver/environment/environment.py
+++ b/src/gbserver/environment/environment.py
@@ -1180,6 +1180,52 @@ class Environment(ABC):
 
         return asyncio.create_task(teardown_helper())
 
+    @staticmethod
+    async def _drain_thread_future(
+        pending_fut: "asyncio.Future",
+        description: str,
+        timeout: float = 60.0,
+    ) -> Any:
+        """Wait up to ``timeout`` for a shielded ``to_thread`` future to finish
+        so its OS thread is retired, without blocking indefinitely.
+
+        A ``to_thread`` future only completes when its blocking call returns;
+        the thread cannot be interrupted. After a caller aborts an in-flight
+        request the thread should unblock quickly, but if the abort was rejected
+        or did not take effect the call would otherwise run to natural
+        completion (e.g. the full provisioning time, or never). Bounding the
+        wait ensures whatever runs next — teardown, cleanup — is never gated on
+        that. If the future is still pending at the deadline we stop waiting and
+        attach a callback that retrieves its eventual result, so asyncio does
+        not log "Future exception was never retrieved" when the orphaned thread
+        finally finishes (its result is discarded).
+
+        Args:
+            pending_fut: The shielded ``to_thread`` future to drain.
+            description: Human-readable label for the timeout log message.
+            timeout: Maximum seconds to wait for the thread to retire.
+
+        Returns:
+            The future's result if it completed within ``timeout``, else None.
+        """
+        _, pending = await asyncio.wait({pending_fut}, timeout=timeout)
+        if pending:
+            logger.warning(
+                "%s did not retire within %ss after abort; proceeding without it",
+                description,
+                timeout,
+            )
+            # Swallow the eventual result/exception (guard cancelled: .exception()
+            # would raise CancelledError on a cancelled future).
+            pending_fut.add_done_callback(
+                lambda f: None if f.cancelled() else f.exception()
+            )
+            return None
+        try:
+            return pending_fut.result()
+        except BaseException:
+            return None
+
     def _get_storeconfig(
         self: Self, uri: URI, raise_exceptions: bool = False
     ) -> Tuple[Optional[Assetstore], Optional[AssetStoreEnvironmentConfig]]:

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -997,6 +997,28 @@ class K8s(Environment):
                 e,
             )
 
+    @staticmethod
+    def _is_helm_release_not_found(error: Exception) -> bool:
+        """Return True if a helm uninstall failure means the release is absent.
+
+        ``helm uninstall`` of a release that was never installed (or already
+        removed) exits non-zero with a message like
+        ``Error: uninstall: Release not loaded: <name>: release: not found``.
+        This is a *permanent* condition, not a transient one, so cleanup should
+        treat it as success (nothing to uninstall) rather than retrying. This
+        situation arises, e.g., when a build is cancelled during the
+        ``helm install --dry-run`` phase, before the real release exists.
+
+        Args:
+            error: The exception raised by the uninstall command (its message
+                embeds the command stderr).
+
+        Returns:
+            True if the error indicates the release does not exist.
+        """
+        msg = str(error).lower()
+        return "not loaded" in msg or "release: not found" in msg
+
     async def _helm_uninstall_with_retry(
         self: Self, release_name: str, launch_id: str
     ) -> None:
@@ -1005,7 +1027,8 @@ class K8s(Environment):
 
         Retries up to GBSERVER_CLEANUP_MAX_RETRIES times with exponential backoff
         (base_delay * 2^attempt) to handle cases where the K8s API is temporarily
-        unreachable at cleanup time.
+        unreachable at cleanup time. A "release not found" failure is treated as
+        success (nothing to uninstall) and is not retried.
 
         Args:
             release_name: The helm release name to uninstall.
@@ -1041,6 +1064,17 @@ class K8s(Environment):
                 logger.debug("process: %s", process)
                 break  # success
             except Exception as e:
+                if self._is_helm_release_not_found(e):
+                    # Release was never installed (e.g. cancelled during the
+                    # dry-run) or is already gone. Nothing to uninstall, so this
+                    # is a successful teardown, not a retryable failure.
+                    logger.info(
+                        "[K8s launch_id %s] helm release %s not found at cleanup; "
+                        "treating uninstall as complete",
+                        launch_id,
+                        release_name,
+                    )
+                    break
                 if attempt < max_attempts - 1:
                     delay = GBSERVER_CLEANUP_RETRY_BASE_DELAY * (2**attempt)
                     logger.warning(

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -1029,8 +1029,7 @@ class K8s(Environment):
         """
         msg = str(error).lower()
         return (
-            "uninstall: release not loaded" in msg
-            or "error: release: not found" in msg
+            "uninstall: release not loaded" in msg or "error: release: not found" in msg
         )
 
     async def _helm_uninstall_with_retry(

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -1002,22 +1002,36 @@ class K8s(Environment):
         """Return True if a helm uninstall failure means the release is absent.
 
         ``helm uninstall`` of a release that was never installed (or already
-        removed) exits non-zero with a message like
-        ``Error: uninstall: Release not loaded: <name>: release: not found``.
+        removed) exits non-zero with one of these messages::
+
+            Error: uninstall: Release not loaded: <name>: release: not found
+            Error: release: not found
+
         This is a *permanent* condition, not a transient one, so cleanup should
         treat it as success (nothing to uninstall) rather than retrying. This
         situation arises, e.g., when a build is cancelled during the
         ``helm install --dry-run`` phase, before the real release exists.
 
+        The match is anchored to helm's structured error phrasing (the
+        ``uninstall:`` command context and the ``error:`` prefix) rather than
+        loose ``"not loaded"`` / ``"not found"`` fragments. The exception
+        message embeds both the command line and the full stderr, so a bare
+        substring could match a *transient* failure whose stderr incidentally
+        contains one of those words — misclassifying it as success, skipping a
+        needed uninstall, and leaking the RayCluster/pods.
+
         Args:
             error: The exception raised by the uninstall command (its message
-                embeds the command stderr).
+                embeds the command line and stderr).
 
         Returns:
             True if the error indicates the release does not exist.
         """
         msg = str(error).lower()
-        return "not loaded" in msg or "release: not found" in msg
+        return (
+            "uninstall: release not loaded" in msg
+            or "error: release: not found" in msg
+        )
 
     async def _helm_uninstall_with_retry(
         self: Self, release_name: str, launch_id: str

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -1268,18 +1268,35 @@ class Skypilot(Environment):
         ):
             with attempt:
                 try:
-                    request_id = await asyncio.to_thread(
-                        sky.launch,
-                        task,
-                        cluster_name=cluster_name,
-                        idle_minutes_to_autostop=autostop,
+                    # Both sky.launch (submit) and sky.stream_and_get (wait)
+                    # block in an OS thread, so a CancelledError delivered to
+                    # this task is deferred until the thread returns — the
+                    # submit can block while the cluster is in INIT (see
+                    # build/run.py), the stream wait for 2-5 min. Shield each
+                    # future so the outer await observes the cancel
+                    # *immediately* while the thread keeps running, letting us
+                    # abort the SkyPilot request server-side and tear down any
+                    # partial cluster rather than leaking it.
+                    launch_fut = asyncio.ensure_future(
+                        asyncio.to_thread(
+                            sky.launch,
+                            task,
+                            cluster_name=cluster_name,
+                            idle_minutes_to_autostop=autostop,
+                        )
                     )
-                    # sky.stream_and_get blocks in an OS thread during
-                    # provisioning, so a CancelledError delivered to this task
-                    # is deferred until it returns (2-5 min). Shield the future
-                    # so the outer await observes the cancel *immediately* while
-                    # the thread keeps running, letting us abort the SkyPilot
-                    # request server-side rather than waiting out provisioning.
+                    try:
+                        request_id = await asyncio.shield(launch_fut)
+                    except asyncio.CancelledError:
+                        # Cancelled during the submit: no request_id yet, but
+                        # the thread may still be creating the cluster under the
+                        # deterministic name. _abort_provision drains the submit
+                        # to recover the request_id (if any) and tears down by
+                        # name so the cluster is not leaked.
+                        await self._abort_provision(
+                            None, cluster_name, launch_fut
+                        )
+                        raise
                     stream_fut = asyncio.ensure_future(
                         asyncio.to_thread(sky.stream_and_get, request_id)
                     )
@@ -1313,14 +1330,15 @@ class Skypilot(Environment):
         self: Self,
         request_id: Any,
         cluster_name: str,
-        stream_fut: "asyncio.Future",
+        pending_fut: Optional["asyncio.Future"],
     ) -> None:
         """Abort an in-flight SkyPilot provisioning request after cancellation.
 
-        Called when the task is cancelled while blocked in
-        ``sky.stream_and_get``. Tells the SkyPilot API server to abort the
-        request (unblocking the shielded thread), drains that future, then tears
-        down any partial cluster so the cancel does not leak resources.
+        Called when the task is cancelled while blocked in either the
+        ``sky.launch`` submit or the ``sky.stream_and_get`` wait. Tells the
+        SkyPilot API server to abort the request (unblocking the shielded
+        thread), drains the pending future, then tears down any partial cluster
+        so the cancel does not leak resources.
 
         The current task is already flagged for cancellation, so every ``await``
         here would re-raise ``CancelledError`` immediately. We temporarily clear
@@ -1330,32 +1348,49 @@ class Skypilot(Environment):
 
         Args:
             request_id: The id returned by ``sky.launch``, passed to
-                ``sky.api_cancel`` to abort the request server-side.
+                ``sky.api_cancel`` to abort the request server-side. ``None``
+                when cancelled during the submit (before it returned); we then
+                recover it by draining ``pending_fut``.
             cluster_name: Deterministic cluster name to tear down. The
                 ``self._cluster_names`` bookkeeping is not populated until
-                provisioning returns, so we tear down by name here.
-            stream_fut: The shielded ``sky.stream_and_get`` future to drain once
-                the request has been aborted.
+                provisioning returns, so we tear down by name here — this is the
+                safety net that reclaims the cluster even when there is no
+                request_id to abort.
+            pending_fut: The shielded future still running on its OS thread — the
+                ``sky.launch`` submit or the ``sky.stream_and_get`` wait — drained
+                so the thread is retired.
         """
         current = asyncio.current_task()
         cancels = current.cancelling() if current else 0
         for _ in range(cancels):
             current.uncancel()  # type: ignore[union-attr]
         try:
+            # Cancelled during the submit: recover the request_id from the
+            # (shielded) submit future so the request can still be aborted
+            # server-side. If the drain raises, the submit never produced a
+            # request — the teardown-by-name below is the safety net either way.
+            if request_id is None:
+                assert pending_fut is not None  # submit-cancel path always passes it
+                with contextlib.suppress(BaseException):
+                    request_id = await pending_fut
+                pending_fut = None  # already drained above
             logger.info(
                 "Cancellation requested; aborting SkyPilot request %s for %s",
                 request_id,
                 cluster_name,
             )
-            try:
-                abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
-                await asyncio.to_thread(sky.get, abort_id)
-            except Exception as e:
-                logger.warning("api_cancel for %s failed: %s", request_id, e)
-            # Drain the now-unblocked stream_and_get thread; it may finish or
+            if request_id is not None:
+                try:
+                    abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
+                    await asyncio.to_thread(sky.get, abort_id)
+                except Exception as e:
+                    logger.warning("api_cancel for %s failed: %s", request_id, e)
+            # Drain the still-running future (the stream wait, or the submit if
+            # its recovery raised) so its OS thread is retired; it may finish or
             # raise (aborted/failed) — either is fine, we only want it retired.
-            with contextlib.suppress(BaseException):
-                await stream_fut
+            if pending_fut is not None:
+                with contextlib.suppress(BaseException):
+                    await pending_fut
             await self._teardown(cluster_name)
         finally:
             if cancels > 0 and current:

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -88,14 +88,17 @@ async def _abort_shielded_request(
     reclaim step (``on_abort``): teardown-by-name vs cancel-job-by-name.
 
     The current task is already flagged for cancellation, so every ``await``
-    here would re-raise ``CancelledError`` immediately. We temporarily clear the
-    cancellation with ``Task.uncancel()`` (mirroring ``build/run.py``) so the
-    cleanup awaits can block normally, then re-arm it in the ``finally`` so the
-    ``CancelledError`` keeps propagating. The steps: recover the request_id from
-    the submit future if we were cancelled before it returned; tell the API
-    server to abort the request (unblocking the shielded thread); drain the
-    still-running thread (bounded, so a rejected/ineffective abort does not gate
-    the reclaim on the full provisioning time); then run ``on_abort``.
+    here would re-raise ``CancelledError`` immediately. We run the reclaim as a
+    shielded task and, mirroring ``build/run.py``, clear the pending
+    cancellation with ``Task.uncancel()`` so the awaits block normally,
+    re-uncancel on each *further* ``CancelledError`` (e.g. a double
+    ``gb build cancel``) so a mid-abort cancel can't skip the by-name reclaim,
+    and re-arm the cancel in the ``finally`` so it keeps propagating once the
+    reclaim is done. The reclaim steps: recover the request_id from the submit
+    future if we were cancelled before it returned; tell the API server to abort
+    the request (unblocking the shielded thread); drain the still-running thread
+    (bounded, so a rejected/ineffective abort does not gate the reclaim on the
+    full provisioning time); then run ``on_abort``.
 
     Args:
         request_id: The id from ``sky.(jobs.)launch``; ``None`` when cancelled
@@ -109,30 +112,44 @@ async def _abort_shielded_request(
             deterministic name — the safety net that runs even when there is no
             request_id to abort.
     """
+    async def _do_abort() -> None:
+        # The reclaim body, run as a shielded task so repeated cancels can't
+        # interrupt it before on_abort() (the by-name reclaim) has run.
+        local_id, local_fut = request_id, pending_fut
+        if local_id is None and local_fut is not None:
+            local_id = await Environment._drain_thread_future(
+                local_fut, f"{description} submit"
+            )
+            local_fut = None  # already drained above
+        logger.info(
+            "Cancellation requested; aborting %s (request %s)", description, local_id
+        )
+        if local_id is not None:
+            try:
+                abort_id = await asyncio.to_thread(sky.api_cancel, local_id)
+                await asyncio.to_thread(sky.get, abort_id)
+            except Exception as e:
+                logger.warning("api_cancel for %s failed: %s", local_id, e)
+        if local_fut is not None:
+            await Environment._drain_thread_future(local_fut, description)
+        await on_abort()
+
+    abort_task = asyncio.ensure_future(_do_abort())
     current = asyncio.current_task()
     cancels = current.cancelling() if current else 0
     for _ in range(cancels):
         current.uncancel()  # type: ignore[union-attr]
     try:
-        if request_id is None and pending_fut is not None:
-            request_id = await Environment._drain_thread_future(
-                pending_fut, f"{description} submit"
-            )
-            pending_fut = None  # already drained above
-        logger.info(
-            "Cancellation requested; aborting %s (request %s)",
-            description,
-            request_id,
-        )
-        if request_id is not None:
+        while not abort_task.done():
             try:
-                abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
-                await asyncio.to_thread(sky.get, abort_id)
-            except Exception as e:
-                logger.warning("api_cancel for %s failed: %s", request_id, e)
-        if pending_fut is not None:
-            await Environment._drain_thread_future(pending_fut, description)
-        await on_abort()
+                await asyncio.shield(abort_task)
+            except asyncio.CancelledError:
+                # A further cancel arrived mid-abort; suppress it and re-uncancel
+                # so the reclaim still runs to completion (matches build/run.py).
+                if current and current.cancelling() > 0:
+                    cancels += current.cancelling()
+                    for _ in range(current.cancelling()):
+                        current.uncancel()
     finally:
         if cancels > 0 and current:
             current.cancel()

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -7,7 +7,6 @@ require it unless a Skypilot environment is actually configured.
 """
 
 import asyncio
-import contextlib
 import glob
 import os
 import shlex
@@ -1367,12 +1366,13 @@ class Skypilot(Environment):
         try:
             # Cancelled during the submit: recover the request_id from the
             # (shielded) submit future so the request can still be aborted
-            # server-side. If the drain raises, the submit never produced a
-            # request — the teardown-by-name below is the safety net either way.
+            # server-side. Bounded so a slow/stuck submit does not gate teardown;
+            # if we cannot recover it, teardown-by-name below is the safety net.
             if request_id is None:
                 assert pending_fut is not None  # submit-cancel path always passes it
-                with contextlib.suppress(BaseException):
-                    request_id = await pending_fut
+                request_id = await self._drain_thread_future(
+                    pending_fut, f"SkyPilot submit for {cluster_name}"
+                )
                 pending_fut = None  # already drained above
             logger.info(
                 "Cancellation requested; aborting SkyPilot request %s for %s",
@@ -1386,11 +1386,13 @@ class Skypilot(Environment):
                 except Exception as e:
                     logger.warning("api_cancel for %s failed: %s", request_id, e)
             # Drain the still-running future (the stream wait, or the submit if
-            # its recovery raised) so its OS thread is retired; it may finish or
-            # raise (aborted/failed) — either is fine, we only want it retired.
+            # its recovery raised) so its OS thread is retired. Bounded: if the
+            # abort above was rejected or did not unblock the thread, we must not
+            # wait out the full provisioning time before tearing down by name.
             if pending_fut is not None:
-                with contextlib.suppress(BaseException):
-                    await pending_fut
+                await self._drain_thread_future(
+                    pending_fut, f"SkyPilot stream_and_get for {cluster_name}"
+                )
             await self._teardown(cluster_name)
         finally:
             if cancels > 0 and current:

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -7,6 +7,8 @@ require it unless a Skypilot environment is actually configured.
 """
 
 import asyncio
+import concurrent.futures
+import functools
 import glob
 import os
 import shlex
@@ -60,6 +62,57 @@ else:
     sky = None  # type: ignore[assignment]
 
 _DEFAULT_POLL_INTERVAL_SECONDS = 300
+
+# Dedicated thread pool for the blocking SkyPilot provisioning submits that a
+# cancel may *orphan* — the shielded sky.launch / sky.jobs.launch /
+# sky.stream_and_get calls whose futures _abort_shielded_request abandons when
+# its drain times out. asyncio.to_thread runs on the event loop's default
+# ThreadPoolExecutor (~min(32, cpu+4) workers), shared by every to_thread in
+# gbserver; an abandoned provisioning thread blocks until its SDK call returns
+# naturally (potentially the full provisioning time), holding a shared slot, so
+# a few aborted provisions could starve unrelated offloaded work. Running them
+# on their own pool bounds the blast radius to SkyPilot provisioning. Lazily
+# created so merely importing this module (or running without SkyPilot) does not
+# spin up threads.
+_SKY_EXECUTOR: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_SKY_EXECUTOR_LOCK = threading.Lock()
+
+
+def _get_sky_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Return the dedicated SkyPilot provisioning thread pool, creating it once.
+
+    :returns: the process-wide ThreadPoolExecutor used for orphanable SkyPilot
+        submit/stream calls (double-checked lazy singleton).
+    """
+    global _SKY_EXECUTOR
+    if _SKY_EXECUTOR is None:
+        with _SKY_EXECUTOR_LOCK:
+            if _SKY_EXECUTOR is None:
+                _SKY_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                    thread_name_prefix="gb-sky-provision"
+                )
+    return _SKY_EXECUTOR
+
+
+async def _sky_submit_to_thread(
+    func: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    """Run a blocking, possibly-orphaned SkyPilot call on the dedicated pool.
+
+    Mirrors ``asyncio.to_thread`` but targets ``_get_sky_executor()`` instead of
+    the loop's shared default executor, so a thread abandoned after a cancel
+    (drain timeout) cannot starve unrelated ``to_thread`` work elsewhere in
+    gbserver.
+
+    :param func: the blocking SkyPilot SDK call (e.g. ``sky.launch``).
+    :param args: positional arguments forwarded to ``func``.
+    :param kwargs: keyword arguments forwarded to ``func``.
+    :returns: the call's result once the worker thread completes.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _get_sky_executor(), functools.partial(func, *args, **kwargs)
+    )
 
 
 def _require_skypilot():
@@ -1452,7 +1505,7 @@ class Skypilot(Environment):
                     # abort the SkyPilot request server-side and tear down any
                     # partial cluster rather than leaking it.
                     launch_fut = asyncio.ensure_future(
-                        asyncio.to_thread(
+                        _sky_submit_to_thread(
                             sky.launch,
                             task,
                             cluster_name=cluster_name,
@@ -1470,7 +1523,7 @@ class Skypilot(Environment):
                         await self._abort_provision(None, cluster_name, launch_fut)
                         raise
                     stream_fut = asyncio.ensure_future(
-                        asyncio.to_thread(sky.stream_and_get, request_id)
+                        _sky_submit_to_thread(sky.stream_and_get, request_id)
                     )
                     try:
                         return await asyncio.shield(stream_fut)

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -1366,9 +1366,7 @@ class Skypilot(Environment):
                         # deterministic name. _abort_provision drains the submit
                         # to recover the request_id (if any) and tears down by
                         # name so the cluster is not leaked.
-                        await self._abort_provision(
-                            None, cluster_name, launch_fut
-                        )
+                        await self._abort_provision(None, cluster_name, launch_fut)
                         raise
                     stream_fut = asyncio.ensure_future(
                         asyncio.to_thread(sky.stream_and_get, request_id)

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -112,6 +112,7 @@ async def _abort_shielded_request(
             deterministic name — the safety net that runs even when there is no
             request_id to abort.
     """
+
     async def _do_abort() -> None:
         # The reclaim body, run as a shielded task so repeated cancels can't
         # interrupt it before on_abort() (the by-name reclaim) has run.

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -170,17 +170,18 @@ async def _abort_shielded_request(
         # The reclaim body, run as a shielded task so repeated cancels can't
         # interrupt it before on_abort() (the by-name reclaim) has run.
         local_id, local_fut = request_id, pending_fut
-        orphaned_submit = None  # set if the submit drain timed out (see below)
+        # Set if a drain below times out: the submit or stream_and_get thread is
+        # still running and could create/finish the resource *after* the by-name
+        # reclaim returns. Keeping the future lets us retry the reclaim when it
+        # settles (closes the post-timeout leak window). At most one of the two
+        # drains runs per call, so a single slot suffices.
+        orphaned_fut = None
         if local_id is None and local_fut is not None:
             local_id = await Environment._drain_thread_future(
                 local_fut, f"{description} submit"
             )
             if local_id is None and not local_fut.done():
-                # Submit drain timed out: the sky.(jobs.)launch thread is still
-                # running and could create the resource *after* the by-name
-                # reclaim below returns. Keep the future so we can retry the
-                # reclaim when it settles (closes the post-timeout leak window).
-                orphaned_submit = local_fut
+                orphaned_fut = local_fut
             local_fut = None  # already drained above
         logger.info(
             "Cancellation requested; aborting %s (request %s)", description, local_id
@@ -193,9 +194,14 @@ async def _abort_shielded_request(
                 logger.warning("api_cancel for %s failed: %s", local_id, e)
         if local_fut is not None:
             await Environment._drain_thread_future(local_fut, description)
+            if not local_fut.done():
+                # Same window on the stream_and_get path: if api_cancel was
+                # rejected or ineffective, provisioning continues server-side and
+                # can finish after on_abort() returns.
+                orphaned_fut = local_fut
         await on_abort()
-        if orphaned_submit is not None:
-            _reclaim_when_submit_settles(orphaned_submit, description, on_abort)
+        if orphaned_fut is not None:
+            _reclaim_when_thread_settles(orphaned_fut, description, on_abort)
 
     abort_task = asyncio.ensure_future(_do_abort())
     current = asyncio.current_task()
@@ -218,23 +224,43 @@ async def _abort_shielded_request(
             current.cancel()
 
 
-def _reclaim_when_submit_settles(
-    submit_fut: "asyncio.Future",
+def _reclaim_when_thread_settles(
+    orphaned_fut: "asyncio.Future",
     description: str,
     on_abort: Callable[[], Awaitable[None]],
 ) -> None:
-    """Re-run the by-name reclaim once an orphaned submit thread finally settles.
+    """Re-run the by-name reclaim once an orphaned launch/stream thread settles.
 
-    When the submit drain in ``_abort_shielded_request`` times out, the
-    ``sky.(jobs.)launch`` thread keeps running and can create the cluster/job
-    *after* the first by-name reclaim has already returned — the exact leak the
-    reclaim exists to prevent, with no further attempt. This attaches a
-    done-callback that fires a *second* reclaim when the orphaned submit settles
-    (i.e. once the resource, if any, has actually been created), so it is reaped
-    best-effort. ``on_abort`` is idempotent (teardown/cancel-by-name tolerate an
-    already-gone resource), so the extra call is safe when nothing leaked.
+    When a drain in ``_abort_shielded_request`` times out, the underlying
+    ``sky.(jobs.)launch`` (submit) or ``sky.stream_and_get`` (stream) thread
+    keeps running and can create/finish the cluster/job *after* the first by-name
+    reclaim has already returned — the exact leak the reclaim exists to prevent,
+    with no further attempt. This attaches a done-callback that fires a *second*
+    reclaim when the orphaned future settles (i.e. once the resource, if any, has
+    actually been created), so it is reaped best-effort. ``on_abort`` is
+    idempotent (teardown/cancel-by-name tolerate an already-gone resource), so
+    the extra call is safe when nothing leaked.
 
-    :param submit_fut: the still-pending ``to_thread`` submit future to watch.
+    Best-effort, with real limits:
+
+    * **Loop already closed.** We only reach here 60s+ after the abort (the drain
+      timeout), by which point the build has usually finished. In a one-shot
+      ``gb`` invocation the event loop is then closed, so the done-callback never
+      fires and *nothing is logged at all* — the resource is leaked silently. The
+      ``except RuntimeError`` branch below only catches "no running loop" at
+      ``ensure_future`` time, which is close to unreachable (if a callback fires,
+      a loop is usually running); it does not cover the loop-already-gone case.
+      In long-lived ``gbserver`` the loop outlives the build, so the reclaim does
+      fire — this gap mainly affects short-lived CLI processes.
+    * **Fire-and-forget.** The second reclaim is scheduled with no strong
+      reference retained and its exceptions are never retrieved. This is safe
+      only because both ``on_abort`` implementations
+      (``_abort_provision._teardown`` and ``_abort_managed_launch._cancel_job``)
+      swallow their own errors and complete quickly; a future ``on_abort`` that
+      raised, or ran long enough to be GC'd mid-flight, would need a held
+      reference and a result-consuming callback here.
+
+    :param orphaned_fut: the still-pending ``to_thread`` submit/stream future.
     :param description: resource label used in the log messages.
     :param on_abort: the idempotent by-name reclaim coroutine to re-run.
     """
@@ -245,30 +271,32 @@ def _reclaim_when_submit_settles(
         if fut.exception() is not None:
             # The launch itself failed → no resource was created; nothing to reap.
             logger.info(
-                "Orphaned %s submit failed after abort timeout (%s); "
+                "Orphaned %s thread failed after abort timeout (%s); "
                 "no second reclaim needed",
                 description,
                 fut.exception(),
             )
             return
         logger.warning(
-            "Orphaned %s submit completed after abort timeout; running a second "
+            "Orphaned %s thread completed after abort timeout; running a second "
             "by-name reclaim to reap the possibly-created resource",
             description,
         )
         try:
             asyncio.ensure_future(on_abort())
         except RuntimeError as e:
-            # No running loop (e.g. a one-shot build already exited). Surface it
-            # loudly so the possible leak is actionable rather than silent.
+            # No running loop at schedule time. Surface it loudly so the possible
+            # leak is actionable rather than silent. (Does not cover the more
+            # likely one-shot case where the loop is already closed before this
+            # callback fires — see the docstring.)
             logger.error(
-                "Could not schedule second reclaim for orphaned %s submit (%s); "
+                "Could not schedule second reclaim for orphaned %s thread (%s); "
                 "a cluster/job may be leaked and need manual teardown",
                 description,
                 e,
             )
 
-    submit_fut.add_done_callback(_on_settled)
+    orphaned_fut.add_done_callback(_on_settled)
 
 
 async def _run_sky_verb_off_loop(

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -7,6 +7,7 @@ require it unless a Skypilot environment is actually configured.
 """
 
 import asyncio
+import contextlib
 import glob
 import os
 import shlex
@@ -1273,7 +1274,22 @@ class Skypilot(Environment):
                         cluster_name=cluster_name,
                         idle_minutes_to_autostop=autostop,
                     )
-                    return await asyncio.to_thread(sky.stream_and_get, request_id)
+                    # sky.stream_and_get blocks in an OS thread during
+                    # provisioning, so a CancelledError delivered to this task
+                    # is deferred until it returns (2-5 min). Shield the future
+                    # so the outer await observes the cancel *immediately* while
+                    # the thread keeps running, letting us abort the SkyPilot
+                    # request server-side rather than waiting out provisioning.
+                    stream_fut = asyncio.ensure_future(
+                        asyncio.to_thread(sky.stream_and_get, request_id)
+                    )
+                    try:
+                        return await asyncio.shield(stream_fut)
+                    except asyncio.CancelledError:
+                        await self._abort_provision(
+                            request_id, cluster_name, stream_fut
+                        )
+                        raise
                 except Exception as e:
                     # Clear the partial INIT/FAILED cluster record before the
                     # next attempt so the relaunch doesn't reuse the stale
@@ -1292,6 +1308,58 @@ class Skypilot(Environment):
         # Unreachable: AsyncRetrying with reraise=True either returns from the
         # `return` above or raises; this satisfies the type checker.
         raise AssertionError("unreachable: _provision_with_retry exited loop")
+
+    async def _abort_provision(
+        self: Self,
+        request_id: Any,
+        cluster_name: str,
+        stream_fut: "asyncio.Future",
+    ) -> None:
+        """Abort an in-flight SkyPilot provisioning request after cancellation.
+
+        Called when the task is cancelled while blocked in
+        ``sky.stream_and_get``. Tells the SkyPilot API server to abort the
+        request (unblocking the shielded thread), drains that future, then tears
+        down any partial cluster so the cancel does not leak resources.
+
+        The current task is already flagged for cancellation, so every ``await``
+        here would re-raise ``CancelledError`` immediately. We temporarily clear
+        the cancellation with ``Task.uncancel()`` (mirroring the idiom in
+        ``build/run.py``) so the cleanup awaits can block normally, then re-arm
+        it in the ``finally`` so the ``CancelledError`` keeps propagating.
+
+        Args:
+            request_id: The id returned by ``sky.launch``, passed to
+                ``sky.api_cancel`` to abort the request server-side.
+            cluster_name: Deterministic cluster name to tear down. The
+                ``self._cluster_names`` bookkeeping is not populated until
+                provisioning returns, so we tear down by name here.
+            stream_fut: The shielded ``sky.stream_and_get`` future to drain once
+                the request has been aborted.
+        """
+        current = asyncio.current_task()
+        cancels = current.cancelling() if current else 0
+        for _ in range(cancels):
+            current.uncancel()  # type: ignore[union-attr]
+        try:
+            logger.info(
+                "Cancellation requested; aborting SkyPilot request %s for %s",
+                request_id,
+                cluster_name,
+            )
+            try:
+                abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
+                await asyncio.to_thread(sky.get, abort_id)
+            except Exception as e:
+                logger.warning("api_cancel for %s failed: %s", request_id, e)
+            # Drain the now-unblocked stream_and_get thread; it may finish or
+            # raise (aborted/failed) — either is fine, we only want it retired.
+            with contextlib.suppress(BaseException):
+                await stream_fut
+            await self._teardown(cluster_name)
+        finally:
+            if cancels > 0 and current:
+                current.cancel()
 
     async def monitor_skypilot_monitor(
         self: Self,

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -138,6 +138,27 @@ async def _abort_shielded_request(
             current.cancel()
 
 
+async def _run_sky_verb_off_loop(
+    verb: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    """Run a blocking sky SDK verb and its ``sky.get`` off the event loop.
+
+    Mutating sky verbs (``sky.down``, ``sky.jobs.cancel``, ``sky.api_cancel``)
+    return a request id that must be passed to ``sky.get`` to make the call
+    synchronous. Both block, so running them inline freezes the event loop for
+    the whole server round-trip and defeats any enclosing ``wait_for``; this
+    offloads both to threads. Exceptions propagate — the caller owns error
+    handling.
+
+    :param verb: the blocking sky verb to invoke (e.g. ``sky.jobs.cancel``).
+    :param args: positional arguments forwarded to ``verb``.
+    :param kwargs: keyword arguments forwarded to ``verb``.
+    :returns: the result of ``sky.get`` on the verb's request id.
+    """
+    request_id = await asyncio.to_thread(verb, *args, **kwargs)
+    return await asyncio.to_thread(sky.get, request_id)
+
+
 def _ensure_skypilot_api_running():
     """Start the SkyPilot API server if not already healthy.
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -117,10 +117,17 @@ async def _abort_shielded_request(
         # The reclaim body, run as a shielded task so repeated cancels can't
         # interrupt it before on_abort() (the by-name reclaim) has run.
         local_id, local_fut = request_id, pending_fut
+        orphaned_submit = None  # set if the submit drain timed out (see below)
         if local_id is None and local_fut is not None:
             local_id = await Environment._drain_thread_future(
                 local_fut, f"{description} submit"
             )
+            if local_id is None and not local_fut.done():
+                # Submit drain timed out: the sky.(jobs.)launch thread is still
+                # running and could create the resource *after* the by-name
+                # reclaim below returns. Keep the future so we can retry the
+                # reclaim when it settles (closes the post-timeout leak window).
+                orphaned_submit = local_fut
             local_fut = None  # already drained above
         logger.info(
             "Cancellation requested; aborting %s (request %s)", description, local_id
@@ -134,6 +141,8 @@ async def _abort_shielded_request(
         if local_fut is not None:
             await Environment._drain_thread_future(local_fut, description)
         await on_abort()
+        if orphaned_submit is not None:
+            _reclaim_when_submit_settles(orphaned_submit, description, on_abort)
 
     abort_task = asyncio.ensure_future(_do_abort())
     current = asyncio.current_task()
@@ -154,6 +163,59 @@ async def _abort_shielded_request(
     finally:
         if cancels > 0 and current:
             current.cancel()
+
+
+def _reclaim_when_submit_settles(
+    submit_fut: "asyncio.Future",
+    description: str,
+    on_abort: Callable[[], Awaitable[None]],
+) -> None:
+    """Re-run the by-name reclaim once an orphaned submit thread finally settles.
+
+    When the submit drain in ``_abort_shielded_request`` times out, the
+    ``sky.(jobs.)launch`` thread keeps running and can create the cluster/job
+    *after* the first by-name reclaim has already returned — the exact leak the
+    reclaim exists to prevent, with no further attempt. This attaches a
+    done-callback that fires a *second* reclaim when the orphaned submit settles
+    (i.e. once the resource, if any, has actually been created), so it is reaped
+    best-effort. ``on_abort`` is idempotent (teardown/cancel-by-name tolerate an
+    already-gone resource), so the extra call is safe when nothing leaked.
+
+    :param submit_fut: the still-pending ``to_thread`` submit future to watch.
+    :param description: resource label used in the log messages.
+    :param on_abort: the idempotent by-name reclaim coroutine to re-run.
+    """
+
+    def _on_settled(fut: "asyncio.Future") -> None:
+        if fut.cancelled():
+            return
+        if fut.exception() is not None:
+            # The launch itself failed → no resource was created; nothing to reap.
+            logger.info(
+                "Orphaned %s submit failed after abort timeout (%s); "
+                "no second reclaim needed",
+                description,
+                fut.exception(),
+            )
+            return
+        logger.warning(
+            "Orphaned %s submit completed after abort timeout; running a second "
+            "by-name reclaim to reap the possibly-created resource",
+            description,
+        )
+        try:
+            asyncio.ensure_future(on_abort())
+        except RuntimeError as e:
+            # No running loop (e.g. a one-shot build already exited). Surface it
+            # loudly so the possible leak is actionable rather than silent.
+            logger.error(
+                "Could not schedule second reclaim for orphaned %s submit (%s); "
+                "a cluster/job may be leaked and need manual teardown",
+                description,
+                e,
+            )
+
+    submit_fut.add_done_callback(_on_settled)
 
 
 async def _run_sky_verb_off_loop(

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -14,7 +14,18 @@ import threading
 import time
 import urllib.parse
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Self, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Self,
+    Tuple,
+    Union,
+)
 
 from tenacity import (
     AsyncRetrying,
@@ -62,6 +73,69 @@ def _require_skypilot():
             "The 'skypilot' package is required for the Skypilot environment. "
             "Install it with: pip install 'gbserver[skypilot]'"
         )
+
+
+async def _abort_shielded_request(
+    request_id: Any,
+    pending_fut: Optional["asyncio.Future"],
+    description: str,
+    on_abort: Callable[[], Awaitable[None]],
+) -> None:
+    """Abort an in-flight, shielded SkyPilot request after cancellation.
+
+    Shared by the unmanaged (``_abort_provision``) and managed
+    (``_abort_managed_launch``) launchers, which differ only in the final
+    reclaim step (``on_abort``): teardown-by-name vs cancel-job-by-name.
+
+    The current task is already flagged for cancellation, so every ``await``
+    here would re-raise ``CancelledError`` immediately. We temporarily clear the
+    cancellation with ``Task.uncancel()`` (mirroring ``build/run.py``) so the
+    cleanup awaits can block normally, then re-arm it in the ``finally`` so the
+    ``CancelledError`` keeps propagating. The steps: recover the request_id from
+    the submit future if we were cancelled before it returned; tell the API
+    server to abort the request (unblocking the shielded thread); drain the
+    still-running thread (bounded, so a rejected/ineffective abort does not gate
+    the reclaim on the full provisioning time); then run ``on_abort``.
+
+    Args:
+        request_id: The id from ``sky.(jobs.)launch``; ``None`` when cancelled
+            during the submit (before it returned), then recovered by draining
+            ``pending_fut`` so the request can still be aborted server-side.
+        pending_fut: The shielded ``to_thread`` future still running on its OS
+            thread (the submit or the ``stream_and_get`` wait), drained here.
+        description: Resource label used in the log/timeout messages, e.g.
+            ``"SkyPilot cluster gb-xyz"``.
+        on_abort: Coroutine performing the resource-specific reclaim by the
+            deterministic name — the safety net that runs even when there is no
+            request_id to abort.
+    """
+    current = asyncio.current_task()
+    cancels = current.cancelling() if current else 0
+    for _ in range(cancels):
+        current.uncancel()  # type: ignore[union-attr]
+    try:
+        if request_id is None and pending_fut is not None:
+            request_id = await Environment._drain_thread_future(
+                pending_fut, f"{description} submit"
+            )
+            pending_fut = None  # already drained above
+        logger.info(
+            "Cancellation requested; aborting %s (request %s)",
+            description,
+            request_id,
+        )
+        if request_id is not None:
+            try:
+                abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
+                await asyncio.to_thread(sky.get, abort_id)
+            except Exception as e:
+                logger.warning("api_cancel for %s failed: %s", request_id, e)
+        if pending_fut is not None:
+            await Environment._drain_thread_future(pending_fut, description)
+        await on_abort()
+    finally:
+        if cancels > 0 and current:
+            current.cancel()
 
 
 def _ensure_skypilot_api_running():
@@ -1333,70 +1407,29 @@ class Skypilot(Environment):
     ) -> None:
         """Abort an in-flight SkyPilot provisioning request after cancellation.
 
-        Called when the task is cancelled while blocked in either the
-        ``sky.launch`` submit or the ``sky.stream_and_get`` wait. Tells the
-        SkyPilot API server to abort the request (unblocking the shielded
-        thread), drains the pending future, then tears down any partial cluster
-        so the cancel does not leak resources.
-
-        The current task is already flagged for cancellation, so every ``await``
-        here would re-raise ``CancelledError`` immediately. We temporarily clear
-        the cancellation with ``Task.uncancel()`` (mirroring the idiom in
-        ``build/run.py``) so the cleanup awaits can block normally, then re-arm
-        it in the ``finally`` so the ``CancelledError`` keeps propagating.
+        Thin wrapper over the shared ``_abort_shielded_request`` whose only
+        launcher-specific part is the reclaim: tear down the (possibly partial)
+        cluster by its deterministic name. ``self._cluster_names`` is not
+        populated until provisioning returns, so teardown-by-name is the safety
+        net that reclaims the cluster even when there is no request_id to abort.
 
         Args:
-            request_id: The id returned by ``sky.launch``, passed to
-                ``sky.api_cancel`` to abort the request server-side. ``None``
-                when cancelled during the submit (before it returned); we then
-                recover it by draining ``pending_fut``.
-            cluster_name: Deterministic cluster name to tear down. The
-                ``self._cluster_names`` bookkeeping is not populated until
-                provisioning returns, so we tear down by name here — this is the
-                safety net that reclaims the cluster even when there is no
-                request_id to abort.
-            pending_fut: The shielded future still running on its OS thread — the
-                ``sky.launch`` submit or the ``sky.stream_and_get`` wait — drained
-                so the thread is retired.
+            request_id: The id from ``sky.launch``, or ``None`` if cancelled
+                during the submit (recovered by draining ``pending_fut``).
+            cluster_name: Deterministic cluster name to tear down.
+            pending_fut: The shielded ``to_thread`` future to drain (the submit
+                or the ``sky.stream_and_get`` wait).
         """
-        current = asyncio.current_task()
-        cancels = current.cancelling() if current else 0
-        for _ in range(cancels):
-            current.uncancel()  # type: ignore[union-attr]
-        try:
-            # Cancelled during the submit: recover the request_id from the
-            # (shielded) submit future so the request can still be aborted
-            # server-side. Bounded so a slow/stuck submit does not gate teardown;
-            # if we cannot recover it, teardown-by-name below is the safety net.
-            if request_id is None:
-                assert pending_fut is not None  # submit-cancel path always passes it
-                request_id = await self._drain_thread_future(
-                    pending_fut, f"SkyPilot submit for {cluster_name}"
-                )
-                pending_fut = None  # already drained above
-            logger.info(
-                "Cancellation requested; aborting SkyPilot request %s for %s",
-                request_id,
-                cluster_name,
-            )
-            if request_id is not None:
-                try:
-                    abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
-                    await asyncio.to_thread(sky.get, abort_id)
-                except Exception as e:
-                    logger.warning("api_cancel for %s failed: %s", request_id, e)
-            # Drain the still-running future (the stream wait, or the submit if
-            # its recovery raised) so its OS thread is retired. Bounded: if the
-            # abort above was rejected or did not unblock the thread, we must not
-            # wait out the full provisioning time before tearing down by name.
-            if pending_fut is not None:
-                await self._drain_thread_future(
-                    pending_fut, f"SkyPilot stream_and_get for {cluster_name}"
-                )
+
+        async def _teardown_cluster() -> None:
             await self._teardown(cluster_name)
-        finally:
-            if cancels > 0 and current:
-                current.cancel()
+
+        await _abort_shielded_request(
+            request_id,
+            pending_fut,
+            description=f"SkyPilot cluster {cluster_name}",
+            on_abort=_teardown_cluster,
+        )
 
     async def monitor_skypilot_monitor(
         self: Self,

--- a/src/gbserver/environment/skypilot_managed.py
+++ b/src/gbserver/environment/skypilot_managed.py
@@ -61,6 +61,7 @@ from gbserver.environment._skypilot_ssh import (
 from gbserver.environment.skypilot import (
     _abort_shielded_request,
     _build_skypilot_mounts,
+    _run_sky_verb_off_loop,
 )
 
 
@@ -321,8 +322,7 @@ class Skypilot_managed(Environment):
             # Cancel the managed job by name in case the controller already
             # accepted it before the launch request was aborted.
             try:
-                cancel_id = await asyncio.to_thread(sky.jobs.cancel, name=job_name)
-                await asyncio.to_thread(sky.get, cancel_id)
+                await _run_sky_verb_off_loop(sky.jobs.cancel, name=job_name)
             except Exception as e:
                 logger.warning("jobs.cancel for %s failed: %s", job_name, e)
 
@@ -531,8 +531,7 @@ class Skypilot_managed(Environment):
                 job_name,
                 launch_id,
             )
-            request_id = sky.jobs.cancel(name=job_name)
-            sky.get(request_id)
+            await _run_sky_verb_off_loop(sky.jobs.cancel, name=job_name)
             logger.info("Cancelled SkyPilot managed job %s", job_name)
         except Exception as e:
             logger.error("Failed to cancel SkyPilot managed job %s: %s", job_name, e)

--- a/src/gbserver/environment/skypilot_managed.py
+++ b/src/gbserver/environment/skypilot_managed.py
@@ -199,13 +199,25 @@ class Skypilot_managed(Environment):
             # Both sky.jobs.launch and sky.stream_and_get are blocking calls.
             # Running them directly on the event loop freezes it (defeating any
             # enclosing wait_for) and makes cancellation impossible, so offload
-            # them to threads. stream_and_get blocks in an OS thread while the
-            # controller provisions, so a CancelledError delivered to this task
-            # would be deferred until it returns. Shield the future so the outer
-            # await observes the cancel *immediately* while the thread keeps
-            # running, letting us abort the request server-side (mirrors the
-            # unmanaged launcher's _provision_with_retry).
-            request_id = await asyncio.to_thread(sky.jobs.launch, task, name=job_name)
+            # them to threads. Each blocks in an OS thread (the submit while the
+            # jobs controller provisions, stream_and_get while the job runs), so
+            # a CancelledError delivered to this task would be deferred until the
+            # thread returns. Shield each future so the outer await observes the
+            # cancel *immediately* while the thread keeps running, letting us
+            # abort the request server-side and cancel the job by name (mirrors
+            # the unmanaged launcher's _provision_with_retry).
+            launch_fut = asyncio.ensure_future(
+                asyncio.to_thread(sky.jobs.launch, task, name=job_name)
+            )
+            try:
+                request_id = await asyncio.shield(launch_fut)
+            except asyncio.CancelledError:
+                # Cancelled during the submit: no request_id yet, but the
+                # controller may already be accepting the job. _abort_managed_launch
+                # recovers the request_id by draining the submit and cancels the
+                # job by its deterministic name so it is not left running.
+                await self._abort_managed_launch(None, job_name, launch_fut)
+                raise
             stream_fut = asyncio.ensure_future(
                 asyncio.to_thread(sky.stream_and_get, request_id)
             )
@@ -283,17 +295,20 @@ class Skypilot_managed(Environment):
         self: Self,
         request_id: Any,
         job_name: str,
-        stream_fut: "asyncio.Future",
+        pending_fut: Optional["asyncio.Future"],
     ) -> None:
         """Abort an in-flight managed-job launch after cancellation.
 
-        Called when the task is cancelled while blocked in
-        ``sky.stream_and_get``. Aborts the launch request server-side (which
-        unblocks the shielded thread), drains that future, then cancels the
-        managed job by name so a job the controller already accepted does not
-        keep running. ``self._job_names`` is not populated until the launch
-        returns, so ``cleanup_skypilot_managed`` cannot find the job on the
-        cancel path — we cancel by the deterministic ``job_name`` here instead.
+        Called when the task is cancelled while blocked in either the
+        ``sky.jobs.launch`` submit or the ``sky.stream_and_get`` wait. Aborts the
+        launch request server-side (which unblocks the shielded thread), drains
+        the pending future, then cancels the managed job by name so a job the
+        controller already accepted does not keep running. ``self._job_names``
+        is not populated until the launch returns, so
+        ``cleanup_skypilot_managed`` cannot find the job on the cancel path — we
+        cancel by the deterministic ``job_name`` here instead, which is also the
+        safety net when the submit was cancelled before it returned a
+        request_id.
 
         The current task is already flagged for cancellation, so every ``await``
         here would re-raise ``CancelledError`` immediately. We temporarily clear
@@ -304,30 +319,44 @@ class Skypilot_managed(Environment):
 
         Args:
             request_id: The id returned by ``sky.jobs.launch``, passed to
-                ``sky.api_cancel`` to abort the request server-side.
+                ``sky.api_cancel`` to abort the request server-side. ``None``
+                when cancelled during the submit (before it returned); we then
+                recover it by draining ``pending_fut``.
             job_name: Deterministic managed-job name to cancel.
-            stream_fut: The shielded ``sky.stream_and_get`` future to drain once
-                the request has been aborted.
+            pending_fut: The shielded future still running on its OS thread — the
+                ``sky.jobs.launch`` submit or the ``sky.stream_and_get`` wait —
+                drained so the thread is retired.
         """
         current = asyncio.current_task()
         cancels = current.cancelling() if current else 0
         for _ in range(cancels):
             current.uncancel()  # type: ignore[union-attr]
         try:
+            # Cancelled during the submit: recover the request_id from the
+            # (shielded) submit future so the request can be aborted
+            # server-side. jobs.cancel-by-name below is the safety net when
+            # there is no request_id.
+            if request_id is None:
+                assert pending_fut is not None  # submit-cancel path always passes it
+                with contextlib.suppress(BaseException):
+                    request_id = await pending_fut
+                pending_fut = None  # already drained above
             logger.info(
                 "Cancellation requested; aborting managed job launch %s (%s)",
                 request_id,
                 job_name,
             )
-            try:
-                abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
-                await asyncio.to_thread(sky.get, abort_id)
-            except Exception as e:
-                logger.warning("api_cancel for %s failed: %s", request_id, e)
-            # Drain the now-unblocked stream_and_get thread; it may finish or
-            # raise (aborted/failed) — either is fine, we only want it retired.
-            with contextlib.suppress(BaseException):
-                await stream_fut
+            if request_id is not None:
+                try:
+                    abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
+                    await asyncio.to_thread(sky.get, abort_id)
+                except Exception as e:
+                    logger.warning("api_cancel for %s failed: %s", request_id, e)
+            # Drain the still-running future (the stream wait, or the submit if
+            # its recovery raised) so its OS thread is retired.
+            if pending_fut is not None:
+                with contextlib.suppress(BaseException):
+                    await pending_fut
             # Cancel the managed job by name in case the controller already
             # accepted it before the launch request was aborted.
             try:

--- a/src/gbserver/environment/skypilot_managed.py
+++ b/src/gbserver/environment/skypilot_managed.py
@@ -7,7 +7,6 @@ The gbserver process does not need to stay running for jobs to complete.
 """
 
 import asyncio
-import contextlib
 import glob
 import os
 from typing import Any, Dict, List, Optional, Self
@@ -334,12 +333,14 @@ class Skypilot_managed(Environment):
         try:
             # Cancelled during the submit: recover the request_id from the
             # (shielded) submit future so the request can be aborted
-            # server-side. jobs.cancel-by-name below is the safety net when
-            # there is no request_id.
+            # server-side. Bounded so a slow/stuck submit does not gate the
+            # cancel-by-name below, which is the safety net when there is no
+            # request_id.
             if request_id is None:
                 assert pending_fut is not None  # submit-cancel path always passes it
-                with contextlib.suppress(BaseException):
-                    request_id = await pending_fut
+                request_id = await self._drain_thread_future(
+                    pending_fut, f"SkyPilot managed submit for {job_name}"
+                )
                 pending_fut = None  # already drained above
             logger.info(
                 "Cancellation requested; aborting managed job launch %s (%s)",
@@ -353,10 +354,13 @@ class Skypilot_managed(Environment):
                 except Exception as e:
                     logger.warning("api_cancel for %s failed: %s", request_id, e)
             # Drain the still-running future (the stream wait, or the submit if
-            # its recovery raised) so its OS thread is retired.
+            # its recovery raised) so its OS thread is retired. Bounded: if the
+            # abort above was rejected or did not unblock the thread, we must not
+            # wait out the full provisioning time before cancelling by name.
             if pending_fut is not None:
-                with contextlib.suppress(BaseException):
-                    await pending_fut
+                await self._drain_thread_future(
+                    pending_fut, f"SkyPilot managed stream_and_get for {job_name}"
+                )
             # Cancel the managed job by name in case the controller already
             # accepted it before the launch request was aborted.
             try:

--- a/src/gbserver/environment/skypilot_managed.py
+++ b/src/gbserver/environment/skypilot_managed.py
@@ -58,7 +58,10 @@ from gbserver.environment._skypilot_ssh import (
 
 # Shared file_mounts builder — keeps the unmanaged and managed launchers in sync
 # (relative-source resolution against the step.yaml dir, bucket sub-path handling).
-from gbserver.environment.skypilot import _build_skypilot_mounts
+from gbserver.environment.skypilot import (
+    _abort_shielded_request,
+    _build_skypilot_mounts,
+)
 
 
 class Skypilot_managed(Environment):
@@ -298,69 +301,23 @@ class Skypilot_managed(Environment):
     ) -> None:
         """Abort an in-flight managed-job launch after cancellation.
 
-        Called when the task is cancelled while blocked in either the
-        ``sky.jobs.launch`` submit or the ``sky.stream_and_get`` wait. Aborts the
-        launch request server-side (which unblocks the shielded thread), drains
-        the pending future, then cancels the managed job by name so a job the
-        controller already accepted does not keep running. ``self._job_names``
-        is not populated until the launch returns, so
-        ``cleanup_skypilot_managed`` cannot find the job on the cancel path — we
-        cancel by the deterministic ``job_name`` here instead, which is also the
-        safety net when the submit was cancelled before it returned a
-        request_id.
-
-        The current task is already flagged for cancellation, so every ``await``
-        here would re-raise ``CancelledError`` immediately. We temporarily clear
-        the cancellation with ``Task.uncancel()`` (mirroring the idiom in
-        ``skypilot.py`` / ``build/run.py``) so the cleanup awaits can block
-        normally, then re-arm it in the ``finally`` so the ``CancelledError``
-        keeps propagating.
+        Thin wrapper over the shared ``_abort_shielded_request`` whose only
+        launcher-specific part is the reclaim: cancel the managed job by its
+        deterministic name so a job the controller already accepted does not
+        keep running. ``self._job_names`` is not populated until the launch
+        returns, so ``cleanup_skypilot_managed`` cannot find the job on the
+        cancel path — cancelling by name here is the safety net, and also covers
+        the case where the submit was cancelled before it returned a request_id.
 
         Args:
-            request_id: The id returned by ``sky.jobs.launch``, passed to
-                ``sky.api_cancel`` to abort the request server-side. ``None``
-                when cancelled during the submit (before it returned); we then
-                recover it by draining ``pending_fut``.
+            request_id: The id from ``sky.jobs.launch``, or ``None`` if cancelled
+                during the submit (recovered by draining ``pending_fut``).
             job_name: Deterministic managed-job name to cancel.
-            pending_fut: The shielded future still running on its OS thread — the
-                ``sky.jobs.launch`` submit or the ``sky.stream_and_get`` wait —
-                drained so the thread is retired.
+            pending_fut: The shielded ``to_thread`` future to drain (the submit
+                or the ``sky.stream_and_get`` wait).
         """
-        current = asyncio.current_task()
-        cancels = current.cancelling() if current else 0
-        for _ in range(cancels):
-            current.uncancel()  # type: ignore[union-attr]
-        try:
-            # Cancelled during the submit: recover the request_id from the
-            # (shielded) submit future so the request can be aborted
-            # server-side. Bounded so a slow/stuck submit does not gate the
-            # cancel-by-name below, which is the safety net when there is no
-            # request_id.
-            if request_id is None:
-                assert pending_fut is not None  # submit-cancel path always passes it
-                request_id = await self._drain_thread_future(
-                    pending_fut, f"SkyPilot managed submit for {job_name}"
-                )
-                pending_fut = None  # already drained above
-            logger.info(
-                "Cancellation requested; aborting managed job launch %s (%s)",
-                request_id,
-                job_name,
-            )
-            if request_id is not None:
-                try:
-                    abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
-                    await asyncio.to_thread(sky.get, abort_id)
-                except Exception as e:
-                    logger.warning("api_cancel for %s failed: %s", request_id, e)
-            # Drain the still-running future (the stream wait, or the submit if
-            # its recovery raised) so its OS thread is retired. Bounded: if the
-            # abort above was rejected or did not unblock the thread, we must not
-            # wait out the full provisioning time before cancelling by name.
-            if pending_fut is not None:
-                await self._drain_thread_future(
-                    pending_fut, f"SkyPilot managed stream_and_get for {job_name}"
-                )
+
+        async def _cancel_job() -> None:
             # Cancel the managed job by name in case the controller already
             # accepted it before the launch request was aborted.
             try:
@@ -368,9 +325,13 @@ class Skypilot_managed(Environment):
                 await asyncio.to_thread(sky.get, cancel_id)
             except Exception as e:
                 logger.warning("jobs.cancel for %s failed: %s", job_name, e)
-        finally:
-            if cancels > 0 and current:
-                current.cancel()
+
+        await _abort_shielded_request(
+            request_id,
+            pending_fut,
+            description=f"SkyPilot managed job {job_name}",
+            on_abort=_cancel_job,
+        )
 
     async def monitor_skypilot_managed_monitor(
         self: Self,

--- a/src/gbserver/environment/skypilot_managed.py
+++ b/src/gbserver/environment/skypilot_managed.py
@@ -62,6 +62,7 @@ from gbserver.environment.skypilot import (
     _abort_shielded_request,
     _build_skypilot_mounts,
     _run_sky_verb_off_loop,
+    _sky_submit_to_thread,
 )
 
 
@@ -210,7 +211,7 @@ class Skypilot_managed(Environment):
             # abort the request server-side and cancel the job by name (mirrors
             # the unmanaged launcher's _provision_with_retry).
             launch_fut = asyncio.ensure_future(
-                asyncio.to_thread(sky.jobs.launch, task, name=job_name)
+                _sky_submit_to_thread(sky.jobs.launch, task, name=job_name)
             )
             try:
                 request_id = await asyncio.shield(launch_fut)
@@ -222,7 +223,7 @@ class Skypilot_managed(Environment):
                 await self._abort_managed_launch(None, job_name, launch_fut)
                 raise
             stream_fut = asyncio.ensure_future(
-                asyncio.to_thread(sky.stream_and_get, request_id)
+                _sky_submit_to_thread(sky.stream_and_get, request_id)
             )
             try:
                 await asyncio.shield(stream_fut)

--- a/src/gbserver/environment/skypilot_managed.py
+++ b/src/gbserver/environment/skypilot_managed.py
@@ -7,9 +7,10 @@ The gbserver process does not need to stay running for jobs to complete.
 """
 
 import asyncio
+import contextlib
 import glob
 import os
-from typing import Dict, List, Optional, Self
+from typing import Any, Dict, List, Optional, Self
 
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -195,8 +196,24 @@ class Skypilot_managed(Environment):
                 res_config,
             )
 
-            request_id = sky.jobs.launch(task, name=job_name)
-            sky.stream_and_get(request_id)
+            # Both sky.jobs.launch and sky.stream_and_get are blocking calls.
+            # Running them directly on the event loop freezes it (defeating any
+            # enclosing wait_for) and makes cancellation impossible, so offload
+            # them to threads. stream_and_get blocks in an OS thread while the
+            # controller provisions, so a CancelledError delivered to this task
+            # would be deferred until it returns. Shield the future so the outer
+            # await observes the cancel *immediately* while the thread keeps
+            # running, letting us abort the request server-side (mirrors the
+            # unmanaged launcher's _provision_with_retry).
+            request_id = await asyncio.to_thread(sky.jobs.launch, task, name=job_name)
+            stream_fut = asyncio.ensure_future(
+                asyncio.to_thread(sky.stream_and_get, request_id)
+            )
+            try:
+                await asyncio.shield(stream_fut)
+            except asyncio.CancelledError:
+                await self._abort_managed_launch(request_id, job_name, stream_fut)
+                raise
 
             self._job_names[launch_id] = job_name
             logger.info(
@@ -261,6 +278,66 @@ class Skypilot_managed(Environment):
             raise
         finally:
             self._release_monitors(launch_id)
+
+    async def _abort_managed_launch(
+        self: Self,
+        request_id: Any,
+        job_name: str,
+        stream_fut: "asyncio.Future",
+    ) -> None:
+        """Abort an in-flight managed-job launch after cancellation.
+
+        Called when the task is cancelled while blocked in
+        ``sky.stream_and_get``. Aborts the launch request server-side (which
+        unblocks the shielded thread), drains that future, then cancels the
+        managed job by name so a job the controller already accepted does not
+        keep running. ``self._job_names`` is not populated until the launch
+        returns, so ``cleanup_skypilot_managed`` cannot find the job on the
+        cancel path — we cancel by the deterministic ``job_name`` here instead.
+
+        The current task is already flagged for cancellation, so every ``await``
+        here would re-raise ``CancelledError`` immediately. We temporarily clear
+        the cancellation with ``Task.uncancel()`` (mirroring the idiom in
+        ``skypilot.py`` / ``build/run.py``) so the cleanup awaits can block
+        normally, then re-arm it in the ``finally`` so the ``CancelledError``
+        keeps propagating.
+
+        Args:
+            request_id: The id returned by ``sky.jobs.launch``, passed to
+                ``sky.api_cancel`` to abort the request server-side.
+            job_name: Deterministic managed-job name to cancel.
+            stream_fut: The shielded ``sky.stream_and_get`` future to drain once
+                the request has been aborted.
+        """
+        current = asyncio.current_task()
+        cancels = current.cancelling() if current else 0
+        for _ in range(cancels):
+            current.uncancel()  # type: ignore[union-attr]
+        try:
+            logger.info(
+                "Cancellation requested; aborting managed job launch %s (%s)",
+                request_id,
+                job_name,
+            )
+            try:
+                abort_id = await asyncio.to_thread(sky.api_cancel, request_id)
+                await asyncio.to_thread(sky.get, abort_id)
+            except Exception as e:
+                logger.warning("api_cancel for %s failed: %s", request_id, e)
+            # Drain the now-unblocked stream_and_get thread; it may finish or
+            # raise (aborted/failed) — either is fine, we only want it retired.
+            with contextlib.suppress(BaseException):
+                await stream_fut
+            # Cancel the managed job by name in case the controller already
+            # accepted it before the launch request was aborted.
+            try:
+                cancel_id = await asyncio.to_thread(sky.jobs.cancel, name=job_name)
+                await asyncio.to_thread(sky.get, cancel_id)
+            except Exception as e:
+                logger.warning("jobs.cancel for %s failed: %s", job_name, e)
+        finally:
+            if cancels > 0 and current:
+                current.cancel()
 
     async def monitor_skypilot_managed_monitor(
         self: Self,


### PR DESCRIPTION
## Description

Cancelling an in-flight build was slow to actually stop work: a build could be
marked `CANCELLED` in the DB while a SkyPilot cluster continued to fully
provision (a ~2 min hang observed on bluevela), because the cancel never reached
the launch task and even when it did, provisioning blocked uninterruptibly on an
OS thread. This PR makes cancellation propagate promptly and abort in-flight
provisioning, and fixes a latent cleanup-idempotency bug that prompt cancellation
exposed.

### Changes

- **`build/buildrun.py`** — `BuildRun._cleanup` now cancels and drains the
  still-running detached target/step run tasks (`_cancel_inflight_run_tasks`)
  *before* teardown. These tasks are created detached (not under a TaskGroup), so
  parent cancellation never reached them; this delivers `CancelledError` down to
  the launch task so provisioning can be aborted.

- **`environment/skypilot.py`** — `_provision_with_retry` offloads
  `sky.stream_and_get` to a shielded future so a cancel is observed immediately
  even while the OS thread keeps running, then `_abort_provision` calls
  `sky.api_cancel` and tears down any partial cluster by deterministic name
  (the launch_id→cluster map is only populated after provisioning returns).

- **`environment/skypilot_managed.py`** — same fix for managed jobs:
  `sky.jobs.launch` / `sky.stream_and_get` were running synchronously on the
  event loop (froze the loop *and* uncancellable). Now offloaded + shielded, with
  `_abort_managed_launch` aborting the request and cancelling the job by name.

- **`environment/k8s.py`** — prompt cancellation exposed a latent bug:
  `_helm_uninstall_with_retry` treated helm's "release: not found" as a transient
  failure and retried at 10/20/40s backoff (~70s) then raised, because a cancel
  during `helm install --dry-run` meant the release was never created. Added
  `_is_helm_release_not_found` → treat as success (both call sites).

- **`environment/environment.py`** — documented the idempotency contract on the
  base `cleanup` and `teardown` methods: concrete implementations must tolerate a
  resource that was never created or is already gone, since prompt cancellation
  can land before/during/after launch.

### Verification

- Typechecks clean (no new mypy errors in changed files).
- Integrated cancellation tests are the real signal for this orchestration
  behaviour and require real clusters (bluevela SkyPilot; k8s
  `test_runner_cancellation`); they must not run under CICD. To be run manually.

## Checklist

- [x] Tests pass (`pytest -m "not ibm" -s test`)
- [x] Code formatted (`make xformat`)
- [x] Linting passes (`make xcheck`)
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable)
