### PR TITLE
Pin isort<9 to fix repo-wide CI lint drift (#337)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,11 @@ all = [
 dev = [
     "black",
     "coverage",
-    "isort",
+    # Pin below 9 to match the pre-commit-pinned isort (rev 8.0.0) and
+    # contributors' local installs. Unpinned, CI resolves to isort 9.0.1, whose
+    # reordering breaks the repo-wide `isort --check .` lint on files committed
+    # under 8.x -- failing every PR while local/pre-commit pass (#337).
+    "isort<9",
     "mypy",
     "pre-commit",
     "psutil",


### PR DESCRIPTION
## Summary

- CI leaves `isort` **unpinned** (`pyproject.toml` `dev` deps) and resolves to **9.0.1**, whose import ordering differs from the pre-commit-pinned isort **8.0.0** (`.pre-commit-config.yaml:7`) the repo is formatted under. `isort --profile black --check .` (`ci.yml:38`) then fails on already-committed files — `src/gbcli/services/service_space.py`, `src/gbserver/api/root_api.py` — on **every PR**, while local dev / pre-commit pass. CI is the outlier.
- Pin `isort<9` in the `dev` deps so CI matches pre-commit and contributors' local installs.
- Adopting isort 9 deliberately (pin pyproject to 9 + bump the pre-commit rev + reformat the two files + contributors re-sync local) can be a follow-up.

## Test plan

- [ ] CI `lint` job passes (isort resolves to 8.x; the two flagged files are already clean under 8.x)
- No source or behavior changes — dependency constraint only.

Closes ibm-granite/granite.build#337

Generated with [Claude Code](https://claude.com/claude-code)
