### PR TITLE
Don't fail a live AppWrapper when retries are disabled (#335)

### DIFF
--- a/src/gbserver/resilience/retry_handler.py
+++ b/src/gbserver/resilience/retry_handler.py
@@ -394,10 +394,22 @@ class RetryHandler:
                 # retry -- but can't, because retry_count >= max_retries -- would
                 # be neither relaunched nor raised, leaving a monitor's deferred
                 # wait (e.g. LSF's _retry_pending_after_monitor) hanging forever.
+                #
+                # But this escalation must not fire while the workload is still
+                # live: a retriable event that reports a present, non-terminal
+                # state (e.g. a K8s AppWrapper still Running/Unhealthy whose pod
+                # is stuck in FailedScheduling on cluster-wide GPU exhaustion) is
+                # transient backpressure, not a failure. Failing it -- especially
+                # when retries are disabled (max_retries == 0, so retry_count 0 >=
+                # 0 is immediately true) -- would turn a workload that is merely
+                # waiting for capacity, and may still succeed, into a false-positive
+                # build failure (#335). Stateless failure events (e.g. LSF's) carry
+                # no state and so still escalate.
                 retries_exhausted_on_retriable = (
                     not retry_triggered
                     and self.retry_count >= self.max_retries
                     and self._is_retriable_event(event)
+                    and not self._is_live_nonterminal_state(event)
                 )
 
                 # Always forward the event downstream, but enrich with retry metadata
@@ -684,6 +696,41 @@ class RetryHandler:
     def stop(self: Self) -> None:
         """Stop processing events."""
         self.stop_processing = True
+
+    def _is_live_nonterminal_state(self: Self, event: BuildEvent) -> bool:
+        """
+        Report whether the event shows the workload is still live / non-terminal.
+
+        A retriable event that reports a present, non-terminal ``state`` (e.g. a
+        K8s AppWrapper still ``Running``/``Unhealthy`` while a pod waits on GPU
+        capacity) describes transient backpressure, not a failure -- so it must
+        not be escalated to a terminal verdict when retries are exhausted/disabled
+        (see ``process_events``).
+
+        Returns False when no ``state`` can be parsed (e.g. LSF-style plain failure
+        events), so those still escalate, and False for terminal states
+        (``Failed`` / ``Exception:``), which are handled by
+        ``_is_terminal_failure_event``.
+
+        Args:
+            event: BuildEvent from the monitor
+
+        Returns:
+            bool: True if the event reports a present, non-terminal state
+        """
+        msg = getattr(event.payload, "msg", None)
+        if not msg:
+            return False
+        try:
+            json_match = re.search(r"```json\s*\n(.*?)\n```", msg, re.DOTALL)
+            if not json_match:
+                return False
+            state = json.loads(json_match.group(1)).get("state", "")
+        except (json.JSONDecodeError, AttributeError):
+            return False
+        if not state or state == "Failed" or state.startswith("Exception:"):
+            return False
+        return True
 
     def _is_terminal_failure_event(self: Self, event: BuildEvent) -> bool:
         """

--- a/src/gbserver/resilience/retry_handler.py
+++ b/src/gbserver/resilience/retry_handler.py
@@ -697,6 +697,38 @@ class RetryHandler:
         """Stop processing events."""
         self.stop_processing = True
 
+    def _parse_event_json(self: Self, event: BuildEvent) -> Optional[dict]:
+        """Parse the ```json block an AppWrapper monitor embeds in the event msg.
+
+        Single source of truth for the state classifiers
+        (``_is_terminal_failure_event`` / ``_is_live_nonterminal_state``) and the
+        failure-message formatter, so the extraction can't drift between them.
+
+        Args:
+            event: BuildEvent from the monitor
+
+        Returns:
+            The decoded object, or ``None`` when the event has no ``msg``, no
+            ```json``` block, the block is not valid JSON, or it does not decode
+            to an object.
+        """
+        msg = getattr(event.payload, "msg", None)
+        if not msg:
+            return None
+        json_match = re.search(r"```json\s*\n(.*?)\n```", msg, re.DOTALL)
+        if not json_match:
+            return None
+        try:
+            data = json.loads(json_match.group(1))
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.debug(
+                "[RetryHandler launch_id %s] Could not parse event message as JSON: %s",
+                self.launch_id,
+                e,
+            )
+            return None
+        return data if isinstance(data, dict) else None
+
     def _is_live_nonterminal_state(self: Self, event: BuildEvent) -> bool:
         """
         Report whether the event shows the workload is still live / non-terminal.
@@ -718,16 +750,10 @@ class RetryHandler:
         Returns:
             bool: True if the event reports a present, non-terminal state
         """
-        msg = getattr(event.payload, "msg", None)
-        if not msg:
+        data = self._parse_event_json(event)
+        if data is None:
             return False
-        try:
-            json_match = re.search(r"```json\s*\n(.*?)\n```", msg, re.DOTALL)
-            if not json_match:
-                return False
-            state = json.loads(json_match.group(1)).get("state", "")
-        except (json.JSONDecodeError, AttributeError):
-            return False
+        state = data.get("state", "")
         if not state or state == "Failed" or state.startswith("Exception:"):
             return False
         return True
@@ -760,27 +786,12 @@ class RetryHandler:
         ):
             return True
 
-        msg = getattr(payload, "msg", None)
-        if not msg:
+        data = self._parse_event_json(event)
+        if data is None:
             return False
-
-        # Parse JSON from markdown code blocks
-        try:
-            # Extract JSON from ```json ... ``` blocks
-            json_match = re.search(r"```json\s*\n(.*?)\n```", msg, re.DOTALL)
-            if json_match:
-                data = json.loads(json_match.group(1))
-                state = data.get("state", "")
-                # Terminal states that should stop the build
-                return state == "Failed" or state.startswith("Exception:")
-        except (json.JSONDecodeError, AttributeError) as e:
-            logger.debug(
-                "[RetryHandler launch_id %s] Could not parse event message as JSON: %s",
-                self.launch_id,
-                e,
-            )
-
-        return False
+        state = data.get("state", "")
+        # Terminal states that should stop the build
+        return state == "Failed" or state.startswith("Exception:")
 
     def _extract_failure_message(self: Self, event: BuildEvent) -> str:
         """
@@ -792,26 +803,19 @@ class RetryHandler:
         Returns:
             str: Error message describing the failure
         """
-        if not event.payload or not hasattr(event.payload, "msg"):
-            return f"Workload failed for launch_id {self.launch_id}"
+        data = self._parse_event_json(event)
+        if data is not None:
+            appwrapper = data.get("appwrapper", "unknown")
+            state = data.get("state", "Failed")
+            return (
+                f"[RetryHandler launch_id {self.launch_id}] {appwrapper} is in a {state} state. "
+                + "Build will stop because of an appwrapper workload error. "
+                + "The `failed_pods` and `events` sections in the message above have more error details."
+            )
 
-        msg = event.payload.msg
+        # No parseable AppWrapper JSON: preserve the original wording,
+        # distinguishing "no message at all" from "message present but not JSON".
+        msg = getattr(event.payload, "msg", None) if event.payload else None
         if not msg:
             return f"Workload failed for launch_id {self.launch_id}"
-
-        # Try to extract more context from JSON
-        try:
-            json_match = re.search(r"```json\s*\n(.*?)\n```", msg, re.DOTALL)
-            if json_match:
-                data = json.loads(json_match.group(1))
-                appwrapper = data.get("appwrapper", "unknown")
-                state = data.get("state", "Failed")
-                return (
-                    f"[RetryHandler launch_id {self.launch_id}] {appwrapper} is in a {state} state. "
-                    + "Build will stop because of an appwrapper workload error. "
-                    + "The `failed_pods` and `events` sections in the message above have more error details."
-                )
-        except (json.JSONDecodeError, AttributeError):
-            pass
-
         return f"[RetryHandler launch_id {self.launch_id}] Workload failed. See event message for details."

--- a/test/unit/monitoring/test_lsf_bsub_monitor.py
+++ b/test/unit/monitoring/test_lsf_bsub_monitor.py
@@ -30,6 +30,7 @@ itself the assertion.
 import asyncio
 import contextlib
 import json
+import types
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -181,11 +182,21 @@ def _as_message_event(msg: str) -> BuildEvent:
 def _is_build_failing(event: BuildEvent) -> bool:
     """Ask the real RetryHandler whether this event fails the build.
 
-    Called unbound with a dummy ``self``: the method only touches ``self`` for a
-    log line. Reusing the real predicate rather than reimplementing its regex
-    keeps these tests honest if that logic changes.
+    Reusing the real predicate rather than reimplementing its regex keeps these
+    tests honest if that logic changes.
+
+    ``_is_terminal_failure_event`` now delegates JSON extraction to
+    ``self._parse_event_json``, so a bare ``MagicMock()`` self no longer works: a
+    mock's ``_parse_event_json(event)`` returns another (truthy) ``MagicMock``
+    instead of ``None``/a dict, which would classify *every* event -- even a
+    benign ``DONE`` -- as a terminal failure. Bind the real ``_parse_event_json``
+    onto the fake self so the predicate runs for real; the fake self is only
+    otherwise touched for ``self.launch_id`` in that method's debug branch, where
+    a mock attribute is harmless.
     """
-    return bool(RetryHandler._is_terminal_failure_event(MagicMock(), event))
+    fake = MagicMock()
+    fake._parse_event_json = types.MethodType(RetryHandler._parse_event_json, fake)
+    return bool(RetryHandler._is_terminal_failure_event(fake, event))
 
 
 def _has_terminal_failure(msgs: List[str]) -> bool:
@@ -520,6 +531,27 @@ async def test_stop_event_set_during_terminal_poll_is_not_a_failure():
 # ---------------------------------------------------------------------------
 # Case P / Q / R -- invariants
 # ---------------------------------------------------------------------------
+
+
+def test_is_build_failing_harness_distinguishes_benign_from_terminal():
+    """Guard the ``_is_build_failing`` harness itself against a truthy-mock trap.
+
+    ``_is_build_failing`` invokes the real ``RetryHandler._is_terminal_failure_event``
+    unbound with a fake ``self``. That predicate delegates to
+    ``self._parse_event_json``; if the fake self ever fails to run the real
+    method (e.g. a future ``self.*`` dependency is added that the fake doesn't
+    satisfy), a bare ``MagicMock`` silently returns a *truthy* mock, classifying
+    every event as a terminal failure and flipping every "must not fail"
+    assertion in this file into a false pass/fail. Pin both directions so that
+    regression fails loudly here, at the source, rather than as a confusing wave
+    of unrelated failures: a benign informational line must NOT fail the build,
+    and a real ``state == "Failed"`` block MUST.
+    """
+    assert _is_build_failing(_as_message_event("LSF job 12345: RUN -> DONE")) is False
+    assert (
+        _is_build_failing(_as_message_event('```json\n{"state": "Failed"}\n```'))
+        is True
+    )
 
 
 @pytest.mark.asyncio

--- a/test/unit/resilience/test_retry_handler.py
+++ b/test/unit/resilience/test_retry_handler.py
@@ -675,7 +675,12 @@ class TestExhaustedRetriableIsTerminal:
         """max_retries reached + a strategy would retry + no terminal json block
         -> raise WorkloadFailedException instead of silently forwarding."""
         handler = self._handler(0, AlwaysRetryStrategy())
-        await handler.get_wrapper_queue().put(create_test_event("transient error"))
+        event = create_test_event("transient error")
+        # Coupling that preserves #254: a stateless event (no json state block) is
+        # not a live non-terminal state, so the exhausted-retriable escalation is
+        # allowed to fire and unblock a monitor's deferred wait (e.g. LSF).
+        assert handler._is_live_nonterminal_state(event) is False
+        await handler.get_wrapper_queue().put(event)
         with pytest.raises(WorkloadFailedException):
             await asyncio.wait_for(handler.process_events(), timeout=5.0)
         # The event is still forwarded downstream before the exception is raised.
@@ -735,6 +740,8 @@ class TestExhaustedRetriableIsTerminal:
         )
         failed = create_test_event('\n```json\n{"state": "Failed"}\n```\n')
         assert h._is_live_nonterminal_state(failed) is False
+        exception = create_test_event('\n```json\n{"state": "Exception: boom"}\n```\n')
+        assert h._is_live_nonterminal_state(exception) is False
         assert (
             h._is_live_nonterminal_state(create_test_event("transient error")) is False
         )

--- a/test/unit/resilience/test_retry_handler.py
+++ b/test/unit/resilience/test_retry_handler.py
@@ -129,6 +129,31 @@ def create_unhealthy_event(node_name: str = "worker-node-1") -> BuildEvent:
     )
 
 
+def create_quota_exhaustion_event(state: str = "Running") -> BuildEvent:
+    """A still-live AppWrapper (``state``) whose pod is stuck in FailedScheduling
+    due to cluster-wide GPU exhaustion -- transient scheduling backpressure, not
+    a terminal failure. Matches UnhealthyInsufficientPodsRetryStrategy."""
+    events = [
+        {
+            "object_type": "Pod",
+            "object_name": "gbtest-0-0",
+            "reason": "FailedScheduling",
+            "message": "0/179 nodes are available: 156 Insufficient nvidia.com/gpu.",
+        }
+    ]
+    data = {"appwrapper": "gbtest", "state": state, "events": events}
+    msg = f"```json\n{json.dumps(data, indent=2)}\n```"
+    payload = EventPayload.payload_parser(
+        event_type=BuildEventType.MESSAGE_EVENT,
+        data={"msg": msg},
+    )
+    return BuildEvent(
+        run_metadata=EntityRunMetadata(build_id="test-build-id"),
+        type=BuildEventType.MESSAGE_EVENT,
+        payload=payload,
+    )
+
+
 class TestRetryHandler:
     """Tests for RetryHandler orchestration logic."""
 
@@ -671,3 +696,45 @@ class TestExhaustedRetriableIsTerminal:
         handler.stop()
         await processor_task  # completes without raising
         assert handler.downstream_queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_running_appwrapper_with_quota_exhaustion_does_not_raise(
+        self: Self,
+    ) -> None:
+        """Regression for #335: a retriable quota-exhaustion event on a still-live
+        (state=Running) AppWrapper must NOT be failed as terminal even when retries
+        are disabled (max_retries=0). The workload is alive and merely waiting for
+        GPU capacity; the exhausted-retriable escalation is only meant to unblock a
+        monitor deferred-waiting for a retry (e.g. LSF), not to fail a running one."""
+        handler = self._handler(
+            0, UnhealthyInsufficientPodsRetryStrategy(object_types=["AppWrapper"])
+        )
+        await handler.get_wrapper_queue().put(create_quota_exhaustion_event("Running"))
+        processor_task = asyncio.create_task(handler.process_events())
+        for _ in range(100):
+            if handler.downstream_queue.qsize() >= 1:
+                break
+            await asyncio.sleep(0.01)
+        handler.stop()
+        await processor_task  # completes without raising
+        assert handler.downstream_queue.qsize() == 1
+        assert handler.environment.retry_called is False
+
+    def test_is_live_nonterminal_state(self: Self) -> None:
+        """A present, non-terminal state (Running/Unhealthy) is live; a terminal
+        state (Failed) or a stateless event is not -- so LSF-style plain failure
+        events still escalate when retries are exhausted."""
+        h = self._handler(0, NeverRetryStrategy())
+        assert (
+            h._is_live_nonterminal_state(create_quota_exhaustion_event("Running"))
+            is True
+        )
+        assert (
+            h._is_live_nonterminal_state(create_quota_exhaustion_event("Unhealthy"))
+            is True
+        )
+        failed = create_test_event('\n```json\n{"state": "Failed"}\n```\n')
+        assert h._is_live_nonterminal_state(failed) is False
+        assert (
+            h._is_live_nonterminal_state(create_test_event("transient error")) is False
+        )


### PR DESCRIPTION
## Summary

- `RetryHandler.process_events`'s `retries_exhausted_on_retriable` escalation (added in #254) fired on **transient scheduling backpressure** — a K8s AppWrapper still `Running`/`Unhealthy` whose pod is stuck in `FailedScheduling` on cluster-wide GPU exhaustion (which `UnhealthyInsufficientPodsRetryStrategy` treats as retryable) — whenever retries were **disabled** (`max_retries == 0`, the default when a step has no `retry_enabled`, so `retry_count 0 >= max_retries 0` is immediately true). That turned a workload merely waiting for capacity, which may still succeed, into a false-positive build failure (with the self-contradicting "X is in a Running state. Build will stop…" message) and cascaded other in-flight targets. Confirmed on a prod build.
- Fix: gate the escalation with a new `_is_live_nonterminal_state(event)`. A present, non-terminal `state` (`Running`/`Unhealthy`/…) is treated as live and **not** escalated.
- **Preserves #254:** stateless failure events (e.g. LSF's) carry no `state`, so they still escalate — keeping the `_retry_pending_after_monitor` anti-hang behavior. Terminal `Failed`/`Exception:` and `WORKLOAD_STATUS_EVENT(FAILED)` are unaffected (still raise via `_is_terminal_failure_event`).

## Test plan

- [x] `pytest test/unit/resilience/test_retry_handler.py` — **21 passed** (19 existing + 2 new)
- [x] `pytest test/unit/resilience/` — **168 passed, 2 skipped**
- New regression tests: `test_running_appwrapper_with_quota_exhaustion_does_not_raise`, `test_is_live_nonterminal_state`
- Locked-in #254 behavior still green: `test_retriable_but_exhausted_raises`, `test_terminal_failure_raises_with_zero_max_retries`

Closes ibm-granite/granite.build#335

Generated with [Claude Code](https://claude.com/claude-code)
