### PR TITLE
Fix LSF command redaction splicing placeholder on empty env-var value

### DIFF
--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -77,6 +77,7 @@ from gbserver.utils.launch import (
     launch_command_and_retry_or_raise_errors,
 )
 from gbserver.utils.logger import get_logger
+from gbserver.utils.redaction import REDACTED, SENSITIVE_KEY_RE, scrub_url_credentials
 from gbserver.utils.ssh_keys import write_private_key_file
 from gbserver.utils.ssh_tunnel import SshTunnel
 from gbserver.utils.utils import cmd_safe_join, get_uuid, short_alphanumeric_lower_hash
@@ -413,23 +414,32 @@ class Lsf(Environment):
         """
         Build ``[KEY=val ...] /path/jobsub.sh`` as a remote command string.
 
+        The redacted variant masks by *env-var name* (via
+        :data:`~gbserver.utils.redaction.SENSITIVE_KEY_RE`) rather than by matching
+        the value text. Value-substring matching was fragile: an empty-string value
+        caused ``str.replace("", ...)`` to splice the placeholder between every
+        character of the command, and an empty (or short) value could also shatter a
+        genuinely secret value so it survived unmasked. Masking by name sidesteps both.
+        A surviving value still has any embedded URL credentials scrubbed.
+
         Returns:
-            Tuple of (command_str, redacted_command_str) where secret values
-            in env_vars are replaced with ``<redacted>`` in the redacted version.
+            Tuple of (command_str, redacted_command_str) where the value of any
+            secret-looking env var is replaced with ``<redacted>`` in the redacted
+            version.
         """
         parts: List[str] = []
-        to_redact: set[str] = set()
+        redacted_parts: List[str] = []
         if env_vars:
             logger.info("injecting env_vars: %s", env_vars.keys())
             for k, v in env_vars.items():
                 parts.append(f"{k}={v}")
-                to_redact.add(str(v))
+                if isinstance(k, str) and SENSITIVE_KEY_RE.search(k):
+                    redacted_parts.append(f"{k}={REDACTED}")
+                else:
+                    redacted_parts.append(f"{k}={scrub_url_credentials(str(v))}")
         parts.append(str(jobsub_path))
-        cmd = " ".join(parts)
-        redacted = cmd
-        for v in to_redact:
-            redacted = redacted.replace(v, "'<redacted>'")
-        return cmd, redacted
+        redacted_parts.append(str(jobsub_path))
+        return " ".join(parts), " ".join(redacted_parts)
 
     def _get_local_bsub_command(
         self: Self,

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -410,7 +410,7 @@ class Lsf(Environment):
         self: Self,
         jobsub_path: Path,
         env_vars: Optional[Dict] = None,
-        secret_keys: Optional[set] = None,
+        secret_keys: Optional[set[str]] = None,
     ) -> Tuple[str, str]:
         """
         Build ``[KEY=val ...] /path/jobsub.sh`` as a remote command string.
@@ -427,6 +427,10 @@ class Lsf(Environment):
         ``str.replace("", ...)`` splice the placeholder between every character of
         the command, and an empty or short value could also shatter a genuinely
         secret value so it survived unmasked. Rebuilding from parts avoids both.
+
+        Masking is by name, so a secret duplicated inside a different
+        non-secret-named var's value is not caught (accepted tradeoff; callers here
+        never do that).
 
         :param secret_keys: env-var names whose value must be masked regardless of
             whether the name looks secret — the caller passes the names it injected

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -410,30 +410,43 @@ class Lsf(Environment):
         self: Self,
         jobsub_path: Path,
         env_vars: Optional[Dict] = None,
+        secret_keys: Optional[set] = None,
     ) -> Tuple[str, str]:
         """
         Build ``[KEY=val ...] /path/jobsub.sh`` as a remote command string.
 
-        The redacted variant masks by *env-var name* (via
-        :data:`~gbserver.utils.redaction.SENSITIVE_KEY_RE`) rather than by matching
-        the value text. Value-substring matching was fragile: an empty-string value
-        caused ``str.replace("", ...)`` to splice the placeholder between every
-        character of the command, and an empty (or short) value could also shatter a
-        genuinely secret value so it survived unmasked. Masking by name sidesteps both.
-        A surviving value still has any embedded URL credentials scrubbed.
+        The redacted variant is built by rebuilding the command from parts and
+        masking a value whenever its env-var name is in ``secret_keys`` (names the
+        caller knows carry injected space secrets, whatever the user chose to call
+        them) **or** its name matches
+        :data:`~gbserver.utils.redaction.SENSITIVE_KEY_RE` (defense-in-depth). A
+        surviving value still has any embedded URL credentials scrubbed.
+
+        This deliberately does not redact by matching the value *text* in the
+        assembled string, as an earlier version did: an empty-string value made
+        ``str.replace("", ...)`` splice the placeholder between every character of
+        the command, and an empty or short value could also shatter a genuinely
+        secret value so it survived unmasked. Rebuilding from parts avoids both.
+
+        :param secret_keys: env-var names whose value must be masked regardless of
+            whether the name looks secret — the caller passes the names it injected
+            space secrets under, since those names are user-chosen and arbitrary.
 
         Returns:
             Tuple of (command_str, redacted_command_str) where the value of any
-            secret-looking env var is replaced with ``<redacted>`` in the redacted
-            version.
+            secret env var is replaced with ``<redacted>`` in the redacted version.
         """
+        secret_keys = secret_keys or set()
         parts: List[str] = []
         redacted_parts: List[str] = []
         if env_vars:
             logger.info("injecting env_vars: %s", env_vars.keys())
             for k, v in env_vars.items():
                 parts.append(f"{k}={v}")
-                if isinstance(k, str) and SENSITIVE_KEY_RE.search(k):
+                is_secret = k in secret_keys or (
+                    isinstance(k, str) and SENSITIVE_KEY_RE.search(k) is not None
+                )
+                if is_secret:
                     redacted_parts.append(f"{k}={REDACTED}")
                 else:
                     redacted_parts.append(f"{k}={scrub_url_credentials(str(v))}")
@@ -638,6 +651,9 @@ class Lsf(Environment):
         )
         # Get useful env vars to inject for LhPull and LhPush
         env_vars = {}
+        # Names of env vars holding injected space secrets — their values must be
+        # masked in the redacted command regardless of what the user named them.
+        secret_env_keys: set[str] = set()
         # Forward GBTEST_ test-control vars (e.g. GBTEST_MOCKED_HF_OPS) to the LSF
         # job so hfpull/hfpush steps honor mocking on the remote node.
         env_vars.update(get_exported_gbtest_env_vars())
@@ -674,12 +690,13 @@ class Lsf(Environment):
                     secret_name in space_secrets
                 ), f"failed to find the secret {secret_name} in {all_keys}"
                 env_vars[env_var_name] = space_secrets[secret_name]
+                secret_env_keys.add(env_var_name)
         try:
             if self.use_ssh:
                 ssh_tunnel = self._ssh_tunnel
                 assert ssh_tunnel
                 remote_cmd, redacted_cmd = self._build_cmd_to_run_with_ssh(
-                    final_jobsub_path, env_vars
+                    final_jobsub_path, env_vars, secret_env_keys
                 )
                 msg = f"⚡ Launching LSF job with command:\n```\n{redacted_cmd}\n```"
                 self._send_message(msg=msg, **kwargs)

--- a/test/unit/environment/test_lsf_cmd_redaction.py
+++ b/test/unit/environment/test_lsf_cmd_redaction.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Lsf._build_cmd_to_run_with_ssh command redaction.
+
+The redacted command string is surfaced into build lineage (space-member readable),
+so a secret env-var value must never appear there. These guard the switch from
+value-substring matching to key-name masking — in particular the empty-value case
+that previously spliced the placeholder between every character and, as a side
+effect, left a genuinely secret value unmasked.
+"""
+
+from pathlib import Path
+from typing import Self
+from unittest.mock import patch
+
+import pytest
+
+from gbserver.environment.lsf import Lsf
+from gbserver.utils.redaction import REDACTED
+
+# A synthetic secret used only in tests — not a real credential.
+FAKE_SECRET = "s3cr3t-fake-value-not-real"
+JOBSUB = Path("/tmp/jobsub.sh")
+
+
+def _make_lsf() -> Lsf:
+    """Create a minimal Lsf instance without running the real constructor."""
+    with patch.object(Lsf, "__init__", lambda self, **kw: None):
+        return Lsf.__new__(Lsf)
+
+
+class TestBuildCmdRedaction:
+    """Redaction of secret env-var values in the LSF-over-ssh command string."""
+
+    def test_empty_value_does_not_splice_placeholder(self: Self) -> None:
+        """An empty-valued env var must not interleave the placeholder per-char.
+
+        Regression: ``str.replace("", ...)`` inserts the replacement between every
+        character, mangling the whole command. Key-name masking avoids this.
+        """
+        lsf = _make_lsf()
+        cmd, redacted = lsf._build_cmd_to_run_with_ssh(
+            JOBSUB,
+            {"EMPTY_VAR": "", "OTHER_VAR": "keep-me"},
+        )
+        assert cmd == f"EMPTY_VAR= OTHER_VAR=keep-me {JOBSUB}"
+        # No per-character splicing: the placeholder appears nowhere.
+        assert REDACTED not in redacted
+        assert redacted == f"EMPTY_VAR= OTHER_VAR=keep-me {JOBSUB}"
+
+    def test_secret_value_masked_even_alongside_empty_var(self: Self) -> None:
+        """A secret-named var is masked, and an empty var can't unmask it.
+
+        This is the security core of the regression: previously an empty value in
+        ``to_redact`` shattered the command before the secret's own replace ran, so
+        the secret leaked. Masking by key name is independent of any value.
+        """
+        lsf = _make_lsf()
+        _, redacted = lsf._build_cmd_to_run_with_ssh(
+            JOBSUB,
+            {
+                "MOCK_FLAG": "",  # empty value, present but unset
+                "HF_TOKEN": FAKE_SECRET,
+            },
+        )
+        assert FAKE_SECRET not in redacted
+        assert f"HF_TOKEN={REDACTED}" in redacted
+        assert "MOCK_FLAG=" in redacted
+
+    def test_secret_key_names_masked(self: Self) -> None:
+        """Common secret-looking env-var names have their values masked."""
+        lsf = _make_lsf()
+        _, redacted = lsf._build_cmd_to_run_with_ssh(
+            JOBSUB,
+            {
+                "HF_TOKEN": FAKE_SECRET,
+                "MY_PASSWORD": FAKE_SECRET,
+                "API_KEY": FAKE_SECRET,
+                "AWS_SECRET_ACCESS_KEY": FAKE_SECRET,
+            },
+        )
+        assert FAKE_SECRET not in redacted
+        assert redacted.count(REDACTED) == 4
+
+    def test_non_secret_values_preserved(self: Self) -> None:
+        """Operational (non-secret) env vars survive into the redacted command."""
+        lsf = _make_lsf()
+        cmd, redacted = lsf._build_cmd_to_run_with_ssh(
+            JOBSUB,
+            {"BUILD_ID": "abc-123", "TARGET_NAME": "download_file"},
+        )
+        assert redacted == cmd
+        assert "BUILD_ID=abc-123" in redacted
+        assert "TARGET_NAME=download_file" in redacted
+
+    def test_url_credentials_scrubbed_under_non_secret_key(self: Self) -> None:
+        """A credentialed URL under an innocuous key still gets scrubbed."""
+        lsf = _make_lsf()
+        _, redacted = lsf._build_cmd_to_run_with_ssh(
+            JOBSUB,
+            {"REPO_URL": "https://user:pw@github.com/org/repo.git"},
+        )
+        assert "user:pw" not in redacted
+        assert f"REPO_URL=https://{REDACTED}@github.com/org/repo.git" in redacted
+
+    def test_no_env_vars(self: Self) -> None:
+        """With no env vars the command is just the jobsub path, unredacted."""
+        lsf = _make_lsf()
+        cmd, redacted = lsf._build_cmd_to_run_with_ssh(JOBSUB, None)
+        assert cmd == str(JOBSUB)
+        assert redacted == str(JOBSUB)

--- a/test/unit/environment/test_lsf_cmd_redaction.py
+++ b/test/unit/environment/test_lsf_cmd_redaction.py
@@ -27,8 +27,6 @@ from pathlib import Path
 from typing import Self
 from unittest.mock import patch
 
-import pytest
-
 from gbserver.environment.lsf import Lsf
 from gbserver.utils.redaction import REDACTED
 

--- a/test/unit/environment/test_lsf_cmd_redaction.py
+++ b/test/unit/environment/test_lsf_cmd_redaction.py
@@ -16,11 +16,13 @@
 
 """Tests for Lsf._build_cmd_to_run_with_ssh command redaction.
 
-The redacted command string is surfaced into build lineage (space-member readable),
-so a secret env-var value must never appear there. These guard the switch from
-value-substring matching to key-name masking — in particular the empty-value case
-that previously spliced the placeholder between every character and, as a side
-effect, left a genuinely secret value unmasked.
+The redacted command string is surfaced into build lineage (space-member readable)
+and posted to the space via Slack, so a secret env-var value must never appear
+there. These guard the switch from value-substring matching to masking by
+env-var name — via the caller-supplied ``secret_keys`` (injected space secrets,
+whatever the user named them) and ``SENSITIVE_KEY_RE`` — in particular the
+empty-value case that previously spliced the placeholder between every character
+and, as a side effect, left a genuinely secret value unmasked.
 """
 
 from pathlib import Path
@@ -65,7 +67,7 @@ class TestBuildCmdRedaction:
 
         This is the security core of the regression: previously an empty value in
         ``to_redact`` shattered the command before the secret's own replace ran, so
-        the secret leaked. Masking by key name is independent of any value.
+        the secret leaked. Masking is now independent of the value text.
         """
         lsf = _make_lsf()
         _, redacted = lsf._build_cmd_to_run_with_ssh(
@@ -93,6 +95,43 @@ class TestBuildCmdRedaction:
         )
         assert FAKE_SECRET not in redacted
         assert redacted.count(REDACTED) == 4
+
+    def test_injected_secret_masked_under_non_secret_name(self: Self) -> None:
+        """A space secret injected under an arbitrary name is masked via secret_keys.
+
+        Injected space-secret env-var names are user-chosen and need not look
+        secret (``GH_PAT``, ``DB_PASS``, ``DEPLOY_KEY``, ...). The caller marks
+        those names in ``secret_keys`` so their values are masked even though
+        ``SENSITIVE_KEY_RE`` would not match the name. Without this, such a secret
+        would leak into the redacted command surfaced to space-readable lineage and
+        Slack.
+        """
+        lsf = _make_lsf()
+        env = {
+            "GH_PAT": FAKE_SECRET,
+            "DB_PASS": FAKE_SECRET,
+            "DEPLOY_KEY": FAKE_SECRET,
+        }
+        _, redacted = lsf._build_cmd_to_run_with_ssh(JOBSUB, env, secret_keys=set(env))
+        assert FAKE_SECRET not in redacted
+        assert redacted.count(REDACTED) == 3
+
+    def test_secret_keys_and_key_name_masking_combine(self: Self) -> None:
+        """secret_keys and SENSITIVE_KEY_RE both mask; non-secret vars survive."""
+        lsf = _make_lsf()
+        _, redacted = lsf._build_cmd_to_run_with_ssh(
+            JOBSUB,
+            {
+                "CUSTOM_CRED": FAKE_SECRET,  # masked via secret_keys only
+                "HF_TOKEN": FAKE_SECRET,  # masked via key-name only
+                "BUILD_ID": "abc-123",  # not secret, preserved
+            },
+            secret_keys={"CUSTOM_CRED"},
+        )
+        assert FAKE_SECRET not in redacted
+        assert "CUSTOM_CRED=<redacted>" in redacted
+        assert f"HF_TOKEN={REDACTED}" in redacted
+        assert "BUILD_ID=abc-123" in redacted
 
     def test_non_secret_values_preserved(self: Self) -> None:
         """Operational (non-secret) env vars survive into the redacted command."""


### PR DESCRIPTION
## Summary

Fixes a redaction bug in `Lsf._build_cmd_to_run_with_ssh` that both garbled the "Launching LSF job with command" message and leaked a secret into space-member-readable build lineage.

**The bug:** the redacted command was built by replacing each env-var *value* substring in the assembled command with a placeholder. When any injected env var had an **empty-string value** (e.g. a forwarded `GBTEST_MOCKED_HF_OPS` set to empty), `str.replace("", placeholder)` splices the placeholder between *every character* of the command — producing the mangled `<redacted>`-interleaved line. Worse, that empty-string pass runs first and shatters the string character-by-character, so a genuinely secret value (e.g. an `HF_TOKEN`) no longer matches contiguously and **leaks in cleartext** into `redacted_cmd`, which is posted to the space via `_send_message` (Slack-visible) and recorded in lineage/logs.

**The fix:** build the redacted command by rebuilding from parts and masking a value when:
- its env-var name is in `secret_keys` — the names under which the caller injected space secrets (user-chosen and arbitrary, so not necessarily matched by a name regex), **or**
- its name matches the shared `SENSITIVE_KEY_RE` (defense-in-depth), and

any surviving value still has embedded URL credentials scrubbed via `scrub_url_credentials`. This is independent of the value text, so it cannot be defeated by an empty or short value, and it preserves the prior behavior of masking every injected secret.

## Changes

- `src/gbserver/environment/lsf.py`
  - `_build_cmd_to_run_with_ssh`: rebuild-from-parts redaction; new `secret_keys` param; drop the fragile value-substring `str.replace`.
  - caller: track injected space-secret env-var names in `secret_env_keys` and pass them through.
- `test/unit/environment/test_lsf_cmd_redaction.py` (new): regression coverage.

## Test plan

- `make quick-tests` selection covering the new file:
  - `GB_ENVIRONMENT=STANDALONE GBTEST_MODE=mock pytest test/unit/environment/test_lsf_cmd_redaction.py` — 8 passed.
- Regression checks (no behavior change): `test/unit/environment/test_lsf_cleanup.py`, `test/unit/utils/test_redaction.py` — all pass (27 total).
- New tests assert: empty value no longer splices the placeholder; a secret alongside an empty var stays masked; secret-looking key names are masked; a space secret injected under a non-secret-looking name (`GH_PAT`, `DB_PASS`, `DEPLOY_KEY`) is masked via `secret_keys`; non-secret operational vars are preserved; URL credentials are scrubbed.

## Known limitations (out of scope)

- **Masking is by name**, so a secret duplicated inside a *different, non-secret-named* var's value would not be caught. Callers on this path never duplicate a secret under a benign key, so this is not a live leak — the same defense-in-depth tradeoff already documented on `SENSITIVE_KEY_RE`.
- **The executed command interpolates values unquoted** (`f"{k}={v}"`). Pre-existing and unchanged here; a value containing spaces/shell metacharacters could break the remote command. Left for a separate change since it concerns shell execution, not redaction.

> Note: any HF token that appeared in an affected lineage/Slack message should be rotated regardless of this fix.

Generated with [Claude Code](https://claude.com/claude-code)
