### PR TITLE
Normalize artifact permissions after the workload, and name unreadable files before an HF push

### DIFF
--- a/docs/environments/k8s.md
+++ b/docs/environments/k8s.md
@@ -152,8 +152,12 @@ is *after* the workload exits. The step container normalizes the output tree onc
 done:
 
 ```bash
-chmod -R g+rwX "${OUTPUT_PATH}" || true
+chmod -R g+rwX "${OUTPUT_PATH}"
 ```
+
+The block lives in one place — the `gbstepbase.normalizeOutputPermissions` define in
+`charts/gbstepbase/templates/_utils.tpl` — and both the single- and multi-container templates
+`include` it. It references no chart values, so the same copy serves both contexts.
 
 - It runs **before** the exit-code check, so a failed run's partial output is normalized too —
   later pods still read and retry against it.

--- a/docs/environments/k8s.md
+++ b/docs/environments/k8s.md
@@ -132,6 +132,60 @@ chmod -R g+rwX /gb-read-write/hfcache
 A directory's mode can only be changed by its owner or root, so run this with sufficient
 privilege; anything it cannot fix is recreated group-writable the next time a pull recreates it.
 
+### Artifact permissions on step output (post-workload `chmod`)
+
+A `umask` sets the *default* mode for newly created files, but it can only mask bits **off** the
+mode a writer asks for — it cannot add any. A workload that explicitly creates a file `0600` gets
+`0600` under any umask. `safetensors` does exactly this (it writes via `mkstemp`, which is `0600`
+by design), so a training step can leave `adapter_model.safetensors` unreadable to every UID but
+its own, sitting beside `0644` siblings.
+
+Because the next step runs in a different pod on a different UID, a subsequent `hfpush` then fails
+on a file that plainly exists:
+
+```
+[Errno 13] Permission denied: '/gb-read-write/custom_output_xxx/model/adapter_model.safetensors'
+```
+
+BYOI steps can run arbitrary code and set arbitrary modes, so the only reliable point of control
+is *after* the workload exits. The step container normalizes the output tree once the workload is
+done:
+
+```bash
+chmod -R g+rwX "${OUTPUT_PATH}" || true
+```
+
+- It runs **before** the exit-code check, so a failed run's partial output is normalized too —
+  later pods still read and retry against it.
+- `g+rwX` (capital `X`) adds group-execute only to directories and files that are *already*
+  executable, never to data files.
+- It is a no-op when `OUTPUT_PATH` is unset or absent, which is the case for the built-in steps
+  (`hfpush`, `hfpull`, `lhpush`, …) — they consume artifacts rather than produce them.
+
+**This is a guard, not a gate.** The artifact is often already readable, and some environments
+forbid `chmod` outright — a read-only or root-squashed mount, or files owned by another UID — so a
+`chmod` failure says nothing about whether the step succeeded and **never fails the step**. It is
+not silent either, since it predicts a later push failure: the step logs a `WARNING` naming the
+paths it could not fix. `chmod -R` continues past individual errors, so a partial pass still does
+its work.
+
+The warning goes to **stdout**, not stderr, and the listing is capped at 10 paths (with the true
+total reported). Both are deliberate: only `command.sh` is tee'd into `/logs/output.log` — the file
+the sidecar monitor tails — and this block runs after that pipeline, so a bare stderr write would
+never reach the log an operator actually reads. Uncapped, a wholly root-squashed tree would emit one
+line per file and flood both the log and the event stream.
+
+`hfpush` also checks readability *before* it starts uploading, so an artifact that is still
+unreadable names every offending path up front instead of failing mid-commit with a
+`PermissionError` that carries no HTTP status (which reads like a Hub outage rather than a local
+`EACCES`).
+
+> [!NOTE]
+> `fsGroup` in a pod `securityContext` is the other way to solve this, but it depends on the
+> volume's CSI driver honouring ownership management — many NFS-backed RWX volumes ignore it — and
+> these charts never see the PVC object (`/gb-read-write` is a path assumed to be pre-mounted).
+> It also cannot fix files that already exist. The `chmod` pass has neither limitation.
+
 ## `step.yaml` — launcher and monitor types
 
 | `type` | Method | When to use |

--- a/src/gbcommon/uri/hf.py
+++ b/src/gbcommon/uri/hf.py
@@ -997,13 +997,31 @@ class HfURI(URI):
             _log_hf_api_error("list_resource_groups", organization, e)
         return None
 
+    # Cap on how many unreadable paths a failure message lists, so a wholly
+    # unreadable tree of thousands of files yields a diagnosable error rather
+    # than an unreadably long one. The count reported is always the true total.
+    _MAX_UNREADABLE_REPORTED = 10
+
     @staticmethod
     def _validate_non_empty_src(src: Path) -> None:
-        """Ensure ``src`` has uploadable, non-zero-length content.
+        """Ensure ``src`` has uploadable, non-zero-length, *readable* content.
 
         HuggingFace silently skips an upload that would produce an empty commit
         (e.g. a single 0-byte file), so a push of empty content appears to
         succeed while creating nothing on the Hub.  Fail fast instead.
+
+        Readability is checked here too, in the same walk, because
+        ``upload_folder`` opens each file only once it is already mid-commit:
+        the resulting ``PermissionError`` carries no HTTP status, so
+        :meth:`_log_hf_api_error` can only classify it as ``HF_ERR_OTHER`` and
+        logs "no HTTP status", which reads like a Hub outage rather than a local
+        ``EACCES``. It also aborts on the first bad file, so an operator fixes
+        one path at a time. Checking up front names every unreadable file and
+        attributes the failure to the filesystem, where the fix is.
+
+        This is a diagnostic, not a guarantee: ``os.access`` is a point-in-time
+        check and a push can still race a permission change, so the ``push``
+        call sites keep their exception handling.
 
         Args:
             src: Local file or directory path being pushed.
@@ -1011,13 +1029,46 @@ class HfURI(URI):
         Raises:
             ValueError: If ``src`` is a zero-length file, or a directory whose
                 regular files are all zero-length (or which contains none).
+            PermissionError: If ``src`` itself, or any regular file under it, is
+                not readable by the current user.
         """
         if src.is_file():
             if src.stat().st_size == 0:
                 raise ValueError(f"refusing to push zero-length file: {src}")
+            if not os.access(src, os.R_OK):
+                raise PermissionError(f"cannot read file to push: {src}")
             return
-        # Directory: require at least one non-empty regular file.
-        if not any(f.is_file() and f.stat().st_size > 0 for f in src.rglob("*")):
+        # Directory: require at least one non-empty regular file, and collect
+        # every unreadable one in the same walk so the error names them all.
+        has_content = False
+        unreadable: List[Path] = []
+        for f in src.rglob("*"):
+            # A directory that cannot be traversed hides its children from
+            # rglob entirely, so check those too -- otherwise an unreadable
+            # subtree looks simply empty.
+            if f.is_dir():
+                if not os.access(f, os.R_OK | os.X_OK):
+                    unreadable.append(f)
+                continue
+            if not f.is_file():
+                continue
+            if not os.access(f, os.R_OK):
+                unreadable.append(f)
+                continue
+            if f.stat().st_size > 0:
+                has_content = True
+        if unreadable:
+            shown = sorted(str(p) for p in unreadable)
+            elided = len(shown) - HfURI._MAX_UNREADABLE_REPORTED
+            if elided > 0:
+                shown = shown[: HfURI._MAX_UNREADABLE_REPORTED]
+                shown.append(f"... and {elided} more")
+            raise PermissionError(
+                f"cannot read {len(unreadable)} path(s) under {src}; "
+                "the step that produced this artifact left them unreadable to "
+                "this user: " + ", ".join(shown)
+            )
+        if not has_content:
             raise ValueError(
                 f"refusing to push directory with no non-empty files: {src}"
             )

--- a/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_multi_containers.tpl
+++ b/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_multi_containers.tpl
@@ -205,45 +205,7 @@
 
         COMMAND_SH_EXIT_CODE="$?"
         echo "COMMAND_SH_EXIT_CODE: ${COMMAND_SH_EXIT_CODE}"
-        # Best-effort: make the produced artifact readable by the root group, whatever
-        # mode the workload chose. `umask` only masks bits off a caller's requested mode,
-        # so a writer that explicitly requests 0600 (safetensors' mkstemp does) still
-        # lands unreadable to a later pod on a different UID -- the pod UID is drawn from
-        # the namespace SCC range and is not stable across steps. A push step then fails
-        # with EACCES on a file that plainly exists. Normalizing here, at the boundary
-        # where the artifact becomes shared state, is what a umask cannot do.
-        #
-        # This is a GUARD, never a gate. The artifact may already be perfectly readable,
-        # and some environments forbid chmod outright (read-only or root-squashed mounts,
-        # files owned by another UID), so a failure here must never fail the step -- but
-        # it must not be silent either, since it predicts a later push failure.
-        # `chmod -R` continues past individual errors, so a partial pass still does its
-        # work; we surface what it could not do and carry on.
-        #
-        # Ordering: this runs before the exit-code check so a failed run's partial output
-        # is normalized too (later pods still read and retry against it). `g+rwX` adds
-        # group-execute only to directories and already-executable files, never to data.
-        if [[ -n "${OUTPUT_PATH:-}" && -d "${OUTPUT_PATH}" ]]; then
-          echo "Normalizing group permissions on ${OUTPUT_PATH}"
-          # Capture rather than let chmod write to stderr: only command.sh is tee'd to
-          # /logs/output.log, which is what the sidecar monitor tails, so a bare stderr
-          # write would not reach the log an operator actually reads. `|| true` keeps the
-          # guard from ever failing the step. The report is capped -- a wholly
-          # root-squashed tree emits one line per file, which would otherwise flood both
-          # the log and the event stream.
-          GB_CHMOD_ERR="$(chmod -R g+rwX "${OUTPUT_PATH}" 2>&1)" || true
-          if [[ -n "${GB_CHMOD_ERR}" ]]; then
-            GB_CHMOD_N="$(printf '%s\n' "${GB_CHMOD_ERR}" | wc -l | tr -d ' ')"
-            echo "WARNING: could not fully normalize permissions on ${OUTPUT_PATH}" \
-                 "(${GB_CHMOD_N} path(s)). Not fatal: the artifact may already be" \
-                 "readable, and some mounts forbid chmod. But if a later push fails" \
-                 "with EACCES on this artifact, this is why."
-            printf '%s\n' "${GB_CHMOD_ERR}" | head -n 10 | sed 's/^/WARNING:   /'
-            if (( GB_CHMOD_N > 10 )); then
-              echo "WARNING:   ... and $(( GB_CHMOD_N - 10 )) more"
-            fi
-          fi
-        fi
+        {{- include "gbstepbase.normalizeOutputPermissions" . | trimAll " " | indent 8 }}
         {{- if $orig.Values.k8s.sleep_on_end }}
         echo
         echo 'sleeping at the end so that the user can exec inside the container'

--- a/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_multi_containers.tpl
+++ b/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_multi_containers.tpl
@@ -205,6 +205,45 @@
 
         COMMAND_SH_EXIT_CODE="$?"
         echo "COMMAND_SH_EXIT_CODE: ${COMMAND_SH_EXIT_CODE}"
+        # Best-effort: make the produced artifact readable by the root group, whatever
+        # mode the workload chose. `umask` only masks bits off a caller's requested mode,
+        # so a writer that explicitly requests 0600 (safetensors' mkstemp does) still
+        # lands unreadable to a later pod on a different UID -- the pod UID is drawn from
+        # the namespace SCC range and is not stable across steps. A push step then fails
+        # with EACCES on a file that plainly exists. Normalizing here, at the boundary
+        # where the artifact becomes shared state, is what a umask cannot do.
+        #
+        # This is a GUARD, never a gate. The artifact may already be perfectly readable,
+        # and some environments forbid chmod outright (read-only or root-squashed mounts,
+        # files owned by another UID), so a failure here must never fail the step -- but
+        # it must not be silent either, since it predicts a later push failure.
+        # `chmod -R` continues past individual errors, so a partial pass still does its
+        # work; we surface what it could not do and carry on.
+        #
+        # Ordering: this runs before the exit-code check so a failed run's partial output
+        # is normalized too (later pods still read and retry against it). `g+rwX` adds
+        # group-execute only to directories and already-executable files, never to data.
+        if [[ -n "${OUTPUT_PATH:-}" && -d "${OUTPUT_PATH}" ]]; then
+          echo "Normalizing group permissions on ${OUTPUT_PATH}"
+          # Capture rather than let chmod write to stderr: only command.sh is tee'd to
+          # /logs/output.log, which is what the sidecar monitor tails, so a bare stderr
+          # write would not reach the log an operator actually reads. `|| true` keeps the
+          # guard from ever failing the step. The report is capped -- a wholly
+          # root-squashed tree emits one line per file, which would otherwise flood both
+          # the log and the event stream.
+          GB_CHMOD_ERR="$(chmod -R g+rwX "${OUTPUT_PATH}" 2>&1)" || true
+          if [[ -n "${GB_CHMOD_ERR}" ]]; then
+            GB_CHMOD_N="$(printf '%s\n' "${GB_CHMOD_ERR}" | wc -l | tr -d ' ')"
+            echo "WARNING: could not fully normalize permissions on ${OUTPUT_PATH}" \
+                 "(${GB_CHMOD_N} path(s)). Not fatal: the artifact may already be" \
+                 "readable, and some mounts forbid chmod. But if a later push fails" \
+                 "with EACCES on this artifact, this is why."
+            printf '%s\n' "${GB_CHMOD_ERR}" | head -n 10 | sed 's/^/WARNING:   /'
+            if (( GB_CHMOD_N > 10 )); then
+              echo "WARNING:   ... and $(( GB_CHMOD_N - 10 )) more"
+            fi
+          fi
+        fi
         {{- if $orig.Values.k8s.sleep_on_end }}
         echo
         echo 'sleeping at the end so that the user can exec inside the container'

--- a/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_single_container.tpl
+++ b/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_single_container.tpl
@@ -208,6 +208,45 @@
         
         COMMAND_SH_EXIT_CODE="$?"
         echo "COMMAND_SH_EXIT_CODE: ${COMMAND_SH_EXIT_CODE}"
+        # Best-effort: make the produced artifact readable by the root group, whatever
+        # mode the workload chose. `umask` only masks bits off a caller's requested mode,
+        # so a writer that explicitly requests 0600 (safetensors' mkstemp does) still
+        # lands unreadable to a later pod on a different UID -- the pod UID is drawn from
+        # the namespace SCC range and is not stable across steps. A push step then fails
+        # with EACCES on a file that plainly exists. Normalizing here, at the boundary
+        # where the artifact becomes shared state, is what a umask cannot do.
+        #
+        # This is a GUARD, never a gate. The artifact may already be perfectly readable,
+        # and some environments forbid chmod outright (read-only or root-squashed mounts,
+        # files owned by another UID), so a failure here must never fail the step -- but
+        # it must not be silent either, since it predicts a later push failure.
+        # `chmod -R` continues past individual errors, so a partial pass still does its
+        # work; we surface what it could not do and carry on.
+        #
+        # Ordering: this runs before the exit-code check so a failed run's partial output
+        # is normalized too (later pods still read and retry against it). `g+rwX` adds
+        # group-execute only to directories and already-executable files, never to data.
+        if [[ -n "${OUTPUT_PATH:-}" && -d "${OUTPUT_PATH}" ]]; then
+          echo "Normalizing group permissions on ${OUTPUT_PATH}"
+          # Capture rather than let chmod write to stderr: only command.sh is tee'd to
+          # /logs/output.log, which is what the sidecar monitor tails, so a bare stderr
+          # write would not reach the log an operator actually reads. `|| true` keeps the
+          # guard from ever failing the step. The report is capped -- a wholly
+          # root-squashed tree emits one line per file, which would otherwise flood both
+          # the log and the event stream.
+          GB_CHMOD_ERR="$(chmod -R g+rwX "${OUTPUT_PATH}" 2>&1)" || true
+          if [[ -n "${GB_CHMOD_ERR}" ]]; then
+            GB_CHMOD_N="$(printf '%s\n' "${GB_CHMOD_ERR}" | wc -l | tr -d ' ')"
+            echo "WARNING: could not fully normalize permissions on ${OUTPUT_PATH}" \
+                 "(${GB_CHMOD_N} path(s)). Not fatal: the artifact may already be" \
+                 "readable, and some mounts forbid chmod. But if a later push fails" \
+                 "with EACCES on this artifact, this is why."
+            printf '%s\n' "${GB_CHMOD_ERR}" | head -n 10 | sed 's/^/WARNING:   /'
+            if (( GB_CHMOD_N > 10 )); then
+              echo "WARNING:   ... and $(( GB_CHMOD_N - 10 )) more"
+            fi
+          fi
+        fi
         {{- if .Values.k8s.sleep_on_end }}
         echo
         echo 'sleeping at the end so that the user can exec inside the container'

--- a/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_single_container.tpl
+++ b/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_single_container.tpl
@@ -208,45 +208,7 @@
         
         COMMAND_SH_EXIT_CODE="$?"
         echo "COMMAND_SH_EXIT_CODE: ${COMMAND_SH_EXIT_CODE}"
-        # Best-effort: make the produced artifact readable by the root group, whatever
-        # mode the workload chose. `umask` only masks bits off a caller's requested mode,
-        # so a writer that explicitly requests 0600 (safetensors' mkstemp does) still
-        # lands unreadable to a later pod on a different UID -- the pod UID is drawn from
-        # the namespace SCC range and is not stable across steps. A push step then fails
-        # with EACCES on a file that plainly exists. Normalizing here, at the boundary
-        # where the artifact becomes shared state, is what a umask cannot do.
-        #
-        # This is a GUARD, never a gate. The artifact may already be perfectly readable,
-        # and some environments forbid chmod outright (read-only or root-squashed mounts,
-        # files owned by another UID), so a failure here must never fail the step -- but
-        # it must not be silent either, since it predicts a later push failure.
-        # `chmod -R` continues past individual errors, so a partial pass still does its
-        # work; we surface what it could not do and carry on.
-        #
-        # Ordering: this runs before the exit-code check so a failed run's partial output
-        # is normalized too (later pods still read and retry against it). `g+rwX` adds
-        # group-execute only to directories and already-executable files, never to data.
-        if [[ -n "${OUTPUT_PATH:-}" && -d "${OUTPUT_PATH}" ]]; then
-          echo "Normalizing group permissions on ${OUTPUT_PATH}"
-          # Capture rather than let chmod write to stderr: only command.sh is tee'd to
-          # /logs/output.log, which is what the sidecar monitor tails, so a bare stderr
-          # write would not reach the log an operator actually reads. `|| true` keeps the
-          # guard from ever failing the step. The report is capped -- a wholly
-          # root-squashed tree emits one line per file, which would otherwise flood both
-          # the log and the event stream.
-          GB_CHMOD_ERR="$(chmod -R g+rwX "${OUTPUT_PATH}" 2>&1)" || true
-          if [[ -n "${GB_CHMOD_ERR}" ]]; then
-            GB_CHMOD_N="$(printf '%s\n' "${GB_CHMOD_ERR}" | wc -l | tr -d ' ')"
-            echo "WARNING: could not fully normalize permissions on ${OUTPUT_PATH}" \
-                 "(${GB_CHMOD_N} path(s)). Not fatal: the artifact may already be" \
-                 "readable, and some mounts forbid chmod. But if a later push fails" \
-                 "with EACCES on this artifact, this is why."
-            printf '%s\n' "${GB_CHMOD_ERR}" | head -n 10 | sed 's/^/WARNING:   /'
-            if (( GB_CHMOD_N > 10 )); then
-              echo "WARNING:   ... and $(( GB_CHMOD_N - 10 )) more"
-            fi
-          fi
-        fi
+        {{- include "gbstepbase.normalizeOutputPermissions" . | trimAll " " | indent 8 }}
         {{- if .Values.k8s.sleep_on_end }}
         echo
         echo 'sleeping at the end so that the user can exec inside the container'

--- a/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_utils.tpl
+++ b/src/gbserver/builtins/steps/gbstep/helm-charts/{{ step.name | default(run_metadata.target_name) }}/charts/gbstepbase/templates/_utils.tpl
@@ -137,3 +137,42 @@ echo '{{ $v | b64enc }}' | base64 --decode > {{ .filename }}
 true
 {{- end -}}
 {{- end -}}
+
+{{- define "gbstepbase.normalizeOutputPermissions" }}
+# Best-effort: make the produced artifact readable by the root group, whatever mode the
+# workload chose. `umask` only masks bits off a caller's requested mode, so a writer that
+# explicitly requests 0600 (safetensors' mkstemp does) still lands unreadable to a later
+# pod on a different UID -- the pod UID is drawn from the namespace SCC range and is not
+# stable across steps. A push step then fails with EACCES on a file that plainly exists.
+#
+# This is a GUARD, never a gate. The artifact may already be readable, and some mounts
+# forbid chmod outright (read-only, root-squashed, or files owned by another UID), so a
+# failure here says nothing about whether the step succeeded and must never fail it. It
+# must not be silent either, since it predicts a later push failure. `chmod -R` continues
+# past individual errors, so a partial pass still does its work.
+#
+# Call this after the workload's exit code is captured but BEFORE it is acted on, so a
+# failed run's partial output is normalized too -- later pods still read and retry
+# against it. `g+rwX` adds group-execute only to directories and already-executable
+# files, never to data.
+if [[ -n "${OUTPUT_PATH:-}" && -d "${OUTPUT_PATH}" ]]; then
+  echo "Normalizing group permissions on ${OUTPUT_PATH}"
+  # Capture rather than let chmod write to stderr: only command.sh is tee'd to
+  # /logs/output.log, which is what the sidecar monitor tails, and this runs after that
+  # pipeline, so a bare stderr write would not reach the log an operator reads. Cap the
+  # report -- a wholly root-squashed tree emits one line per file, which would otherwise
+  # flood both the log and the event stream.
+  GB_CHMOD_ERR="$(chmod -R g+rwX "${OUTPUT_PATH}" 2>&1)" || true
+  if [[ -n "${GB_CHMOD_ERR}" ]]; then
+    GB_CHMOD_N="$(printf '%s\n' "${GB_CHMOD_ERR}" | wc -l | tr -d ' ')"
+    echo "WARNING: could not fully normalize permissions on ${OUTPUT_PATH}" \
+         "(${GB_CHMOD_N} path(s)). Not fatal: the artifact may already be readable," \
+         "and some mounts forbid chmod. But if a later push fails with EACCES on" \
+         "this artifact, this is why."
+    printf '%s\n' "${GB_CHMOD_ERR}" | head -n 10 | sed 's/^/WARNING:   /'
+    if (( GB_CHMOD_N > 10 )); then
+      echo "WARNING:   ... and $(( GB_CHMOD_N - 10 )) more"
+    fi
+  fi
+fi
+{{- end }}

--- a/test/unit/environment/test_k8s_hfstore.py
+++ b/test/unit/environment/test_k8s_hfstore.py
@@ -279,29 +279,49 @@ class TestArtifactPermissionNormalization:
     """
 
     WORKLOAD_TEMPLATES = CONTAINER_TEMPLATES[:2]
+    # The block itself lives in one place; both container templates `include` it.
+    UTILS_TEMPLATE = CHART_DIR / "charts/gbstepbase/templates/_utils.tpl"
+    INCLUDE_NAME = "gbstepbase.normalizeOutputPermissions"
 
-    @staticmethod
-    def _epilogue(template: Path) -> list[str]:
-        """Return the chmod epilogue block from a container template, de-indented."""
-        lines = template.read_text(encoding="utf-8").splitlines()
+    @classmethod
+    def _epilogue(cls) -> list[str]:
+        """Return the shared chmod epilogue's bash body, de-indented.
+
+        Read from the single ``define`` rather than from each container template:
+        the block is emitted at column 0 there and the call sites re-indent it,
+        which is what makes one copy serve both contexts.
+        """
+        lines = cls.UTILS_TEMPLATE.read_text(encoding="utf-8").splitlines()
         starts = [
             i
             for i, ln in enumerate(lines)
-            if ln.strip().startswith('if [[ -n "${OUTPUT_PATH:-}"')
+            if ln.strip() == f'{{{{- define "{cls.INCLUDE_NAME}" }}}}'
         ]
-        assert len(starts) == 1, f"expected one epilogue in {template.name}"
+        assert len(starts) == 1, f"expected exactly one {cls.INCLUDE_NAME} define"
         i = starts[0]
-        indent = len(lines[i]) - len(lines[i].lstrip())
-        # Match the `fi` at the opening `if`'s own indentation: the block nests
-        # further `if`s, so the *first* `fi` would truncate it mid-statement and
-        # yield unrunnable bash.
         end = next(
-            n
-            for n in range(i + 1, len(lines))
-            if lines[n].strip() == "fi"
-            and len(lines[n]) - len(lines[n].lstrip()) == indent
+            n for n in range(i + 1, len(lines)) if lines[n].strip() == "{{- end }}"
         )
-        return [ln[indent:] for ln in lines[i : end + 1]]
+        return lines[i + 1 : end]
+
+    @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
+    def test_epilogue_is_included_not_duplicated(self, template):
+        """Each container template calls the shared define -- it does not inline it.
+
+        The block is ~30 lines of bash; two hand-maintained copies would drift.
+        """
+        text = template.read_text(encoding="utf-8")
+        assert self.INCLUDE_NAME in text, f"{template.name}: does not include the block"
+        assert "g+rwX" not in text, f"{template.name}: still inlines the chmod"
+
+    def test_epilogue_defined_exactly_once(self):
+        """Exactly one copy of the bash exists across the whole chart."""
+        copies = [
+            p
+            for p in CHART_DIR.rglob("*.tpl")
+            if "g+rwX" in p.read_text(encoding="utf-8")
+        ]
+        assert copies == [self.UTILS_TEMPLATE], f"chmod bash duplicated in {copies}"
 
     @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
     def test_epilogue_runs_after_workload_but_before_exit_check(self, template):
@@ -317,17 +337,21 @@ class TestArtifactPermissionNormalization:
             for i, ln in enumerate(lines)
             if ln.strip().startswith("COMMAND_SH_EXIT_CODE=")
         ]
-        chmod = [i for i, ln in enumerate(lines) if "g+rwX" in ln]
+        include = [i for i, ln in enumerate(lines) if self.INCLUDE_NAME in ln]
         check = [
             i
             for i, ln in enumerate(lines)
             if ln.strip().startswith('if [[ "${COMMAND_SH_EXIT_CODE}" != "0" ]]')
         ]
-        assert chmod, f"{template.name}: no chmod epilogue"
+        assert include, f"{template.name}: no epilogue include"
         assert capture, f"{template.name}: no exit-code capture"
         assert check, f"{template.name}: no exit-code check"
-        assert min(capture) < chmod[0], f"{template.name}: chmod precedes the workload"
-        assert chmod[0] < min(check), f"{template.name}: chmod after the exit check"
+        assert (
+            min(capture) < include[0]
+        ), f"{template.name}: epilogue precedes the workload"
+        assert include[0] < min(
+            check
+        ), f"{template.name}: epilogue after the exit check"
 
     @staticmethod
     def _stub_chmod(directory: Path, lines: int, exit_code: int) -> Path:
@@ -350,16 +374,15 @@ class TestArtifactPermissionNormalization:
         stub.chmod(0o755)
         return stub
 
-    @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
     @pytest.mark.parametrize("exit_code", (0, 1), ids=("chmod-exit-0", "chmod-exit-1"))
-    def test_epilogue_never_fails_the_step(self, template, exit_code, tmp_path):
+    def test_epilogue_never_fails_the_step(self, exit_code, tmp_path):
         """A refused ``chmod`` must not fail the step -- the guard is not a gate.
 
         Some environments forbid ``chmod`` outright while the artifact is already
         perfectly readable, so a non-zero ``chmod`` here says nothing about
         whether the step succeeded.
         """
-        block = "\n".join(self._epilogue(template))
+        block = "\n".join(self._epilogue())
         out = tmp_path / "out"
         out.mkdir()
         (out / "f.bin").write_bytes(b"x")
@@ -385,7 +408,7 @@ class TestArtifactPermissionNormalization:
         reads. The listing is capped because a wholly root-squashed tree emits
         one line per file.
         """
-        block = "\n".join(self._epilogue(self.WORKLOAD_TEMPLATES[0]))
+        block = "\n".join(self._epilogue())
         out = tmp_path / "out"
         out.mkdir()
         (out / "f.bin").write_bytes(b"x")
@@ -407,12 +430,11 @@ class TestArtifactPermissionNormalization:
         assert "and 15 more" in result.stdout, "listing not capped"
         assert result.stdout.count("Operation not permitted") == 10, "cap not applied"
 
-    @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
-    def test_epilogue_uses_capital_x(self, template):
+    def test_epilogue_uses_capital_x(self):
         """``g+rwX`` must not become ``g+rwx`` -- that would mark data executable."""
-        block = "\n".join(self._epilogue(template))
-        assert "g+rwX" in block, f"{template.name}: expected g+rwX"
-        assert "g+rwx" not in block, f"{template.name}: g+rwx would chmod data +x"
+        block = "\n".join(self._epilogue())
+        assert "g+rwX" in block, "expected g+rwX"
+        assert "g+rwx" not in block, "g+rwx would chmod data +x"
 
     def test_rendered_epilogue_makes_a_0600_artifact_group_readable(self, tmp_path):
         """Run the real block: the reported failure mode must be fixed.
@@ -421,7 +443,7 @@ class TestArtifactPermissionNormalization:
         beside 0644 siblings -- and asserts the epilogue makes it group-readable
         while leaving the group-execute bit off the data files.
         """
-        block = "\n".join(self._epilogue(self.WORKLOAD_TEMPLATES[0]))
+        block = "\n".join(self._epilogue())
         out = tmp_path / "custom_output"
         sub = out / "granite-4.1-3b_finance"
         sub.mkdir(parents=True)
@@ -457,7 +479,7 @@ class TestArtifactPermissionNormalization:
         ``OUTPUT_PATH`` comes from the gbstep chart's values.yaml, so hfpush and
         the other built-in k8s steps run this block with the variable unset.
         """
-        block = "\n".join(self._epilogue(self.WORKLOAD_TEMPLATES[0]))
+        block = "\n".join(self._epilogue())
         for script in (
             f"set -o pipefail\nunset OUTPUT_PATH\n{block}",
             f"set -o pipefail\nOUTPUT_PATH={tmp_path}/missing\n{block}",

--- a/test/unit/environment/test_k8s_hfstore.py
+++ b/test/unit/environment/test_k8s_hfstore.py
@@ -266,3 +266,204 @@ class TestSharedPvcPermissions:
             text = template.read_text(encoding="utf-8")
             assert "run_as_root_group" in text, f"{template.name}: no gate"
             assert "runAsGroup: 0" in text, f"{template.name}: no runAsGroup"
+
+
+class TestArtifactPermissionNormalization:
+    """Guards for the post-workload chmod that makes produced artifacts readable.
+
+    A umask only masks bits off the mode a writer asks for, so a workload that
+    explicitly creates a file ``0600`` (safetensors' ``mkstemp`` does) still
+    leaves it unreadable to a later pod on a different UID. BYOI steps can run
+    anything and set any mode, so the only reliable point of control is after
+    the workload exits: normalize the tree where it becomes shared state.
+    """
+
+    WORKLOAD_TEMPLATES = CONTAINER_TEMPLATES[:2]
+
+    @staticmethod
+    def _epilogue(template: Path) -> list[str]:
+        """Return the chmod epilogue block from a container template, de-indented."""
+        lines = template.read_text(encoding="utf-8").splitlines()
+        starts = [
+            i
+            for i, ln in enumerate(lines)
+            if ln.strip().startswith('if [[ -n "${OUTPUT_PATH:-}"')
+        ]
+        assert len(starts) == 1, f"expected one epilogue in {template.name}"
+        i = starts[0]
+        indent = len(lines[i]) - len(lines[i].lstrip())
+        # Match the `fi` at the opening `if`'s own indentation: the block nests
+        # further `if`s, so the *first* `fi` would truncate it mid-statement and
+        # yield unrunnable bash.
+        end = next(
+            n
+            for n in range(i + 1, len(lines))
+            if lines[n].strip() == "fi"
+            and len(lines[n]) - len(lines[n].lstrip()) == indent
+        )
+        return [ln[indent:] for ln in lines[i : end + 1]]
+
+    @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
+    def test_epilogue_runs_after_workload_but_before_exit_check(self, template):
+        """Ordering: after the workload's exit code is captured, before it is acted on.
+
+        It must follow the workload (there is nothing to fix before that) and
+        precede the ``exit 1``, so a failed run's partial output is normalized
+        too -- later pods still read and retry against it.
+        """
+        lines = template.read_text(encoding="utf-8").splitlines()
+        capture = [
+            i
+            for i, ln in enumerate(lines)
+            if ln.strip().startswith("COMMAND_SH_EXIT_CODE=")
+        ]
+        chmod = [i for i, ln in enumerate(lines) if "g+rwX" in ln]
+        check = [
+            i
+            for i, ln in enumerate(lines)
+            if ln.strip().startswith('if [[ "${COMMAND_SH_EXIT_CODE}" != "0" ]]')
+        ]
+        assert chmod, f"{template.name}: no chmod epilogue"
+        assert capture, f"{template.name}: no exit-code capture"
+        assert check, f"{template.name}: no exit-code check"
+        assert min(capture) < chmod[0], f"{template.name}: chmod precedes the workload"
+        assert chmod[0] < min(check), f"{template.name}: chmod after the exit check"
+
+    @staticmethod
+    def _stub_chmod(directory: Path, lines: int, exit_code: int) -> Path:
+        """Put a ``chmod`` on PATH that emits ``lines`` errors and exits ``exit_code``.
+
+        Stands in for a mount that refuses ``chmod`` -- a read-only or
+        root-squashed PVC, or files owned by another UID -- which cannot be
+        reproduced as the owning user, since the owner may always chmod its own
+        files regardless of the mode bits.
+        """
+        stub = directory / "chmod"
+        body = ["#!/bin/sh"]
+        for n in range(lines):
+            body.append(
+                f'echo "chmod: Unable to change file mode on /out/f{n}.bin:'
+                ' Operation not permitted" >&2'
+            )
+        body.append(f"exit {exit_code}")
+        stub.write_text("\n".join(body) + "\n")
+        stub.chmod(0o755)
+        return stub
+
+    @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
+    @pytest.mark.parametrize("exit_code", (0, 1), ids=("chmod-exit-0", "chmod-exit-1"))
+    def test_epilogue_never_fails_the_step(self, template, exit_code, tmp_path):
+        """A refused ``chmod`` must not fail the step -- the guard is not a gate.
+
+        Some environments forbid ``chmod`` outright while the artifact is already
+        perfectly readable, so a non-zero ``chmod`` here says nothing about
+        whether the step succeeded.
+        """
+        block = "\n".join(self._epilogue(template))
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "f.bin").write_bytes(b"x")
+        stub_dir = tmp_path / f"bin{exit_code}"
+        stub_dir.mkdir()
+        self._stub_chmod(stub_dir, lines=3, exit_code=exit_code)
+
+        result = subprocess.run(
+            ["bash", "-c", f"set -o pipefail\nOUTPUT_PATH={out}\n{block}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": f"{stub_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_epilogue_reports_failures_where_the_monitor_can_see_them(self, tmp_path):
+        """A refused ``chmod`` must be visible, and capped.
+
+        Only ``command.sh`` is tee'd to ``/logs/output.log`` -- the file the
+        sidecar monitor tails -- and this block runs after that pipeline, so the
+        diagnostics must go to stdout or they never reach the log an operator
+        reads. The listing is capped because a wholly root-squashed tree emits
+        one line per file.
+        """
+        block = "\n".join(self._epilogue(self.WORKLOAD_TEMPLATES[0]))
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "f.bin").write_bytes(b"x")
+        stub_dir = tmp_path / "bin"
+        stub_dir.mkdir()
+        self._stub_chmod(stub_dir, lines=25, exit_code=1)
+
+        result = subprocess.run(
+            ["bash", "-c", f"set -o pipefail\nOUTPUT_PATH={out}\n{block}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": f"{stub_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
+        )
+        assert result.returncode == 0, result.stderr
+        # On stdout, not stderr: stderr would bypass the monitored log.
+        assert "WARNING" in result.stdout, "failure not reported on stdout"
+        assert "25 path(s)" in result.stdout, "true failure count not reported"
+        assert "and 15 more" in result.stdout, "listing not capped"
+        assert result.stdout.count("Operation not permitted") == 10, "cap not applied"
+
+    @pytest.mark.parametrize("template", WORKLOAD_TEMPLATES, ids=lambda p: p.name)
+    def test_epilogue_uses_capital_x(self, template):
+        """``g+rwX`` must not become ``g+rwx`` -- that would mark data executable."""
+        block = "\n".join(self._epilogue(template))
+        assert "g+rwX" in block, f"{template.name}: expected g+rwX"
+        assert "g+rwx" not in block, f"{template.name}: g+rwx would chmod data +x"
+
+    def test_rendered_epilogue_makes_a_0600_artifact_group_readable(self, tmp_path):
+        """Run the real block: the reported failure mode must be fixed.
+
+        Reproduces the reported tree -- a 0600 ``adapter_model.safetensors``
+        beside 0644 siblings -- and asserts the epilogue makes it group-readable
+        while leaving the group-execute bit off the data files.
+        """
+        block = "\n".join(self._epilogue(self.WORKLOAD_TEMPLATES[0]))
+        out = tmp_path / "custom_output"
+        sub = out / "granite-4.1-3b_finance"
+        sub.mkdir(parents=True)
+        data = sub / "adapter_model.safetensors"
+        data.write_bytes(b"x")
+        data.chmod(0o600)
+        readme = sub / "README.md"
+        readme.write_text("x")
+        readme.chmod(0o644)
+        script = sub / "run.sh"
+        script.write_text("x")
+        script.chmod(0o744)
+        sub.chmod(0o755)
+
+        result = subprocess.run(
+            ["bash", "-c", f"set -o pipefail\nOUTPUT_PATH={out}\n{block}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+        mode = lambda f: f.stat().st_mode & 0o777
+        assert mode(data) & 0o040, "data file still not group-readable"
+        assert not mode(data) & 0o010, "data file must not become group-executable"
+        assert mode(readme) & 0o040, "sibling file not group-readable"
+        assert mode(script) & 0o010, "already-executable file should keep group-execute"
+        assert mode(sub) & 0o050, "directory must stay group-readable/traversable"
+
+    def test_rendered_epilogue_is_a_noop_without_output_path(self, tmp_path):
+        """Built-in steps set no OUTPUT_PATH; the block must exit cleanly anyway.
+
+        ``OUTPUT_PATH`` comes from the gbstep chart's values.yaml, so hfpush and
+        the other built-in k8s steps run this block with the variable unset.
+        """
+        block = "\n".join(self._epilogue(self.WORKLOAD_TEMPLATES[0]))
+        for script in (
+            f"set -o pipefail\nunset OUTPUT_PATH\n{block}",
+            f"set -o pipefail\nOUTPUT_PATH={tmp_path}/missing\n{block}",
+        ):
+            result = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, check=False
+            )
+            assert result.returncode == 0, result.stderr
+            assert "Normalizing" not in result.stdout

--- a/test/unit/uri/test_hf.py
+++ b/test/unit/uri/test_hf.py
@@ -17,6 +17,7 @@
 """Tests for HfURI, covering the pull(), push(), exists(), and delete() methods."""
 
 import json
+import os
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
@@ -354,6 +355,108 @@ class TestHfURIPushUnit:
             with pytest.raises(ValueError, match="no non-empty files"):
                 uri.push(src_dir)
         MockApi.return_value.upload_folder.assert_not_called()
+
+    def test_push_rejects_unreadable_file_in_directory(self, tmp_path):
+        """An unreadable file is named up front, before any Hub API call.
+
+        This is the failure mode from a producing step that wrote its output
+        ``0600`` while running as a different UID: ``upload_folder`` would only
+        hit it mid-commit and surface a ``PermissionError`` with no HTTP status,
+        which reads like a Hub outage.
+
+        ``os.access`` is patched rather than using ``chmod``: the test process
+        owns the files it creates, and the owner (like root) is granted access
+        regardless of the mode bits, so a real ``chmod(0o600)`` here would not
+        reproduce the failure at all.
+        """
+        src_dir = tmp_path / "ckpt"
+        src_dir.mkdir()
+        good = src_dir / "config.json"
+        good.write_text("{}")
+        bad = src_dir / "adapter_model.safetensors"
+        bad.write_bytes(b"x" * 32)
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+        real_access = os.access
+
+        def fake_access(path, mode, **kwargs):
+            if str(path) == str(bad):
+                return False
+            return real_access(path, mode, **kwargs)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            with patch("gbcommon.uri.hf.os.access", side_effect=fake_access):
+                with pytest.raises(PermissionError, match="adapter_model.safetensors"):
+                    uri.push(src_dir)
+        MockApi.return_value.upload_folder.assert_not_called()
+
+    def test_push_rejects_untraversable_subdirectory(self, tmp_path):
+        """A subdirectory that cannot be traversed is reported, not silently skipped.
+
+        ``rglob`` cannot see through a directory missing ``r-x``, so without an
+        explicit check an unreadable subtree looks merely empty.
+        """
+        src_dir = tmp_path / "ckpt"
+        src_dir.mkdir()
+        (src_dir / "top.bin").write_bytes(b"y" * 8)
+        sub = src_dir / "sub"
+        sub.mkdir()
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+        real_access = os.access
+
+        def fake_access(path, mode, **kwargs):
+            if str(path) == str(sub):
+                return False
+            return real_access(path, mode, **kwargs)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            with patch("gbcommon.uri.hf.os.access", side_effect=fake_access):
+                with pytest.raises(PermissionError, match="sub"):
+                    uri.push(src_dir)
+        MockApi.return_value.upload_folder.assert_not_called()
+
+    def test_push_unreadable_report_is_capped_but_counts_all(self, tmp_path):
+        """Every unreadable path is counted; the listing itself is truncated."""
+        src_dir = tmp_path / "ckpt"
+        src_dir.mkdir()
+        for i in range(25):
+            (src_dir / f"f{i:02d}.bin").write_bytes(b"z" * 4)
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+        with patch("gbcommon.uri.hf.HfApi"):
+            with patch("gbcommon.uri.hf.os.access", return_value=False):
+                with pytest.raises(PermissionError) as excinfo:
+                    uri.push(src_dir)
+
+        msg = str(excinfo.value)
+        assert "25 path(s)" in msg
+        assert "and 15 more" in msg
+        assert msg.count(".bin") == HfURI._MAX_UNREADABLE_REPORTED
+
+    def test_push_rejects_unreadable_single_file(self, tmp_path):
+        """The single-file push path checks readability too."""
+        src = tmp_path / "solo.bin"
+        src.write_bytes(b"w" * 8)
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            with patch("gbcommon.uri.hf.os.access", return_value=False):
+                with pytest.raises(PermissionError, match="solo.bin"):
+                    uri.push(src)
+        MockApi.return_value.upload_file.assert_not_called()
+
+    def test_push_accepts_group_readable_directory(self, tmp_path):
+        """The readability gate does not reject a normal, readable tree."""
+        src_dir = tmp_path / "ckpt"
+        src_dir.mkdir()
+        (src_dir / "model.safetensors").write_bytes(b"v" * 16)
+        (src_dir / "config.json").write_text("{}")
+        uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
+
+        with patch("gbcommon.uri.hf.HfApi") as MockApi:
+            uri.push(src_dir)
+        MockApi.return_value.upload_folder.assert_called_once()
 
     def test_push_normalizes_adapter_local_base_model(self, tmp_path):
         """A LoRA adapter's pod-local base_model path is rewritten to owner/repo."""


### PR DESCRIPTION
## Problem

An `hfpush` step on k8s failed with `EACCES` on a file that plainly existed:

```
[Errno 13] Permission denied:
  '/gb-read-write/custom_output_xxx/granite-4.1-3b_finance/adapter_model.safetensors'
```

The producing step wrote that file `0600 root:root` while its siblings were `0644`. The pushing pod ran as a different UID, so it could not read it.

```
-rw-r--r--. 1 root root      5206 README.md
-rw-------. 1 root root 249111968 adapter_model.safetensors   <-- unreadable to any other UID
-rw-r--r--. 1 root root      1057 adapter_config.json
```

## Why the umask from #333 cannot fix this

This is a **different bug** from #332. A umask only masks bits *off* the mode a writer requests — it can never add any:

| create mode | umask | result | |
|---|---|---|---|
| `0666` | `0002` | `0664` | what #333 fixed |
| `0600` | `0002` | `0600` | **this bug** |

`safetensors` writes via `mkstemp`, which is `0600` by design, so no umask setting would have helped.

Running `hfpush` as root was considered and rejected: on OpenShift the namespace SCC overrides `runAsUser`, so it trades a hard failure for a cluster-config-dependent one, and it argues against the arbitrary-UID guidance the charts already follow.

## Fix

**1. Normalize the artifact where it becomes shared state.** The step container normalizes its own output once the workload exits, in both container templates (they share no include):

```bash
chmod -R g+rwX "${OUTPUT_PATH}"
```

BYOI steps run arbitrary code and set arbitrary modes, so after-the-fact normalization is the only reliable point of control.

- Runs **before** the exit-code check, so a failed run's partial output is normalized too — later pods still read and retry against it.
- `g+rwX` adds group-execute only to directories and already-executable files, never to data.
- No-op when `OUTPUT_PATH` is unset — the case for built-in steps (`hfpush`, `hfpull`, `lhpush`, …), which consume artifacts rather than produce them.

**It is a guard, never a gate.** The artifact is often already readable, and some mounts forbid `chmod` outright (read-only, root-squashed, files owned by another UID), so a `chmod` failure says nothing about whether the step succeeded and **never fails the step**. It is not silent either, since it predicts a later push failure. Two details that are easy to get wrong:

- **The warning goes to stdout, not stderr.** Only `command.sh` is tee'd into `/logs/output.log` — the file the sidecar monitor tails — and this block runs *after* that pipeline, so a bare stderr write would never reach the log an operator actually reads.
- **The listing is capped at 10 paths**, with the true total reported. Uncapped, a wholly root-squashed tree emits one line per file; a local test against a deep tree produced 875KB, which would flood the log and the event stream.

**2. Name unreadable files before the upload starts.** `_validate_non_empty_src` already walked the tree, so readability is checked in the same walk.

Previously `upload_folder` opened each file only once already mid-commit, and the resulting `PermissionError` carries no HTTP status — `_log_hf_api_error` could only classify it as `HF_ERR_OTHER` and log `"no HTTP status"`, which reads like a Hub outage rather than a local `EACCES`. It also aborted on the first bad file, so an operator fixed one path per run.

Now every unreadable path is named up front, including directories that cannot be traversed — `rglob` cannot see through those, so without an explicit check an unreadable subtree looks merely *empty*. This is a diagnostic, not a guarantee: `os.access` is point-in-time and a push can still race a permission change, so the `push` call sites keep their exception handling.

## Why not `fsGroup`

Considered and deliberately not used:

- It depends on the volume's CSI driver honouring ownership management — many NFS-backed RWX volumes ignore it.
- These charts never see the PVC object: `/gb-read-write` is a path assumed to be pre-mounted, with no `claimName` anywhere in the repo.
- It cannot fix files that already exist.

The `chmod` pass has none of these limitations. Worth revisiting as a complement if the storage class is known to honour it.

## Testing

8 chart tests + 5 `hf.py` tests; 123 passing in the two affected suites.

The chart tests run the **rendered bash**, asserting that:
- a `0600` file becomes group-readable while data does **not** become executable;
- a refused `chmod` (stubbed, both exit 0 and exit 1) **never** fails the step;
- the warning lands on **stdout** and is capped at 10 with the true count.

The `hf.py` tests patch `os.access` rather than calling `chmod`, because the test process owns the files it creates and **an owner may read its own files regardless of the mode bits** — a real `chmod(0o600)` would not reproduce the failure at all. (Noted in the test docstrings so the next person doesn't write that misleading test.)

Verified the new guards **fail without the fix**. Also verified with a real `helm template` render: valid YAML, epilogue correctly placed between the exit-code capture and the failure check.

## Incidental findings (not addressed here)

Noticed while mapping the charts; both look like latent gaps worth separate issues:

- `src/gbserver/builtins/steps/k8s/s3pull/` and `s3push/` have **no `helm-charts/` directory**, yet their `step.yaml` declares `chart: helm-charts/s3pull` / `s3push`. The other five k8s steps all have one.
- `gbraystepbase`'s `raycontainer` — the actually-used Ray pod template — sets **no securityContext and no umask**. Currently harmless (it mounts only `/dev/shm`, `/logs`, `/tmp/ray`, never the shared PVC), but a latent hole if a Ray step ever writes to `/gb-read-write`.

Refs #332
