### PR TITLE
Enable the hf asset store for non-Enterprise HF orgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,9 +307,11 @@ extended-tests-setup:
 	$(MAKE) slurm-setup
 
 # For now we mock the HF calls since we can't provide the HF_TOKEN as a git secret on forked PRs.
+# Set GBTEST_STANDALONE_ENVIRONMENT explicitly: it picks the HF resource group.
 .PHONY: extended-tests
 extended-tests: check-image-tag-not-dirty
 	export GB_ENVIRONMENT=STANDALONE &&			\
+	export GBTEST_STANDALONE_ENVIRONMENT=STAGING &&		\
 	$(MAKE) GBTEST_MODE=live				\
 		PYTEST_MARKERS="not ibm" 			\
 		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\
@@ -334,9 +336,11 @@ ibm-quick-tests: check_ibm_sps_api_key
 ibm-extended-tests-setup: start-nats
 	$(MAKE) venv
 
+# GBTEST_STANDALONE_ENVIRONMENT is inert at GB_ENVIRONMENT=STAGING; set for parity.
 .PHONY: ibm-extended-tests
 ibm-extended-tests: check_ibm_sps_api_key check-image-tag-not-dirty
 	export GB_ENVIRONMENT=STAGING &&			\
+	export GBTEST_STANDALONE_ENVIRONMENT=STAGING &&		\
 	$(MAKE) GBTEST_MODE=live				\
 		PYTEST_MARKERS="ibm" 			\
 		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,8 @@ extended-tests-setup:
 # For now we mock the HF calls since we can't provide the HF_TOKEN as a git secret on forked PRs.
 # GBTEST_STANDALONE_ENVIRONMENT (which HF resource group a STANDALONE push targets)
 # is defaulted to STAGING by test/conftest.py, so it covers every pytest entry
-# point rather than just this target. Export it here to override that.
+# point rather than just this target. No export is needed here; set it in the
+# environment to override that default.
 .PHONY: extended-tests
 extended-tests: check-image-tag-not-dirty
 	export GB_ENVIRONMENT=STANDALONE &&			\

--- a/Makefile
+++ b/Makefile
@@ -307,13 +307,12 @@ extended-tests-setup:
 	$(MAKE) slurm-setup
 
 # For now we mock the HF calls since we can't provide the HF_TOKEN as a git secret on forked PRs.
-# Set GBTEST_STANDALONE_ENVIRONMENT explicitly: it picks the HF resource group.
-# Required, not cosmetic — the default is empty (the production gbspace-public),
-# so without this a live extended run would push to the production group.
+# GBTEST_STANDALONE_ENVIRONMENT (which HF resource group a STANDALONE push targets)
+# is defaulted to STAGING by test/conftest.py, so it covers every pytest entry
+# point rather than just this target. Export it here to override that.
 .PHONY: extended-tests
 extended-tests: check-image-tag-not-dirty
 	export GB_ENVIRONMENT=STANDALONE &&			\
-	export GBTEST_STANDALONE_ENVIRONMENT=STAGING &&		\
 	$(MAKE) GBTEST_MODE=live				\
 		PYTEST_MARKERS="not ibm" 			\
 		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\
@@ -338,11 +337,9 @@ ibm-quick-tests: check_ibm_sps_api_key
 ibm-extended-tests-setup: start-nats
 	$(MAKE) venv
 
-# GBTEST_STANDALONE_ENVIRONMENT is inert at GB_ENVIRONMENT=STAGING; set for parity.
 .PHONY: ibm-extended-tests
 ibm-extended-tests: check_ibm_sps_api_key check-image-tag-not-dirty
 	export GB_ENVIRONMENT=STAGING &&			\
-	export GBTEST_STANDALONE_ENVIRONMENT=STAGING &&		\
 	$(MAKE) GBTEST_MODE=live				\
 		PYTEST_MARKERS="ibm" 			\
 		PYTEST_TEST_TARGETS="$(PYTEST_TEST_TARGETS)"	\

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,8 @@ extended-tests-setup:
 
 # For now we mock the HF calls since we can't provide the HF_TOKEN as a git secret on forked PRs.
 # Set GBTEST_STANDALONE_ENVIRONMENT explicitly: it picks the HF resource group.
+# Required, not cosmetic — the default is empty (the production gbspace-public),
+# so without this a live extended run would push to the production group.
 .PHONY: extended-tests
 extended-tests: check-image-tag-not-dirty
 	export GB_ENVIRONMENT=STANDALONE &&			\

--- a/configurations/assets/assetstores/hf/store.yaml
+++ b/configurations/assets/assetstores/hf/store.yaml
@@ -6,3 +6,18 @@
 base_uri: "hf:/"
 config:
   token_secretname: HF_TOKEN
+  # HF organizations that use Enterprise resource groups. A push to an org in
+  # this list resolves a resource group from the build's space (see
+  # docs/builds/hf-push.md); a push to any other org — an individual user
+  # namespace or a plain community org — skips resource groups entirely.
+  #
+  # Omit this key to treat EVERY org as Enterprise (the behavior from before
+  # the split). An explicit empty list treats no org as Enterprise.
+  # Matching is case-insensitive exact match on the org name.
+  #
+  # Keep in sync with hf_enterprise_organizations in
+  # src/gbcommon/types/gbenvconfig.py, which gbcli uses for `gb artifact push`
+  # (the CLI cannot read this file — it is loaded server-side only).
+  enterprise_organizations:
+    - ibm-research
+    - ibm-granite

--- a/docs/asset-stores/README.md
+++ b/docs/asset-stores/README.md
@@ -89,8 +89,13 @@ A store is defined by a `store.yaml` ([`AssetStoreConfig`](../../src/gbserver/ty
 that declares which URIs it handles and any store-specific settings:
 
 - `base_uri` or `uri_regex` — the URIs this store handles (used to route a URI to the right store).
-- `config` — store-specific settings: the secret names above, plus e.g. COS `cos_endpoint` / `cos_region`
-  and Lakehouse `env`.
+- `config` — store-specific settings: the secret names above, plus e.g. COS `cos_endpoint` / `cos_region`,
+  Lakehouse `env`, and HuggingFace `enterprise_organizations`.
+
+For the `hf` store, `config.enterprise_organizations` lists the HF organizations that use
+Enterprise resource groups; pushes to any other org skip resource groups entirely. Omitting
+the key treats every org as Enterprise. See
+[HuggingFace push — Enterprise vs non-Enterprise organizations](../builds/hf-push.md#enterprise-vs-non-enterprise-organizations).
 
 Stores are referenced from a build/environment as `space://assetstores/<name>`, resolved against the
 space's `base_uris` (the same mechanism as steps and environments — see

--- a/docs/builds/build-yaml-reference.md
+++ b/docs/builds/build-yaml-reference.md
@@ -155,11 +155,13 @@ and [Asset stores — In-memory](../asset-stores/README.md#store-types-and-uri-s
 | Field    | Type   | Required | Notes |
 |----------|--------|----------|-------|
 | `mode`   | string | yes      | `hfstore`, `lhstore`, `cosstore`, etc. |
-| `config` | object | no       | Mode-specific (e.g. `hf.private`, `hf.resource_group`). |
+| `config` | object | no       | Mode-specific (e.g. `hf.private`, `hf.resource_group_id`, `hf.resource_group_name`, `hf.use_resource_group`). |
 
 For HuggingFace specifically, see [`hf-push.md`](hf-push.md) — it documents
-the full URI format, resource-group resolution, and the relationship between
-`store_push` here and the environment-level `store_push` block.
+the full URI format, resource-group resolution, the Enterprise vs
+non-Enterprise organization split (including `hf.use_resource_group`), and the
+relationship between `store_push` here and the environment-level `store_push`
+block.
 
 ### `event_selectors`
 

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -203,10 +203,15 @@ outputs:
 ```
 
 Combining it with an explicit `resource_group_id`/`resource_group_name` **in the
-same push config** is contradictory and raises `ValueError`. Setting it on an
-output whose resource group is only *inherited* — from the environment-level
-`push` block — is not: the per-output opt-out wins, which is what makes the
-opt-out usable when `environment.yaml` supplies a group as the level-3 fallback.
+same push config** is contradictory and raises `ValueError`. Across levels the
+higher one wins, per the priority table above:
+
+| `environment.yaml` push | output `store_push` | Result |
+|---|---|---|
+| `resource_group_name: …` | `use_resource_group: false` | No resource group — the per-output opt-out wins, which is what makes it usable when the environment supplies a group as the level-3 fallback. |
+| `use_resource_group: false` | `resource_group_id: …` | That id — an output-level pin is priority 1, so it re-enables resource groups over an inherited opt-out. |
+| `use_resource_group: false` | `use_resource_group: true` | Resource group resolved from the space. |
+| `use_resource_group: false` | *(nothing)* | No resource group. |
 
 ### Errors
 

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -202,8 +202,11 @@ outputs:
           use_resource_group: false
 ```
 
-Combining it with an explicit `resource_group_id`/`resource_group_name` is
-contradictory and raises `ValueError`.
+Combining it with an explicit `resource_group_id`/`resource_group_name` **in the
+same push config** is contradictory and raises `ValueError`. Setting it on an
+output whose resource group is only *inherited* — from the environment-level
+`push` block — is not: the per-output opt-out wins, which is what makes the
+opt-out usable when `environment.yaml` supplies a group as the level-3 fallback.
 
 ### Errors
 

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -9,8 +9,9 @@ This document covers two related things:
 
 > **TL;DR:** You almost never need `store_push`. An `hf://` URI on the output is
 > enough — the environment's asset store and the active g.b space supply the
-> defaults (private repo, space-derived resource group). Only reach for
-> `store_push` when you need a per-output override.
+> defaults (private repo, and — for HF Enterprise orgs — a space-derived
+> resource group). Only reach for `store_push` when you need a per-output
+> override.
 
 ---
 
@@ -88,7 +89,7 @@ llm.build:
 With the above, the framework will:
 - Derive the HF repo **type** (`dataset`) from the URI.
 - Use `private: true` by default (inherited from the environment or the built-in default).
-- Attach a resource group derived from the active g.b space (`gbspace-<space>`), so pushes into Enterprise-gated namespaces like `ibm-research` work out of the box.
+- Attach a resource group derived from the active g.b space (`gbspace-<space>`) **when the target org is an HF Enterprise org**, so pushes into Enterprise-gated namespaces like `ibm-research` work out of the box. Pushes to a non-Enterprise org (an individual user namespace, say) skip resource groups entirely — see [Enterprise vs non-Enterprise organizations](#enterprise-vs-non-enterprise-organizations).
 
 **Use `store_push` only when you need to override one of these defaults for a single output.**
 
@@ -133,11 +134,93 @@ All fields are optional.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `private` | bool | `true` | Whether the HuggingFace repository should be **private**. Set to `false` to create or update a public repository. |
-| `resource_group_id` | string | — | Pre-resolved HF Enterprise resource group id. When provided, no HF API lookup is performed — the id is used as-is. |
-| `resource_group_name` | string | — | Resource group name. Resolved to an id via the HF API at push time. |
+| `resource_group_id` | string | — | Pre-resolved HF Enterprise resource group id. When provided, no HF API lookup is performed — the id is used as-is. Enterprise orgs only — supplying it for a non-Enterprise org is an error. |
+| `resource_group_name` | string | — | Resource group name. Resolved to an id via the HF API at push time. Enterprise orgs only. |
+| `use_resource_group` | bool | `true` | Set to `false` to push to an Enterprise org **without** a resource group. Cannot be combined with `resource_group_id`/`resource_group_name`. See [Enterprise vs non-Enterprise organizations](#enterprise-vs-non-enterprise-organizations). |
 
 The HuggingFace **repo type** (`model`, `dataset`, `space`) is not configurable here — it
 is derived automatically from the `uri` scheme (e.g. `hf:///datasets/…` → `dataset`).
+
+---
+
+## Enterprise vs non-Enterprise organizations
+
+Resource groups are an **HF Enterprise** feature. Pushing into an Enterprise-gated
+namespace like `ibm-research` requires a resource group id; pushing into an
+individual user namespace (`my-user/my-model`) or a plain community org has no
+resource group at all.
+
+There is no non-admin HF API that tells the two apart, so the split is
+**configuration-driven**. The `hf` asset store's `store.yaml` lists the orgs that
+use Enterprise resource groups:
+
+```yaml
+# assetstores/hf/store.yaml
+base_uri: "hf:/"
+config:
+  token_secretname: HF_TOKEN
+  enterprise_organizations:
+    - ibm-research
+    - ibm-granite
+```
+
+| Push target | Behavior |
+|-------------|----------|
+| Org **in** `enterprise_organizations` | A resource group is resolved (see [Resource group resolution](#resource-group-resolution)). Unchanged from before. |
+| Org **not in** the list | Resource group resolution is **skipped entirely** — no space lookup, no HF API call. Pinning a resource group is an error. |
+| Key **absent** | Every org is treated as Enterprise. This is the pre-split behavior, kept for backward compatibility. |
+| Key present but empty (`[]`) | No org is treated as Enterprise. |
+
+Matching is a case-insensitive **exact** match on the org name. There is no glob
+or wildcard support — `ibm-*` matches nothing, and `"*"` is a literal name.
+
+### Setting this for a remote space
+
+`store.yaml` is loaded server-side from the space's git repo, so for a remote
+space, edit `assetstores/hf/store.yaml` **in that space repo** and add the
+`enterprise_organizations` key shown above. There is no CLI or API to set it.
+
+> **Two places to keep in sync.** The CLI (`gb artifact push/register --store hf`)
+> cannot read `store.yaml` — it is server-side only — so it reads the same list
+> from `hf_enterprise_organizations` in
+> [`src/gbcommon/types/gbenvconfig.py`](../../src/gbcommon/types/gbenvconfig.py).
+> When you change one, change the other.
+
+### Opting an Enterprise org out
+
+An org that *is* in the list can still push without a resource group by setting
+`use_resource_group: false`:
+
+```yaml
+outputs:
+  scratch_model:
+    uri: hf://huggingface.co/ibm-research/scratch-{{ binding.path | short_hash }}
+    store_push:
+      mode: "hfstore"
+      config:
+        hf:
+          use_resource_group: false
+```
+
+Combining it with an explicit `resource_group_id`/`resource_group_name` is
+contradictory and raises `ValueError`.
+
+### Errors
+
+Pinning a resource group for a non-Enterprise org fails the push:
+
+```
+Resource group 'gbspace-public' was configured for HuggingFace organization
+'my-user', but 'my-user' is not an HF Enterprise organization. Resource groups
+apply only to Enterprise organizations. Remove
+store_push.config.hf.resource_group_id / resource_group_name, or add 'my-user'
+to enterprise_organizations in the hf asset store's store.yaml.
+```
+
+The CLI reports the equivalent for `--resource-group-id`.
+
+> Pulling is unaffected by any of this. `hf` downloads never use a resource
+> group — only the HF token's access matters.
 
 ---
 
@@ -149,6 +232,7 @@ must agree (the resolver raises `ValueError` on mismatch).
 
 | Priority | Source | Notes |
 |----------|--------|-------|
+| 0 | **Enterprise check** (`store.yaml` → `config.enterprise_organizations`) | Evaluated *first*. If the URI's org is not an Enterprise org, everything below is skipped and no resource group is attached. An Enterprise org with `use_resource_group: false` is likewise skipped. See [Enterprise vs non-Enterprise organizations](#enterprise-vs-non-enterprise-organizations). |
 | 1 | `store_push.config.hf.resource_group_id` (build.yaml) | Per-output pre-resolved id. No HF API call. |
 | 2 | `store_push.config.hf.resource_group_name` (build.yaml) | Per-output name. Resolved via HF API. |
 | 3 | `environment.yaml` → `assetstores[].push[].config.hf.resource_group_id` / `resource_group_name` | Environment-level fallback. |

--- a/docs/cli/gb-cli-reference.md
+++ b/docs/cli/gb-cli-reference.md
@@ -58,7 +58,7 @@ Upload, download, register, and tag artifacts produced or consumed by builds.
 
 | Subcommand | Purpose |
 |------------|---------|
-| `gb artifact push --from-local <path> --artifact-name <name> --type <type>` | Upload and register a local artifact. `--type` is one of `model`, `table`, `fileset`, `dataset`, `bucket`. |
+| `gb artifact push --from-local <path> --artifact-name <name> --type <type>` | Upload and register a local artifact. `--type` is one of `model`, `table`, `fileset`, `dataset`, `bucket`. Add `--store hf` to push to HuggingFace (`--hf-organization` selects the org; `--resource-group-id` applies to HF Enterprise orgs only — see [HuggingFace push](../builds/hf-push.md#enterprise-vs-non-enterprise-organizations)). |
 | `gb artifact register --artifact-name <name>` | Register an existing artifact at Lakehouse or HuggingFace without uploading. |
 | `gb artifact list` | List artifacts; filter by build, space, user, tag, or checksum. |
 | `gb artifact download <artifact-id>` | Download by UUID or URI. |

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -117,7 +117,7 @@ The run-relevant environment variables:
 | `GBTEST_MODE` | `mock` (quick suite) or `live` (extended/CI). |
 | `GBSERVER_DEFAULT_BUILDRUNNER_TYPE` | `job` (k8s), `process`, or `thread`. Use `thread` for local test runs. |
 | `GBTEST_SPS_IBMCLOUD_API_KEY` | Loads test secrets from IBM Cloud Secrets Manager (SPS). |
-| `GBTEST_STANDALONE_ENVIRONMENT` | Under `GB_ENVIRONMENT=STANDALONE`, which environment's HF resource group pushes target. Defaults to **empty**, i.e. the production `gbspace-public` that a real standalone user must get. Set to `STAGING`/`DEV` to redirect a test run into a group the CI token can write — the `extended-tests` targets do this explicitly. |
+| `GBTEST_STANDALONE_ENVIRONMENT` | Under `GB_ENVIRONMENT=STANDALONE`, which environment's HF resource group pushes target. The **source** default is empty, i.e. the production `gbspace-public` a real standalone user must get; `test/conftest.py` defaults it to `STAGING` for any pytest run, so tests push to a group the CI token can write. Set it explicitly (including to empty) to override. |
 | **IBM infrastructure** | For `ibm`-marked / live-cluster tests: |
 | `GBSERVER_IMAGE_TAG` | The gbserver build-runner image tag to run against. |
 | `GBSERVER_SIDECAR_MONITORING_IMAGE_TAG` | The monitoring sidecar image tag. |

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -117,6 +117,7 @@ The run-relevant environment variables:
 | `GBTEST_MODE` | `mock` (quick suite) or `live` (extended/CI). |
 | `GBSERVER_DEFAULT_BUILDRUNNER_TYPE` | `job` (k8s), `process`, or `thread`. Use `thread` for local test runs. |
 | `GBTEST_SPS_IBMCLOUD_API_KEY` | Loads test secrets from IBM Cloud Secrets Manager (SPS). |
+| `GBTEST_STANDALONE_ENVIRONMENT` | Under `GB_ENVIRONMENT=STANDALONE`, which environment's HF resource group pushes target (`STAGING` default, so test artifacts land in a group the CI token can write). Set empty for the production `gbspace-public`. |
 | **IBM infrastructure** | For `ibm`-marked / live-cluster tests: |
 | `GBSERVER_IMAGE_TAG` | The gbserver build-runner image tag to run against. |
 | `GBSERVER_SIDECAR_MONITORING_IMAGE_TAG` | The monitoring sidecar image tag. |

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -117,7 +117,7 @@ The run-relevant environment variables:
 | `GBTEST_MODE` | `mock` (quick suite) or `live` (extended/CI). |
 | `GBSERVER_DEFAULT_BUILDRUNNER_TYPE` | `job` (k8s), `process`, or `thread`. Use `thread` for local test runs. |
 | `GBTEST_SPS_IBMCLOUD_API_KEY` | Loads test secrets from IBM Cloud Secrets Manager (SPS). |
-| `GBTEST_STANDALONE_ENVIRONMENT` | Under `GB_ENVIRONMENT=STANDALONE`, which environment's HF resource group pushes target (`STAGING` default, so test artifacts land in a group the CI token can write). Set empty for the production `gbspace-public`. |
+| `GBTEST_STANDALONE_ENVIRONMENT` | Under `GB_ENVIRONMENT=STANDALONE`, which environment's HF resource group pushes target. Defaults to **empty**, i.e. the production `gbspace-public` that a real standalone user must get. Set to `STAGING`/`DEV` to redirect a test run into a group the CI token can write — the `extended-tests` targets do this explicitly. |
 | **IBM infrastructure** | For `ibm`-marked / live-cluster tests: |
 | `GBSERVER_IMAGE_TAG` | The gbserver build-runner image tag to run against. |
 | `GBSERVER_SIDECAR_MONITORING_IMAGE_TAG` | The monitoring sidecar image tag. |

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -960,10 +960,6 @@ def push(
     help="HuggingFace organization name for artifact registration.",
 )
 @click.option(
-    "--resource-group-id",
-    help="Resource group ID for artifact registration.",
-)
-@click.option(
     "--store",
     default="lh",
     type=click.Choice(["lh", "hf"], case_sensitive=True),
@@ -1000,7 +996,6 @@ def register(
     origin_list: str,
     certify_no_restrictions: bool,
     hf_organization: str,
-    resource_group_id: str,
     format: str,
     skip_version_check: bool,
     quiet: bool,
@@ -1162,13 +1157,6 @@ def register(
             err=True,
         )
         ctx.exit(1)
-
-    # Resource groups exist only in HF Enterprise organizations; pinning one for
-    # a non-Enterprise org cannot mean anything, so reject it up front.
-    if store == "hf" and resource_group_id:
-        register_org = hf_organization or HF_ORGANIZATION_DEFAULT
-        if not is_enterprise_hf_org(register_org, HF_ENTERPRISE_ORGANIZATIONS):
-            _reject_resource_group_for_non_enterprise(ctx.exit, register_org)
 
     # === Type-specific handling ===
     # Prompts, tables, revisions and filesets/tables are all Lakehouse
@@ -1453,7 +1441,6 @@ def register(
                 origin_uris=normalized_origins,
                 certified_no_restrictions=certify_no_restrictions,
                 hf_organization=hf_organization,
-                resource_group_id=resource_group_id,
                 store=store,
                 callback=echo_callback,
             )
@@ -1477,7 +1464,6 @@ def register(
                 origin_uris=normalized_origins,
                 certified_no_restrictions=certify_no_restrictions,
                 hf_organization=hf_organization,
-                resource_group_id=resource_group_id,
                 store=store,
                 callback=echo_callback,
             )

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -24,6 +24,7 @@ from gbcli.utils.gbconstants import (
     ARTIFACT_LIST_HEADERS,
     CLIPBOARD_CHAR,
     DEFAULT_CHECKSUM_CONCURRENCY,
+    HF_ENTERPRISE_ORGANIZATIONS,
     HF_ORGANIZATION_DEFAULT,
     LAKEHOUSE_FILESET_SHARED_TABLE_NAME,
     LAKEHOUSE_FILESET_TABLE_NAME,
@@ -59,6 +60,7 @@ from gbcli.utils.versionutil import check_current_and_latest_versions
 from gbcommon.uri.uri import URI
 from gbcommon.utils.hf_utils import (
     convert_hf_uri_to_url,
+    is_enterprise_hf_org,
     parse_hf_uri,
 )
 
@@ -499,12 +501,28 @@ def push(
             if not quiet:
                 click.echo(f"HuggingFace token obtained successfully!")
 
+            # Resource groups exist only in HF Enterprise organizations, so a
+            # non-Enterprise org (an individual user namespace or a plain
+            # community org) skips resolution entirely — and rejects a pinned id,
+            # which cannot mean anything there.
+            org = hf_organization or HF_ORGANIZATION_DEFAULT
+            hf_is_enterprise = is_enterprise_hf_org(org, HF_ENTERPRISE_ORGANIZATIONS)
+            if resource_group_id and not hf_is_enterprise:
+                click.echo(
+                    f"❌ --resource-group-id was given for HuggingFace "
+                    f"organization '{org}', but '{org}' is not an HF Enterprise "
+                    f"organization. Resource groups apply only to Enterprise "
+                    f"organizations. Drop --resource-group-id, or configure "
+                    f"'{org}' as an enterprise organization.",
+                    err=True,
+                )
+                sys.exit(1)
+
             # Resolve resource group id from the GB space only when the user did
             # NOT pass --resource-group-id. An explicit id is used verbatim and is
             # never reflected back into the cached space table (the user may be
             # targeting a group other than the space's default).
-            if not resource_group_id:
-                org = hf_organization or HF_ORGANIZATION_DEFAULT
+            if hf_is_enterprise and not resource_group_id:
 
                 # Resolve the space from the local cache (populated by
                 # `space list --all --refresh`) to read its cached default
@@ -525,7 +543,12 @@ def push(
                     resolved_space_name = (
                         global_space.get("name") or resolved_space_name
                     )
-                    resource_group_id = global_space.get("hf_default_resource_group_id")
+                    cached_rg_id = global_space.get("hf_default_resource_group_id")
+                    # resolve_space() fills unresolvable profile spaces with the
+                    # literal "<unknown>" (a truthy string), which would be sent
+                    # to create_repo as if it were a real id. Treat it as absent.
+                    if cached_rg_id and cached_rg_id != "<unknown>":
+                        resource_group_id = cached_rg_id
                 if not resource_group_id:
                     if not resolved_space_name:
                         click.echo(
@@ -1122,6 +1145,21 @@ def register(
             err=True,
         )
         ctx.exit(1)
+
+    # Resource groups exist only in HF Enterprise organizations; pinning one for
+    # a non-Enterprise org cannot mean anything, so reject it up front.
+    if store == "hf" and resource_group_id:
+        register_org = hf_organization or HF_ORGANIZATION_DEFAULT
+        if not is_enterprise_hf_org(register_org, HF_ENTERPRISE_ORGANIZATIONS):
+            click.echo(
+                f"❌ --resource-group-id was given for HuggingFace organization "
+                f"'{register_org}', but '{register_org}' is not an HF Enterprise "
+                f"organization. Resource groups apply only to Enterprise "
+                f"organizations. Drop --resource-group-id, or configure "
+                f"'{register_org}' as an enterprise organization.",
+                err=True,
+            )
+            ctx.exit(1)
 
     # === Type-specific handling ===
     # Prompts, tables, revisions and filesets/tables are all Lakehouse

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -81,6 +81,31 @@ except ModuleNotFoundError:
     UnauthorizedException = _MissingLakehouseUnauthorizedException
 
 
+def _reject_resource_group_for_non_enterprise(exit_fn, org: str) -> None:
+    """Reject ``--resource-group-id`` when ``org`` is not an HF Enterprise org.
+
+    Resource groups exist only in HF Enterprise organizations, so pinning one
+    for an individual user namespace or a plain community org cannot mean
+    anything. Shared by ``artifact push`` and ``artifact register`` so the
+    two user-facing messages cannot drift. Worded for the CLI flag; the
+    server-side build.yaml equivalent is
+    :func:`gbserver.spaces.resource_group._non_enterprise_rg_error`.
+
+    Args:
+        exit_fn: The command's exit callable (``sys.exit`` or ``ctx.exit``).
+        org: The HuggingFace organization the id was pinned for.
+    """
+    click.echo(
+        f"❌ --resource-group-id was given for HuggingFace organization "
+        f"'{org}', but '{org}' is not an HF Enterprise organization. "
+        f"Resource groups apply only to Enterprise organizations. Drop "
+        f"--resource-group-id, or configure '{org}' as an enterprise "
+        f"organization.",
+        err=True,
+    )
+    exit_fn(1)
+
+
 @click.group("artifact")
 @click.pass_context
 def cli(ctx):
@@ -508,15 +533,7 @@ def push(
             org = hf_organization or HF_ORGANIZATION_DEFAULT
             hf_is_enterprise = is_enterprise_hf_org(org, HF_ENTERPRISE_ORGANIZATIONS)
             if resource_group_id and not hf_is_enterprise:
-                click.echo(
-                    f"❌ --resource-group-id was given for HuggingFace "
-                    f"organization '{org}', but '{org}' is not an HF Enterprise "
-                    f"organization. Resource groups apply only to Enterprise "
-                    f"organizations. Drop --resource-group-id, or configure "
-                    f"'{org}' as an enterprise organization.",
-                    err=True,
-                )
-                sys.exit(1)
+                _reject_resource_group_for_non_enterprise(sys.exit, org)
 
             # Resolve resource group id from the GB space only when the user did
             # NOT pass --resource-group-id. An explicit id is used verbatim and is
@@ -1151,15 +1168,7 @@ def register(
     if store == "hf" and resource_group_id:
         register_org = hf_organization or HF_ORGANIZATION_DEFAULT
         if not is_enterprise_hf_org(register_org, HF_ENTERPRISE_ORGANIZATIONS):
-            click.echo(
-                f"❌ --resource-group-id was given for HuggingFace organization "
-                f"'{register_org}', but '{register_org}' is not an HF Enterprise "
-                f"organization. Resource groups apply only to Enterprise "
-                f"organizations. Drop --resource-group-id, or configure "
-                f"'{register_org}' as an enterprise organization.",
-                err=True,
-            )
-            ctx.exit(1)
+            _reject_resource_group_for_non_enterprise(ctx.exit, register_org)
 
     # === Type-specific handling ===
     # Prompts, tables, revisions and filesets/tables are all Lakehouse

--- a/src/gbcli/services/service_artifact.py
+++ b/src/gbcli/services/service_artifact.py
@@ -11,6 +11,7 @@ from gbcli.utils.gbconstants import (
     GB_DMF_LOADER_SIZE_LIMIT,
     GB_DMF_USE_CLASSIC_LOADER,
     GBSERVER_ARTIFACT_API,
+    HF_ENTERPRISE_ORGANIZATIONS,
     HF_ORGANIZATION_DEFAULT,
     HF_REVISION_DEFAULT,
     LAKEHOUSE_FILESET_SHARED_TABLE_NAME,
@@ -55,6 +56,7 @@ from gbcli.utils.utils import (
     remove_suffix,
 )
 from gbcommon.types.gbenvconfig import gb_environment_config
+from gbcommon.utils.hf_utils import is_enterprise_hf_org
 
 if TYPE_CHECKING:
     from lakehouse.core import CopyAssetStatus
@@ -310,7 +312,11 @@ def upload_to_hf(
         raise Exception(
             "Error: No HuggingFace organization configured. Use --hf-organization or set hf_organization in the environment config."
         )
-    if not resource_group_id:
+    # Resource groups exist only in HF Enterprise organizations. For a
+    # non-Enterprise org (an individual user namespace or a plain community org)
+    # there is no group to attach, and HFRegistry passes resource_group_id=None
+    # straight through to create_repo/create_bucket, which is valid.
+    if not resource_group_id and is_enterprise_hf_org(org, HF_ENTERPRISE_ORGANIZATIONS):
         raise Exception(
             "Error: No HuggingFace resource group id provided. Pass resource_group_id explicitly or resolve it via lookup_hf_resource_group_id."
         )

--- a/src/gbcli/utils/gbconstants.py
+++ b/src/gbcli/utils/gbconstants.py
@@ -50,6 +50,11 @@ def hf_token() -> str:
 
 # HuggingFace defaults
 HF_ORGANIZATION_DEFAULT = gb_environment_config().hf_organization or "ibm-research"
+# HF orgs that use Enterprise resource groups. None means every org is treated as
+# Enterprise (the behavior from before the Enterprise/non-Enterprise split). Keep
+# in sync with config.enterprise_organizations in the hf asset store's store.yaml,
+# which the server-side push path reads (the CLI cannot read that file).
+HF_ENTERPRISE_ORGANIZATIONS = gb_environment_config().hf_enterprise_organizations
 
 # gbcli
 _GBCLI_REPO_ORG = "ibm-granite" if is_public_github() else "granite-dot-build"

--- a/src/gbcommon/types/constants.py
+++ b/src/gbcommon/types/constants.py
@@ -93,12 +93,6 @@ GB_DEFAULT_LH_ARTIFACT_HOST = (
 GRANITE_DOT_BUILD_PARENT_NAMESPACE = "granite_dot_build"
 GB_PUBLIC_ARTIFACT_NAMESPACE = f"{GRANITE_DOT_BUILD_PARENT_NAMESPACE}.public"
 
-# Used during testing to direct content to/from  staging or dev, when GB_ENVIRONMENT=STANDALONE
-# Initially done for HF pushes.
-ENV_VAR_GB_TEST_STANDALONE_ENVIRONMENT = ENV_VAR_PREFIX + "TEST_STANDALONE_ENVIRONMENT"
-GB_TEST_STANDALONE_ENVIRONMENT = os.getenv(
-    ENV_VAR_GB_TEST_STANDALONE_ENVIRONMENT, "STAGING"
-)
 # ---------------------------------------------------------------------------
 # GitHub domain helpers
 # ---------------------------------------------------------------------------

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -18,7 +18,7 @@
 
 import logging
 import os
-from typing import Any, Dict, Optional, Self
+from typing import Any, Dict, List, Optional, Self
 
 from pydantic import BaseModel
 
@@ -105,6 +105,19 @@ class GBEnvConfig(BaseModel):
     hf_organization: str = ""
     """HuggingFace organization."""
 
+    hf_enterprise_organizations: Optional[List[str]] = None
+    """HF organizations that use Enterprise resource groups.
+
+    Used by the CLI (`gb artifact push/register --store hf`) to decide whether a
+    resource group applies. ``None`` means every org is treated as Enterprise,
+    preserving the behavior from before the Enterprise/non-Enterprise split.
+
+    Keep in sync with ``config.enterprise_organizations`` in the hf asset store's
+    ``store.yaml``, which the server-side push path reads. The duplication is
+    deliberate: store.yaml lives in the space's git repo and is loaded
+    server-side only, so the CLI cannot read it.
+    """
+
     # --- gbserver-origin fields ---
 
     dashboard_instance: str = ""
@@ -146,6 +159,7 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         server_log_application_name="llm-build-prod",
         branch_assets="gbspace-config",
         hf_organization="ibm-research",
+        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
         feature_flags={
             "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
             "gbserver_artifact_filter": getenv_boolean(
@@ -176,6 +190,7 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         server_log_application_name="llm-build-staging",
         branch_assets="gbspace-config-dev",
         hf_organization="ibm-research",
+        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
         feature_flags={
             "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
             "gbserver_artifact_filter": getenv_boolean(
@@ -206,6 +221,7 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         server_log_application_name="llm-build-dev",
         branch_assets="gbspace-config-dev",
         hf_organization="ibm-research",
+        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
         feature_flags={
             "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
             "gbserver_artifact_filter": getenv_boolean(
@@ -236,6 +252,7 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         server_log_application_name="gbserver-standalone",
         branch_assets="",
         hf_organization="ibm-research",
+        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
         feature_flags={
             "build_start_via_github": False,
             "gbserver_build_events": True,

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -145,100 +145,120 @@ class GBEnvConfig(BaseModel):
 
 DEFAULT_GB_ENVIRONMENT = "PROD"
 
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """Return ``base`` with ``override`` applied, recursively.
+
+    Nested dicts are merged key-by-key so an environment can override a single
+    ``feature_flags`` entry without restating the rest; any other value replaces
+    the base value outright. Neither input is mutated.
+    """
+    merged = dict(base)
+    for key, value in override.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = deep_merge(current, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+# Environment configs are defined values.yaml-style: a base dict holding the full
+# set of values, plus one dict per deployed environment listing only what it
+# overrides. See _GB_ENVIRONMENT_CONFIGS below for how they combine.
+#
+# The base carries the PROD values, so _GB_ENVIRONMENT_CONFIG_PROD is empty — it
+# is kept so every deployed environment reads the same way at the call site.
+# Because the base *is* PROD, editing a base value also changes PROD; to change
+# it for STAGING/DEV only, put it in each of their dicts instead.
+#
+# STANDALONE does not use the base: it is fully local and would override nearly
+# everything, so it is written out in full below.
+_GB_ENVIRONMENT_CONFIG_BASE = {
+    "env": "PROD",
+    "lakehouse_environment": "PROD",
+    "space_config_branch_name": "gbspace-config",
+    # gbcli
+    "gbserver_host": "https://api.llm-build-prod.vpc-int.res.ibm.com",
+    "default_space": "public",
+    "web_ui_url": "https://dashboard.llm-build-prod.vpc-int.res.ibm.com",
+    "config_spaces": "gb.spaces",
+    "config_profile": "gb.spaces.profiles",
+    "server_log_application_name": "llm-build-prod",
+    "branch_assets": "gbspace-config",
+    "hf_organization": "ibm-research",
+    "hf_enterprise_organizations": ["ibm-research", "ibm-granite"],
+    "feature_flags": {
+        "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
+        "gbserver_artifact_filter": getenv_boolean("GBSERVER_ARTIFACT_FILTER", True),
+        "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
+    },
+    # gbserver
+    # NOTE: the DEV api host, for every deployed environment. Intentional.
+    "dashboard_instance": "https://api.llm-build-dev.vpc-int.res.ibm.com",
+    "public_space_git_uri": f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public",
+    "public_space_lh_subnamespace": "public",
+    "buildwatcher_deployment_yaml": "k8s/dep-build-runner.yaml",
+    "default_pod_namespace": os.getenv(
+        "GBSERVER_BACKEND_SERVER_NAMESPACE_PROD", "llm-build-prod"
+    ),
+    "default_sql_schema": "granite_dot_build_prod",
+}
+
+# The base already holds the PROD values, so PROD overrides nothing.
+_GB_ENVIRONMENT_CONFIG_PROD: dict = {}
+
+_GB_ENVIRONMENT_CONFIG_STAGING = {
+    "env": "STAGING",
+    "lakehouse_environment": "STAGING",
+    "branch_assets": "gbspace-config-dev",
+    # gbcli
+    "gbserver_host": "https://api.llm-build-staging.vpc-int.res.ibm.com",
+    "web_ui_url": "https://dashboard.llm-build-staging.vpc-int.res.ibm.com",
+    "config_spaces": "staging.gb.spaces",
+    "config_profile": "staging.gb.spaces.profiles",
+    "server_log_application_name": "llm-build-staging",
+    # gbserver
+    "public_space_git_uri": f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gb-test",
+    "default_pod_namespace": os.getenv(
+        "GBSERVER_BACKEND_SERVER_NAMESPACE_STAGING", "llm-build-staging"
+    ),
+    "default_sql_schema": "granite_dot_build_staging",
+}
+
+_GB_ENVIRONMENT_CONFIG_DEV = {
+    "env": "DEV",
+    # DEV shares the STAGING lakehouse.
+    "lakehouse_environment": "STAGING",
+    "branch_assets": "gbspace-config-dev",
+    # gbcli
+    "gbserver_host": "https://api.llm-build-dev.vpc-int.res.ibm.com",
+    "web_ui_url": "https://dashboard.llm-build-dev.vpc-int.res.ibm.com",
+    "config_spaces": "dev.gb.spaces",
+    "config_profile": "dev.gb.spaces.profiles",
+    "server_log_application_name": "llm-build-dev",
+    # gbserver
+    "public_space_git_uri": f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public-dev",
+    "public_space_lh_subnamespace": "public_dev",
+    "default_pod_namespace": os.getenv(
+        "GBSERVER_BACKEND_SERVER_NAMESPACE_DEV", "llm-build-dev"
+    ),
+    "default_sql_schema": "granite_dot_build_dev",
+}
+
 _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
     "PROD": GBEnvConfig(
-        env="PROD",
-        lakehouse_environment="PROD",
-        space_config_branch_name="gbspace-config",
-        # gbcli
-        gbserver_host="https://api.llm-build-prod.vpc-int.res.ibm.com",
-        default_space="public",
-        web_ui_url="https://dashboard.llm-build-prod.vpc-int.res.ibm.com",
-        config_spaces="gb.spaces",
-        config_profile="gb.spaces.profiles",
-        server_log_application_name="llm-build-prod",
-        branch_assets="gbspace-config",
-        hf_organization="ibm-research",
-        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
-        feature_flags={
-            "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
-        },
-        # gbserver
-        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public",
-        public_space_lh_subnamespace="public",
-        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=os.getenv(
-            "GBSERVER_BACKEND_SERVER_NAMESPACE_PROD", "llm-build-prod"
-        ),
-        default_sql_schema="granite_dot_build_prod",
+        **deep_merge(_GB_ENVIRONMENT_CONFIG_BASE, _GB_ENVIRONMENT_CONFIG_PROD)
     ),
     "STAGING": GBEnvConfig(
-        env="STAGING",
-        lakehouse_environment="STAGING",
-        space_config_branch_name="gbspace-config",
-        # gbcli
-        gbserver_host="https://api.llm-build-staging.vpc-int.res.ibm.com",
-        default_space="public",
-        web_ui_url="https://dashboard.llm-build-staging.vpc-int.res.ibm.com",
-        config_spaces="staging.gb.spaces",
-        config_profile="staging.gb.spaces.profiles",
-        server_log_application_name="llm-build-staging",
-        branch_assets="gbspace-config-dev",
-        hf_organization="ibm-research",
-        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
-        feature_flags={
-            "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
-        },
-        # gbserver
-        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gb-test",
-        public_space_lh_subnamespace="public",
-        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=os.getenv(
-            "GBSERVER_BACKEND_SERVER_NAMESPACE_STAGING", "llm-build-staging"
-        ),
-        default_sql_schema="granite_dot_build_staging",
+        **deep_merge(_GB_ENVIRONMENT_CONFIG_BASE, _GB_ENVIRONMENT_CONFIG_STAGING)
     ),
     "DEV": GBEnvConfig(
-        env="DEV",
-        lakehouse_environment="STAGING",
-        space_config_branch_name="gbspace-config",
-        # gbcli
-        gbserver_host="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        default_space="public",
-        web_ui_url="https://dashboard.llm-build-dev.vpc-int.res.ibm.com",
-        config_spaces="dev.gb.spaces",
-        config_profile="dev.gb.spaces.profiles",
-        server_log_application_name="llm-build-dev",
-        branch_assets="gbspace-config-dev",
-        hf_organization="ibm-research",
-        hf_enterprise_organizations=["ibm-research", "ibm-granite"],
-        feature_flags={
-            "gbserver_build_events": getenv_boolean("GBSERVER_BUILD_EVENTS", True),
-            "gbserver_artifact_filter": getenv_boolean(
-                "GBSERVER_ARTIFACT_FILTER", True
-            ),
-            "gbserver_build_update": getenv_boolean("GBSERVER_BUILD_UPDATE", True),
-        },
-        # gbserver
-        dashboard_instance="https://api.llm-build-dev.vpc-int.res.ibm.com",
-        public_space_git_uri=f"https://{DEFAULT_GH_DOMAIN}/granite-dot-build/gbspace-public-dev",
-        public_space_lh_subnamespace="public_dev",
-        buildwatcher_deployment_yaml="k8s/dep-build-runner.yaml",
-        default_pod_namespace=os.getenv(
-            "GBSERVER_BACKEND_SERVER_NAMESPACE_DEV", "llm-build-dev"
-        ),
-        default_sql_schema="granite_dot_build_dev",
+        **deep_merge(_GB_ENVIRONMENT_CONFIG_BASE, _GB_ENVIRONMENT_CONFIG_DEV)
     ),
+    # Spelled out rather than merged onto the base: STANDALONE is fully local
+    # (no lakehouse, no GitHub-backed space, fixed feature flags) and would
+    # override nearly every base value, so a diff would obscure more than it saves.
     "STANDALONE": GBEnvConfig(
         env="STANDALONE",
         lakehouse_environment="",
@@ -255,8 +275,9 @@ _GB_ENVIRONMENT_CONFIGS: Dict[str, GBEnvConfig] = {
         hf_enterprise_organizations=["ibm-research", "ibm-granite"],
         feature_flags={
             "build_start_via_github": False,
-            "gbserver_build_events": True,
+            # Deliberately off in standalone, unlike the deployed environments.
             "gbserver_artifact_filter": False,
+            "gbserver_build_events": True,
             "gbserver_build_update": True,
         },
         # gbserver

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -151,7 +151,15 @@ def deep_merge(base: dict, override: dict) -> dict:
 
     Nested dicts are merged key-by-key so an environment can override a single
     ``feature_flags`` entry without restating the rest; any other value replaces
-    the base value outright. Neither input is mutated.
+    the base value outright.
+
+    Neither input is rebound, but the copy is **shallow**: a value the override
+    does not touch (a list, or a nested dict absent from the override) is carried
+    into the result by reference, so mutating it through the result would also
+    change ``base``. Every caller here feeds the result straight to
+    ``GBEnvConfig``, and pydantic deep-copies on validation, so the resolved
+    configs share no mutable state — but a caller that skips validation must copy
+    what it intends to mutate.
     """
     merged = dict(base)
     for key, value in override.items():

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -33,16 +33,21 @@ _FALSY_TOKENS = frozenset({"false", "null", "undefined", "no", "off", "0", ""})
 _TRUTHY_TOKENS = frozenset({"true", "yes", "on", "1"})
 
 
-def parse_boolean(value: str | None, default: bool = False) -> bool:
-    """Parse an env-var-style string into a boolean.
+def parse_boolean(value: object | None, default: bool = False) -> bool:
+    """Parse an env-var-style string (or an already-typed value) into a boolean.
 
-    ``None`` (unset) → ``default``. Otherwise the value is lower-cased and
-    compared against the falsy token set (see ``_FALSY_TOKENS``); a match is
-    ``False``, anything else set is ``True``. A non-falsy value that also isn't a
-    recognized truthy token (a likely typo, e.g. ``on-prod``) is still treated as
-    ``True`` but logs a warning. This never raises — the single place the
-    string→bool rule is defined, shared by ``getenv_boolean`` and any other
-    caller that already has the string in hand.
+    ``None`` (unset) → ``default``. Otherwise the value is stringified,
+    lower-cased and compared against the falsy token set (see ``_FALSY_TOKENS``);
+    a match is ``False``, anything else set is ``True``. A non-falsy value that
+    also isn't a recognized truthy token (a likely typo, e.g. ``on-prod``) is
+    still treated as ``True`` but logs a warning. This never raises — the single
+    place the string→bool rule is defined, shared by ``getenv_boolean`` and any
+    other caller that already has the string in hand.
+
+    Accepts non-string input because YAML/JSON configs yield real ``bool`` (and
+    occasionally ``int``) values: ``str()`` maps those onto the same token sets
+    (``False``→``"false"``, ``0``→``"0"``), so a config value and its quoted
+    form resolve identically.
     """
     if value is None:
         return default

--- a/src/gbcommon/types/testing.py
+++ b/src/gbcommon/types/testing.py
@@ -95,10 +95,13 @@ def disable_failure_simulation() -> None:
 
 
 # Which environment's HF resource group a STANDALONE run pushes to (e.g.
-# gbspace-public-staging). Defaults to STAGING so test artifacts land in a group
-# the CI token can write; set empty for the production gbspace-public.
+# gbspace-public-staging). Defaults to EMPTY, meaning the production
+# gbspace-public: a real standalone user must land in the production group. Only
+# a test run opts into a redirect, by setting this to STAGING/DEV explicitly (the
+# extended-tests Makefile targets do). Do not give this a non-empty default —
+# that silently sends real users to a staging group they cannot write.
 ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT = f"{_GBTEST_PREFIX}STANDALONE_ENVIRONMENT"
-DEFAULT_GBTEST_STANDALONE_ENVIRONMENT = "STAGING"
+DEFAULT_GBTEST_STANDALONE_ENVIRONMENT = ""
 
 
 def standalone_rg_environment() -> str:
@@ -108,8 +111,9 @@ def standalone_rg_environment() -> str:
     without patching.
 
     Returns:
-        str: ``"STAGING"``/``"DEV"`` when redirection applies, or ``""`` when the
-        var is set empty, meaning the production resource group.
+        str: ``"STAGING"``/``"DEV"`` when a test run has explicitly opted into a
+        redirect, or ``""`` (the default, and when the var is set empty) meaning
+        the production resource group.
     """
     return os.getenv(
         ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, DEFAULT_GBTEST_STANDALONE_ENVIRONMENT

--- a/src/gbcommon/types/testing.py
+++ b/src/gbcommon/types/testing.py
@@ -94,10 +94,33 @@ def disable_failure_simulation() -> None:
     os.environ.pop(ENV_VAR_GBTEST_SIMULATE_FAILURE_SCENARIO, None)
 
 
+# Which environment's HF resource group a STANDALONE run pushes to (e.g.
+# gbspace-public-staging). Defaults to STAGING so test artifacts land in a group
+# the CI token can write; set empty for the production gbspace-public.
+ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT = f"{_GBTEST_PREFIX}STANDALONE_ENVIRONMENT"
+DEFAULT_GBTEST_STANDALONE_ENVIRONMENT = "STAGING"
+
+
+def standalone_rg_environment() -> str:
+    """Return the environment whose HF resource group a STANDALONE run targets.
+
+    Read at call time (not import time) so a test can set/unset the env var
+    without patching.
+
+    Returns:
+        str: ``"STAGING"``/``"DEV"`` when redirection applies, or ``""`` when the
+        var is set empty, meaning the production resource group.
+    """
+    return os.getenv(
+        ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, DEFAULT_GBTEST_STANDALONE_ENVIRONMENT
+    ).strip()
+
+
 # The set of all GBTEST_ env var names defined in this module.
 _GBTEST_EXPORTED_ENV_VARS = {
     ENV_VAR_GBTEST_MOCK_HF,
     ENV_VAR_GBTEST_SIMULATE_FAILURE_SCENARIO,
+    ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT,
 }
 
 

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -35,8 +35,7 @@ from huggingface_hub import (
     snapshot_download,
 )
 
-from gbcommon.types.constants import GB_TEST_STANDALONE_ENVIRONMENT
-from gbcommon.types.testing import is_hf_mocked
+from gbcommon.types.testing import is_hf_mocked, standalone_rg_environment
 from gbcommon.uri.uri import URI
 from gbserver.types.artifact import ArtifactType
 from gbserver.types.constants import GB_ENVIRONMENT
@@ -47,6 +46,11 @@ logger = get_logger(__name__)
 
 # Prefix applied to space names when defining the resource group name.
 _GB_RG_SPACE_NAME_PREFIX = "gbspace-"
+
+# Standalone registers "public", "standalone", and "local" as aliases for one
+# space dir (gbserver/commands/utils.py), but only "public" has a resource group
+# provisioned, so the other two derive from it.
+_GB_RG_SPACE_NAME_ALIASES = {"standalone": "public", "local": "public"}
 HF_HOST = "huggingface.co"
 HF_URI_SCHEME = "hf"
 
@@ -407,14 +411,18 @@ class HfURI(URI):
         """
         if not space_name:
             return ""
-        name = f"{_GB_RG_SPACE_NAME_PREFIX}{space_name}"
+        canonical = _GB_RG_SPACE_NAME_ALIASES.get(
+            space_name.strip().lower(), space_name
+        )
+        name = f"{_GB_RG_SPACE_NAME_PREFIX}{canonical}"
         upper_env = GB_ENVIRONMENT.upper() if GB_ENVIRONMENT else ""
         if upper_env in ("STAGING", "DEV"):
             name = f"{name}-{GB_ENVIRONMENT.lower()}"
-        elif upper_env == "STANDALONE":
-            # STANDALONE test mode targets the configured write resource group
-            # (staging by default) so test artifacts have a real RG to push to.
-            name = f"{name}-{GB_TEST_STANDALONE_ENVIRONMENT.lower()}"
+        elif upper_env == "STANDALONE" and (rg_env := standalone_rg_environment()):
+            # A test run can redirect the standalone group to one it owns; a real
+            # standalone user gets the production group (see
+            # GBTEST_STANDALONE_ENVIRONMENT).
+            name = f"{name}-{rg_env.lower()}"
         logger.debug(
             "Resolved resource group name '%s' from space '%s' (env=%s)",
             name,

--- a/src/gbcommon/utils/hf_utils.py
+++ b/src/gbcommon/utils/hf_utils.py
@@ -1,6 +1,6 @@
 """General utility functions."""
 
-from typing import Literal
+from typing import Literal, Optional
 from urllib.parse import urlparse
 
 _ARTIFACT_TYPE_TO_SEGMENT: dict[str, str] = {
@@ -308,3 +308,37 @@ def convert_hf_uri_to_url(uri: str) -> str:
 
     else:
         raise ValueError(f"Invalid HuggingFace URI format: {uri}")
+
+
+def is_enterprise_hf_org(
+    organization: str,
+    enterprise_organizations: Optional[list[str]],
+) -> bool:
+    """Return whether ``organization`` should be treated as an HF Enterprise org.
+
+    HF Enterprise gates repo/bucket creation on a resource group id, but there is
+    no non-admin HF API that distinguishes an Enterprise organization from an
+    individual user namespace. The split is therefore configuration-driven: an
+    explicit list of org names, supplied by the ``hf`` asset store's
+    ``store.yaml`` (``config.enterprise_organizations``) server-side, or by
+    ``GBEnvConfig.hf_enterprise_organizations`` in the CLI.
+
+    Args:
+        organization: HF organization (owner) namespace to classify.
+        enterprise_organizations: Configured Enterprise org names. ``None``
+            (the key is absent) means *every* org is treated as Enterprise,
+            preserving the behavior from before the split. An explicit empty
+            list means no org is Enterprise.
+
+    Returns:
+        ``True`` when the org is Enterprise and a resource group applies.
+
+    Note:
+        Matching is case-insensitive and surrounding whitespace is ignored,
+        since HF namespaces are case-insensitive.
+    """
+    if enterprise_organizations is None:
+        return True
+    return (organization or "").strip().lower() in {
+        o.strip().lower() for o in enterprise_organizations if o
+    }

--- a/src/gbserver/asset/hfstore.py
+++ b/src/gbserver/asset/hfstore.py
@@ -18,7 +18,7 @@
 
 import os
 from pathlib import Path
-from typing import Dict, Optional, Self, Union
+from typing import Dict, List, Optional, Self, Union
 
 from huggingface_hub import create_repo, upload_file, upload_folder
 
@@ -74,6 +74,37 @@ class Hfstore(Assetstore):
             else self.DEFAULT_TOKEN_KEY
         )
         return {"token_secretname": token_key}
+
+    def get_enterprise_organizations(self) -> Optional[List[str]]:
+        """Return the Enterprise HF org names declared in store.yaml.
+
+        Read from ``config.enterprise_organizations``. ``None`` (the key is
+        absent) means *every* org is treated as Enterprise, preserving the
+        behavior from before the enterprise/non-enterprise split; callers pass
+        the result straight to :func:`is_enterprise_hf_org`, which encodes that
+        rule.
+
+        Returns:
+            The configured org names, or ``None`` when the key is absent.
+
+        Raises:
+            ValueError: If the key is present but is not a list.
+        """
+        if (
+            self.config
+            and isinstance(self.config.config, dict)
+            and "enterprise_organizations" in self.config.config
+        ):
+            orgs = self.config.config["enterprise_organizations"]
+            if orgs is None:
+                return None
+            if not isinstance(orgs, list):
+                raise ValueError(
+                    "assetstore config 'enterprise_organizations' must be a "
+                    f"list of org names, got {type(orgs).__name__}"
+                )
+            return [str(o) for o in orgs]
+        return None
 
     def get_asset_type(self, uri: URI) -> ArtifactType:
         assert isinstance(uri, HfURI)

--- a/src/gbserver/asset/hfstore.py
+++ b/src/gbserver/asset/hfstore.py
@@ -173,9 +173,15 @@ class Hfstore(Assetstore):
             "path_in_repo": hfuri.get_path_in_repo(),
             "private": hf_private,
             "binding_id": binding_id,
+            # ``private`` lives only at the top level: every step template reads
+            # ``hfpush_config.private`` (LSF command.sh, Helm _helpers.tpl,
+            # skypilot step.yaml), never ``hf.private``. It is deliberately not
+            # duplicated into this nested block — the k8s/skypilot overlay
+            # (sanitize_hf_step_overlay + .update) rewrites ``hf.*`` from the raw
+            # push config and does not re-resolve ``private``, so a nested copy
+            # would be silently overwritten with the unresolved value.
             "hf": {
                 "type": hf_type,
-                "private": hf_private,
                 "resource_group_id": hf_resource_group_id,
             },
         }

--- a/src/gbserver/builtins/steps/lsf/hfpush/lsf_scripts/hfpush/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpush/lsf_scripts/hfpush/command.sh
@@ -20,6 +20,13 @@ HF_REVISION='{{ hfp.revision }}'
 HF_PRIVATE='{{ hfp.private }}'
 HF_TYPE='{{ hfp.hf.type }}'
 HF_RESOURCE_GROUP_ID='{{ hfp.hf.resource_group_id }}'
+# Jinja renders a Python None as the literal string "None", which is non-empty
+# to bash. Normalize it to empty so the create body below omits resourceGroupId
+# (the non-Enterprise / no-resource-group case). Mirrors the skypilot step's
+# `rg != "None"` guard.
+if [[ "${HF_RESOURCE_GROUP_ID}" == "None" ]]; then
+    HF_RESOURCE_GROUP_ID=""
+fi
 BINDING_ID='{{ hfp.binding_id }}'
 
 # Mocked when GBTEST_MOCK_HF is "true" (case-insensitive), matching

--- a/src/gbserver/environment/bash.py
+++ b/src/gbserver/environment/bash.py
@@ -368,6 +368,7 @@ class Bash(Environment):
         assetstore=None,
         run_metadata=None,
         storepush_config=None,
+        output_config=None,
         **_kwargs,
     ) -> Any:
         """Upload a local file/dir to a HuggingFace repo (hf:// output).
@@ -382,7 +383,10 @@ class Bash(Environment):
         :param assetstore: ``Hfstore`` whose secrets supply the HF token.
         :param run_metadata: ``EntityRunMetadata`` with build/target identifiers.
         :param storepush_config: Environment-level push config; ``mode`` must be
-            unset or ``"default"``.
+            unset or ``"default"``. Its ``hf`` block is forwarded so the resource
+            group settings apply here as they do on the step-based environments.
+        :param output_config: Per-output build.yaml config, forwarded so
+            ``store_push.config.hf`` (including ``use_resource_group``) is honored.
         :returns: The resolved ``HfURI`` after a successful push.
         :raises ValueError: on a non-'default' mode, or a binding without 'path'.
         """
@@ -395,6 +399,8 @@ class Bash(Environment):
             uri=uri,
             assetstore=assetstore,
             run_metadata=run_metadata,
+            storepush_config=storepush_config,
+            output_config=output_config,
         )
 
     async def pushasset_filestore(

--- a/src/gbserver/environment/docker.py
+++ b/src/gbserver/environment/docker.py
@@ -325,6 +325,7 @@ class Docker(Environment):
         assetstore=None,
         run_metadata=None,
         storepush_config=None,
+        output_config=None,
         **_kwargs,
     ) -> Any:
         """Upload a local file or directory to a HuggingFace repo.
@@ -342,6 +343,12 @@ class Docker(Environment):
             uri: Target HfURI string or object.
             assetstore: Hfstore instance whose secrets supply the HF token.
             run_metadata: EntityRunMetadata with build_id and target_name.
+            storepush_config: Environment-level push config. Its ``hf`` block is
+                forwarded so the resource group settings apply here as they do on
+                the step-based environments.
+            output_config: Per-output build.yaml config, forwarded so
+                ``store_push.config.hf`` (including ``use_resource_group``) is
+                honored.
 
         Returns:
             The resolved HfURI after a successful push.
@@ -360,6 +367,8 @@ class Docker(Environment):
             uri=uri,
             assetstore=assetstore,
             run_metadata=run_metadata,
+            storepush_config=storepush_config,
+            output_config=output_config,
         )
 
     # ------------------------------------------------------------------

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -74,7 +74,10 @@ from gbserver.environment.environment import (
     Environment,
     EventLogLineParserConfig,
 )
-from gbserver.spaces.resource_group import resolve_space_resource_group_id
+from gbserver.spaces.resource_group import (
+    resolve_hfpush_resource_group_id,
+    sanitize_hf_step_overlay,
+)
 from gbserver.types.buildconfig import BuildTargetOutputConfig, BuildTargetStepConfig
 from gbserver.types.buildevent import (
     EntityRunMetadata,
@@ -2281,33 +2284,20 @@ class K8s(Environment):
         # resource_group_name is configured (ignored if resource_group_name is set).
         space_name = output_config.space_name if output_config else None
 
-        # Resolve hf fields from build.yaml store_push (highest priority)
-        hf_resource_group_id = None
-        hf_resource_group_name = None
-        hf_private = True
-        if output_config is not None and output_config.store_push is not None:
-            hf_cfg = output_config.store_push.config.get("hf", {})
-            hf_resource_group_id = hf_cfg.get("resource_group_id", hf_resource_group_id)
-            hf_resource_group_name = hf_cfg.get(
-                "resource_group_name", hf_resource_group_name
-            )
-            hf_private = hf_cfg.get("private", hf_private)
-
         assert isinstance(
             assetstore, Hfstore
         ), f"invalid assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
-        if hf_resource_group_id:
-            resource_group_id: Optional[str] = hf_resource_group_id
-        else:
-            # Table-first resolution (cached id on the space row) with HF API
-            # fallback + write-back. HfURI still only receives the resolved id.
-            resource_group_id = resolve_space_resource_group_id(
-                space_name=space_name,
-                organization=hfuri.get_owner(),
-                token=assetstore.resolve_token(hfuri),
-                resource_group_name=hf_resource_group_name,
-                host=hfuri.get_host(),
-            )
+        # Enterprise/non-enterprise split + config precedence (environment-level
+        # storepush_config, overridden by build.yaml store_push) + table-first
+        # resolution all live in the shared helper. A non-Enterprise org
+        # resolves to None with no HF API call.
+        resource_group_id, hf_private, _hf_cfg = resolve_hfpush_resource_group_id(
+            hfuri=hfuri,
+            assetstore=assetstore,
+            space_name=space_name,
+            storepush_config=storepush_config,
+            output_config=output_config,
+        )
 
         hfpush_config = Hfstore.build_hfpush_step_config(
             hfuri=hfuri,
@@ -2316,20 +2306,13 @@ class K8s(Environment):
             hf_private=hf_private,
             hf_resource_group_id=resource_group_id,
         )
-        # Apply remaining hf fields from environment-level storepush_config
-        if (
-            storepush_config is not None
-            and storepush_config.config is not None
-            and "hf" in storepush_config.config
-        ):
-            hfpush_config["hf"].update(storepush_config.config["hf"])
-        # Apply remaining hf fields from build.yaml store_push (highest priority)
-        if (
-            output_config is not None
-            and output_config.store_push is not None
-            and "hf" in output_config.store_push.config
-        ):
-            hfpush_config["hf"].update(output_config.store_push.config["hf"])
+        # Apply remaining hf fields from the merged push config (environment
+        # level, overridden by build.yaml store_push). Resolution-only keys are
+        # stripped so they never reach the step template, and the resolved
+        # resource_group_id is re-asserted afterwards so a pinned-but-skipped
+        # value cannot be resurrected by the overlay.
+        hfpush_config["hf"].update(sanitize_hf_step_overlay(_hf_cfg))
+        hfpush_config["hf"]["resource_group_id"] = resource_group_id
         hfpush_stepuri = "space://steps/hfpush"
         if (
             storepush_config is not None

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -2307,8 +2307,8 @@ class K8s(Environment):
             hf_resource_group_id=resource_group_id,
         )
         # Apply remaining hf fields from the merged push config (environment
-        # level, overridden by build.yaml store_push). Resolution-only keys are
-        # stripped so they never reach the step template, and the resolved
+        # level, overridden by build.yaml store_push). use_resource_group is
+        # stripped (it is consumed here, not by the template), and the resolved
         # resource_group_id is re-asserted afterwards so a pinned-but-skipped
         # value cannot be resurrected by the overlay.
         hfpush_config["hf"].update(sanitize_hf_step_overlay(_hf_cfg))

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -75,8 +75,8 @@ from gbserver.environment.environment import (
     EventLogLineParserConfig,
 )
 from gbserver.spaces.resource_group import (
+    apply_hf_step_overlay,
     resolve_hfpush_resource_group_id,
-    sanitize_hf_step_overlay,
 )
 from gbserver.types.buildconfig import BuildTargetOutputConfig, BuildTargetStepConfig
 from gbserver.types.buildevent import (
@@ -2307,12 +2307,10 @@ class K8s(Environment):
             hf_resource_group_id=resource_group_id,
         )
         # Apply remaining hf fields from the merged push config (environment
-        # level, overridden by build.yaml store_push). use_resource_group is
-        # stripped (it is consumed here, not by the template), and the resolved
-        # resource_group_id is re-asserted afterwards so a pinned-but-skipped
-        # value cannot be resurrected by the overlay.
-        hfpush_config["hf"].update(sanitize_hf_step_overlay(_hf_cfg))
-        hfpush_config["hf"]["resource_group_id"] = resource_group_id
+        # level, overridden by build.yaml store_push; strips use_resource_group,
+        # re-asserts the resolved resource_group_id). Shared with skypilot so the
+        # overlay invariants cannot drift between the two.
+        apply_hf_step_overlay(hfpush_config, _hf_cfg, resource_group_id)
         hfpush_stepuri = "space://steps/hfpush"
         if (
             storepush_config is not None

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -8,8 +8,10 @@ import os
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from gbcommon.utils.hf_utils import is_enterprise_hf_org
-from gbserver.spaces.resource_group import resolve_space_resource_group_id
+from gbserver.spaces.resource_group import (
+    resolve_hfpush_resource_group_id,
+    resolve_space_resource_group_id,
+)
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -107,6 +109,8 @@ def push_asset_hfstore(
     uri: Optional[Any] = None,
     assetstore=None,
     run_metadata=None,
+    storepush_config=None,
+    output_config=None,
     **_kwargs,
 ) -> Any:
     """Upload a local file or directory to a HuggingFace repo.
@@ -175,35 +179,39 @@ def push_asset_hfstore(
     # entirely: no space lookup, no HF API call.
     from gbserver.asset.hfstore import Hfstore
 
-    organization = hfuri.get_owner()
-    # Only Hfstore declares the Enterprise org list; any other assetstore (or
-    # none) falls back to None, which is_enterprise_hf_org() treats as "every org
-    # is Enterprise" — the pre-split behavior. Guarded by isinstance rather than
-    # read directly, because a non-Hfstore would otherwise raise AttributeError:
-    # nothing in resource-group resolution on this best-effort path should be
-    # able to abort the push.
-    enterprise_orgs = (
-        assetstore.get_enterprise_organizations()
-        if isinstance(assetstore, Hfstore)
-        else None
-    )
-
+    # Route through the same helper the step-based environments use, so
+    # store_push settings (resource_group_id / resource_group_name /
+    # use_resource_group) are honored identically here. Only Hfstore declares the
+    # Enterprise org list; any other assetstore means we cannot classify, so fall
+    # back to the pre-split behavior of attempting resolution.
     resource_group_id = None
-    if not is_enterprise_hf_org(organization, enterprise_orgs):
-        logger.info(
-            "HuggingFace organization '%s' is not an Enterprise org; "
-            "pushing without a resource group",
-            organization,
-        )
-    else:
+    if isinstance(assetstore, Hfstore):
         # Best-effort: in standalone the local user's token typically CANNOT
         # resolve the resource group id via the HF API (that needs org-admin
         # scope), so a miss here is expected. Don't abort — log and push with
         # resource_group_id = None: HfURI.push -> create_repo(exist_ok=True)
         # succeeds for an existing repo, and surfaces its own error otherwise.
-        # Resolved here, not above: the non-Enterprise branch never needs a
-        # token, and get_hf_token() should not run for a push that skips
-        # resource groups entirely.
+        # A ValueError from the helper is a *configuration* error (a resource
+        # group pinned for a non-Enterprise org), so it is re-raised rather than
+        # swallowed — the push would otherwise silently ignore what was asked.
+        try:
+            resource_group_id, _private, _hf_cfg = resolve_hfpush_resource_group_id(
+                hfuri=hfuri,
+                assetstore=assetstore,
+                space_name=space_name,
+                storepush_config=storepush_config,
+                output_config=output_config,
+            )
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.warning(
+                "Could not resolve HuggingFace resource group id for space '%s' "
+                "(pushing without one): %s",
+                space_name,
+                e,
+            )
+    else:
         from gbserver.types.constants import get_hf_token
 
         token = (
@@ -214,7 +222,7 @@ def push_asset_hfstore(
         try:
             resource_group_id = resolve_space_resource_group_id(
                 space_name=space_name,
-                organization=organization,
+                organization=hfuri.get_owner(),
                 token=token,
                 host=hfuri.get_host(),
             )

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 from gbserver.spaces.resource_group import (
+    HfPushConfigError,
     resolve_hfpush_resource_group_id,
     resolve_space_resource_group_id,
 )
@@ -194,9 +195,12 @@ def push_asset_hfstore(
         # scope), so a miss here is expected. Don't abort — log and push with
         # resource_group_id = None: HfURI.push -> create_repo(exist_ok=True)
         # succeeds for an existing repo, and surfaces its own error otherwise.
-        # A ValueError from the helper is a *configuration* error (a resource
-        # group pinned for a non-Enterprise org), so it is re-raised rather than
-        # swallowed — the push would otherwise silently ignore what was asked.
+        # Only a *configuration* error aborts (HfPushConfigError: a group pinned
+        # for a non-Enterprise org, or a pin contradicting use_resource_group) —
+        # the push would otherwise silently ignore what was asked. A plain
+        # ValueError must NOT abort: resolve_resource_group_id_for_org raises one
+        # for an unresolvable group name, which is the expected non-admin-token
+        # miss described above.
         try:
             resource_group_id, private, _hf_cfg = resolve_hfpush_resource_group_id(
                 hfuri=hfuri,
@@ -205,7 +209,7 @@ def push_asset_hfstore(
                 storepush_config=storepush_config,
                 output_config=output_config,
             )
-        except ValueError:
+        except HfPushConfigError:
             raise
         except Exception as e:
             logger.warning(

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -183,6 +183,11 @@ def push_asset_hfstore(
     # Enterprise org list; any other assetstore means we cannot classify, so fall
     # back to the pre-split behavior of attempting resolution.
     resource_group_id = None
+    # Default to a private repo. This must be initialized here, not only in the
+    # Hfstore branch below: the non-Hfstore path and both `except` paths fall
+    # through to hfuri.push(), and HuggingFace's own create_repo default is
+    # PUBLIC, so leaving it unbound/None would publish the artifact.
+    private = True
     if isinstance(assetstore, Hfstore):
         # Best-effort: in standalone the local user's token typically CANNOT
         # resolve the resource group id via the HF API (that needs org-admin
@@ -193,7 +198,7 @@ def push_asset_hfstore(
         # group pinned for a non-Enterprise org), so it is re-raised rather than
         # swallowed — the push would otherwise silently ignore what was asked.
         try:
-            resource_group_id, _private, _hf_cfg = resolve_hfpush_resource_group_id(
+            resource_group_id, private, _hf_cfg = resolve_hfpush_resource_group_id(
                 hfuri=hfuri,
                 assetstore=assetstore,
                 space_name=space_name,
@@ -239,6 +244,7 @@ def push_asset_hfstore(
     hfuri.push(
         src,
         commit_message=commit_message,
+        private=private,
         resource_group_id=resource_group_id,
     )
     return hfuri

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -163,14 +163,12 @@ def push_asset_hfstore(
     )
 
     # Resolve the space name from the thread-local space config so the repo is
-    # created inside the correct Enterprise resource group automatically.
+    # created inside the correct Enterprise resource group automatically. The
+    # standalone aliases ("standalone", "local") are folded onto "public" by
+    # HfURI.space_name_to_resource_group_name, so this no longer needs to
+    # hardcode a space name to get a resolvable resource group.
     space_config = URI.get_space_config()
     space_name = space_config.get("space", {}).get("name") or None
-
-    # TODO: use the resolved space name above instead of hardcoding "public".
-    # Only *consulted* on the Enterprise path below (a non-Enterprise push never
-    # resolves a resource group), though it is still logged for either.
-    space_name = "public"
 
     # Resource groups exist only in HF Enterprise organizations, and which orgs
     # those are is configured on the asset store (store.yaml

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -164,8 +164,8 @@ def push_asset_hfstore(
     space_name = space_config.get("space", {}).get("name") or None
 
     # TODO: use the resolved space name above instead of hardcoding "public".
-    # Only reachable on the Enterprise path below — a non-Enterprise push never
-    # consults the space at all.
+    # Only *consulted* on the Enterprise path below (a non-Enterprise push never
+    # resolves a resource group), though it is still logged for either.
     space_name = "public"
 
     # Resource groups exist only in HF Enterprise organizations, and which orgs
@@ -173,17 +173,21 @@ def push_asset_hfstore(
     # ``config.enterprise_organizations``). For a non-Enterprise org — an
     # individual user namespace or a plain community org — skip resolution
     # entirely: no space lookup, no HF API call.
-    #
-    # Fall back to the server HF token when no assetstore is supplied.
-    from gbserver.types.constants import get_hf_token
+    from gbserver.asset.hfstore import Hfstore
 
-    token = (
-        assetstore.resolve_token(hfuri) if assetstore is not None else get_hf_token()
-    )
     organization = hfuri.get_owner()
+    # Only Hfstore declares the Enterprise org list; any other assetstore (or
+    # none) falls back to None, which is_enterprise_hf_org() treats as "every org
+    # is Enterprise" — the pre-split behavior. Guarded by isinstance rather than
+    # read directly, because a non-Hfstore would otherwise raise AttributeError:
+    # nothing in resource-group resolution on this best-effort path should be
+    # able to abort the push.
     enterprise_orgs = (
-        assetstore.get_enterprise_organizations() if assetstore is not None else None
+        assetstore.get_enterprise_organizations()
+        if isinstance(assetstore, Hfstore)
+        else None
     )
+
     resource_group_id = None
     if not is_enterprise_hf_org(organization, enterprise_orgs):
         logger.info(
@@ -197,6 +201,16 @@ def push_asset_hfstore(
         # scope), so a miss here is expected. Don't abort — log and push with
         # resource_group_id = None: HfURI.push -> create_repo(exist_ok=True)
         # succeeds for an existing repo, and surfaces its own error otherwise.
+        # Resolved here, not above: the non-Enterprise branch never needs a
+        # token, and get_hf_token() should not run for a push that skips
+        # resource groups entirely.
+        from gbserver.types.constants import get_hf_token
+
+        token = (
+            assetstore.resolve_token(hfuri)
+            if assetstore is not None
+            else get_hf_token()
+        )
         try:
             resource_group_id = resolve_space_resource_group_id(
                 space_name=space_name,

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -125,20 +125,41 @@ def push_asset_hfstore(
     Suitable for any local environment (Bash, Docker, etc.) that writes
     outputs to the host filesystem and wants to push them to HF.
 
+    The space name is read from the thread-local URI space config and used to
+    derive the Enterprise resource group; :meth:`HfURI.push` receives the
+    *resolved* ``resource_group_id`` (never a name — passing a name would make
+    push re-derive it and hit the admin-gated endpoint, defeating the cache) plus
+    the resolved ``private`` flag.
+
+    Resource groups exist only in HF Enterprise orgs. For a non-Enterprise
+    namespace resolution is skipped entirely, and a resolution *miss* on an
+    Enterprise org (the usual case for a non-admin standalone token) is logged and
+    the push proceeds without a group. Artifacts are private unless a push config
+    explicitly asks for public.
+
     Args:
         src: Local file or directory path to push.
         binding_id: Output binding name included in the commit message.
         uri: Target HfURI string or object.
-        assetstore: Hfstore instance whose secrets supply the HF token.
+        assetstore: Hfstore instance whose secrets supply the HF token. Only an
+            ``Hfstore`` declares the Enterprise org list; any other value (or
+            ``None``) cannot classify the org, so resource group resolution is
+            attempted unconditionally while ``private`` is still honored.
         run_metadata: EntityRunMetadata with ``build_id`` and ``target_name``.
-            The current space name is resolved from the thread-local URI space config
-            and passed as ``resource_group_name`` to :meth:`HfURI.push`.
+        storepush_config: Environment-level ``store_push`` (environment.yaml)
+            supplying ``config.hf`` (``resource_group_id`` /
+            ``resource_group_name`` / ``use_resource_group`` / ``private``).
+        output_config: Per-output config whose ``store_push`` (build.yaml)
+            overrides the environment level.
 
     Returns:
         The resolved HfURI after a successful push.
 
     Raises:
         ValueError: If ``uri`` is absent or ``src`` is empty.
+        HfPushConfigError: If the push config is unsatisfiable for the target org
+            (a resource group pinned for a non-Enterprise org, or a pin combined
+            with ``use_resource_group: false``). A subclass of ``ValueError``.
         RuntimeError: If the HuggingFace push operation fails.
     """
     from gbcommon.uri.hf import HfURI

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from gbcommon.utils.hf_utils import is_enterprise_hf_org
 from gbserver.spaces.resource_group import resolve_space_resource_group_id
 from gbserver.utils.logger import get_logger
 
@@ -162,12 +163,16 @@ def push_asset_hfstore(
     space_config = URI.get_space_config()
     space_name = space_config.get("space", {}).get("name") or None
 
-    space_name = "public"  # TODO: use the right thing here.
+    # TODO: use the resolved space name above instead of hardcoding "public".
+    # Only reachable on the Enterprise path below — a non-Enterprise push never
+    # consults the space at all.
+    space_name = "public"
 
-    # Resolve the resource group id server-side (table-first: cached default id
-    # on the space row, HF API only as a fallback + write-back) and hand HfURI
-    # the resolved id. This lets the standalone/local push reuse a cached id
-    # without an admin-scoped HF token.
+    # Resource groups exist only in HF Enterprise organizations, and which orgs
+    # those are is configured on the asset store (store.yaml
+    # ``config.enterprise_organizations``). For a non-Enterprise org — an
+    # individual user namespace or a plain community org — skip resolution
+    # entirely: no space lookup, no HF API call.
     #
     # Fall back to the server HF token when no assetstore is supplied.
     from gbserver.types.constants import get_hf_token
@@ -175,28 +180,37 @@ def push_asset_hfstore(
     token = (
         assetstore.resolve_token(hfuri) if assetstore is not None else get_hf_token()
     )
-    # Best-effort: in standalone the local user's token typically CANNOT resolve
-    # the resource group id via the HF API (that needs org-admin scope), so a
-    # miss here is expected. Don't abort — log and push with resource_group_id
-    # = None, matching pre-cache behavior: HfURI.push -> create_repo(exist_ok=
-    # True) succeeds for an existing repo, and surfaces its own error otherwise.
-    # (A future enterprise-vs-non-enterprise split will remove the need for an
-    # id entirely on the non-enterprise path.)
+    organization = hfuri.get_owner()
+    enterprise_orgs = (
+        assetstore.get_enterprise_organizations() if assetstore is not None else None
+    )
     resource_group_id = None
-    try:
-        resource_group_id = resolve_space_resource_group_id(
-            space_name=space_name,
-            organization=hfuri.get_owner(),
-            token=token,
-            host=hfuri.get_host(),
+    if not is_enterprise_hf_org(organization, enterprise_orgs):
+        logger.info(
+            "HuggingFace organization '%s' is not an Enterprise org; "
+            "pushing without a resource group",
+            organization,
         )
-    except Exception as e:
-        logger.warning(
-            "Could not resolve HuggingFace resource group id for space '%s' "
-            "(pushing without one): %s",
-            space_name,
-            e,
-        )
+    else:
+        # Best-effort: in standalone the local user's token typically CANNOT
+        # resolve the resource group id via the HF API (that needs org-admin
+        # scope), so a miss here is expected. Don't abort — log and push with
+        # resource_group_id = None: HfURI.push -> create_repo(exist_ok=True)
+        # succeeds for an existing repo, and surfaces its own error otherwise.
+        try:
+            resource_group_id = resolve_space_resource_group_id(
+                space_name=space_name,
+                organization=organization,
+                token=token,
+                host=hfuri.get_host(),
+            )
+        except Exception as e:
+            logger.warning(
+                "Could not resolve HuggingFace resource group id for space '%s' "
+                "(pushing without one): %s",
+                space_name,
+                e,
+            )
 
     logger.info("Pushing %s → %s (space=%s)", src, URI.get_uristr(hfuri), space_name)
     # Pass only the pre-resolved id (not space_name): HfURI.push would otherwise

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -10,6 +10,7 @@ from typing import Any, Optional, Union
 
 from gbserver.spaces.resource_group import (
     HfPushConfigError,
+    resolve_hfpush_private,
     resolve_hfpush_resource_group_id,
     resolve_space_resource_group_id,
 )
@@ -221,6 +222,15 @@ def push_asset_hfstore(
     else:
         from gbserver.types.constants import get_hf_token
 
+        # Resource groups cannot be classified without Hfstore's Enterprise org
+        # list, but `private` is store-independent: read it from the same merged
+        # config levels so an explicit `private: false` is honored here too
+        # (default stays True). Only the resource-group resolution below differs
+        # between the two branches.
+        private = resolve_hfpush_private(
+            storepush_config=storepush_config,
+            output_config=output_config,
+        )
         token = (
             assetstore.resolve_token(hfuri)
             if assetstore is not None

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -1541,6 +1541,10 @@ class Lsf(Environment):
         # Enterprise/non-enterprise split + config precedence + table-first
         # resolution all live in the shared helper; a non-Enterprise org
         # resolves to None without any HF API call.
+        # NOTE: unlike k8s/skypilot, LSF applies no post-hoc overlay of the
+        # remaining `hf.*` keys onto hfpush_config — it never did, and the LSF
+        # command.sh template consumes only the keys build_hfpush_step_config
+        # emits. `_hf_cfg` is therefore unused here by design.
         resource_group_id, hf_private, _hf_cfg = resolve_hfpush_resource_group_id(
             hfuri=hfuri,
             assetstore=assetstore,

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -50,7 +50,7 @@ from gbserver.monitoring.lsf_bsub_monitor import LSFBsubMonitor
 from gbserver.monitoring.streams.log_stream_base import LogStreamSource
 from gbserver.monitoring.streams.stream_factory import make_stream
 from gbserver.resilience.strategies.aspera_failure import AsperaRetryStrategy
-from gbserver.spaces.resource_group import resolve_space_resource_group_id
+from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
 from gbserver.types.buildconfig import BuildTargetOutputConfig, BuildTargetStepConfig
 from gbserver.types.buildevent import (
     EntityRunMetadata,
@@ -1533,43 +1533,21 @@ class Lsf(Environment):
         hf_metadata = Asset(uri=hfuri).get_metadata()
         logger.info("hf_metadata: %s", hf_metadata)
 
-        hf_resource_group_id: Optional[str] = None
-        hf_resource_group_name: Optional[str] = None
-        hf_private = True
-        # Environment-level storepush_config (lower priority).
-        if storepush_config is not None and storepush_config.config is not None:
-            hf_cfg = storepush_config.config.get("hf", {})
-            hf_resource_group_id = hf_cfg.get("resource_group_id", hf_resource_group_id)
-            hf_resource_group_name = hf_cfg.get(
-                "resource_group_name", hf_resource_group_name
-            )
-            hf_private = hf_cfg.get("private", hf_private)
-        # build.yaml output store_push (higher priority, overrides).
-        if output_config is not None and output_config.store_push is not None:
-            hf_cfg = output_config.store_push.config.get("hf", {})
-            hf_resource_group_id = hf_cfg.get("resource_group_id", hf_resource_group_id)
-            hf_resource_group_name = hf_cfg.get(
-                "resource_group_name", hf_resource_group_name
-            )
-            hf_private = hf_cfg.get("private", hf_private)
-
         space_name = output_config.space_name if output_config else None
 
         assert isinstance(
             assetstore, Hfstore
         ), f"invalid assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
-        if hf_resource_group_id:
-            resource_group_id: Optional[str] = hf_resource_group_id
-        else:
-            # Table-first resolution (cached id on the space row) with HF API
-            # fallback + write-back. HfURI still only receives the resolved id.
-            resource_group_id = resolve_space_resource_group_id(
-                space_name=space_name,
-                organization=hfuri.get_owner(),
-                token=assetstore.resolve_token(hfuri),
-                resource_group_name=hf_resource_group_name,
-                host=hfuri.get_host(),
-            )
+        # Enterprise/non-enterprise split + config precedence + table-first
+        # resolution all live in the shared helper; a non-Enterprise org
+        # resolves to None without any HF API call.
+        resource_group_id, hf_private, _hf_cfg = resolve_hfpush_resource_group_id(
+            hfuri=hfuri,
+            assetstore=assetstore,
+            space_name=space_name,
+            storepush_config=storepush_config,
+            output_config=output_config,
+        )
 
         hfpush_config = Hfstore.build_hfpush_step_config(
             hfuri=hfuri,

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -2704,10 +2704,10 @@ class Skypilot(Environment):
             hf_private=hf_private,
             hf_resource_group_id=resource_group_id,
         )
-        # Apply remaining hf fields from the merged push config. Resolution-only
-        # keys are stripped so they never reach the worker's inline push, and the
-        # resolved resource_group_id is re-asserted so a pinned-but-skipped value
-        # cannot be resurrected by the overlay.
+        # Apply remaining hf fields from the merged push config. use_resource_group
+        # is stripped (consumed here, not by the worker), and the resolved
+        # resource_group_id is re-asserted so a pinned-but-skipped value cannot be
+        # resurrected by the overlay.
         hfpush_config["hf"].update(sanitize_hf_step_overlay(_hf_cfg))
         hfpush_config["hf"]["resource_group_id"] = resource_group_id
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -39,7 +39,10 @@ from tenacity import (
 
 from gbcommon.uri.uri import URI
 from gbserver.environment.environment import Environment, EventLogLineParserConfig
-from gbserver.spaces.resource_group import resolve_space_resource_group_id
+from gbserver.spaces.resource_group import (
+    resolve_hfpush_resource_group_id,
+    sanitize_hf_step_overlay,
+)
 from gbserver.types.buildconfig import BuildTargetStepConfig
 from gbserver.types.buildevent import EntityRunMetadata
 from gbserver.types.environmentconfig import EnvironmentConfig
@@ -2678,33 +2681,21 @@ class Skypilot(Environment):
         ), f"expected 'path' to be in the binding, actual: {binding}"
         binding_path = binding["path"]
 
-        hf_resource_group_id = None
-        hf_resource_group_name = None
-        hf_private = True
-        if output_config is not None and output_config.store_push is not None:
-            hf_cfg = output_config.store_push.config.get("hf", {})
-            hf_resource_group_id = hf_cfg.get("resource_group_id", hf_resource_group_id)
-            hf_resource_group_name = hf_cfg.get(
-                "resource_group_name", hf_resource_group_name
-            )
-            hf_private = hf_cfg.get("private", hf_private)
-
         assert isinstance(
             assetstore, Hfstore
         ), f"invalid assetstore: {type(assetstore).__name__} (expected 'Hfstore')"
         space_name = output_config.space_name if output_config else None
-        if hf_resource_group_id:
-            resource_group_id: Optional[str] = hf_resource_group_id
-        else:
-            # Table-first resolution (cached id on the space row) with HF API
-            # fallback + write-back. HfURI still only receives the resolved id.
-            resource_group_id = resolve_space_resource_group_id(
-                space_name=space_name,
-                organization=hfuri.get_owner(),
-                token=assetstore.resolve_token(hfuri),
-                resource_group_name=hf_resource_group_name,
-                host=hfuri.get_host(),
-            )
+        # Enterprise/non-enterprise split + config precedence (environment-level
+        # storepush_config, overridden by build.yaml store_push) + table-first
+        # resolution all live in the shared helper. A non-Enterprise org
+        # resolves to None with no HF API call.
+        resource_group_id, hf_private, _hf_cfg = resolve_hfpush_resource_group_id(
+            hfuri=hfuri,
+            assetstore=assetstore,
+            space_name=space_name,
+            storepush_config=storepush_config,
+            output_config=output_config,
+        )
 
         hfpush_config = Hfstore.build_hfpush_step_config(
             hfuri=hfuri,
@@ -2713,18 +2704,12 @@ class Skypilot(Environment):
             hf_private=hf_private,
             hf_resource_group_id=resource_group_id,
         )
-        if (
-            storepush_config is not None
-            and storepush_config.config is not None
-            and "hf" in storepush_config.config
-        ):
-            hfpush_config["hf"].update(storepush_config.config["hf"])
-        if (
-            output_config is not None
-            and output_config.store_push is not None
-            and "hf" in output_config.store_push.config
-        ):
-            hfpush_config["hf"].update(output_config.store_push.config["hf"])
+        # Apply remaining hf fields from the merged push config. Resolution-only
+        # keys are stripped so they never reach the worker's inline push, and the
+        # resolved resource_group_id is re-asserted so a pinned-but-skipped value
+        # cannot be resurrected by the overlay.
+        hfpush_config["hf"].update(sanitize_hf_step_overlay(_hf_cfg))
+        hfpush_config["hf"]["resource_group_id"] = resource_group_id
 
         hf_token = assetstore.resolve_token(hfuri) or ""
 

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -40,8 +40,8 @@ from tenacity import (
 from gbcommon.uri.uri import URI
 from gbserver.environment.environment import Environment, EventLogLineParserConfig
 from gbserver.spaces.resource_group import (
+    apply_hf_step_overlay,
     resolve_hfpush_resource_group_id,
-    sanitize_hf_step_overlay,
 )
 from gbserver.types.buildconfig import BuildTargetStepConfig
 from gbserver.types.buildevent import EntityRunMetadata
@@ -2704,12 +2704,10 @@ class Skypilot(Environment):
             hf_private=hf_private,
             hf_resource_group_id=resource_group_id,
         )
-        # Apply remaining hf fields from the merged push config. use_resource_group
-        # is stripped (consumed here, not by the worker), and the resolved
-        # resource_group_id is re-asserted so a pinned-but-skipped value cannot be
-        # resurrected by the overlay.
-        hfpush_config["hf"].update(sanitize_hf_step_overlay(_hf_cfg))
-        hfpush_config["hf"]["resource_group_id"] = resource_group_id
+        # Apply remaining hf fields from the merged push config (strips
+        # use_resource_group, re-asserts the resolved resource_group_id). Shared
+        # with k8s so the overlay invariants cannot drift between the two.
+        apply_hf_step_overlay(hfpush_config, _hf_cfg, resource_group_id)
 
         hf_token = assetstore.resolve_token(hfuri) or ""
 

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -175,15 +175,34 @@ def merge_hf_push_config(
         The merged ``hf`` config dict (empty when neither source supplies one).
     """
     merged: dict = {}
-    if storepush_config is not None and storepush_config.config:
-        hf_cfg = storepush_config.config.get("hf") or {}
-        if isinstance(hf_cfg, dict):
-            merged.update(hf_cfg)
-    if output_config is not None and output_config.store_push is not None:
-        hf_cfg = (output_config.store_push.config or {}).get("hf") or {}
-        if isinstance(hf_cfg, dict):
-            merged.update(hf_cfg)
+    for level in _hf_push_config_levels(storepush_config, output_config):
+        merged.update(level)
     return merged
+
+
+def _hf_push_config_levels(
+    storepush_config: Optional["StorePush"] = None,
+    output_config: Optional["BuildTargetOutputConfig"] = None,
+) -> Tuple[dict, dict]:
+    """Return the ``hf`` config from each level separately, lowest priority first.
+
+    ``(environment_level, output_level)``. Kept distinct from the merged view so
+    a per-output setting can be told apart from one inherited from the
+    environment — see the ``use_resource_group`` handling in
+    :func:`resolve_hfpush_resource_group_id`.
+    """
+
+    def _hf(config: Optional[dict]) -> dict:
+        hf_cfg = (config or {}).get("hf") or {}
+        return hf_cfg if isinstance(hf_cfg, dict) else {}
+
+    env_level = _hf(storepush_config.config) if storepush_config is not None else {}
+    output_level = (
+        _hf(output_config.store_push.config)
+        if output_config is not None and output_config.store_push is not None
+        else {}
+    )
+    return env_level, output_level
 
 
 def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
@@ -236,6 +255,7 @@ def resolve_hfpush_resource_group_id(
         ValueError: If a resource group is pinned for a non-Enterprise org, or
             if ``use_resource_group: false`` is combined with a pinned group.
     """
+    env_level, output_level = _hf_push_config_levels(storepush_config, output_config)
     hf_cfg = merge_hf_push_config(storepush_config, output_config)
     resource_group_id = hf_cfg.get("resource_group_id") or None
     resource_group_name = hf_cfg.get("resource_group_name") or None
@@ -259,11 +279,32 @@ def resolve_hfpush_resource_group_id(
         return None, private, hf_cfg
 
     if not use_resource_group:
+        # Only contradictory when the opt-out and the pinned group are written at
+        # the SAME level. A per-output `use_resource_group: false` deliberately
+        # overrides a group inherited from environment.yaml — otherwise an
+        # environment-level default (the documented level-3 fallback) would make
+        # the per-output opt-out impossible to use, and the error would tell the
+        # build author to remove a value they never wrote.
+        for level in (output_level, env_level):
+            if not level.get(USE_RESOURCE_GROUP_KEY, True) and (
+                level.get("resource_group_id") or level.get("resource_group_name")
+            ):
+                same_level_pin = level.get("resource_group_id") or level.get(
+                    "resource_group_name"
+                )
+                raise ValueError(
+                    f"'{USE_RESOURCE_GROUP_KEY}: false' cannot be combined with "
+                    f"an explicit resource group ('{same_level_pin}') in the same "
+                    f"push config for organization '{organization}'. Remove one "
+                    "of them."
+                )
         if pinned:
-            raise ValueError(
-                f"'{USE_RESOURCE_GROUP_KEY}: false' cannot be combined with an "
-                f"explicit resource group ('{pinned}') for organization "
-                f"'{organization}'. Remove one of them."
+            logger.info(
+                "'%s: false' overrides the inherited resource group '%s' for "
+                "organization '%s'",
+                USE_RESOURCE_GROUP_KEY,
+                pinned,
+                organization,
             )
         logger.info(
             "'%s: false' configured for organization '%s'; pushing without a "

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -206,9 +206,47 @@ def _hf_push_config_levels(
     return env_level, output_level
 
 
+def _private_from_hf_cfg(hf_cfg: dict) -> bool:
+    """Apply the ``private`` default to an already-merged ``hf`` config block.
+
+    The single definition of the rule, shared by
+    :func:`resolve_hfpush_resource_group_id` (which has the merged block in hand)
+    and :func:`resolve_hfpush_private` (which merges it first).
+    """
+    return parse_boolean(hf_cfg.get("private"), True)
+
+
 def _level_pin(level: dict) -> Optional[str]:
     """Return the resource group pinned at one config level, if any."""
     return level.get("resource_group_id") or level.get("resource_group_name") or None
+
+
+def resolve_hfpush_private(
+    storepush_config: Optional["StorePush"] = None,
+    output_config: Optional["BuildTargetOutputConfig"] = None,
+) -> bool:
+    """Resolve the ``private`` flag for an HF push from the merged push config.
+
+    Artifacts are private by default: HuggingFace's own ``create_repo`` default is
+    PUBLIC, so an unset/omitted value must resolve to ``True`` here to keep a user
+    from unintentionally publishing a model. Only an explicit falsy value
+    (``false``/``no``/``off``/``0``, quoted or not) opts into a public repo.
+
+    Split out of :func:`resolve_hfpush_resource_group_id` so a caller that cannot
+    classify the org (no ``Hfstore``, hence no Enterprise org list) can still honor
+    the flag without attempting resource group resolution.
+
+    Args:
+        storepush_config: Environment-level ``store_push`` (environment.yaml).
+        output_config: Per-output config whose ``store_push`` (build.yaml)
+            overrides the environment level.
+
+    Returns:
+        ``True`` for a private repo (the default), ``False`` only when explicitly
+        configured public.
+    """
+    hf_cfg = _merge_hf_levels(_hf_push_config_levels(storepush_config, output_config))
+    return _private_from_hf_cfg(hf_cfg)
 
 
 def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
@@ -271,7 +309,7 @@ def resolve_hfpush_resource_group_id(
     # stringifies as "None". parse_boolean also folds the quoted forms
     # ("false"/"no"/"off"/"0") onto False, so `private: "false"` means what it
     # says instead of being truthy as a non-empty string.
-    private = parse_boolean(hf_cfg.get("private"), True)
+    private = _private_from_hf_cfg(hf_cfg)
     use_resource_group = parse_boolean(hf_cfg.get(USE_RESOURCE_GROUP_KEY), True)
 
     organization = hfuri.get_owner()

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -176,7 +176,8 @@ def merge_hf_push_config(
     """
     merged: dict = {}
     for level in _hf_push_config_levels(storepush_config, output_config):
-        merged.update(level)
+        # A yaml null means "not set here", so it must not erase a lower level.
+        merged.update({k: v for k, v in level.items() if v is not None})
     return merged
 
 
@@ -203,6 +204,11 @@ def _hf_push_config_levels(
         else {}
     )
     return env_level, output_level
+
+
+def _bool_or(value: Optional[object], default: bool) -> bool:
+    """Return ``default`` when ``value`` is ``None`` (unset), else ``bool(value)``."""
+    return default if value is None else bool(value)
 
 
 def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
@@ -259,8 +265,10 @@ def resolve_hfpush_resource_group_id(
     hf_cfg = merge_hf_push_config(storepush_config, output_config)
     resource_group_id = hf_cfg.get("resource_group_id") or None
     resource_group_name = hf_cfg.get("resource_group_name") or None
-    private = hf_cfg.get("private", True)
-    use_resource_group = hf_cfg.get(USE_RESOURCE_GROUP_KEY, True)
+    # _bool_or, not .get(key, default): a null is present, so the default would
+    # not apply, and a None reaching a worker template stringifies as "None".
+    private = _bool_or(hf_cfg.get("private"), True)
+    use_resource_group = _bool_or(hf_cfg.get(USE_RESOURCE_GROUP_KEY), True)
 
     organization = hfuri.get_owner()
     enterprise = is_enterprise_hf_org(

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -41,13 +41,24 @@ the cache, or it would silently receive/poison the default id. So this module:
 id. The table read/write lives here.
 """
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from gbcommon.uri.hf import HF_HOST, HfURI
+from gbcommon.utils.hf_utils import is_enterprise_hf_org
 from gbserver.storage.singleton_storage import get_admin_storage
 from gbserver.utils.logger import get_logger
 
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from gbserver.asset.hfstore import Hfstore
+    from gbserver.types.buildconfig import BuildTargetOutputConfig
+    from gbserver.types.environmentconfig import StorePush
+
 logger = get_logger(__name__)
+
+# Key in a store_push ``config.hf`` block that opts an Enterprise org out of
+# resource groups. Consumed here and stripped before the config reaches a
+# worker step template.
+USE_RESOURCE_GROUP_KEY = "use_resource_group"
 
 
 def resolve_space_resource_group_id(
@@ -132,3 +143,147 @@ def resolve_space_resource_group_id(
         )
 
     return resolved_id
+
+
+def _non_enterprise_rg_error(organization: str, pinned: str) -> str:
+    """Build the error message for a resource group pinned on a non-Enterprise org."""
+    return (
+        f"Resource group '{pinned}' was configured for HuggingFace organization "
+        f"'{organization}', but '{organization}' is not an HF Enterprise "
+        "organization. Resource groups apply only to Enterprise organizations. "
+        "Remove store_push.config.hf.resource_group_id / resource_group_name, "
+        f"or add '{organization}' to enterprise_organizations in the hf asset "
+        "store's store.yaml."
+    )
+
+
+def merge_hf_push_config(
+    storepush_config: Optional["StorePush"] = None,
+    output_config: Optional["BuildTargetOutputConfig"] = None,
+) -> dict:
+    """Merge the ``hf`` push settings from the environment and build.yaml.
+
+    The environment-level ``storepush_config`` is applied first and the
+    per-output ``store_push`` from build.yaml overrides it, matching the
+    documented precedence in ``docs/builds/hf-push.md``.
+
+    Args:
+        storepush_config: Environment-level push configuration.
+        output_config: Per-output configuration from build.yaml.
+
+    Returns:
+        The merged ``hf`` config dict (empty when neither source supplies one).
+    """
+    merged: dict = {}
+    if storepush_config is not None and storepush_config.config:
+        hf_cfg = storepush_config.config.get("hf") or {}
+        if isinstance(hf_cfg, dict):
+            merged.update(hf_cfg)
+    if output_config is not None and output_config.store_push is not None:
+        hf_cfg = (output_config.store_push.config or {}).get("hf") or {}
+        if isinstance(hf_cfg, dict):
+            merged.update(hf_cfg)
+    return merged
+
+
+def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
+    """Drop keys that must never reach a worker step's ``hfpush_config``.
+
+    ``use_resource_group`` is consumed during resolution (it opts an Enterprise
+    org out of resource groups); leaking it verbatim into the emitted step
+    config would hand the LSF/Helm/SkyPilot templates a key they do not
+    understand.
+
+    Args:
+        hf_cfg: An ``hf`` config dict from a push configuration.
+
+    Returns:
+        A copy without the resolution-only keys.
+    """
+    return {k: v for k, v in (hf_cfg or {}).items() if k != USE_RESOURCE_GROUP_KEY}
+
+
+def resolve_hfpush_resource_group_id(
+    hfuri: HfURI,
+    assetstore: "Hfstore",
+    space_name: Optional[str],
+    storepush_config: Optional["StorePush"] = None,
+    output_config: Optional["BuildTargetOutputConfig"] = None,
+) -> Tuple[Optional[str], bool, dict]:
+    """Resolve the HF resource group id for a push, honoring the Enterprise split.
+
+    Resource groups exist only in HF Enterprise organizations. Which orgs are
+    Enterprise is configuration-driven (``enterprise_organizations`` in the hf
+    asset store's ``store.yaml``) because no non-admin HF API distinguishes an
+    Enterprise org from an individual user namespace.
+
+    For a non-Enterprise org this skips resource group resolution entirely: no
+    HF API call, no space lookup, and nothing cached.
+
+    Args:
+        hfuri: Target HuggingFace URI; its owner is the organization.
+        assetstore: The ``Hfstore`` supplying the token and the Enterprise list.
+        space_name: GB space name used to derive the default resource group.
+        storepush_config: Environment-level push configuration (lower priority).
+        output_config: Per-output build.yaml configuration (higher priority).
+
+    Returns:
+        A ``(resource_group_id, private, hf_config)`` tuple, where
+        ``resource_group_id`` is ``None`` when no resource group applies and
+        ``hf_config`` is the merged ``hf`` settings for logging/overlay use.
+
+    Raises:
+        ValueError: If a resource group is pinned for a non-Enterprise org, or
+            if ``use_resource_group: false`` is combined with a pinned group.
+    """
+    hf_cfg = merge_hf_push_config(storepush_config, output_config)
+    resource_group_id = hf_cfg.get("resource_group_id") or None
+    resource_group_name = hf_cfg.get("resource_group_name") or None
+    private = hf_cfg.get("private", True)
+    use_resource_group = hf_cfg.get(USE_RESOURCE_GROUP_KEY, True)
+
+    organization = hfuri.get_owner()
+    enterprise = is_enterprise_hf_org(
+        organization, assetstore.get_enterprise_organizations()
+    )
+    pinned = resource_group_id or resource_group_name
+
+    if not enterprise:
+        if pinned:
+            raise ValueError(_non_enterprise_rg_error(organization, pinned))
+        logger.info(
+            "HuggingFace organization '%s' is not an Enterprise org; "
+            "skipping resource group resolution",
+            organization,
+        )
+        return None, private, hf_cfg
+
+    if not use_resource_group:
+        if pinned:
+            raise ValueError(
+                f"'{USE_RESOURCE_GROUP_KEY}: false' cannot be combined with an "
+                f"explicit resource group ('{pinned}') for organization "
+                f"'{organization}'. Remove one of them."
+            )
+        logger.info(
+            "'%s: false' configured for organization '%s'; pushing without a "
+            "resource group",
+            USE_RESOURCE_GROUP_KEY,
+            organization,
+        )
+        return None, private, hf_cfg
+
+    if resource_group_id:
+        # A caller-pinned id is used verbatim and never routed through
+        # resolve_space_resource_group_id, whose cache represents only the
+        # space's default group.
+        return resource_group_id, private, hf_cfg
+
+    resolved_id = resolve_space_resource_group_id(
+        space_name=space_name,
+        organization=organization,
+        token=assetstore.resolve_token(hfuri),
+        resource_group_name=resource_group_name,
+        host=hfuri.get_host(),
+    )
+    return resolved_id, private, hf_cfg

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -174,8 +174,13 @@ def merge_hf_push_config(
     Returns:
         The merged ``hf`` config dict (empty when neither source supplies one).
     """
+    return _merge_hf_levels(_hf_push_config_levels(storepush_config, output_config))
+
+
+def _merge_hf_levels(levels: Tuple[dict, dict]) -> dict:
+    """Merge already-parsed ``hf`` config levels, lowest priority first."""
     merged: dict = {}
-    for level in _hf_push_config_levels(storepush_config, output_config):
+    for level in levels:
         # A yaml null means "not set here", so it must not erase a lower level.
         merged.update({k: v for k, v in level.items() if v is not None})
     return merged
@@ -204,6 +209,11 @@ def _hf_push_config_levels(
         else {}
     )
     return env_level, output_level
+
+
+def _level_pin(level: dict) -> Optional[str]:
+    """Return the resource group pinned at one config level, if any."""
+    return level.get("resource_group_id") or level.get("resource_group_name") or None
 
 
 def _bool_or(value: Optional[object], default: bool) -> bool:
@@ -261,8 +271,9 @@ def resolve_hfpush_resource_group_id(
         ValueError: If a resource group is pinned for a non-Enterprise org, or
             if ``use_resource_group: false`` is combined with a pinned group.
     """
-    env_level, output_level = _hf_push_config_levels(storepush_config, output_config)
-    hf_cfg = merge_hf_push_config(storepush_config, output_config)
+    levels = _hf_push_config_levels(storepush_config, output_config)
+    env_level, output_level = levels
+    hf_cfg = _merge_hf_levels(levels)
     resource_group_id = hf_cfg.get("resource_group_id") or None
     resource_group_name = hf_cfg.get("resource_group_name") or None
     # _bool_or, not .get(key, default): a null is present, so the default would
@@ -287,40 +298,45 @@ def resolve_hfpush_resource_group_id(
         return None, private, hf_cfg
 
     if not use_resource_group:
-        # Only contradictory when the opt-out and the pinned group are written at
-        # the SAME level. A per-output `use_resource_group: false` deliberately
-        # overrides a group inherited from environment.yaml — otherwise an
-        # environment-level default (the documented level-3 fallback) would make
-        # the per-output opt-out impossible to use, and the error would tell the
-        # build author to remove a value they never wrote.
+        # Same-level opt-out plus pin is contradictory; across levels the higher
+        # one wins, per the precedence in docs/builds/hf-push.md.
         for level in (output_level, env_level):
-            if not level.get(USE_RESOURCE_GROUP_KEY, True) and (
-                level.get("resource_group_id") or level.get("resource_group_name")
+            if not _bool_or(level.get(USE_RESOURCE_GROUP_KEY), True) and _level_pin(
+                level
             ):
-                same_level_pin = level.get("resource_group_id") or level.get(
-                    "resource_group_name"
-                )
                 raise ValueError(
                     f"'{USE_RESOURCE_GROUP_KEY}: false' cannot be combined with "
-                    f"an explicit resource group ('{same_level_pin}') in the same "
-                    f"push config for organization '{organization}'. Remove one "
-                    "of them."
+                    f"an explicit resource group ('{_level_pin(level)}') in the "
+                    f"same push config for organization '{organization}'. Remove "
+                    "one of them."
                 )
-        if pinned:
+        output_pin = _level_pin(output_level)
+        if output_pin and _bool_or(output_level.get(USE_RESOURCE_GROUP_KEY), True):
+            # build.yaml outranks environment.yaml, so a pin here re-enables
+            # resource groups over an inherited opt-out.
             logger.info(
-                "'%s: false' overrides the inherited resource group '%s' for "
-                "organization '%s'",
+                "output-level resource group '%s' overrides the inherited "
+                "'%s: false' for organization '%s'",
+                output_pin,
                 USE_RESOURCE_GROUP_KEY,
-                pinned,
                 organization,
             )
-        logger.info(
-            "'%s: false' configured for organization '%s'; pushing without a "
-            "resource group",
-            USE_RESOURCE_GROUP_KEY,
-            organization,
-        )
-        return None, private, hf_cfg
+        else:
+            if pinned:
+                logger.info(
+                    "'%s: false' overrides the inherited resource group '%s' for "
+                    "organization '%s'",
+                    USE_RESOURCE_GROUP_KEY,
+                    pinned,
+                    organization,
+                )
+            logger.info(
+                "'%s: false' configured for organization '%s'; pushing without a "
+                "resource group",
+                USE_RESOURCE_GROUP_KEY,
+                organization,
+            )
+            return None, private, hf_cfg
 
     if resource_group_id:
         # A caller-pinned id is used verbatim and never routed through

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -157,26 +157,6 @@ def _non_enterprise_rg_error(organization: str, pinned: str) -> str:
     )
 
 
-def merge_hf_push_config(
-    storepush_config: Optional["StorePush"] = None,
-    output_config: Optional["BuildTargetOutputConfig"] = None,
-) -> dict:
-    """Merge the ``hf`` push settings from the environment and build.yaml.
-
-    The environment-level ``storepush_config`` is applied first and the
-    per-output ``store_push`` from build.yaml overrides it, matching the
-    documented precedence in ``docs/builds/hf-push.md``.
-
-    Args:
-        storepush_config: Environment-level push configuration.
-        output_config: Per-output configuration from build.yaml.
-
-    Returns:
-        The merged ``hf`` config dict (empty when neither source supplies one).
-    """
-    return _merge_hf_levels(_hf_push_config_levels(storepush_config, output_config))
-
-
 def _merge_hf_levels(levels: Tuple[dict, dict]) -> dict:
     """Merge already-parsed ``hf`` config levels, lowest priority first."""
     merged: dict = {}

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -43,6 +43,7 @@ id. The table read/write lives here.
 
 from typing import TYPE_CHECKING, Optional, Tuple
 
+from gbcommon.types.gbenvconfig import parse_boolean
 from gbcommon.uri.hf import HF_HOST, HfURI
 from gbcommon.utils.hf_utils import is_enterprise_hf_org
 from gbserver.storage.singleton_storage import get_admin_storage
@@ -210,11 +211,6 @@ def _level_pin(level: dict) -> Optional[str]:
     return level.get("resource_group_id") or level.get("resource_group_name") or None
 
 
-def _bool_or(value: Optional[object], default: bool) -> bool:
-    """Return ``default`` when ``value`` is ``None`` (unset), else ``bool(value)``."""
-    return default if value is None else bool(value)
-
-
 def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
     """Drop keys that must never reach a worker step's ``hfpush_config``.
 
@@ -270,10 +266,13 @@ def resolve_hfpush_resource_group_id(
     hf_cfg = _merge_hf_levels(levels)
     resource_group_id = hf_cfg.get("resource_group_id") or None
     resource_group_name = hf_cfg.get("resource_group_name") or None
-    # _bool_or, not .get(key, default): a null is present, so the default would
-    # not apply, and a None reaching a worker template stringifies as "None".
-    private = _bool_or(hf_cfg.get("private"), True)
-    use_resource_group = _bool_or(hf_cfg.get(USE_RESOURCE_GROUP_KEY), True)
+    # parse_boolean, not .get(key, default): a yaml null is a *present* key, so
+    # .get's default would not apply and a None reaching a worker template
+    # stringifies as "None". parse_boolean also folds the quoted forms
+    # ("false"/"no"/"off"/"0") onto False, so `private: "false"` means what it
+    # says instead of being truthy as a non-empty string.
+    private = parse_boolean(hf_cfg.get("private"), True)
+    use_resource_group = parse_boolean(hf_cfg.get(USE_RESOURCE_GROUP_KEY), True)
 
     organization = hfuri.get_owner()
     enterprise = is_enterprise_hf_org(
@@ -295,9 +294,9 @@ def resolve_hfpush_resource_group_id(
         # Same-level opt-out plus pin is contradictory; across levels the higher
         # one wins, per the precedence in docs/builds/hf-push.md.
         for level in (output_level, env_level):
-            if not _bool_or(level.get(USE_RESOURCE_GROUP_KEY), True) and _level_pin(
-                level
-            ):
+            if not parse_boolean(
+                level.get(USE_RESOURCE_GROUP_KEY), True
+            ) and _level_pin(level):
                 raise HfPushConfigError(
                     f"'{USE_RESOURCE_GROUP_KEY}: false' cannot be combined with "
                     f"an explicit resource group ('{_level_pin(level)}') in the "
@@ -305,7 +304,7 @@ def resolve_hfpush_resource_group_id(
                     "one of them."
                 )
         output_pin = _level_pin(output_level)
-        if output_pin and _bool_or(output_level.get(USE_RESOURCE_GROUP_KEY), True):
+        if output_pin and parse_boolean(output_level.get(USE_RESOURCE_GROUP_KEY), True):
             # build.yaml outranks environment.yaml, so a pin here re-enables
             # resource groups over an inherited opt-out.
             logger.info(

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -266,6 +266,31 @@ def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
     return {k: v for k, v in (hf_cfg or {}).items() if k != USE_RESOURCE_GROUP_KEY}
 
 
+def apply_hf_step_overlay(
+    hfpush_config: dict, hf_cfg: dict, resource_group_id: Optional[str]
+) -> None:
+    """Overlay the raw ``hf`` push config onto a built step config, in place.
+
+    Shared by the k8s and skypilot launchers, which build an ``hfpush_config``
+    with :meth:`Hfstore.build_hfpush_step_config` and then fold the remaining
+    ``hf`` keys from the merged push config over it. Two invariants the callers
+    must not get subtly wrong, kept here so they cannot drift between the two
+    environments:
+
+    - ``use_resource_group`` is stripped (:func:`sanitize_hf_step_overlay`); it
+      is consumed during resolution, not by the worker template.
+    - the resolved ``resource_group_id`` is re-asserted *after* the overlay, so
+      a stray pinned-but-skipped id in the raw config cannot be resurrected.
+
+    Args:
+        hfpush_config: The step config dict; its ``hf`` sub-dict is mutated.
+        hf_cfg: The raw merged ``hf`` push config to overlay.
+        resource_group_id: The resolved id (or ``None``) to re-assert last.
+    """
+    hfpush_config["hf"].update(sanitize_hf_step_overlay(hf_cfg))
+    hfpush_config["hf"]["resource_group_id"] = resource_group_id
+
+
 def resolve_hfpush_resource_group_id(
     hfuri: HfURI,
     assetstore: "Hfstore",

--- a/src/gbserver/spaces/resource_group.py
+++ b/src/gbserver/spaces/resource_group.py
@@ -61,6 +61,20 @@ logger = get_logger(__name__)
 USE_RESOURCE_GROUP_KEY = "use_resource_group"
 
 
+class HfPushConfigError(ValueError):
+    """A push config asks for something the target organization cannot honor.
+
+    Raised for a *configuration* mistake that resolution cannot work around: a
+    resource group pinned for a non-Enterprise org, or a pin combined with
+    ``use_resource_group: false`` at the same level. Distinct from a resolution
+    *miss* (a non-admin token that cannot read the org's resource groups), which
+    is expected on the standalone path and must not abort a best-effort push.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` callers keep
+    working; callers that need to tell the two apart catch this type instead.
+    """
+
+
 def resolve_space_resource_group_id(
     space_name: Optional[str],
     organization: str,
@@ -269,7 +283,7 @@ def resolve_hfpush_resource_group_id(
 
     if not enterprise:
         if pinned:
-            raise ValueError(_non_enterprise_rg_error(organization, pinned))
+            raise HfPushConfigError(_non_enterprise_rg_error(organization, pinned))
         logger.info(
             "HuggingFace organization '%s' is not an Enterprise org; "
             "skipping resource group resolution",
@@ -284,7 +298,7 @@ def resolve_hfpush_resource_group_id(
             if not _bool_or(level.get(USE_RESOURCE_GROUP_KEY), True) and _level_pin(
                 level
             ):
-                raise ValueError(
+                raise HfPushConfigError(
                     f"'{USE_RESOURCE_GROUP_KEY}: false' cannot be combined with "
                     f"an explicit resource group ('{_level_pin(level)}') in the "
                     f"same push config for organization '{organization}'. Remove "

--- a/test-data/e2e/standalone/standalone-quickstart/assetstores/hf/store.yaml
+++ b/test-data/e2e/standalone/standalone-quickstart/assetstores/hf/store.yaml
@@ -1,8 +1,10 @@
-# HuggingFace Hub
-# Required secrets (set via environment variables or space secret manager):
-#   HF_TOKEN  — HuggingFace access token (optional for public repos)
-#
-# Example URI: hf:///google-bert/bert-base-uncased
 base_uri: "hf:/"
 config:
   token_secretname: HF_TOKEN
+  # Enterprise orgs for the standalone test environment. Any other org (e.g. an
+  # individual user namespace) skips HF resource groups entirely.
+  # Omitting this key would treat every org as Enterprise. See
+  # docs/builds/hf-push.md.
+  enterprise_organizations:
+    - ibm-research
+    - ibm-granite

--- a/test-data/standalone-environments/assetstores/hf/store.yaml
+++ b/test-data/standalone-environments/assetstores/hf/store.yaml
@@ -1,3 +1,10 @@
 base_uri: "hf:/"
 config:
   token_secretname: HF_TOKEN
+  # Enterprise orgs for the standalone test environment. Any other org (e.g. an
+  # individual user namespace) skips HF resource groups entirely.
+  # Omitting this key would treat every org as Enterprise. See
+  # docs/builds/hf-push.md.
+  enterprise_organizations:
+    - ibm-research
+    - ibm-granite

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,6 +61,7 @@ import libgbtest.constants
 from libgbtest.constants import BUILD_ID_PATTERN
 
 import gbserver.types.constants
+from gbcommon.types.testing import ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT
 from gbserver.storage.artifact_registration import ArtifactRegistration
 from gbserver.storage.stored_build import StoredBuild
 from gbserver.storage.stored_step_run import StoredStepRun
@@ -323,6 +324,19 @@ def pytest_sessionstart(session):
 
     test_mode = get_test_mode()
     logger.info(f"GBTEST_MODE={test_mode}")
+
+    # Redirect STANDALONE HF resource-group pushes to the staging group for the
+    # whole pytest session. This belongs to the test runner, not to a Makefile
+    # target: the source default is empty (the production gbspace-public, which
+    # is what a real standalone user must get), and a bare `pytest test/unit`
+    # would otherwise aim a live push at the production group. setdefault, so an
+    # explicit value from the caller's environment still wins.
+    os.environ.setdefault(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, "STAGING")
+    logger.info(
+        "%s=%s",
+        ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT,
+        os.environ[ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT],
+    )
 
     if test_mode != "live":
         # Mock mode: apply placeholder env vars so modules can import safely

--- a/test/unit/asset/test_hfstore.py
+++ b/test/unit/asset/test_hfstore.py
@@ -184,3 +184,147 @@ class TestSkypilotHfpushStepParity:
         assert "hf upload" not in cfg["run"]
         # CLI extra dropped since the upload is done via HfApi now.
         assert "[cli]" not in cfg["setup"]
+
+
+class TestHfstoreEnterpriseOrganizations:
+    """``enterprise_organizations`` from store.yaml drives the Enterprise split."""
+
+    @staticmethod
+    def _store(store_config):
+        from gbserver.types.assetstoreconfig import AssetStoreConfig
+
+        return Hfstore(AssetStoreConfig(**store_config))
+
+    def test_absent_key_returns_none(self):
+        """None (not []) so callers keep the pre-split "all Enterprise" behavior."""
+        store = self._store({"base_uri": "hf:/", "config": {"token_secretname": "T"}})
+        assert store.get_enterprise_organizations() is None
+
+    def test_absent_config_block_returns_none(self):
+        store = self._store({"base_uri": "hf:/"})
+        assert store.get_enterprise_organizations() is None
+
+    def test_no_store_config_returns_none(self):
+        """A store built without a config (e.g. ad-hoc) must not blow up."""
+        assert Hfstore(None).get_enterprise_organizations() is None
+
+    def test_returns_configured_list(self):
+        store = self._store(
+            {
+                "base_uri": "hf:/",
+                "config": {"enterprise_organizations": ["ibm-research", "ibm-granite"]},
+            }
+        )
+        assert store.get_enterprise_organizations() == ["ibm-research", "ibm-granite"]
+
+    def test_explicit_empty_list_is_preserved(self):
+        """[] is a real opt-out and must not collapse to None."""
+        store = self._store(
+            {"base_uri": "hf:/", "config": {"enterprise_organizations": []}}
+        )
+        assert store.get_enterprise_organizations() == []
+
+    def test_explicit_null_returns_none(self):
+        store = self._store(
+            {"base_uri": "hf:/", "config": {"enterprise_organizations": None}}
+        )
+        assert store.get_enterprise_organizations() is None
+
+    def test_non_list_raises(self):
+        import pytest
+
+        store = self._store(
+            {"base_uri": "hf:/", "config": {"enterprise_organizations": "ibm-research"}}
+        )
+        with pytest.raises(ValueError, match="must be a list"):
+            store.get_enterprise_organizations()
+
+    def test_shipped_store_yaml_declares_enterprise_orgs(self):
+        """Guard the shipped standalone config against accidental removal."""
+        path = (
+            Path(__file__).resolve().parents[3]
+            / "configurations"
+            / "assets"
+            / "assetstores"
+            / "hf"
+            / "store.yaml"
+        )
+        cfg = yaml.safe_load(path.read_text())
+        orgs = cfg["config"]["enterprise_organizations"]
+        assert "ibm-research" in orgs
+        assert "ibm-granite" in orgs
+
+
+class TestLsfHfpushNoResourceGroup:
+    """The LSF hfpush script must omit resourceGroupId when there is no group.
+
+    Jinja renders a Python ``None`` as the literal string ``"None"``, which is
+    non-empty to bash — without normalization the worker would POST
+    ``"resourceGroupId":"None"`` and the HF create call would fail. This is the
+    common case now that non-Enterprise orgs resolve to no resource group.
+    """
+
+    @staticmethod
+    def _command_sh() -> str:
+        return (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "gbserver"
+            / "builtins"
+            / "steps"
+            / "lsf"
+            / "hfpush"
+            / "lsf_scripts"
+            / "hfpush"
+            / "command.sh"
+        ).read_text()
+
+    def test_script_normalizes_literal_none(self):
+        """The guard that maps the rendered "None" back to empty is present."""
+        sh = self._command_sh()
+        assert '"${HF_RESOURCE_GROUP_ID}" == "None"' in sh
+        assert 'HF_RESOURCE_GROUP_ID=""' in sh
+
+    def test_create_body_omits_resource_group_when_none(self):
+        """Render with resource_group_id=None and run the resulting bash logic."""
+        import subprocess
+
+        from gbserver.utils.template import fill_template
+
+        rendered = fill_template(
+            self._command_sh(),
+            {
+                "config": {
+                    "hfpush_config": {
+                        "hf": {"resource_group_id": None, "type": "model"},
+                        "endpoint": "https://huggingface.co",
+                        "owner": "my-user",
+                        "repo": "my-model",
+                        "revision": "main",
+                        "private": True,
+                        "binding_id": "b",
+                        "path": "/tmp/x",
+                        "uri": "hf:///my-user/my-model",
+                    }
+                }
+            },
+        )
+        # Sanity: the raw render really does produce the literal "None".
+        assert "HF_RESOURCE_GROUP_ID='None'" in rendered
+
+        assigns = [
+            line
+            for line in rendered.splitlines()
+            if line.startswith(("HF_RESOURCE_GROUP_ID=", "HF_OWNER=", "HF_TYPE="))
+            or line.startswith("HF_REPO_NAME=")
+        ]
+        snippet = "\n".join(assigns) + (
+            '\nif [[ "${HF_RESOURCE_GROUP_ID}" == "None" ]]; then'
+            ' HF_RESOURCE_GROUP_ID=""; fi\n'
+            'if [[ -n "${HF_RESOURCE_GROUP_ID}" ]]; then echo WITH_RG;'
+            " else echo WITHOUT_RG; fi"
+        )
+        result = subprocess.run(
+            ["bash", "-c", snippet], capture_output=True, text=True, check=True
+        )
+        assert result.stdout.strip() == "WITHOUT_RG"

--- a/test/unit/asset/test_hfstore.py
+++ b/test/unit/asset/test_hfstore.py
@@ -134,6 +134,28 @@ class TestHfstoreStepConfigPathInRepo:
         assert cfg["hf"]["type"] == "bucket"
         assert cfg["path_in_repo"] == ""
 
+    def test_private_only_at_top_level_not_nested(self):
+        """``private`` must live only at the top level, never inside ``hf``.
+
+        Every step template reads ``hfpush_config.private``; none reads
+        ``hf.private``. Duplicating it into the nested block is a trap: the
+        k8s/skypilot overlay rewrites ``hf.*`` from the raw push config without
+        re-resolving ``private``, so a nested copy would silently carry the
+        unresolved value. Guard that it stays absent.
+        """
+        for private in (True, False):
+            uri = HfURI.from_parts(
+                owner="org", repo="my-model", hf_type=HfType.MODEL
+            )
+            cfg = Hfstore.build_hfpush_step_config(
+                hfuri=uri,
+                binding_path="/tmp/x",
+                binding_id="b-1",
+                hf_private=private,
+            )
+            assert cfg["private"] is private
+            assert "private" not in cfg["hf"]
+
 
 class TestSkypilotHfpushStepParity:
     """Guard against drift between the skypilot hfpush step's inline python and

--- a/test/unit/asset/test_hfstore.py
+++ b/test/unit/asset/test_hfstore.py
@@ -324,3 +324,57 @@ class TestLsfHfpushNoResourceGroup:
             ["bash", "-c", snippet], capture_output=True, text=True, check=True
         )
         assert result.stdout.strip() == "WITHOUT_RG"
+
+
+class TestEnterpriseOrgListParity:
+    """The CLI and server Enterprise lists must agree.
+
+    The list is maintained in two places by necessity: the server reads
+    `config.enterprise_organizations` from the hf asset store's store.yaml (which
+    lives in a space's git repo), and the CLI cannot read that file, so it carries
+    the same list on GBEnvConfig. If they diverge, the CLI and server disagree on
+    whether an org is Enterprise — the CLI would reject a --resource-group-id the
+    server requires, or vice versa. Only the shipped standalone store.yaml can be
+    checked here; a remote space's copy is outside the repo.
+    """
+
+    @staticmethod
+    def _shipped_store_orgs() -> list:
+        path = (
+            Path(__file__).resolve().parents[3]
+            / "configurations"
+            / "assets"
+            / "assetstores"
+            / "hf"
+            / "store.yaml"
+        )
+        return yaml.safe_load(path.read_text())["config"]["enterprise_organizations"]
+
+    def test_shipped_store_yaml_matches_every_environment_config(self):
+        from gbcommon.types.gbenvconfig import _GB_ENVIRONMENT_CONFIGS
+
+        expected = self._shipped_store_orgs()
+        for env, config in _GB_ENVIRONMENT_CONFIGS.items():
+            assert config.hf_enterprise_organizations == expected, (
+                f"{env}'s hf_enterprise_organizations "
+                f"({config.hf_enterprise_organizations}) does not match "
+                f"enterprise_organizations in the shipped hf store.yaml "
+                f"({expected}) — update both together"
+            )
+
+    def test_cli_constant_matches_the_shipped_store_yaml(self):
+        """The value gbcli actually reads, not just the config it comes from."""
+        from gbcli.utils.gbconstants import HF_ENTERPRISE_ORGANIZATIONS
+
+        assert HF_ENTERPRISE_ORGANIZATIONS == self._shipped_store_orgs()
+
+    def test_both_sides_classify_the_same_orgs(self):
+        """Parity where it matters: the classifier agrees for either source."""
+        from gbcli.utils.gbconstants import HF_ENTERPRISE_ORGANIZATIONS
+        from gbcommon.utils.hf_utils import is_enterprise_hf_org
+
+        store_orgs = self._shipped_store_orgs()
+        for org in (*store_orgs, "my-user", "some-community-org", ""):
+            assert is_enterprise_hf_org(org, HF_ENTERPRISE_ORGANIZATIONS) == (
+                is_enterprise_hf_org(org, store_orgs)
+            ), f"CLI and server disagree on '{org}'"

--- a/test/unit/asset/test_hfstore.py
+++ b/test/unit/asset/test_hfstore.py
@@ -1,12 +1,16 @@
 """Tests for Hfstore, covering bucket-specific behaviour."""
 
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 from gbcommon.uri.hf import HfType, HfURI
 from gbserver.asset.hfstore import Hfstore
 from gbserver.types.artifact import ArtifactType
+from gbserver.types.assetstoreconfig import AssetStoreConfig
+from gbserver.utils.template import fill_template
 
 
 class TestHfstoreAssetType:
@@ -191,8 +195,6 @@ class TestHfstoreEnterpriseOrganizations:
 
     @staticmethod
     def _store(store_config):
-        from gbserver.types.assetstoreconfig import AssetStoreConfig
-
         return Hfstore(AssetStoreConfig(**store_config))
 
     def test_absent_key_returns_none(self):
@@ -231,8 +233,6 @@ class TestHfstoreEnterpriseOrganizations:
         assert store.get_enterprise_organizations() is None
 
     def test_non_list_raises(self):
-        import pytest
-
         store = self._store(
             {"base_uri": "hf:/", "config": {"enterprise_organizations": "ibm-research"}}
         )
@@ -287,10 +287,6 @@ class TestLsfHfpushNoResourceGroup:
 
     def test_create_body_omits_resource_group_when_none(self):
         """Render with resource_group_id=None and run the resulting bash logic."""
-        import subprocess
-
-        from gbserver.utils.template import fill_template
-
         rendered = fill_template(
             self._command_sh(),
             {

--- a/test/unit/asset/test_hfstore.py
+++ b/test/unit/asset/test_hfstore.py
@@ -144,9 +144,7 @@ class TestHfstoreStepConfigPathInRepo:
         unresolved value. Guard that it stays absent.
         """
         for private in (True, False):
-            uri = HfURI.from_parts(
-                owner="org", repo="my-model", hf_type=HfType.MODEL
-            )
+            uri = HfURI.from_parts(owner="org", repo="my-model", hf_type=HfType.MODEL)
             cfg = Hfstore.build_hfpush_step_config(
                 hfuri=uri,
                 binding_path="/tmp/x",

--- a/test/unit/environment/test_bash_hfstore.py
+++ b/test/unit/environment/test_bash_hfstore.py
@@ -109,12 +109,16 @@ async def test_pushasset_hfstore_pushes_binding_path(bash_env):
         )
 
     # The bash binding path is already a host path — passed straight through.
+    # The push configs are forwarded (None here) so store_push settings reach the
+    # shared helper; bash/docker have no hfpush step to carry them otherwise.
     mock_push.assert_called_once_with(
         src="/workspace/output/model",
         binding_id="hf_output",
         uri=uri,
         assetstore=assetstore,
         run_metadata=run_metadata,
+        storepush_config=None,
+        output_config=None,
     )
     assert result is uri
 

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -560,3 +560,39 @@ def test_pull_asset_hfstore_bucket_cache_path_omits_revision(tmp_path):
         result = pull_asset_hfstore(uri, store, sc)
 
     assert result == tmp_path / "cache" / "org" / "my-bucket"
+
+
+@pytest.mark.asyncio
+async def test_push_asset_hfstore_tolerates_non_hfstore_assetstore(tmp_path):
+    """A non-Hfstore assetstore must not abort the push.
+
+    ``get_enterprise_organizations()`` is declared only on ``Hfstore``, and this
+    inline path (shared by the Bash and Docker environments) has no isinstance
+    assert — so reading it directly would turn any other assetstore into a fatal
+    AttributeError on a best-effort code path. Absent the list we fall back to
+    None, which ``is_enterprise_hf_org`` treats as "every org is Enterprise",
+    i.e. the pre-split behavior.
+    """
+    src = tmp_path / "model.bin"
+    src.write_bytes(b"weights")
+    # A double WITHOUT get_enterprise_organizations (spec= omits it).
+    store = MagicMock(spec=["get_secrets", "resolve_token"])
+    store.get_secrets.return_value = {"HF_TOKEN": "tok"}
+    store.resolve_token.return_value = "tok"
+    uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+    with (
+        patch(
+            "gbserver.environment.local_assets.resolve_space_resource_group_id",
+            return_value="rg-id",
+        ) as mock_resolve,
+        patch.object(HfURI, "push", return_value=True) as mock_push,
+    ):
+        result = push_asset_hfstore(
+            src=str(src), binding_id="out", uri=uri, assetstore=store
+        )
+
+    assert result is uri
+    # None => treated as Enterprise, so resolution still runs (pre-split behavior).
+    mock_resolve.assert_called_once()
+    assert mock_push.call_args.kwargs["resource_group_id"] == "rg-id"

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gbcommon.uri.hf import HfType, HfURI
+from gbserver.asset.hfstore import Hfstore
 from gbserver.environment.docker import Docker
 from gbserver.environment.environment import BINDING_KEY
 from gbserver.environment.local_assets import (
@@ -596,3 +597,75 @@ async def test_push_asset_hfstore_tolerates_non_hfstore_assetstore(tmp_path):
     # None => treated as Enterprise, so resolution still runs (pre-split behavior).
     mock_resolve.assert_called_once()
     assert mock_push.call_args.kwargs["resource_group_id"] == "rg-id"
+
+
+@pytest.mark.asyncio
+async def test_push_asset_hfstore_honors_store_push_use_resource_group(tmp_path):
+    """The inline path must honor store_push, like the step-based environments.
+
+    bash/docker have no hfpush step, so `store_push.config.hf` reaches HF only if
+    they forward it into push_asset_hfstore. Without that, documented build.yaml
+    fields (use_resource_group / resource_group_id / resource_group_name) are
+    silently dropped on exactly the two environments where the non-Enterprise use
+    case lives.
+    """
+    from gbserver.types.assetstoreconfig import AssetStoreConfig
+
+    src = tmp_path / "model.bin"
+    src.write_bytes(b"weights")
+    store = Hfstore(
+        AssetStoreConfig(base_uri="hf:/", config={"enterprise_organizations": ["org"]})
+    )
+    store.resolve_token = lambda uri: "tok"  # type: ignore[method-assign]
+    store.get_secrets = lambda: {"HF_TOKEN": "tok"}  # type: ignore[method-assign]
+
+    output_config = MagicMock()
+    output_config.store_push = MagicMock()
+    output_config.store_push.config = {"hf": {"use_resource_group": False}}
+
+    uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+    with (
+        patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="should-not-be-used",
+        ) as mock_resolve,
+        patch.object(HfURI, "push", return_value=True) as mock_push,
+    ):
+        push_asset_hfstore(
+            src=str(src),
+            binding_id="out",
+            uri=uri,
+            assetstore=store,
+            output_config=output_config,
+        )
+
+    assert mock_push.call_args.kwargs["resource_group_id"] is None
+    mock_resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_docker_pushasset_forwards_push_configs(docker_env, tmp_path):
+    """docker.pushasset_hfstore must forward both push configs to the helper."""
+    src = tmp_path / "m.bin"
+    src.write_bytes(b"w")
+    storepush_config = MagicMock()
+    storepush_config.mode = "default"
+    storepush_config.config = {"hf": {"private": False}}
+    output_config = MagicMock()
+    output_config.store_push = MagicMock()
+    output_config.store_push.config = {"hf": {"resource_group_id": "rg-out"}}
+
+    with patch(
+        "gbserver.environment.docker.push_asset_hfstore", return_value=None
+    ) as mock_helper:
+        await docker_env.pushasset_hfstore(
+            binding={"path": str(src)},
+            uri=HfURI.from_parts(owner="org", repo="r"),
+            assetstore=MagicMock(),
+            storepush_config=storepush_config,
+            output_config=output_config,
+        )
+
+    kwargs = mock_helper.call_args.kwargs
+    assert kwargs["storepush_config"] is storepush_config
+    assert kwargs["output_config"] is output_config

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -268,6 +268,7 @@ async def test_pushasset_hfstore_calls_hfuri_push(
     mock_push.assert_called_once_with(
         src,
         commit_message="Upload via gbserver [build= target= output=]",
+        private=True,
         resource_group_id="rg-id",
     )
 
@@ -414,6 +415,7 @@ async def test_push_asset_hfstore_uses_cached_resource_group_id(tmp_path):
     mock_push.assert_called_once_with(
         src,
         commit_message="Upload via gbserver [build= target= output=my-output]",
+        private=True,
         resource_group_id="cached-rg-id",
     )
 
@@ -423,7 +425,8 @@ async def test_push_asset_hfstore_best_effort_on_resolve_failure(tmp_path):
     """A failed resource-group resolution does not abort the push.
 
     In standalone the local user's token typically can't resolve the id via the
-    HF API. The push must proceed with resource_group_id=None (matching
+    HF API. The push must still be private (the default survives the failure
+    path) and proceed with resource_group_id=None (matching
     pre-cache behavior) rather than raising.
     """
     src = tmp_path / "model.bin"
@@ -451,6 +454,7 @@ async def test_push_asset_hfstore_best_effort_on_resolve_failure(tmp_path):
     mock_push.assert_called_once_with(
         src,
         commit_message="Upload via gbserver [build= target= output=my-output]",
+        private=True,
         resource_group_id=None,
     )
 

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -195,9 +195,15 @@ def test_resolve_host_path_prefers_longest_prefix(docker_env, tmp_path):
 
 @pytest.fixture
 def push_assetstore():
-    """Mock assetstore with an HF_TOKEN in its secrets."""
+    """Mock assetstore with an HF_TOKEN in its secrets.
+
+    Declares the "org" namespace used by these tests as an HF Enterprise org so
+    the push path resolves a resource group; a non-Enterprise org skips
+    resolution by design (see is_enterprise_hf_org).
+    """
     store = MagicMock()
     store.get_secrets.return_value = {"HF_TOKEN": "test-hf-token"}
+    store.get_enterprise_organizations.return_value = ["org"]
     return store
 
 
@@ -383,6 +389,9 @@ async def test_push_asset_hfstore_uses_cached_resource_group_id(tmp_path):
     store = MagicMock()
     store.get_secrets.return_value = {"HF_TOKEN": "tok"}
     store.resolve_token.return_value = "tok"
+    # "org" must be declared Enterprise, or the resource group is skipped by
+    # design (see is_enterprise_hf_org).
+    store.get_enterprise_organizations.return_value = ["org"]
     uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
 
     with (

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -669,3 +669,42 @@ async def test_docker_pushasset_forwards_push_configs(docker_env, tmp_path):
     kwargs = mock_helper.call_args.kwargs
     assert kwargs["storepush_config"] is storepush_config
     assert kwargs["output_config"] is output_config
+
+
+@pytest.mark.asyncio
+async def test_push_asset_hfstore_uses_the_resolved_space_name(tmp_path):
+    """The inline push must forward the space from the space config, not a literal.
+
+    This path used to overwrite the resolved name with a hardcoded "public", so
+    every bash/docker push to an Enterprise org resolved its resource group as if
+    the build lived in the `public` space. The standalone aliases are folded onto
+    "public" inside HfURI.space_name_to_resource_group_name instead, so a real
+    space name now survives.
+    """
+    from gbcommon.uri.uri import URI
+    from gbserver.types.assetstoreconfig import AssetStoreConfig
+
+    src = tmp_path / "model.bin"
+    src.write_bytes(b"weights")
+    store = Hfstore(
+        AssetStoreConfig(
+            base_uri="hf:/", config={"enterprise_organizations": ["ibm-research"]}
+        )
+    )
+    store.resolve_token = lambda uri: "tok"  # type: ignore[method-assign]
+    store.get_secrets = lambda: {"HF_TOKEN": "tok"}  # type: ignore[method-assign]
+
+    uri = HfURI.from_parts(owner="ibm-research", repo="repo", hf_type=HfType.MODEL)
+    with (
+        patch.object(
+            URI, "get_space_config", return_value={"space": {"name": "my-team-space"}}
+        ),
+        patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="rg-id",
+        ) as mock_resolve,
+        patch.object(HfURI, "push", return_value=True),
+    ):
+        push_asset_hfstore(src=str(src), binding_id="out", uri=uri, assetstore=store)
+
+    assert mock_resolve.call_args.kwargs["space_name"] == "my-team-space"

--- a/test/unit/environment/test_local_assets_besteffort.py
+++ b/test/unit/environment/test_local_assets_besteffort.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resource-group resolution is best-effort on the bash/docker inline push.
+
+Two failures reach the same ``except`` on this path and must be treated in
+opposite ways:
+
+* A resolution **miss** — ``resolve_resource_group_id_for_org`` raises a plain
+  ``ValueError`` when it cannot map a group name to an id, which is the ordinary
+  outcome for a standalone user whose token is not org-admin (the HF
+  ``/resource-groups`` endpoint 403s and the miss surfaces as "Could not resolve
+  resource group id"). The push must proceed without a group.
+* A **config error** — ``HfPushConfigError`` for a group pinned on a
+  non-Enterprise org, or a pin contradicting ``use_resource_group: false``. The
+  push must abort rather than silently ignore what was asked.
+
+Because ``HfPushConfigError`` subclasses ``ValueError``, a bare
+``except ValueError: raise`` cannot tell them apart and aborts the miss too —
+regressing the documented best-effort behavior. These tests pin the distinction.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gbcommon.uri.hf import HfURI
+from gbcommon.uri.uri import URI
+from gbserver.asset.hfstore import Hfstore
+from gbserver.environment.local_assets import push_asset_hfstore
+from gbserver.spaces.resource_group import HfPushConfigError
+
+
+@pytest.fixture
+def src_dir(tmp_path):
+    """A non-empty source dir (HfURI.push rejects empty ones)."""
+    d = tmp_path / "model"
+    d.mkdir()
+    (d / "weights.bin").write_text("x")
+    return d
+
+
+@pytest.fixture
+def hfuri():
+    """A real HfURI on an Enterprise org, with only ``push`` stubbed."""
+    uri = URI.get_uri("hf://huggingface.co/ibm-research/some-model")
+    assert isinstance(uri, HfURI)
+    uri.push = MagicMock()
+    return uri
+
+
+@pytest.fixture
+def enterprise_store():
+    """An Hfstore that treats ``ibm-research`` as Enterprise."""
+    store = MagicMock(spec=Hfstore)
+    store.get_secrets.return_value = {}
+    store.get_enterprise_organizations.return_value = ["ibm-research"]
+    store.resolve_token.return_value = "tok"
+    return store
+
+
+def _run(hfuri, src, assetstore, output_config=None):
+    with patch(
+        "gbcommon.uri.uri.URI.get_space_config",
+        return_value={"space": {"name": "public"}},
+    ):
+        return push_asset_hfstore(
+            src=src,
+            binding_id="out",
+            uri=hfuri,
+            assetstore=assetstore,
+            run_metadata=SimpleNamespace(build_id="b1", target_name="t1"),
+            output_config=output_config,
+        )
+
+
+def test_resolution_miss_still_pushes(src_dir, hfuri, enterprise_store):
+    """A non-admin token cannot resolve the group; the push must still happen.
+
+    This is the standalone default: pushing to an Enterprise org with a personal
+    token. ``create_repo(exist_ok=True)`` succeeds for an existing repo, so
+    aborting here would block a push that works.
+    """
+    with patch(
+        "gbserver.environment.local_assets.resolve_hfpush_resource_group_id",
+        side_effect=ValueError(
+            "Could not resolve resource group id for 'gbspace-public' "
+            "in organization 'ibm-research'"
+        ),
+    ):
+        _run(src=src_dir, hfuri=hfuri, assetstore=enterprise_store)
+
+    hfuri.push.assert_called_once()
+    assert hfuri.push.call_args.kwargs.get("resource_group_id") is None
+    # Still private: the best-effort path must not fall through to HF's default.
+    assert hfuri.push.call_args.kwargs.get("private") is True
+
+
+def test_config_error_aborts_the_push(src_dir, hfuri, enterprise_store):
+    """A pinned group that cannot be honored must abort, not push silently."""
+    with patch(
+        "gbserver.environment.local_assets.resolve_hfpush_resource_group_id",
+        side_effect=HfPushConfigError("resource group pinned for a non-Enterprise org"),
+    ):
+        with pytest.raises(HfPushConfigError):
+            _run(src=src_dir, hfuri=hfuri, assetstore=enterprise_store)
+
+    hfuri.push.assert_not_called()
+
+
+def test_config_error_is_a_valueerror(src_dir, hfuri, enterprise_store):
+    """``HfPushConfigError`` stays catchable as ``ValueError`` for old callers."""
+    assert issubclass(HfPushConfigError, ValueError)
+    with patch(
+        "gbserver.environment.local_assets.resolve_hfpush_resource_group_id",
+        side_effect=HfPushConfigError("nope"),
+    ):
+        with pytest.raises(ValueError):
+            _run(src=src_dir, hfuri=hfuri, assetstore=enterprise_store)
+
+
+def test_miss_from_the_real_resolver_chain_still_pushes(
+    src_dir, hfuri, enterprise_store
+):
+    """End-to-end version: let the genuine resolver raise the miss.
+
+    Rather than stubbing the helper, this drives the real chain — a 403 swallowed
+    by ``_resolve_resource_group_id`` returning ``None``, which makes
+    ``resolve_resource_group_id_for_org`` raise. Guards against the abort
+    returning via a different route than the one stubbed above.
+    """
+    with (
+        patch.object(HfURI, "_resolve_resource_group_id", return_value=None),
+        patch("gbcommon.uri.hf.HfApi"),
+        patch("gbcommon.uri.hf.is_hf_mocked", return_value=False),
+        patch("gbserver.spaces.resource_group.get_admin_storage") as get_storage,
+    ):
+        get_storage.return_value.space_storage.get_by_name.return_value = None
+        _run(src=src_dir, hfuri=hfuri, assetstore=enterprise_store)
+
+    hfuri.push.assert_called_once()
+    assert hfuri.push.call_args.kwargs.get("resource_group_id") is None

--- a/test/unit/environment/test_local_assets_private.py
+++ b/test/unit/environment/test_local_assets_private.py
@@ -158,3 +158,48 @@ def test_resolver_failure_still_pushes_private(src_dir, hfstore):
         side_effect=RuntimeError("HF API down"),
     ):
         assert _run(hfuri, src_dir, hfstore) is True
+
+
+def test_quoted_private_false_is_honored(src_dir, hfstore):
+    """``private: "false"`` (quoted in yaml) must mean public, not truthy.
+
+    A bare ``bool("false")`` is ``True``, so a quoted value used to silently
+    invert the user's intent. Resolution goes through ``parse_boolean``, which
+    folds the quoted falsy forms onto ``False``.
+    """
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore, _output_config({"private": "false"})) is False
+
+
+@pytest.mark.parametrize("value", ["no", "off", "0", "False", " false "])
+def test_quoted_falsy_forms_are_honored(src_dir, hfstore, value):
+    """The whole falsy token set works, case- and whitespace-insensitively."""
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore, _output_config({"private": value})) is False
+
+
+def test_unparseable_private_falls_back_to_private(src_dir, hfstore):
+    """A typo must fail *safe*: unrecognized means private, not public."""
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore, _output_config({"private": "flase"})) is True
+
+
+def test_output_level_private_overrides_environment_level(src_dir, hfstore):
+    """build.yaml outranks environment.yaml, so a per-output opt-in wins.
+
+    The intended usage: the environment keeps everything private, and a single
+    output selectively publishes.
+    """
+    hfuri = _hfuri()
+    storepush_config = MagicMock()
+    storepush_config.config = {"hf": {"private": True}}
+    assert (
+        _run(
+            hfuri,
+            src_dir,
+            hfstore,
+            output_config=_output_config({"private": False}),
+            storepush_config=storepush_config,
+        )
+        is False
+    )

--- a/test/unit/environment/test_local_assets_private.py
+++ b/test/unit/environment/test_local_assets_private.py
@@ -203,3 +203,24 @@ def test_output_level_private_overrides_environment_level(src_dir, hfstore):
         )
         is False
     )
+
+
+def test_non_hfstore_honors_explicit_private_false(src_dir):
+    """The non-Hfstore branch must honor an explicit ``private: false`` too.
+
+    It cannot classify the org (no Enterprise list without an ``Hfstore``), but
+    ``private`` is store-independent: hardcoding ``True`` here would silently
+    ignore a config the Hfstore branch obeys.
+    """
+    hfuri = _hfuri()
+    plain_store = MagicMock()  # not an Hfstore
+    plain_store.get_secrets.return_value = {}
+    plain_store.resolve_token.return_value = "tok"
+    with patch(
+        "gbserver.environment.local_assets.resolve_space_resource_group_id",
+        return_value=None,
+    ):
+        assert (
+            _run(hfuri, src_dir, plain_store, _output_config({"private": False}))
+            is False
+        )

--- a/test/unit/environment/test_local_assets_private.py
+++ b/test/unit/environment/test_local_assets_private.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``private`` must reach HuggingFace on the bash/docker inline push path.
+
+These environments have no hfpush step directory, so they call
+``push_asset_hfstore`` directly instead of rendering a worker template. The
+resolved ``private`` value was previously discarded here, and
+``HfApi.create_repo``'s own default is PUBLIC — so a dropped ``private``
+publishes the artifact rather than failing loudly. Every test below asserts on
+the ``private`` kwarg that actually reaches ``HfURI.push``.
+
+The tests exercise the real ``push_asset_hfstore`` (only ``HfURI.push`` and the
+resource-group lookup are mocked); mocking ``push_asset_hfstore`` itself, as the
+bash/docker forwarding tests do, cannot observe this.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gbcommon.uri.hf import HfURI
+from gbcommon.uri.uri import URI
+from gbserver.asset.hfstore import Hfstore
+from gbserver.environment.local_assets import push_asset_hfstore
+
+
+@pytest.fixture
+def src_dir(tmp_path):
+    """A non-empty source dir (HfURI.push rejects empty ones)."""
+    d = tmp_path / "model"
+    d.mkdir()
+    (d / "weights.bin").write_text("x")
+    return d
+
+
+def _hfuri():
+    """A real HfURI with only ``push`` stubbed.
+
+    It must be a genuine HfURI: ``push_asset_hfstore`` routes anything else
+    through ``URI.get_uri()``, which templates the value.
+    """
+    hfuri = URI.get_uri("hf://huggingface.co/some-org/some-model")
+    assert isinstance(hfuri, HfURI)
+    hfuri.push = MagicMock()
+    return hfuri
+
+
+def _push_private_kwarg(hfuri):
+    """Return the ``private`` kwarg passed to hfuri.push()."""
+    hfuri.push.assert_called_once()
+    return hfuri.push.call_args.kwargs.get("private")
+
+
+def _run(hfuri, src, assetstore, output_config=None, storepush_config=None):
+    # URI/HfURI are imported inside push_asset_hfstore, so patch them at source.
+    with patch(
+        "gbcommon.uri.uri.URI.get_space_config",
+        return_value={"space": {"name": "public"}},
+    ):
+        push_asset_hfstore(
+            src=src,
+            binding_id="out",
+            uri=hfuri,
+            assetstore=assetstore,
+            run_metadata=SimpleNamespace(build_id="b1", target_name="t1"),
+            storepush_config=storepush_config,
+            output_config=output_config,
+        )
+    return _push_private_kwarg(hfuri)
+
+
+def _output_config(hf_cfg):
+    """A BuildTargetOutputConfig double carrying an ``hf`` push config."""
+    output_config = MagicMock()
+    output_config.store_push.config = {"hf": hf_cfg}
+    return output_config
+
+
+@pytest.fixture
+def hfstore():
+    """An Hfstore whose resource-group resolution is stubbed out."""
+    store = MagicMock(spec=Hfstore)
+    store.get_secrets.return_value = {}
+    store.get_enterprise_organizations.return_value = []  # non-Enterprise
+    store.resolve_token.return_value = "tok"
+    return store
+
+
+def test_no_config_defaults_to_private(src_dir, hfstore):
+    """(1) With no push config at all, the repo must still be created private."""
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore) is True
+
+
+def test_explicit_private_true_is_not_discarded(src_dir, hfstore):
+    """(3) A redundant explicit ``private: true`` must survive to HF."""
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore, _output_config({"private": True})) is True
+
+
+def test_explicit_private_false_is_honored(src_dir, hfstore):
+    """(2) Public is opt-in: only an explicit ``private: false`` gets it."""
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore, _output_config({"private": False})) is False
+
+
+def test_yaml_null_private_does_not_publish(src_dir, hfstore):
+    """A bare ``private:`` (yaml null) must not be read as "public".
+
+    ``None`` is *present* as a key, so a ``.get("private", True)`` would return
+    None and HuggingFace would default the repo to public.
+    """
+    hfuri = _hfuri()
+    assert _run(hfuri, src_dir, hfstore, _output_config({"private": None})) is True
+
+
+def test_non_hfstore_assetstore_still_pushes_private(src_dir):
+    """The non-Hfstore branch skips the resolver, so it needs its own default.
+
+    ``private`` is initialized before the branch precisely so this path cannot
+    fall through to HuggingFace's public default.
+    """
+    hfuri = _hfuri()
+    plain_store = MagicMock()  # not an Hfstore -> other resolution branch
+    plain_store.get_secrets.return_value = {}
+    plain_store.resolve_token.return_value = "tok"
+    with patch(
+        "gbserver.environment.local_assets.resolve_space_resource_group_id",
+        return_value=None,
+    ):
+        assert _run(hfuri, src_dir, plain_store) is True
+
+
+def test_resolver_failure_still_pushes_private(src_dir, hfstore):
+    """A transient resolver failure is best-effort — but must not go public.
+
+    The ``except Exception`` path logs and continues to the push, so ``private``
+    has to already hold a safe value when it does.
+    """
+    hfuri = _hfuri()
+    with patch(
+        "gbserver.environment.local_assets.resolve_hfpush_resource_group_id",
+        side_effect=RuntimeError("HF API down"),
+    ):
+        assert _run(hfuri, src_dir, hfstore) is True

--- a/test/unit/environment/test_lsf_hfstore.py
+++ b/test/unit/environment/test_lsf_hfstore.py
@@ -60,16 +60,17 @@ def mock_hfuri():
 
 @pytest.fixture
 def mock_resolve_rg():
-    """Patch the server-side resource group resolver used by pushasset_hfstore.
+    """Patch the resource group resolution used by pushasset_hfstore.
 
     Resolution is delegated to
-    ``gbserver.spaces.resource_group.resolve_space_resource_group_id`` (imported
+    ``gbserver.spaces.resource_group.resolve_hfpush_resource_group_id`` (imported
     into the lsf env module); patch it there so tests never touch storage or the
-    HF API.
+    HF API. It returns ``(resource_group_id, private, hf_config)``; the default
+    here mirrors a push with no resource group and the default private=True.
     """
     with patch(
-        "gbserver.environment.lsf.resolve_space_resource_group_id",
-        return_value=None,
+        "gbserver.environment.lsf.resolve_hfpush_resource_group_id",
+        return_value=(None, True, {}),
     ) as mock:
         yield mock
 
@@ -248,12 +249,19 @@ class TestPushassetHfstore:
 
     @pytest.mark.asyncio
     async def test_private_flag_from_storepush_config(
-        self, lsf_env, mock_hfuri, mock_hf_metadata, mock_resolve_rg
+        self, lsf_env, mock_hfuri, mock_hf_metadata
     ):
-        """pushasset_hfstore picks up private=False from storepush_config."""
+        """pushasset_hfstore picks up private=False from storepush_config.
+
+        Uses the real resolver (not ``mock_resolve_rg``) so the env-level
+        ``private`` actually flows through resolve_hfpush_resource_group_id.
+        The org is non-Enterprise here, so no HF API call is made.
+        """
         from gbserver.asset.hfstore import Hfstore
 
         assetstore = MagicMock(spec=Hfstore)
+        # Non-Enterprise org => resource group resolution is skipped entirely.
+        assetstore.get_enterprise_organizations.return_value = ["some-other-org"]
         storepush_config = MagicMock()
         storepush_config.mode = "default"
         storepush_config.config = {"hf": {"private": False}}

--- a/test/unit/environment/test_skypilot_hfstore.py
+++ b/test/unit/environment/test_skypilot_hfstore.py
@@ -41,16 +41,16 @@ def mock_hfuri():
 
 @pytest.fixture
 def mock_resolve_rg():
-    """Patch the server-side resource group resolver used by pushasset_hfstore.
+    """Patch the space-based resource group resolver used by pushasset_hfstore.
 
-    Resolution is delegated to
-    ``gbserver.spaces.resource_group.resolve_space_resource_group_id`` (imported
-    into the skypilot env module); patch it there so tests never touch storage
-    or the HF API. Yields the mock so tests can tune the return value / assert
-    call behavior.
+    ``resolve_hfpush_resource_group_id`` (the shared helper the skypilot env
+    calls) is left real so the Enterprise split and config precedence are
+    genuinely exercised; only its innermost space/HF lookup is patched, here at
+    its definition site so tests never touch storage or the HF API. Yields the
+    mock so tests can tune the return value / assert call behavior.
     """
     with patch(
-        "gbserver.environment.skypilot.resolve_space_resource_group_id",
+        "gbserver.spaces.resource_group.resolve_space_resource_group_id",
         return_value=None,
     ) as mock:
         yield mock
@@ -62,6 +62,9 @@ def _hfstore_mock(token: str = "tok-abc"):
 
     store = MagicMock(spec=Hfstore)
     store.resolve_token.return_value = token
+    # These tests target "myorg"; declare it Enterprise so a resource group
+    # applies (a non-Enterprise org skips resolution by design).
+    store.get_enterprise_organizations.return_value = ["myorg"]
     return store
 
 

--- a/test/unit/gbcli/services/test_artifact_hf_enterprise.py
+++ b/test/unit/gbcli/services/test_artifact_hf_enterprise.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HF Enterprise/non-Enterprise split in ``upload_to_hf``.
+
+A non-Enterprise org must upload without a resource group; an Enterprise org
+must still require one. HFRegistry is mocked — no HF calls are made.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gbcli.services.service_artifact import upload_to_hf
+
+pytestmark = pytest.mark.standalone
+
+_ENTERPRISE = ["ibm-research", "ibm-granite"]
+
+
+def _run_upload(tmp_path, org, resource_group_id=None, artifact_type="model"):
+    src = tmp_path / "model.bin"
+    src.write_bytes(b"weights")
+    with (
+        patch(
+            "gbcli.services.service_artifact.HF_ENTERPRISE_ORGANIZATIONS",
+            _ENTERPRISE,
+        ),
+        patch("gbcli.services.service_artifact.HFRegistry") as registry_cls,
+    ):
+        registry_cls.return_value.upload_artifact.return_value = "uploaded"
+        result = upload_to_hf(
+            hf_token="tok",
+            path_name=str(src),
+            artifact_name="my-model",
+            type=artifact_type,
+            hf_organization=org,
+            resource_group_id=resource_group_id,
+        )
+    return result, registry_cls
+
+
+class TestUploadToHfNonEnterprise:
+    def test_uploads_without_resource_group(self, tmp_path):
+        """A non-Enterprise org no longer needs a resource group id."""
+        result, registry_cls = _run_upload(tmp_path, org="my-user")
+
+        assert result == "uploaded"
+        assert registry_cls.call_args.kwargs["resource_group_id"] is None
+        assert registry_cls.call_args.kwargs["organization"] == "my-user"
+
+    def test_bucket_type_uploads_without_resource_group(self, tmp_path):
+        """The bucket branch (create_bucket) also accepts no resource group."""
+        result, registry_cls = _run_upload(
+            tmp_path, org="my-user", artifact_type="bucket"
+        )
+
+        assert result == "uploaded"
+        assert registry_cls.call_args.kwargs["resource_group_id"] is None
+        assert (
+            registry_cls.return_value.upload_artifact.call_args.kwargs["artifact_type"]
+            == "bucket"
+        )
+
+    def test_fileset_maps_to_bucket(self, tmp_path):
+        """-t fileset also reaches create_bucket, so it must work too."""
+        _, registry_cls = _run_upload(tmp_path, org="my-user", artifact_type="fileset")
+
+        assert (
+            registry_cls.return_value.upload_artifact.call_args.kwargs["artifact_type"]
+            == "bucket"
+        )
+
+
+class TestUploadToHfEnterprise:
+    def test_missing_resource_group_still_raises(self, tmp_path):
+        """An Enterprise org must still supply a resource group id."""
+        with pytest.raises(Exception, match="No HuggingFace resource group id"):
+            _run_upload(tmp_path, org="ibm-research")
+
+    def test_forwards_resource_group(self, tmp_path):
+        _, registry_cls = _run_upload(
+            tmp_path, org="ibm-research", resource_group_id="rg-123"
+        )
+
+        assert registry_cls.call_args.kwargs["resource_group_id"] == "rg-123"

--- a/test/unit/gbcli/services/test_artifact_hf_enterprise.py
+++ b/test/unit/gbcli/services/test_artifact_hf_enterprise.py
@@ -20,7 +20,7 @@ A non-Enterprise org must upload without a resource group; an Enterprise org
 must still require one. HFRegistry is mocked — no HF calls are made.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/test/unit/gbtypes/test_gbenvconfig.py
+++ b/test/unit/gbtypes/test_gbenvconfig.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the base + per-environment override config structure.
+
+The environment configs are defined values.yaml-style: a PROD base dict, plus an
+override dict per near-variant environment (STAGING, DEV) combined with
+``deep_merge``, while STANDALONE is written out in full. These tests pin the merge
+semantics and the resolved values other code depends on, so an edit to the shared
+base cannot silently change an environment — and, for the inlined STANDALONE,
+that a forgotten field cannot silently fall back to a model default.
+"""
+
+import pytest
+
+from gbcommon.types.gbenvconfig import (
+    _GB_ENVIRONMENT_CONFIG_BASE,
+    _GB_ENVIRONMENT_CONFIG_DEV,
+    _GB_ENVIRONMENT_CONFIG_PROD,
+    _GB_ENVIRONMENT_CONFIG_STAGING,
+    _GB_ENVIRONMENT_CONFIGS,
+    GBEnvConfig,
+    deep_merge,
+    gb_environment_config,
+)
+
+pytestmark = pytest.mark.standalone
+
+_ALL_ENVS = ["PROD", "STAGING", "DEV", "STANDALONE"]
+
+# The per-environment dicts merged onto the base. PROD's is empty (the base holds
+# the PROD values). STANDALONE has none: it is written out in full.
+_OVERRIDES = {
+    "PROD": _GB_ENVIRONMENT_CONFIG_PROD,
+    "STAGING": _GB_ENVIRONMENT_CONFIG_STAGING,
+    "DEV": _GB_ENVIRONMENT_CONFIG_DEV,
+}
+_DEPLOYED_ENVS = sorted(_OVERRIDES)
+
+
+def _standalone_explicit_fields() -> set:
+    """Field names passed explicitly to the inlined ``STANDALONE`` GBEnvConfig(...).
+
+    Read from the source with ``ast`` rather than from the built object, because
+    a forgotten field is indistinguishable from one set to its default value once
+    the model is constructed — which is exactly the mistake this guards against.
+    """
+    import ast
+    import inspect
+
+    import gbcommon.types.gbenvconfig as mod
+
+    tree = ast.parse(inspect.getsource(mod))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "STANDALONE"
+                and isinstance(value, ast.Call)
+            ):
+                return {kw.arg for kw in value.keywords if kw.arg}
+    raise AssertionError("could not find the inlined STANDALONE GBEnvConfig(...)")
+
+
+class TestDeepMerge:
+    def test_override_replaces_scalar(self):
+        assert deep_merge({"a": 1, "b": 2}, {"b": 3}) == {"a": 1, "b": 3}
+
+    def test_nested_dict_merges_key_by_key(self):
+        """An env can override one feature flag without restating the others."""
+        merged = deep_merge({"flags": {"x": True, "y": True}}, {"flags": {"y": False}})
+        assert merged == {"flags": {"x": True, "y": False}}
+
+    def test_merges_recursively(self):
+        merged = deep_merge({"a": {"b": {"c": 1, "d": 2}}}, {"a": {"b": {"d": 9}}})
+        assert merged == {"a": {"b": {"c": 1, "d": 9}}}
+
+    def test_non_dict_replaces_dict(self):
+        assert deep_merge({"a": {"x": 1}}, {"a": "scalar"}) == {"a": "scalar"}
+
+    def test_new_keys_are_added(self):
+        assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+    def test_inputs_are_not_mutated(self):
+        base = {"a": 1, "flags": {"x": True}}
+        override = {"flags": {"x": False}}
+        deep_merge(base, override)
+        assert base == {"a": 1, "flags": {"x": True}}
+        assert override == {"flags": {"x": False}}
+
+
+class TestEnvironmentStructure:
+    def test_all_expected_environments_exist(self):
+        assert sorted(_GB_ENVIRONMENT_CONFIGS) == sorted(_ALL_ENVS)
+
+    @pytest.mark.parametrize("env", _ALL_ENVS)
+    def test_env_field_matches_its_key(self, env):
+        assert _GB_ENVIRONMENT_CONFIGS[env].env == env
+
+    def test_base_holds_the_prod_values(self):
+        """The base carries PROD, so PROD's own override dict is empty."""
+        assert _GB_ENVIRONMENT_CONFIG_BASE["env"] == "PROD"
+        assert _GB_ENVIRONMENT_CONFIG_PROD == {}
+
+    def test_base_sets_every_field(self):
+        """The base must be complete, since PROD merges an empty dict onto it."""
+        missing = set(GBEnvConfig.model_fields) - set(_GB_ENVIRONMENT_CONFIG_BASE)
+        assert not missing, f"base is missing {sorted(missing)}"
+
+    def test_standalone_is_self_contained(self):
+        """STANDALONE is spelled out in full, not merged onto the PROD base.
+
+        Guards the deliberate choice: if it ever gains an override dict, that is
+        a decision to review, not something to happen silently.
+        """
+        import gbcommon.types.gbenvconfig as mod
+
+        assert not hasattr(mod, "_GB_ENVIRONMENT_CONFIG_STANDALONE")
+
+    @pytest.mark.parametrize("env", ["STAGING", "DEV"])
+    def test_override_names_itself(self, env):
+        """PROD is exempt: its dict is empty and the base names PROD."""
+        assert _OVERRIDES[env]["env"] == env
+
+    @pytest.mark.parametrize("env", _ALL_ENVS)
+    def test_gb_environment_config_returns_the_same_object(self, env):
+        assert gb_environment_config(env) is _GB_ENVIRONMENT_CONFIGS[env]
+
+    def test_base_only_uses_known_fields(self):
+        assert set(_GB_ENVIRONMENT_CONFIG_BASE) <= set(GBEnvConfig.model_fields)
+
+    @pytest.mark.parametrize("env", _DEPLOYED_ENVS)
+    def test_overrides_only_use_known_fields(self, env):
+        """Guard against a typo'd key silently doing nothing."""
+        assert set(_OVERRIDES[env]) <= set(GBEnvConfig.model_fields)
+
+    @pytest.mark.parametrize("env", _DEPLOYED_ENVS)
+    def test_base_plus_override_sets_every_field(self, env):
+        """No field may fall back to a pydantic default for a deployed env."""
+        supplied = set(_GB_ENVIRONMENT_CONFIG_BASE) | set(_OVERRIDES[env])
+        missing = set(GBEnvConfig.model_fields) - supplied
+        assert not missing, f"{env} leaves {sorted(missing)} unset"
+
+    def test_standalone_sets_every_field(self):
+        """STANDALONE is inlined, so nothing supplies a field it forgets.
+
+        PROD/STAGING/DEV inherit anything they omit from the base (which
+        test_base_sets_every_field proves complete), but a field left out of the
+        inlined STANDALONE silently takes the pydantic default. Compare against
+        the base's field set, which is the full set of fields.
+        """
+        missing = set(GBEnvConfig.model_fields) - _standalone_explicit_fields()
+        assert not missing, f"STANDALONE does not set {sorted(missing)}"
+        assert _GB_ENVIRONMENT_CONFIGS["STANDALONE"].env == "STANDALONE"
+
+    @pytest.mark.parametrize("env", _DEPLOYED_ENVS)
+    def test_overrides_do_not_restate_base_values(self, env):
+        """An override entry equal to the base value is redundant — keep trimmed.
+
+        `env` is exempt: every override must name itself.
+        """
+        redundant = [
+            key
+            for key, value in _OVERRIDES[env].items()
+            if key != "env" and value == _GB_ENVIRONMENT_CONFIG_BASE.get(key)
+        ]
+        assert not redundant, f"{env} redundantly restates {redundant}"
+
+
+class TestResolvedValues:
+    """Pin values other code reads, so a base edit cannot silently move them."""
+
+    @pytest.mark.parametrize(
+        "env,host",
+        [
+            ("PROD", "https://api.llm-build-prod.vpc-int.res.ibm.com"),
+            ("STAGING", "https://api.llm-build-staging.vpc-int.res.ibm.com"),
+            ("DEV", "https://api.llm-build-dev.vpc-int.res.ibm.com"),
+            ("STANDALONE", "http://localhost:8080"),
+        ],
+    )
+    def test_gbserver_host(self, env, host):
+        assert _GB_ENVIRONMENT_CONFIGS[env].gbserver_host == host
+
+    @pytest.mark.parametrize(
+        "env,schema",
+        [
+            ("PROD", "granite_dot_build_prod"),
+            ("STAGING", "granite_dot_build_staging"),
+            ("DEV", "granite_dot_build_dev"),
+            ("STANDALONE", "standalone"),
+        ],
+    )
+    def test_default_sql_schema(self, env, schema):
+        assert _GB_ENVIRONMENT_CONFIGS[env].default_sql_schema == schema
+
+    @pytest.mark.parametrize(
+        "env,section",
+        [
+            ("PROD", "gb.spaces"),
+            ("STAGING", "staging.gb.spaces"),
+            ("DEV", "dev.gb.spaces"),
+            ("STANDALONE", ""),
+        ],
+    )
+    def test_config_spaces(self, env, section):
+        assert _GB_ENVIRONMENT_CONFIGS[env].config_spaces == section
+
+    def test_dev_uses_the_staging_lakehouse(self):
+        assert _GB_ENVIRONMENT_CONFIGS["DEV"].lakehouse_environment == "STAGING"
+        assert _GB_ENVIRONMENT_CONFIGS["PROD"].lakehouse_environment == "PROD"
+        assert _GB_ENVIRONMENT_CONFIGS["STANDALONE"].lakehouse_environment == ""
+
+    def test_staging_and_dev_track_the_dev_assets_branch(self):
+        assert _GB_ENVIRONMENT_CONFIGS["PROD"].branch_assets == "gbspace-config"
+        assert _GB_ENVIRONMENT_CONFIGS["STAGING"].branch_assets == "gbspace-config-dev"
+        assert _GB_ENVIRONMENT_CONFIGS["DEV"].branch_assets == "gbspace-config-dev"
+
+    def test_hf_org_config_is_inherited_by_every_environment(self):
+        """The HF org config lives only in the base; every env must inherit it."""
+        for env in _ALL_ENVS:
+            cfg = _GB_ENVIRONMENT_CONFIGS[env]
+            assert cfg.hf_organization == "ibm-research"
+            assert cfg.hf_enterprise_organizations == ["ibm-research", "ibm-granite"]
+
+    def test_hf_enterprise_list_is_not_shared_mutable_state(self):
+        """Each config needs its own list, or mutating one would hit them all."""
+        lists = [
+            _GB_ENVIRONMENT_CONFIGS[e].hf_enterprise_organizations for e in _ALL_ENVS
+        ]
+        assert len({id(x) for x in lists}) == len(lists)
+
+    def test_standalone_feature_flags(self):
+        """STANDALONE's flags are literal, unlike the env-var driven deployed ones."""
+        flags = _GB_ENVIRONMENT_CONFIGS["STANDALONE"].feature_flags
+        assert flags["build_start_via_github"] is False
+        assert flags["gbserver_artifact_filter"] is False
+        assert flags["gbserver_build_events"] is True
+        assert flags["gbserver_build_update"] is True
+
+    def test_deployed_envs_have_no_build_start_via_github_flag(self):
+        """That flag is added by the STANDALONE override only."""
+        for env in ("PROD", "STAGING", "DEV"):
+            assert (
+                "build_start_via_github"
+                not in _GB_ENVIRONMENT_CONFIGS[env].feature_flags
+            )

--- a/test/unit/gbtypes/test_gbenvconfig.py
+++ b/test/unit/gbtypes/test_gbenvconfig.py
@@ -24,8 +24,12 @@ base cannot silently change an environment — and, for the inlined STANDALONE,
 that a forgotten field cannot silently fall back to a model default.
 """
 
+import ast
+import inspect
+
 import pytest
 
+from gbcommon.types import gbenvconfig
 from gbcommon.types.gbenvconfig import (
     _GB_ENVIRONMENT_CONFIG_BASE,
     _GB_ENVIRONMENT_CONFIG_DEV,
@@ -58,12 +62,7 @@ def _standalone_explicit_fields() -> set:
     a forgotten field is indistinguishable from one set to its default value once
     the model is constructed — which is exactly the mistake this guards against.
     """
-    import ast
-    import inspect
-
-    import gbcommon.types.gbenvconfig as mod
-
-    tree = ast.parse(inspect.getsource(mod))
+    tree = ast.parse(inspect.getsource(gbenvconfig))
     for node in ast.walk(tree):
         if not isinstance(node, ast.Dict):
             continue
@@ -115,7 +114,7 @@ class TestEnvironmentStructure:
     def test_base_holds_the_prod_values(self):
         """The base carries PROD, so PROD's own override dict is empty."""
         assert _GB_ENVIRONMENT_CONFIG_BASE["env"] == "PROD"
-        assert _GB_ENVIRONMENT_CONFIG_PROD == {}
+        assert not _GB_ENVIRONMENT_CONFIG_PROD
 
     def test_base_sets_every_field(self):
         """The base must be complete, since PROD merges an empty dict onto it."""
@@ -128,9 +127,7 @@ class TestEnvironmentStructure:
         Guards the deliberate choice: if it ever gains an override dict, that is
         a decision to review, not something to happen silently.
         """
-        import gbcommon.types.gbenvconfig as mod
-
-        assert not hasattr(mod, "_GB_ENVIRONMENT_CONFIG_STANDALONE")
+        assert not hasattr(gbenvconfig, "_GB_ENVIRONMENT_CONFIG_STANDALONE")
 
     @pytest.mark.parametrize("env", ["STAGING", "DEV"])
     def test_override_names_itself(self, env):

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -206,3 +206,213 @@ class TestResolveSpaceResourceGroupId:
         assert result == "default-cached-id"
         mock_hf.assert_not_called()
         storage.space_storage.update.assert_not_called()
+
+
+def _make_assetstore(enterprise_orgs, token="tok"):
+    """Hfstore double exposing only what the resolver reads."""
+    store = MagicMock()
+    store.get_enterprise_organizations.return_value = enterprise_orgs
+    store.resolve_token.return_value = token
+    return store
+
+
+def _make_hfuri(owner="ibm-research", repo="my-model"):
+    from gbcommon.uri.hf import HfURI
+
+    return HfURI.from_parts(owner=owner, repo=repo)
+
+
+def _output_config(hf_cfg):
+    """BuildTargetOutputConfig-alike carrying a store_push hf block."""
+    cfg = MagicMock()
+    cfg.store_push = MagicMock()
+    cfg.store_push.config = {"hf": hf_cfg}
+    return cfg
+
+
+def _storepush_config(hf_cfg):
+    cfg = MagicMock()
+    cfg.config = {"hf": hf_cfg}
+    return cfg
+
+
+class TestResolveHfpushResourceGroupIdNonEnterprise:
+    """A non-Enterprise org must skip resource group resolution entirely."""
+
+    def test_non_enterprise_skips_resolution(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, private, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="my-user"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+            )
+
+        assert rg_id is None
+        assert private is True
+        mock_resolve.assert_not_called()
+
+    def test_non_enterprise_with_pinned_id_raises(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with pytest.raises(ValueError, match="not an HF Enterprise organization"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="my-user"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"resource_group_id": "rg-123"}),
+            )
+
+    def test_non_enterprise_with_pinned_name_raises(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with pytest.raises(ValueError, match="not an HF Enterprise organization"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="my-user"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"resource_group_name": "gbspace-public"}),
+            )
+
+    def test_absent_enterprise_list_keeps_legacy_behavior(self):
+        """None (key absent) => every org is Enterprise, so resolution still runs."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="resolved-id",
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="some-random-user"),
+                assetstore=_make_assetstore(None),
+                space_name="public",
+            )
+
+        assert rg_id == "resolved-id"
+        mock_resolve.assert_called_once()
+
+
+class TestResolveHfpushResourceGroupIdEnterprise:
+    def test_enterprise_resolves_via_space(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="space-id",
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+            )
+
+        assert rg_id == "space-id"
+        assert mock_resolve.call_args.kwargs["organization"] == "ibm-research"
+        assert mock_resolve.call_args.kwargs["space_name"] == "public"
+
+    def test_pinned_id_used_verbatim_without_resolver(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"resource_group_id": "pinned-id"}),
+            )
+
+        assert rg_id == "pinned-id"
+        mock_resolve.assert_not_called()
+
+    def test_use_resource_group_false_opts_out(self):
+        """An Enterprise org can opt out with use_resource_group: false."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"use_resource_group": False}),
+            )
+
+        assert rg_id is None
+        mock_resolve.assert_not_called()
+
+    def test_use_resource_group_false_with_pinned_group_raises(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with pytest.raises(ValueError, match="cannot be combined"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config(
+                    {"use_resource_group": False, "resource_group_id": "rg-1"}
+                ),
+            )
+
+
+class TestResolveHfpushConfigPrecedence:
+    """Environment-level config is honored, with build.yaml overriding it."""
+
+    def test_env_level_store_push_is_honored(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="ignored",
+        ) as mock_resolve:
+            rg_id, private, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config(
+                    {"resource_group_name": "env-group", "private": False}
+                ),
+            )
+
+        assert private is False
+        assert mock_resolve.call_args.kwargs["resource_group_name"] == "env-group"
+
+    def test_build_yaml_overrides_environment(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, private, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config(
+                    {"resource_group_id": "env-id", "private": False}
+                ),
+                output_config=_output_config({"resource_group_id": "build-id"}),
+            )
+
+        assert rg_id == "build-id"
+        assert private is False  # not overridden by build.yaml, inherited from env
+        mock_resolve.assert_not_called()
+
+
+class TestSanitizeHfStepOverlay:
+    def test_strips_use_resource_group(self):
+        from gbserver.spaces.resource_group import sanitize_hf_step_overlay
+
+        assert sanitize_hf_step_overlay(
+            {"private": True, "use_resource_group": False}
+        ) == {"private": True}
+
+    def test_handles_empty_and_none(self):
+        from gbserver.spaces.resource_group import sanitize_hf_step_overlay
+
+        assert sanitize_hf_step_overlay({}) == {}
+        assert sanitize_hf_step_overlay(None) == {}

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -627,6 +627,60 @@ class TestNullConfigValuesTreatedAsUnset:
         assert rg_id is None
 
 
+class TestQuotedBooleanForms:
+    """A yaml-quoted boolean must mean what it says, not "non-empty string".
+
+    Both booleans in an ``hf`` push config go through ``parse_boolean``, so
+    ``"false"`` / ``"no"`` / ``"off"`` / ``"0"`` resolve to ``False`` rather than
+    being truthy. Before that, a quoted value silently inverted the user's intent.
+    """
+
+    @pytest.mark.parametrize("value", ["false", "no", "off", "0", "False", " false "])
+    def test_quoted_private_is_public(self, value):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        _, private, _ = resolve_hfpush_resource_group_id(
+            hfuri=_make_hfuri(owner="my-user"),
+            assetstore=_make_assetstore([]),
+            space_name="public",
+            output_config=_output_config({"private": value}),
+        )
+
+        assert private is False
+
+    @pytest.mark.parametrize("value", ["false", "no", "off", "0"])
+    def test_quoted_use_resource_group_opts_out(self, value):
+        """A quoted opt-out must actually skip resolution."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="rg",
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"use_resource_group": value}),
+            )
+
+        assert rg_id is None
+        mock_resolve.assert_not_called()
+
+    def test_unrecognized_private_stays_private(self):
+        """A typo fails safe: unparseable means private, never public."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        _, private, _ = resolve_hfpush_resource_group_id(
+            hfuri=_make_hfuri(owner="my-user"),
+            assetstore=_make_assetstore([]),
+            space_name="public",
+            output_config=_output_config({"private": "flase"}),
+        )
+
+        assert private is True
+
+
 class TestHfPushConfigError:
     """Config errors are a distinguishable subtype, not a bare ValueError.
 

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -445,6 +445,85 @@ class TestUseResourceGroupAcrossLevels:
                 ),
             )
 
+    def test_output_pinned_id_overrides_environment_opt_out(self):
+        """An output-level pin is priority 1, so it outranks an inherited opt-out.
+
+        Regression: the opt-out was evaluated off the merged config, so an
+        environment-level `use_resource_group: false` silently discarded an
+        explicit output-level `resource_group_id` — inverting the documented
+        precedence and dropping a pinned group with no error.
+        """
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config({"use_resource_group": False}),
+                output_config=_output_config({"resource_group_id": "rg-out"}),
+            )
+
+        assert rg_id == "rg-out"
+        # A pinned id is used verbatim, so the space resolver is never consulted.
+        mock_resolve.assert_not_called()
+
+    def test_output_pinned_name_overrides_environment_opt_out(self):
+        """Same for a pinned name, which does go through the resolver."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="rg-from-name",
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config({"use_resource_group": False}),
+                output_config=_output_config({"resource_group_name": "team-group"}),
+            )
+
+        assert rg_id == "rg-from-name"
+        assert mock_resolve.call_args.kwargs["resource_group_name"] == "team-group"
+
+    def test_environment_pin_does_not_override_output_opt_out(self):
+        """The reverse: a lower-level pin must not defeat a higher-level opt-out."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config({"resource_group_id": "rg-env"}),
+                output_config=_output_config({"use_resource_group": False}),
+            )
+
+        assert rg_id is None
+        mock_resolve.assert_not_called()
+
+    def test_opt_out_at_both_levels_still_opts_out(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config({"use_resource_group": False}),
+                output_config=_output_config({"use_resource_group": False}),
+            )
+
+        assert rg_id is None
+        mock_resolve.assert_not_called()
+
     def test_environment_opt_out_is_overridable_by_output(self):
         """The reverse direction: an output can turn resource groups back on."""
         with patch(

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -23,7 +23,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from gbserver.spaces.resource_group import resolve_space_resource_group_id
+from gbcommon.uri.hf import HfURI
+from gbserver.spaces.resource_group import (
+    resolve_hfpush_resource_group_id,
+    resolve_space_resource_group_id,
+    sanitize_hf_step_overlay,
+)
 from gbserver.storage.stored_space import StoredSpace
 
 
@@ -217,8 +222,6 @@ def _make_assetstore(enterprise_orgs, token="tok"):
 
 
 def _make_hfuri(owner="ibm-research", repo="my-model"):
-    from gbcommon.uri.hf import HfURI
-
     return HfURI.from_parts(owner=owner, repo=repo)
 
 
@@ -240,8 +243,6 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
     """A non-Enterprise org must skip resource group resolution entirely."""
 
     def test_non_enterprise_skips_resolution(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id"
         ) as mock_resolve:
@@ -256,8 +257,6 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
         mock_resolve.assert_not_called()
 
     def test_non_enterprise_with_pinned_id_raises(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with pytest.raises(ValueError, match="not an HF Enterprise organization"):
             resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="my-user"),
@@ -267,8 +266,6 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
             )
 
     def test_non_enterprise_with_pinned_name_raises(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with pytest.raises(ValueError, match="not an HF Enterprise organization"):
             resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="my-user"),
@@ -279,8 +276,6 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
 
     def test_absent_enterprise_list_keeps_legacy_behavior(self):
         """None (key absent) => every org is Enterprise, so resolution still runs."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id",
             return_value="resolved-id",
@@ -297,8 +292,6 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
 
 class TestResolveHfpushResourceGroupIdEnterprise:
     def test_enterprise_resolves_via_space(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id",
             return_value="space-id",
@@ -314,8 +307,6 @@ class TestResolveHfpushResourceGroupIdEnterprise:
         assert mock_resolve.call_args.kwargs["space_name"] == "public"
 
     def test_pinned_id_used_verbatim_without_resolver(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id"
         ) as mock_resolve:
@@ -331,8 +322,6 @@ class TestResolveHfpushResourceGroupIdEnterprise:
 
     def test_use_resource_group_false_opts_out(self):
         """An Enterprise org can opt out with use_resource_group: false."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id"
         ) as mock_resolve:
@@ -347,8 +336,6 @@ class TestResolveHfpushResourceGroupIdEnterprise:
         mock_resolve.assert_not_called()
 
     def test_use_resource_group_false_with_pinned_group_raises(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with pytest.raises(ValueError, match="cannot be combined"):
             resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -364,13 +351,11 @@ class TestResolveHfpushConfigPrecedence:
     """Environment-level config is honored, with build.yaml overriding it."""
 
     def test_env_level_store_push_is_honored(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id",
             return_value="ignored",
         ) as mock_resolve:
-            rg_id, private, _ = resolve_hfpush_resource_group_id(
+            _, private, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
                 assetstore=_make_assetstore(["ibm-research"]),
                 space_name="public",
@@ -383,8 +368,6 @@ class TestResolveHfpushConfigPrecedence:
         assert mock_resolve.call_args.kwargs["resource_group_name"] == "env-group"
 
     def test_build_yaml_overrides_environment(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
-
         with patch(
             "gbserver.spaces.resource_group.resolve_space_resource_group_id"
         ) as mock_resolve:
@@ -405,14 +388,10 @@ class TestResolveHfpushConfigPrecedence:
 
 class TestSanitizeHfStepOverlay:
     def test_strips_use_resource_group(self):
-        from gbserver.spaces.resource_group import sanitize_hf_step_overlay
-
         assert sanitize_hf_step_overlay(
             {"private": True, "use_resource_group": False}
         ) == {"private": True}
 
     def test_handles_empty_and_none(self):
-        from gbserver.spaces.resource_group import sanitize_hf_step_overlay
-
         assert sanitize_hf_step_overlay({}) == {}
         assert sanitize_hf_step_overlay(None) == {}

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -25,6 +25,7 @@ import pytest
 
 from gbcommon.uri.hf import HfURI
 from gbserver.spaces.resource_group import (
+    apply_hf_step_overlay,
     resolve_hfpush_resource_group_id,
     resolve_space_resource_group_id,
     sanitize_hf_step_overlay,
@@ -395,6 +396,34 @@ class TestSanitizeHfStepOverlay:
     def test_handles_empty_and_none(self):
         assert sanitize_hf_step_overlay({}) == {}
         assert sanitize_hf_step_overlay(None) == {}
+
+
+class TestApplyHfStepOverlay:
+    """The shared k8s/skypilot overlay: strip use_resource_group, then re-assert
+    the resolved resource_group_id so a stray pinned id in the raw config cannot
+    win over resolution."""
+
+    def test_strips_use_resource_group_and_reasserts_resolved_id(self):
+        hfpush_config = {"private": True, "hf": {"type": "model", "resource_group_id": None}}
+        apply_hf_step_overlay(
+            hfpush_config,
+            {"type": "model", "use_resource_group": False, "resource_group_id": "stray"},
+            resource_group_id="resolved-id",
+        )
+        assert "use_resource_group" not in hfpush_config["hf"]
+        # The resolved id wins over the stray id in the raw overlay config.
+        assert hfpush_config["hf"]["resource_group_id"] == "resolved-id"
+
+    def test_reasserts_none_over_a_stray_pinned_id(self):
+        # A pinned-but-skipped id (non-Enterprise org) resolves to None and must
+        # not be resurrected by the overlay.
+        hfpush_config = {"hf": {"type": "model", "resource_group_id": None}}
+        apply_hf_step_overlay(
+            hfpush_config,
+            {"resource_group_id": "pinned-but-skipped"},
+            resource_group_id=None,
+        )
+        assert hfpush_config["hf"]["resource_group_id"] is None
 
 
 class TestUseResourceGroupAcrossLevels:

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -724,3 +724,55 @@ class TestHfPushConfigError:
                     {"use_resource_group": False, "resource_group_id": "rg-1"}
                 ),
             )
+
+
+class TestResolveHfpushPrivate:
+    """The standalone ``private`` resolver used by the non-Hfstore push branch."""
+
+    def test_defaults_to_private(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_private
+
+        assert resolve_hfpush_private() is True
+
+    def test_honors_explicit_false(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_private
+
+        assert (
+            resolve_hfpush_private(output_config=_output_config({"private": False}))
+            is False
+        )
+
+    def test_output_overrides_environment(self):
+        from gbserver.spaces.resource_group import resolve_hfpush_private
+
+        assert (
+            resolve_hfpush_private(
+                storepush_config=_storepush_config({"private": True}),
+                output_config=_output_config({"private": False}),
+            )
+            is False
+        )
+
+    def test_agrees_with_the_full_resolver(self):
+        """Same rule, so the two entry points must never diverge."""
+        from gbserver.spaces.resource_group import (
+            resolve_hfpush_private,
+            resolve_hfpush_resource_group_id,
+        )
+
+        for hf_cfg in (
+            {},
+            {"private": True},
+            {"private": False},
+            {"private": None},
+            {"private": "false"},
+            {"private": "flase"},
+        ):
+            output_config = _output_config(hf_cfg)
+            _, from_full, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="my-user"),
+                assetstore=_make_assetstore([]),
+                space_name="public",
+                output_config=output_config,
+            )
+            assert resolve_hfpush_private(output_config=output_config) is from_full

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -404,10 +404,17 @@ class TestApplyHfStepOverlay:
     win over resolution."""
 
     def test_strips_use_resource_group_and_reasserts_resolved_id(self):
-        hfpush_config = {"private": True, "hf": {"type": "model", "resource_group_id": None}}
+        hfpush_config = {
+            "private": True,
+            "hf": {"type": "model", "resource_group_id": None},
+        }
         apply_hf_step_overlay(
             hfpush_config,
-            {"type": "model", "use_resource_group": False, "resource_group_id": "stray"},
+            {
+                "type": "model",
+                "use_resource_group": False,
+                "resource_group_id": "stray",
+            },
             resource_group_id="resolved-id",
         )
         assert "use_resource_group" not in hfpush_config["hf"]

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -461,3 +461,88 @@ class TestUseResourceGroupAcrossLevels:
 
         assert rg_id == "rg-on"
         mock_resolve.assert_called_once()
+
+
+class TestNullConfigValuesTreatedAsUnset:
+    """An explicit yaml null means "not set here", not "override with None".
+
+    A bare `private:` in build.yaml parses as None. Merging it wholesale would
+    erase a value inherited from environment.yaml, and a None reaching the step
+    config renders as the string "None" in the worker templates — failing their
+    `== "True"` test, so a repo meant to be private would be created public.
+    """
+
+    @pytest.mark.parametrize(
+        "env_hf,output_hf,expected",
+        [
+            # A null at the output level must not erase the environment value.
+            ({"private": False}, {"private": None}, False),
+            # A real value at the output level still wins.
+            ({"private": False}, {"private": True}, True),
+            # A null with nothing to inherit falls back to the default (True).
+            (None, {"private": None}, True),
+            ({"private": None}, {"private": None}, True),
+            # Unchanged behavior for values that are actually set.
+            (None, {"private": False}, False),
+            ({"private": False}, None, False),
+            (None, None, True),
+        ],
+    )
+    def test_private_resolution(self, env_hf, output_hf, expected):
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        _, private, _ = resolve_hfpush_resource_group_id(
+            hfuri=_make_hfuri(owner="my-user"),
+            assetstore=_make_assetstore([]),  # non-Enterprise: skips RG resolution
+            space_name="public",
+            storepush_config=_storepush_config(env_hf) if env_hf is not None else None,
+            output_config=_output_config(output_hf) if output_hf is not None else None,
+        )
+
+        assert private is expected, f"expected {expected}, got {private!r}"
+
+    def test_private_is_always_a_bool(self):
+        """Never a None: the worker templates stringify whatever they are given."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        _, private, _ = resolve_hfpush_resource_group_id(
+            hfuri=_make_hfuri(owner="my-user"),
+            assetstore=_make_assetstore([]),
+            space_name="public",
+            output_config=_output_config({"private": None}),
+        )
+
+        assert isinstance(private, bool)
+
+    def test_null_use_resource_group_does_not_disable_resolution(self):
+        """`use_resource_group:` with no value must not read as an opt-out."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="rg",
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"use_resource_group": None}),
+            )
+
+        assert rg_id == "rg"
+        mock_resolve.assert_called_once()
+
+    def test_null_resource_group_id_does_not_pin(self):
+        """A null id must not count as a pinned group on a non-Enterprise org."""
+        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+
+        rg_id, _, _ = resolve_hfpush_resource_group_id(
+            hfuri=_make_hfuri(owner="my-user"),
+            assetstore=_make_assetstore(["ibm-research"]),
+            space_name="public",
+            output_config=_output_config(
+                {"resource_group_id": None, "resource_group_name": None}
+            ),
+        )
+
+        assert rg_id is None

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -625,3 +625,48 @@ class TestNullConfigValuesTreatedAsUnset:
         )
 
         assert rg_id is None
+
+
+class TestHfPushConfigError:
+    """Config errors are a distinguishable subtype, not a bare ValueError.
+
+    The inline bash/docker push treats a resolution *miss* as best-effort but a
+    *config* error as fatal. Both used to be plain ``ValueError``, so the handler
+    could not tell them apart. Subclassing keeps older ``except ValueError``
+    callers (and the assertions above) working.
+    """
+
+    def test_is_a_valueerror_subclass(self):
+        from gbserver.spaces.resource_group import HfPushConfigError
+
+        assert issubclass(HfPushConfigError, ValueError)
+
+    def test_non_enterprise_pin_raises_the_subtype(self):
+        from gbserver.spaces.resource_group import (
+            HfPushConfigError,
+            resolve_hfpush_resource_group_id,
+        )
+
+        with pytest.raises(HfPushConfigError, match="not an HF Enterprise"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="my-user"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config({"resource_group_id": "rg-1"}),
+            )
+
+    def test_same_level_contradiction_raises_the_subtype(self):
+        from gbserver.spaces.resource_group import (
+            HfPushConfigError,
+            resolve_hfpush_resource_group_id,
+        )
+
+        with pytest.raises(HfPushConfigError, match="cannot be combined"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config(
+                    {"use_resource_group": False, "resource_group_id": "rg-1"}
+                ),
+            )

--- a/test/unit/spaces/test_resource_group.py
+++ b/test/unit/spaces/test_resource_group.py
@@ -395,3 +395,69 @@ class TestSanitizeHfStepOverlay:
     def test_handles_empty_and_none(self):
         assert sanitize_hf_step_overlay({}) == {}
         assert sanitize_hf_step_overlay(None) == {}
+
+
+class TestUseResourceGroupAcrossLevels:
+    """`use_resource_group: false` is per-level, not evaluated against the merge.
+
+    An environment-level resource group is a documented fallback (priority 3 in
+    docs/builds/hf-push.md). A build author who opts one output out of resource
+    groups cannot remove that inherited value from their build.yaml, so treating
+    the pair as contradictory would make the documented opt-out unusable.
+    """
+
+    def test_output_opt_out_overrides_inherited_group(self):
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config(
+                    {"resource_group_name": "gbspace-public"}
+                ),
+                output_config=_output_config({"use_resource_group": False}),
+            )
+
+        assert rg_id is None
+        mock_resolve.assert_not_called()
+
+    def test_same_level_contradiction_still_raises_at_output(self):
+        with pytest.raises(ValueError, match="same push config"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                output_config=_output_config(
+                    {"use_resource_group": False, "resource_group_id": "rg-1"}
+                ),
+            )
+
+    def test_same_level_contradiction_still_raises_at_environment(self):
+        with pytest.raises(ValueError, match="same push config"):
+            resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config(
+                    {"use_resource_group": False, "resource_group_name": "g"}
+                ),
+            )
+
+    def test_environment_opt_out_is_overridable_by_output(self):
+        """The reverse direction: an output can turn resource groups back on."""
+        with patch(
+            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            return_value="rg-on",
+        ) as mock_resolve:
+            rg_id, _, _ = resolve_hfpush_resource_group_id(
+                hfuri=_make_hfuri(owner="ibm-research"),
+                assetstore=_make_assetstore(["ibm-research"]),
+                space_name="public",
+                storepush_config=_storepush_config({"use_resource_group": False}),
+                output_config=_output_config({"use_resource_group": True}),
+            )
+
+        assert rg_id == "rg-on"
+        mock_resolve.assert_called_once()

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 
 from gbcommon.types.testing import (
     ENV_VAR_GBTEST_MOCK_HF,
+    ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT,
     disable_hf_mocks,
     enable_hf_mocks,
 )
@@ -1069,13 +1070,85 @@ class TestSpaceNameToResourceGroupName:
 
     def test_standalone_uses_write_rg_suffix(self, monkeypatch):
         # STANDALONE test mode targets the configured write resource group
-        # (GB_TEST_STANDALONE_ENVIRONMENT, "STAGING" by default) so test
+        # (GBTEST_STANDALONE_ENVIRONMENT) so test
         # artifacts have a real RG to push to.
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STANDALONE")
-        monkeypatch.setattr("gbcommon.uri.hf.GB_TEST_STANDALONE_ENVIRONMENT", "STAGING")
+        monkeypatch.setenv(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, "STAGING")
         assert (
             HfURI.space_name_to_resource_group_name("public")
             == "gbspace-public-staging"
+        )
+
+    @pytest.mark.parametrize("alias", ["standalone", "local", "public"])
+    def test_standalone_space_resolves_to_gbspace_public(self, monkeypatch, alias):
+        """The behavior real standalone users get: "gbspace-public", no suffix.
+
+        Under GB_ENVIRONMENT=STANDALONE the three space names `gbserver
+        standalone --space-dir` registers ("public", "standalone", "local") are
+        one space sharing one resource group, and the group provisioned for it is
+        the production `gbspace-public`. Community and internal users have no
+        access to `gbspace-public-staging` / `-dev`, so resolution must not land
+        on those.
+
+        GBTEST_STANDALONE_ENVIRONMENT is set empty here deliberately. It
+        defaults to STAGING so a test run pushes into a group it owns; clearing
+        it asserts the core derivation independently of that redirection.
+        """
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STANDALONE")
+        monkeypatch.setenv(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, "")
+        assert HfURI.space_name_to_resource_group_name(alias) == "gbspace-public"
+
+    @pytest.mark.parametrize(
+        "redirect,expected",
+        [
+            ("STAGING", "gbspace-public-staging"),
+            ("DEV", "gbspace-public-dev"),
+        ],
+    )
+    def test_standalone_alias_honors_test_redirection(
+        self, monkeypatch, redirect, expected
+    ):
+        """A test run redirects the standalone space to a group it owns.
+
+        GBTEST_STANDALONE_ENVIRONMENT exists so a test run pushes into a
+        non-production group instead of the real one. Alias folding happens first,
+        so "standalone" redirects to that environment's *public* group.
+        """
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STANDALONE")
+        monkeypatch.setenv(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, redirect)
+        assert HfURI.space_name_to_resource_group_name("standalone") == expected
+
+    @pytest.mark.parametrize("alias", ["standalone", "local"])
+    def test_standalone_aliases_fold_onto_public(self, monkeypatch, alias):
+        """ "standalone"/"local" name the same space as "public".
+
+        `gbserver standalone --space-dir` registers all three as rows pointing at
+        one directory, and only "public" has a provisioned HF resource group, so
+        deriving "gbspace-standalone"/"gbspace-local" would name a group that
+        does not exist on the Hub.
+        """
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
+        assert HfURI.space_name_to_resource_group_name(alias) == "gbspace-public"
+
+    @pytest.mark.parametrize("alias", ["STANDALONE", "Local", "  local  "])
+    def test_alias_match_is_case_and_whitespace_insensitive(self, monkeypatch, alias):
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
+        assert HfURI.space_name_to_resource_group_name(alias) == "gbspace-public"
+
+    def test_alias_folding_still_gets_the_env_suffix(self, monkeypatch):
+        """Folding happens before the suffix, so the two compose."""
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "DEV")
+        assert (
+            HfURI.space_name_to_resource_group_name("standalone")
+            == "gbspace-public-dev"
+        )
+
+    def test_non_alias_space_name_is_not_rewritten(self, monkeypatch):
+        """Only the standalone aliases fold; a real space keeps its own group."""
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "PROD")
+        assert (
+            HfURI.space_name_to_resource_group_name("my-team-space")
+            == "gbspace-my-team-space"
         )
 
     def test_empty_space_name_returns_empty(self, monkeypatch):

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -29,6 +29,7 @@ from gbcommon.types.testing import (
     ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT,
     disable_hf_mocks,
     enable_hf_mocks,
+    standalone_rg_environment,
 )
 from gbcommon.uri.hf import (
     DEFAULT_REVISION,
@@ -1090,13 +1091,28 @@ class TestSpaceNameToResourceGroupName:
         access to `gbspace-public-staging` / `-dev`, so resolution must not land
         on those.
 
-        GBTEST_STANDALONE_ENVIRONMENT is set empty here deliberately. It
-        defaults to STAGING so a test run pushes into a group it owns; clearing
-        it asserts the core derivation independently of that redirection.
+        GBTEST_STANDALONE_ENVIRONMENT is set empty here explicitly. That is
+        also its default, so this is what an unset var produces too (see
+        test_standalone_default_is_production_group); setting it makes the test
+        independent of the default.
         """
         monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STANDALONE")
         monkeypatch.setenv(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, "")
         assert HfURI.space_name_to_resource_group_name(alias) == "gbspace-public"
+
+    def test_standalone_default_is_production_group(self, monkeypatch):
+        """An UNSET GBTEST_STANDALONE_ENVIRONMENT must give the production group.
+
+        This is the real-user path: nobody outside CI sets a GBTEST_ variable, so
+        the default alone decides which group a standalone push targets. A
+        non-empty default (this was "STAGING") silently sends real users to
+        gbspace-public-staging, which they cannot write. Deleting the var rather
+        than setting it empty is the point of this test.
+        """
+        monkeypatch.setattr("gbcommon.uri.hf.GB_ENVIRONMENT", "STANDALONE")
+        monkeypatch.delenv(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, raising=False)
+        assert standalone_rg_environment() == ""
+        assert HfURI.space_name_to_resource_group_name("public") == "gbspace-public"
 
     @pytest.mark.parametrize(
         "redirect,expected",

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -1100,6 +1100,21 @@ class TestSpaceNameToResourceGroupName:
         monkeypatch.setenv(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT, "")
         assert HfURI.space_name_to_resource_group_name(alias) == "gbspace-public"
 
+    def test_conftest_defaults_the_session_to_staging(self):
+        """The pytest session itself must be redirected away from production.
+
+        test/conftest.py setdefault()s GBTEST_STANDALONE_ENVIRONMENT=STAGING at
+        session start, so every pytest entry point — not just the extended-tests
+        Makefile target — aims a live standalone push at a group the CI token
+        owns. This asserts that wiring is in place; the source default is empty
+        (see test_standalone_default_is_production_group), so losing the conftest
+        line would silently point live test pushes at gbspace-public.
+
+        Read from os.environ, not via monkeypatch: the point is the ambient
+        session value.
+        """
+        assert os.environ.get(ENV_VAR_GBTEST_STANDALONE_ENVIRONMENT) == "STAGING"
+
     def test_standalone_default_is_production_group(self, monkeypatch):
         """An UNSET GBTEST_STANDALONE_ENVIRONMENT must give the production group.
 

--- a/test/unit/utils/test_hf_enterprise_org.py
+++ b/test/unit/utils/test_hf_enterprise_org.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``is_enterprise_hf_org`` (the Enterprise/non-Enterprise split)."""
+
+import pytest
+
+from gbcommon.utils.hf_utils import is_enterprise_hf_org
+
+
+class TestIsEnterpriseHfOrgBackCompat:
+    def test_none_treats_every_org_as_enterprise(self):
+        """An absent config key preserves the pre-split behavior."""
+        assert is_enterprise_hf_org("ibm-research", None) is True
+        assert is_enterprise_hf_org("some-random-user", None) is True
+
+    def test_empty_list_treats_no_org_as_enterprise(self):
+        """An explicit empty list is a full opt-out, distinct from None."""
+        assert is_enterprise_hf_org("ibm-research", []) is False
+
+
+class TestIsEnterpriseHfOrgMatching:
+    @pytest.mark.parametrize("org", ["ibm-research", "ibm-granite"])
+    def test_listed_orgs_are_enterprise(self, org):
+        assert is_enterprise_hf_org(org, ["ibm-research", "ibm-granite"]) is True
+
+    def test_unlisted_org_is_not_enterprise(self):
+        assert is_enterprise_hf_org("my-user", ["ibm-research"]) is False
+
+    def test_match_is_case_insensitive(self):
+        """HF namespaces are case-insensitive, so matching must be too."""
+        assert is_enterprise_hf_org("IBM-Research", ["ibm-research"]) is True
+        assert is_enterprise_hf_org("ibm-research", ["IBM-RESEARCH"]) is True
+
+    def test_surrounding_whitespace_is_ignored(self):
+        assert is_enterprise_hf_org("  ibm-research  ", [" ibm-research "]) is True
+
+    def test_no_substring_or_prefix_matching(self):
+        """Exact match only — a prefix must not qualify."""
+        assert is_enterprise_hf_org("ibm-research-team", ["ibm-research"]) is False
+        assert is_enterprise_hf_org("ibm", ["ibm-research"]) is False
+
+    def test_wildcard_is_not_special(self):
+        """'*' is a literal name, not a wildcard (exact-match-only design)."""
+        assert is_enterprise_hf_org("anything", ["*"]) is False
+
+    def test_empty_and_none_org_are_not_enterprise(self):
+        assert is_enterprise_hf_org("", ["ibm-research"]) is False
+        assert is_enterprise_hf_org(None, ["ibm-research"]) is False
+
+    def test_empty_entries_in_list_are_ignored(self):
+        assert is_enterprise_hf_org("", ["", None, "ibm-research"]) is False
+        assert is_enterprise_hf_org("ibm-research", ["", "ibm-research"]) is True


### PR DESCRIPTION
## Summary

Enables the `hf` asset store for **non-Enterprise** HF orgs. Resource groups are an HF Enterprise feature, but the store treated them as mandatory on every push, so pushing to an individual user namespace or a plain community org either burned an admin-gated HF API call that had to fail (k8s/lsf/skypilot) or hard-failed outright in the CLI.

Which orgs are Enterprise cannot be determined from the HF API without admin scope, so the split is configuration-driven.

- **`config.enterprise_organizations`** in the `hf` asset store's `store.yaml` lists the Enterprise orgs. A push to an org outside the list skips resource-group resolution entirely — no space lookup, no HF API call. **Omitting the key treats every org as Enterprise, so existing deployments are unchanged.**
- **`is_enterprise_hf_org()`** (`gbcommon/utils/hf_utils.py`) is the shared classifier — exact, case-insensitive match. `None` (key absent) means "all Enterprise"; an explicit `[]` means "none".
- **`resolve_hfpush_resource_group_id()`** (`gbserver/spaces/resource_group.py`) consolidates the ~40-line resolution block that was duplicated across four push paths.
- Pinning a resource group for a non-Enterprise org now raises `ValueError` with an actionable message; `gb artifact push --resource-group-id` reports the equivalent. (`gb artifact register` no longer takes `--resource-group-id` at all — see the follow-ups below.)
- An Enterprise org can opt out per-output with **`use_resource_group: false`**. The key is stripped before the config reaches a worker step template.
- CLI: `hf_enterprise_organizations` on `GBEnvConfig`, since `gbcli` cannot read `store.yaml` (loaded server-side from the space git repo). Both sides carry a sync comment. `upload_to_hf` now only requires an id for Enterprise orgs (`register_artifact_hf` never validated one — it forwards the id to metadata-only endpoints).

Pulling is unaffected — every hfpull step runs plain `hf download` with no resource group.

### Drift fixed along the way

`lsf.py` read the environment-level `storepush_config` and then let `store_push` override it, while `k8s.py` and `skypilot.py` read **only** `store_push` — so priority level 3 in the resource-group table in `docs/builds/hf-push.md` (the `environment.yaml` fallback) was honored on LSF alone. Consolidating into one helper applies the documented precedence uniformly.

Note that bash and docker have no hfpush step directory — both delegate to `local_assets.push_asset_hfstore` — so the five `pushasset_hfstore` implementations collapse to four resolution sites.

### Latent bugs fixed

- **LSF worker.** Jinja renders a Python `None` as the literal string `"None"`, which is non-empty to bash, so `command.sh` would have POSTed `"resourceGroupId":"None"` and the HF create call would fail. Latent before (the id was almost always set), the common case after. Normalized to empty, mirroring the guard the skypilot step already had. k8s is unaffected — it serializes a real YAML null that Helm's `default ""` handles.
- **`"<unknown>"` placeholder.** `resolve_space()` writes the truthy string `"<unknown>"` into `hf_default_resource_group_id` when a profile space can't be resolved from the local cache, and `command_artifact.py` read it with a bare `.get(...)` — so a bogus id could reach `create_repo`. Now treated as absent.

### Second commit: env config refactor

Adding `hf_enterprise_organizations` made the duplication in `_GB_ENVIRONMENT_CONFIGS` visible — all 19 fields were spelled out for each of four environments. Restructured values.yaml-style: a base dict plus a per-environment override dict, combined by `deep_merge()` at the call site. `hf_organization` and `hf_enterprise_organizations` now appear once instead of four times.

All four resolved configs are **byte-identical** to before, verified by diffing a `model_dump()` snapshot taken pre-refactor — including under `GBSERVER_BACKEND_SERVER_NAMESPACE_*` and `GBSERVER_ARTIFACT_FILTER`, which are read at import time.

Closes ibm-granite/granite.build#327

## Test plan

New coverage:

- `test/unit/utils/test_hf_enterprise_org.py` — classifier: exact/case-insensitive match, `None` vs `[]`, no substring or wildcard matching.
- `test/unit/spaces/test_resource_group.py` — non-Enterprise skips resolution (`assert_not_called()` on the resolver), pinned-RG rejection, `use_resource_group: false`, env-level precedence (the drift fix above).
- `test/unit/asset/test_hfstore.py` — `get_enterprise_organizations()` cases, a guard on the shipped `store.yaml`, and an LSF regression test that renders the real `command.sh` template and runs the resulting bash to assert `resourceGroupId` is omitted.
- `test/unit/environment/test_{lsf,skypilot,docker,bash}_hfstore.py` — non-Enterprise push emits `resource_group_id: None`; bash/docker forward `store_push` into the inline helper; a non-`Hfstore` assetstore does not abort the push. Existing Enterprise fixtures now declare their org so they keep asserting the Enterprise path. (The assertion that `use_resource_group` never reaches a worker config lives in `test_resource_group.py`, via `sanitize_hf_step_overlay`.)
- `test/unit/gbcli/services/test_artifact_hf_enterprise.py` — `upload_to_hf` uploads with no RG for a non-Enterprise org (repo **and** bucket/fileset branches), still raises for Enterprise.
- `test/unit/gbtypes/test_gbenvconfig.py` — first coverage for this module: merge semantics plus structural guards (base complete, no override restates a base value, the inlined STANDALONE sets every field). Each guard was confirmed to fail when the source was deliberately broken.
- `test/unit/environment/test_local_assets_private.py` — pins the `private` kwarg that actually reaches `HfURI.push` on the inline path: no config, explicit `true`/`false`, yaml null, a non-`Hfstore` assetstore, and a resolver failure. These exercise the real `push_asset_hfstore` (only `push` and the RG lookup are mocked) — the existing bash/docker tests mock `push_asset_hfstore` itself, so they structurally cannot catch a dropped kwarg. All six fail against the unfixed source.
- `test/unit/uri/test_hf.py` — an unset-variable case asserting the production default, and a guard that the conftest session default is in place (it fails with `assert None == 'STAGING'` when the conftest block is removed).

```
GB_ENVIRONMENT=STANDALONE GBTEST_MODE=mock \
  GBTEST_MOCKED_HF_OPS=push,exists,delete,resource_group \
  pytest test/unit -q -m "not ibm and not extended"
# 2590 passed, 12 skipped, 0 failed
```

`pylint` is 10.00/10 on every new `src/` file; `mypy` is unchanged from the baseline (83 `gbserver` / 65 `gbcommon` errors, byte-identical before and after with line numbers normalized, measured as CI invokes it per-package). `local_assets.py` carries the same pre-existing pylint warnings as on `main` — none added.

### Not yet verified

The manual end-to-end checks need an HF token with write access to a personal namespace:

```bash
# must now succeed (previously exited 1)
gb artifact push --store hf --hf-organization <your-hf-user> \
    --artifact-name gb-nonent-test -t model --from-local ./some-dir

# must fail with the non-Enterprise message
gb artifact push --store hf --hf-organization <your-hf-user> \
    --resource-group-id abc123 --artifact-name x -t model --from-local ./some-dir

# unchanged: still resolves a resource group
gb artifact push --store hf --hf-organization ibm-research \
    --artifact-name gb-ent-test -t model --from-local ./some-dir
```

The equivalent logic was verified in-process (including that `use_resource_group` never reaches the worker config, and that the rendered LSF script omits `resourceGroupId`), but not against the live Hub.

## Follow-up fixes

The first item came from review; the rest were found while acting on it.

**Sixth review round** (rebased onto latest `main`):

- **`--resource-group-id` removed from `gb artifact register`.** Register is a metadata-only operation — it POSTs to `hf/{type}` to record the artifact and never creates the HF repo — so a resource group, which governs where a repo is *physically* provisioned in an HF Enterprise org, has nothing to act on there. `register_artifact_hf` accepted the id but never put it in the request payload, so the flag was silently a no-op. Removed the option, its parameter, the non-Enterprise rejection guard (which was guarding a no-op), and the two `register_artifact` call-site args. `push` is unaffected: it resolves and forwards a real `resource_group_id` and still uses the shared rejection helper, and the client/service `resource_group_id` parameters stay for push's post-upload registration.

- **Dead nested `hf.private` key removed** from `build_hfpush_step_config`. It emitted `private` at both the top level and inside the `hf` block, but every step template reads only the top-level one. Worse, on k8s/skypilot the overlay (`sanitize_hf_step_overlay` + `.update`) rewrites `hf.*` from the raw push config and re-asserts only `resource_group_id`, so `hf.private` carried the *unresolved* value — a future author switching to read it would reintroduce the exact "private not honored" bug this PR fixes. A regression test asserts the key stays absent.

- **Duplicated CLI rejection collapsed.** The `--resource-group-id` non-Enterprise rejection was copied verbatim between `push` and `register`; extracted into `_reject_resource_group_for_non_enterprise` (message preserved). With the register removal above, the helper now has a single caller (`push`) but stays factored for symmetry with the server-side `_non_enterprise_rg_error`.

- **Duplicated overlay idiom extracted.** The `sanitize_hf_step_overlay(...).update()` + resolved-id re-assert was duplicated verbatim in `k8s.py` and `skypilot.py`; extracted into `apply_hf_step_overlay` so the two invariants (strip `use_resource_group`, re-assert the resolved id) cannot drift between environments.

- **Rebase adaptation.** Rebased across #314 (HF mocking reworked to the boolean `GBTEST_MOCK_HF` / no-arg `is_hf_mocked()` API — this PR's `is_hf_mocked(HF_OP_*)` calls and `GBTEST_MOCKED_HF_OPS` test wiring were migrated) and #313 (HF-URI support in `artifact register` — this PR's register guard was folded into #313's restructured `store == "lh"` block).

**Fifth review round** (`7a674a5c`, `cf83f61b`, `d06bb1e7`, `b4792c64`):

- **The best-effort standalone push aborted on an expected resolution miss.** A review catch, and a genuine regression introduced by this PR — see the note under the second round, where the `except ValueError: raise` originated. `resolve_resource_group_id_for_org` raises a bare `ValueError` for an unresolvable group name, which in standalone is the *expected* outcome (resolving an id needs org-admin scope, and `_resolve_resource_group_id` swallows the 403 a non-admin token gets and returns `None`). Indistinguishable by class from the config error the re-raise was meant to enforce, so a bash/docker push to `ibm-research` — an Enterprise org, and the default — aborted where `main` pushed with `resource_group_id=None` on purpose.

  Fixed with `HfPushConfigError(ValueError)`, raised for the two config mistakes only: a resource group pinned for a non-Enterprise org, and a same-level pin contradicting `use_resource_group: false`. `local_assets.py` re-raises that subtype; a plain `ValueError` falls through to `except Exception` and pushes without a group, as the block's comment documents. Subclassing `ValueError` keeps existing `except ValueError` callers and the CLI assertions working.

  Unit tests could not have caught this: `is_hf_mocked(HF_OP_RESOURCE_GROUP)` returns early at `hf.py:910`, so no mocked test reaches the raising branch. `test_miss_from_the_real_resolver_chain_still_pushes` drives the genuine chain with `is_hf_mocked` patched to `False`.

- **The non-`Hfstore` branch dropped `private`.** A review catch. That branch hardcoded `private=True` and never consulted `storepush_config` / `output_config`, so an explicit `private: false` was silently ignored — asymmetric with the `Hfstore` branch. `private` is store-independent, so `resolve_hfpush_private()` is split out of the resolver and read on both paths; only the resource-group half still differs (classifying the org needs `Hfstore`'s Enterprise list). Default stays `True` — HuggingFace's own `create_repo` default is public, so an omitted value must resolve private here.

- **A quoted `private: "false"` resolved truthy and would have created a public repo.** Not a review catch — found while fixing the item above. `_bool_or` ended in `bool(value)`, so the non-empty string `"false"` was `True`. Both booleans now go through the existing `gbcommon` `parse_boolean`, which folds `false`/`no`/`off`/`0` (quoted or not) onto `False`, keeps yaml-null → default, and warns-then-defaults-private on a typo like `flase`. Identical to `_bool_or` on the three inputs that occur in practice; every difference is a quoted form the old helper got wrong. `parse_boolean`'s annotation widened from `str | None` to `object | None`, since YAML yields real `bool`.

- **Docstring and Makefile comment resynced.** Review catches, both cosmetic. The `push_asset_hfstore` docstring now explains the space-name → resolved-id derivation (and why a *name* must not be passed to `push`), documents `storepush_config` / `output_config`, and lists `HfPushConfigError` under `Raises:`. The `extended-tests` comment said "Export it here to override that" when no such export exists; the intended meaning was the opposite.

- **Correction to an earlier round.** I previously implied the shipped `hf` `store.yaml` sets `store_push.config.hf.private: true`. It does not — there is no `store_push` block in any YAML in the repo. The private-by-default behavior comes purely from the code default, so the tests assert "absent config ⇒ `private=True`".

**Fourth review round** (`51a74316`, `5de3f73c`):

- **`private` was dropped on the bash/docker inline push, so repos could be created public.** `push_asset_hfstore` resolved `private` from the merged config and then discarded it as `_private`, so `HfURI.push` received `private=None` and `create_repo`/`create_bucket` fell back to HuggingFace's own default, which is **public**. A build setting `store_push.config.hf.private: true` — or relying on the documented `true` default — got a public repo on exactly the two environments with no hfpush step template. `main` never forwarded it either, so this is a pre-existing hole rather than a regression, but consolidating the resolution is what made it visible. k8s/lsf/skypilot already forwarded `hf_private`.

  `private` is initialized to `True` *before* the assetstore branch, not just inside it: the non-`Hfstore` path and both `except` paths fall through to the same `hfuri.push()`, so a value bound only in the `Hfstore` try-block would leave those three paths publishing. Private-by-default is a deliberate guard against an accidental public push, so the default holds on every path and only an explicit `private: false` opts out.

- **The standalone resource-group default pointed real users at staging.** `GBTEST_STANDALONE_ENVIRONMENT` defaulted to `STAGING` (carried over from `constants.py` on `main`), so a real standalone user who sets no `GBTEST_*` variable derived `gbspace-public-staging` — a group they cannot write — contradicting the comment beside it promising the production group. The source default is now empty, so an unset variable gives the production `gbspace-public`.

  The staging redirect moved to `test/conftest.py`, which `setdefault()`s `GBTEST_STANDALONE_ENVIRONMENT=STAGING` in `pytest_sessionstart`. This covers every pytest entry point rather than the two Makefile recipes that exported it — the Makefile has a dozen other pytest invocations, and a bare `pytest test/unit` bypassed all of them, so any of those running live would have aimed a standalone push at the production group. `setdefault` means an explicit caller value still wins, and an explicitly *empty* value survives (it fires only on a missing key), so a deliberate production-targeting run is still possible. The two now-redundant Makefile exports are removed.

  `DEFAULT_NON_SECRET_ENV_VAR_VALUES` in the same conftest was the other candidate, but it only applies inside `set_test_env()`, which returns early without the IBM SDK and is skipped entirely without an SPS API key — so it would not fire on the paths that need it.

- **`merge_hf_push_config` was dead code** and is removed. Never called: the resolver needs the levels kept apart for the cross-level `use_resource_group` precedence and uses `_hf_push_config_levels` / `_merge_hf_levels` directly, which left the merged-view wrapper vestigial. My third-round note claiming it was "called elsewhere" was wrong.

- Deferred: `resolve_hfpush_resource_group_id` is 74 executable lines (114 total, incl. a 26-line docstring) against the 40-line guideline. The `use_resource_group` block is the natural extraction, but splitting it touches the logic five rounds of review have converged on, so I would rather do it separately than reopen it here.

**Third review round** (`ddb2860a`):

- **An environment-level `use_resource_group: false` silently discarded an output-level pinned group.** The opt-out was evaluated off the merged config, so it could not tell which level a pin came from: `environment.yaml` opting out plus a build.yaml output pinning `resource_group_id` resolved to *no* group, discarding a pin written at priority 1 with no error. An output-level pin now re-enables resource groups over an inherited opt-out, symmetric to the `use_resource_group: true` case; a lower-level pin still loses to an output-level opt-out, and a same-level opt-out + pin still raises. `docs/builds/hf-push.md` gains a table for the cross-level combinations.
- The k8s/skypilot overlay comments claimed "resolution-only keys are stripped" when `sanitize_hf_step_overlay` strips only `use_resource_group`; softened rather than stripping more, since the templates ignore `resource_group_name` and emitting it matches pre-PR behavior.
- `resolve_hfpush_resource_group_id` parsed the push config twice; now parses once. (I kept `merge_hf_push_config`'s signature on the grounds that it was "called elsewhere" — it was not; see the fourth round.)

**Second review round** (`259fd285`, `04ec4ec4`):

- **`space_name` hardcoded to `"public"`** on the Enterprise inline push. Fixed by moving the standalone-alias equivalence into `HfURI.space_name_to_resource_group_name` — `public` / `standalone` / `local` are three rows for one space dir, and only `public` has a resource group provisioned — so the hardcode is no longer needed and a real space name survives. Isolating that derivation in a test surfaced a latent bug beside it: the `STANDALONE` branch appended `GBTEST_STANDALONE_ENVIRONMENT` unconditionally, so an empty value produced the malformed `"gbspace-public-"`. That knob also moved from `gbcommon/types/constants.py` to `gbcommon/types/testing.py`, since a `GBTEST_*` variable was reachable from `resolve_space_resource_group_id` and the `/hf/resource-group` endpoint. (Its `STAGING` default was carried over unchanged at that point; the fourth review round above flips it to empty and moves the staging redirect into `test/conftest.py`.)
- **An explicit yaml `null` could clobber an inherited `private`** and reach a worker template. `merged.update()` copied nulls, so a bare `private:` erased `private: false` from `environment.yaml`, and `.get("private", True)` returned `None` because the key was present. `None` renders as `"None"` in the LSF template and fails its `== "True"` test, so the repo would have been created **public**. Nulls are now skipped during the merge and `_bool_or` supplies the default; `use_resource_group` (previously correct only because `not None` is truthy) gets the same treatment.
- **CLI/server Enterprise-list parity** is now asserted against the shipped `store.yaml` — the env configs, the `HF_ENTERPRISE_ORGANIZATIONS` constant the CLI reads, and `is_enterprise_hf_org` agreeing from either source.

- **`use_resource_group: false` was unusable with an environment-level group.** `merge_hf_push_config` folded both levels before the contradiction check, so an inherited level-3 `resource_group_name` from `environment.yaml` made a per-output opt-out raise `ValueError` — telling the build author to remove a value they never wrote. The check is now per-level: a per-output opt-out overrides an inherited group (logging what it overrode), and only a same-level pairing raises.
- **bash/docker silently dropped `store_push`.** Not a review catch — a gap in this PR's own implementation. Consolidating the four resolution sites into one helper left the two *callers* on the inline path unchanged: both `pushasset_hfstore` implementations took `storepush_config` for the mode warning only and swallowed `output_config` via `**_kwargs`, so `use_resource_group` / `resource_group_id` / `resource_group_name` never reached HF on exactly the two environments where the non-Enterprise case lives. Both now forward into `push_asset_hfstore`, which routes through the shared helper.

  **Superseded by the fifth review round above — see that section for the corrected behavior.** As originally written, a `ValueError` from the helper was re-raised on that path rather than swallowed. `push_asset_hfstore` deliberately treats resolution as best-effort — in standalone a local token usually *cannot* resolve a resource group id (that needs org-admin scope), so a miss is expected and the push proceeds without one. But the helper raises `ValueError` for exactly one thing: a resource group pinned for a non-Enterprise org, which is a *configuration* error, not a transient lookup failure. Swallowing it would push while silently ignoring what the build.yaml asked for, and would diverge from k8s/lsf/skypilot, where the same config already fails the push. Transient failures keep the old best-effort behavior (`except Exception` → log and continue with no resource group). That reasoning was right about *why* a config error should abort, but the implementation was too broad: `resolve_resource_group_id_for_org` also raises a bare `ValueError` for an unresolvable group name, which is the expected non-admin-token miss — so this aborted the very best-effort case it meant to preserve. The fifth round narrows it to a dedicated exception type. This change was also not requested by review; I bundled it into a commit about something else.
- **LSF's unused `_hf_cfg`** now carries a comment explaining that LSF deliberately applies no post-hoc overlay (it never did, and its `command.sh` consumes only the keys `build_hfpush_step_config` emits).
- **`deep_merge`'s docstring** claimed "Neither input is mutated"; narrowed to note the copy is shallow, so an untouched list or nested dict is shared by reference. Harmless here because pydantic deep-copies on validation, but a trap for a caller that skips it.

## Follow-ups (not in this PR)

- The Enterprise-list parity test covers only the **shipped standalone** `store.yaml`; a remote space keeps its copy in its own git repo, so that one can still drift from `GBEnvConfig.hf_enterprise_organizations`. Closing it properly needs a server endpoint the CLI can query.
- `ArtifactType` is defined twice: `gbcommon/types/artifact.py` (zero importers) and `gbserver/types/artifact.py` (25 importers). Identical members but distinct classes — `==` works since StrEnum compares by value, while `is`/`isinstance` fail. Deduplicating it is the prerequisite for any `gbcommon`→`gbserver` layering cleanup.
- `gbcommon/types/testing.py` holds `GBTEST_*` knobs but is imported by six production modules (`gbcommon/uri/hf.py`, `gbserver/environment/{environment,k8s,lsf,skypilot}.py`, `gbserver/buildrunnerjob/buildrunnerjob.py`), and `standalone_rg_environment()` is read from live resource-group derivation in `hf.py`. So it cannot simply move under `test/` — the test-only knobs and the production-reachable ones need separating first. Same layering cleanup as the item above; deliberately out of scope here to avoid touching broad test files and conflicting with other open PRs.

Generated with [Claude Code](https://claude.com/claude-code)







