### PR TITLE
feat(cli): add --uri to artifact push and share URI resolution

### DIFF
--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -43,9 +43,6 @@ from gbcli.utils.spaceutil import resolve_space
 from gbcli.utils.utils import (
     check_runnable_browser,
     combine_tags,
-    compare_env_uri,
-    decode_uri,
-    get_artifact_formatted_name,
     get_artifact_uuid,
     humanize_iso_date,
     is_valid_checksum,
@@ -58,8 +55,8 @@ from gbcli.utils.utils import (
     validate_tags,
 )
 from gbcli.utils.versionutil import check_current_and_latest_versions
-from gbcommon.uri.hf import HfURI
-from gbcommon.uri.uri import URI
+from gbcommon.types.gbenvconfig import gb_environment_config
+from gbcommon.uri.uri import URI, UnknownURIScheme
 from gbcommon.utils.hf_utils import (
     convert_hf_uri_to_url,
     is_enterprise_hf_org,
@@ -188,17 +185,29 @@ def _resolve_uri(
         )
         ctx.exit(1)
 
+    # Parse the URI once through the shared URI layer. The store is just the
+    # URI scheme; the identity fields come from get_metadata(). A malformed URI,
+    # an unresolved template variable, or an unknown scheme all surface as a
+    # ValueError/RuntimeError -- report cleanly instead of as a traceback.
+    # (LhURI validates in its constructor; HfURI validates lazily in
+    # get_metadata(), so both calls are guarded.)
+    try:
+        uri_obj = URI.get_uri(uri)
+        store = uri_obj.uri.scheme
+        metadata = uri_obj.get_metadata()
+    except (ValueError, RuntimeError, UnknownURIScheme) as e:
+        click.echo(f"❌ Error: invalid artifact URI '{uri}': {e}", err=True)
+        ctx.exit(1)
+    if store not in ("hf", "lh"):
+        click.echo(
+            f"❌ Error: unsupported artifact URI scheme '{store}' in '{uri}'; "
+            "expected an lh:// or hf:// URI.",
+            err=True,
+        )
+        ctx.exit(1)
+
     uri_env = None
-    if uri.startswith("hf://"):
-        store = "hf"
-        try:
-            metadata = URI.get_uri(uri).get_metadata()
-        except (ValueError, RuntimeError) as e:
-            # get_uri runs the URI through strict templating first: a bad
-            # template string raises ValueError, an undefined variable
-            # RuntimeError. Catch both so neither escapes as a traceback.
-            click.echo(f"❌ Error: invalid HuggingFace URI '{uri}': {e}", err=True)
-            ctx.exit(1)
+    if store == "hf":
         # The type, owner, repo and (when applicable) revision are all
         # encoded in the URI (hf:///[type/]owner/repo[/revision]), so the
         # flags that would otherwise supply them are redundant and rejected
@@ -215,11 +224,11 @@ def _resolve_uri(
         # Buckets decode to revision "" (no revision concept); None lets
         # the service default it to "main" as the non-URI path does.
         revision = metadata["revision"] or None
-    else:
-        store = "lh"
-        decoded_artifact = decode_uri(uri)
-
-        uri_env, cli_env = compare_env_uri(uri)
+    else:  # store == "lh"
+        # The Lakehouse environment is the lh://<env> host (urlparse lowercases
+        # it). Only needed here, for the prod-vs-non-prod guard.
+        uri_env = uri_obj.uri.hostname
+        cli_env = str(gb_environment_config().lakehouse_environment).lower()
 
         if uri_env == "prod" and cli_env != "prod":
             click.echo(
@@ -236,20 +245,20 @@ def _resolve_uri(
             click.echo(lh_conflict_msg)
             ctx.exit(1)
 
-        type = decoded_artifact.type
-        namespace = decoded_artifact.namespace
-        table = decoded_artifact.table_name
+        type = metadata["type"]
+        namespace = metadata["namespace"]
+        table = metadata["table_name"]
 
         if type == "model":
-            label = decoded_artifact.model_label
-            revision = decoded_artifact.model_revision
+            label = metadata["model_label"]
+            revision = metadata["model_revision"]
 
         if type == "fileset":
-            label = decoded_artifact.fileset_label
-            version = decoded_artifact.fileset_version
+            label = metadata["fileset_label"]
+            version = metadata["fileset_version"]
 
         if type == "dataset":
-            dataset = decoded_artifact.dataset_name
+            dataset = metadata["dataset_name"]
 
     return ResolvedURI(
         store=store,
@@ -264,6 +273,27 @@ def _resolve_uri(
         uri_env=uri_env,
         force=force,
     )
+
+
+# The HuggingFace store only holds models, datasets and buckets (no tables or
+# filesets), independent of how the store/type were supplied (a URI or explicit
+# flags). Shared by `artifact push` and `artifact register` so the rule and its
+# message cannot drift.
+HF_STORE_ALLOWED_TYPES = ["model", "dataset", "bucket"]
+
+
+def _validate_hf_store_type(ctx, store: str, type: str | None) -> None:
+    """Reject an artifact ``type`` the HuggingFace store cannot hold.
+
+    A no-op unless ``store == "hf"``. Shared by ``push`` and ``register``.
+    """
+    if store == "hf" and type not in HF_STORE_ALLOWED_TYPES:
+        click.echo(
+            f"❌ Error: store 'hf' is only allowed for artifact types 'model', "
+            f"'dataset', and 'bucket'. Got type '{type}'.",
+            err=True,
+        )
+        ctx.exit(1)
 
 
 @click.group("artifact")
@@ -482,16 +512,13 @@ def push(
     private = not public if store == "hf" else False
 
     # Validate store type compatibility with artifact type
-    if store == "hf" and type not in ["model", "dataset", "bucket"]:
-        click.echo(
-            f"❌ Error: Push and register with store 'hf' is only allowed for artifact types 'model', 'dataset', and 'bucket'. Got type '{type}'.",
-            err=True,
-        )
-        ctx.exit(1)
+    _validate_hf_store_type(ctx, store, type)
 
+    # push-only: Lakehouse does not support pushing dataset content (register
+    # does allow recording an existing lh dataset, so this guard stays in push).
     if store == "lh" and type == "dataset":
         click.echo(
-            f"❌ Error: Push and register with store 'lh' does not support artifact type 'dataset'. Use store 'hf' instead.",
+            f"❌ Error: Push with store 'lh' does not support artifact type 'dataset'. Use store 'hf' instead.",
             err=True,
         )
         ctx.exit(1)
@@ -824,9 +851,9 @@ def push(
             if existing_registration:
                 artifact_id = existing_registration.get("uuid")
                 # Decode the existing (Lakehouse) artifact's URI via the shared
-                # URI class rather than indexing raw "/"-split segments. This
+                # URI layer rather than indexing raw "/"-split segments. This
                 # block only runs for store == "lh" (see the guard above), so
-                # the URI is always lh:// and the LhURI metadata carries the
+                # the URI is always lh:// and the metadata carries the
                 # namespace/table/label/revision/version fields below.
                 existing_meta = URI.get_uri(
                     existing_registration.get("uri")
@@ -1340,12 +1367,7 @@ def register(
         ctx.exit(1)
 
     # Validate store type compatibility with artifact type
-    if store == "hf" and type not in ["model", "dataset", "bucket"]:
-        click.echo(
-            f"❌ Error: Registration with store 'hf' is only allowed for artifact types 'model', 'dataset' and 'bucket'. Got type '{type}'.",
-            err=True,
-        )
-        ctx.exit(1)
+    _validate_hf_store_type(ctx, store, type)
 
     # === Type-specific handling ===
     # Prompts, tables, revisions and filesets/tables are all Lakehouse
@@ -2190,11 +2212,13 @@ def download(
                 click.echo(f"\n❌ Error: artifact does not exist.", err=True)
                 ctx.exit(1)
 
-            # Detect if artifact is in HuggingFace or Lakehouse via the shared
-            # URI class rather than a raw scheme-prefix check.
+            # Parse the artifact URI once through the shared URI layer; the
+            # store is the scheme and the identity comes from get_metadata().
             artifact_uri = artifact["uri"]
             uri_obj = URI.get_uri(artifact_uri)
-            if isinstance(uri_obj, HfURI):
+            uri_store = uri_obj.uri.scheme
+            uri_metadata = uri_obj.get_metadata()
+            if uri_store == "hf":
                 # === HF download path ===
                 hf_token_value = hf_token()
                 if not hf_token_value:
@@ -2204,8 +2228,8 @@ def download(
                     )
                     ctx.exit(1)
 
-                repo_id = f"{uri_obj.get_owner()}/{uri_obj.get_repo()}"
-                artifact_type = str(uri_obj.get_hf_type())
+                repo_id = f"{uri_metadata['owner']}/{uri_metadata['repo']}"
+                artifact_type = str(uri_metadata["hf_type"])
 
                 if not quiet:
                     click.echo(f"Downloading {artifact_type} from HuggingFace...")
@@ -2263,23 +2287,26 @@ def download(
                 return  # done, skip LH path below
 
             # === LH-specific logic (grouped for future disable) ===
-            decoded_artifact = decode_uri(artifact_uri)
-            namespace = decoded_artifact.namespace
-            table_name = decoded_artifact.table_name
-            type = decoded_artifact.type
+            # Anything past the HF branch must be a Lakehouse URI; reject any
+            # other scheme as before.
+            if uri_store != "lh":
+                raise ValueError("Error: Artifact URI formatted incorrectly.")
+            namespace = uri_metadata["namespace"]
+            table_name = uri_metadata["table_name"]
+            type = uri_metadata["type"]
 
             if type == "dataset":
                 selected_type = "dataset"
 
             elif type == "model":
                 selected_type = "model"
-                model_label = decoded_artifact.model_label
-                model_revision = decoded_artifact.model_revision
+                model_label = uri_metadata["model_label"]
+                model_revision = uri_metadata["model_revision"]
 
             elif type == "fileset":
                 selected_type = "fileset"
-                file_label = decoded_artifact.fileset_label
-                version = decoded_artifact.fileset_version
+                file_label = uri_metadata["fileset_label"]
+                version = uri_metadata["fileset_version"]
 
             else:
                 selected_type = "table"
@@ -2709,10 +2736,13 @@ def copy(
             uri = artifact["uri"]
             table_name = artifact_name
 
-            # Detect artifact source: HF or LH via the shared URI class rather
-            # than a raw scheme-prefix check.
+            # Detect artifact source via the shared URI layer: the store is the
+            # URI scheme. Parse once and reuse the metadata below.
 
-            is_hf_artifact = isinstance(URI.get_uri(uri), HfURI)
+            uri_obj = URI.get_uri(uri)
+            uri_store = uri_obj.uri.scheme
+            uri_metadata = uri_obj.get_metadata()
+            is_hf_artifact = uri_store == "hf"
 
         if is_hf_artifact:
             click.echo(
@@ -2722,8 +2752,10 @@ def copy(
             sys.exit(1)  # Exit with a non-zero status
 
         # === Lakehouse-specific copy logic (can be disabled together) ===
-        decoded_artifact = decode_uri(uri)
-        type = decoded_artifact.type
+        # Anything not HF must be a Lakehouse URI; reject any other scheme.
+        if uri_store != "lh":
+            raise ValueError("Error: Artifact URI formatted incorrectly.")
+        type = uri_metadata["type"]
 
         if type != "model":
             click.echo(f"\n❌ Only model artifacts are supported for copy.", err=True)
@@ -2758,18 +2790,15 @@ def copy(
                 f"(3/4) Copying artifact to Lakehouse. This may take a while, please wait..."
             )
 
-        revision = decoded_artifact.model_revision
-        namespace = decoded_artifact.namespace
-        model_label = decoded_artifact.model_label
+        revision = uri_metadata["model_revision"]
+        namespace = uri_metadata["namespace"]
+        model_label = uri_metadata["model_label"]
 
-        source_table_name = (
-            get_artifact_formatted_name(decoded_artifact).split(".")[-1]
-            if uri != None
-            else LAKEHOUSE_MODEL_SHARED_TABLE
-        )
+        # The source table is the URI's own table when it is the per-user model
+        # table; otherwise the copy reads from the shared model table.
         source_table = (
-            source_table_name
-            if source_table_name == LAKEHOUSE_MODEL_TABLE
+            LAKEHOUSE_MODEL_TABLE
+            if uri_metadata["table_name"] == LAKEHOUSE_MODEL_TABLE
             else LAKEHOUSE_MODEL_SHARED_TABLE
         )
         target_table = LAKEHOUSE_MODEL_TABLE

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -185,12 +185,9 @@ def _resolve_uri(
         )
         ctx.exit(1)
 
-    # Parse the URI once through the shared URI layer. The store is just the
-    # URI scheme; the identity fields come from get_metadata(). A malformed URI,
-    # an unresolved template variable, or an unknown scheme all surface as a
-    # ValueError/RuntimeError -- report cleanly instead of as a traceback.
-    # (LhURI validates in its constructor; HfURI validates lazily in
-    # get_metadata(), so both calls are guarded.)
+    # Parse once: the store is the URI scheme, the identity comes from
+    # get_metadata(). get_metadata() is inside the try because HfURI validates
+    # lazily there; a bad URI surfaces as ValueError/RuntimeError, not a traceback.
     try:
         uri_obj = URI.get_uri(uri)
         store = uri_obj.uri.scheme
@@ -208,12 +205,8 @@ def _resolve_uri(
 
     uri_env = None
     if store == "hf":
-        # The type, owner, repo and (when applicable) revision are all
-        # encoded in the URI (hf:///[type/]owner/repo[/revision]), so the
-        # flags that would otherwise supply them are redundant and rejected
-        # outright. This mirrors the Lakehouse path, which likewise refuses
-        # any of these flags alongside a URI (see below), and sidesteps the
-        # ambiguity of an explicit "main" reading as "no revision given".
+        # type/owner/repo/revision come from the URI, so the flags that would
+        # supply them are rejected.
         if type or hf_organization or label or revision:
             click.echo(hf_conflict_msg, err=True)
             ctx.exit(1)
@@ -221,12 +214,11 @@ def _resolve_uri(
         type = str(metadata["hf_type"])
         hf_organization = metadata["owner"]
         label = metadata["repo"]
-        # Buckets decode to revision "" (no revision concept); None lets
-        # the service default it to "main" as the non-URI path does.
+        # Buckets decode to revision ""; None lets the service default to "main".
         revision = metadata["revision"] or None
     else:  # store == "lh"
-        # The Lakehouse environment is the lh://<env> host (urlparse lowercases
-        # it). Only needed here, for the prod-vs-non-prod guard.
+        # The Lakehouse environment is the lh://<env> host, used only for the
+        # prod-vs-non-prod guard below.
         uri_env = uri_obj.uri.hostname
         cli_env = str(gb_environment_config().lakehouse_environment).lower()
 
@@ -275,22 +267,29 @@ def _resolve_uri(
     )
 
 
-# The HuggingFace store only holds models, datasets and buckets (no tables or
-# filesets), independent of how the store/type were supplied (a URI or explicit
-# flags). Shared by `artifact push` and `artifact register` so the rule and its
-# message cannot drift.
-HF_STORE_ALLOWED_TYPES = ["model", "dataset", "bucket"]
+# Artifact types each store accepts. Buckets are HuggingFace-only; Lakehouse
+# push additionally cannot push dataset content (register may still record an
+# existing lh dataset).
+_HF_ALLOWED_TYPES = ("model", "dataset", "bucket")
+_LH_ALLOWED_TYPES = ("model", "table", "fileset", "dataset")
+_LH_PUSH_ALLOWED_TYPES = ("model", "table", "fileset")
 
 
-def _validate_hf_store_type(ctx, store: str, type: str | None) -> None:
-    """Reject an artifact ``type`` the HuggingFace store cannot hold.
+def _validate_store_type(ctx, store: str, type: str | None, is_push: bool) -> None:
+    """Reject an artifact ``type`` incompatible with ``store``.
 
-    A no-op unless ``store == "hf"``. Shared by ``push`` and ``register``.
+    The single place the store-vs-type matrix lives; shared by ``push`` and
+    ``register`` (``is_push`` selects the stricter Lakehouse rules).
     """
-    if store == "hf" and type not in HF_STORE_ALLOWED_TYPES:
+    if store == "hf":
+        allowed = _HF_ALLOWED_TYPES
+    else:  # store == "lh"
+        allowed = _LH_PUSH_ALLOWED_TYPES if is_push else _LH_ALLOWED_TYPES
+    if type not in allowed:
+        allowed_str = ", ".join(f"'{t}'" for t in allowed)
         click.echo(
-            f"❌ Error: store 'hf' is only allowed for artifact types 'model', "
-            f"'dataset', and 'bucket'. Got type '{type}'.",
+            f"❌ Error: store '{store}' is only allowed for artifact types "
+            f"{allowed_str}. Got type '{type}'.",
             err=True,
         )
         ctx.exit(1)
@@ -456,13 +455,9 @@ def push(
 ):
     """A file (for a table) or a directory (for a model, fileset, dataset, or bucket) is uploaded and registered. Additional options will be required depending on the type of artifact."""
 
-    # === URI decoding ===
-    # --uri is syntactic sugar: the store and identity are decoded from the URI
-    # and drive the rest of the command exactly as the individual flags would.
-    # Shared with `artifact register` via _resolve_uri. push has no
-    # --revision/--namespace/--version/--dataset/--force flags, so those are
-    # passed as None/False here and the decoded lh-only extras are discarded
-    # (push overwrites revision/version and sends namespace=None downstream).
+    # --uri is syntactic sugar: _resolve_uri decodes the store and identity.
+    # push has no --revision/--namespace/--version/--dataset/--force, so those
+    # are passed None/False and the decoded lh-only extras are discarded.
     if uri:
         resolved = _resolve_uri(
             ctx,
@@ -511,17 +506,7 @@ def push(
     # For HuggingFace, default is private unless --public flag is used
     private = not public if store == "hf" else False
 
-    # Validate store type compatibility with artifact type
-    _validate_hf_store_type(ctx, store, type)
-
-    # push-only: Lakehouse does not support pushing dataset content (register
-    # does allow recording an existing lh dataset, so this guard stays in push).
-    if store == "lh" and type == "dataset":
-        click.echo(
-            f"❌ Error: Push with store 'lh' does not support artifact type 'dataset'. Use store 'hf' instead.",
-            err=True,
-        )
-        ctx.exit(1)
+    _validate_store_type(ctx, store, type, is_push=True)
 
     if not skip_version_check:
         try:
@@ -540,10 +525,8 @@ def push(
         )
         ctx.exit(1)  # Exit with a non-zero status
 
-    # `and not uri` guards: with a URI the type/label are derived from the URI
-    # itself (e.g. an hf:// dataset/bucket URI legitimately sets label from the
-    # repo), and any user-supplied conflicting flag was already rejected in
-    # _resolve_uri. Only the non-URI, user-supplied combinations are invalid.
+    # `and not uri`: with a URI, type/label are URI-derived (a conflicting flag
+    # was already rejected in _resolve_uri); only user-supplied combos are wrong.
     if (
         (type == "model" or type == "fileset" or type == "dataset" or type == "bucket")
         and table
@@ -850,11 +833,8 @@ def push(
             # if existing artifact registration
             if existing_registration:
                 artifact_id = existing_registration.get("uuid")
-                # Decode the existing (Lakehouse) artifact's URI via the shared
-                # URI layer rather than indexing raw "/"-split segments. This
-                # block only runs for store == "lh" (see the guard above), so
-                # the URI is always lh:// and the metadata carries the
-                # namespace/table/label/revision/version fields below.
+                # This block only runs for the lh store, so the URI is lh:// and
+                # its metadata carries the fields read below.
                 existing_meta = URI.get_uri(
                     existing_registration.get("uri")
                 ).get_metadata()
@@ -879,10 +859,7 @@ def push(
                     table=existing_meta.get("table_name"),
                     dataset=None,
                     label=(
-                        # NOTE: keyed on the outer `type` (the pushed artifact's
-                        # type), not existing_type — preserved from the original
-                        # split-based code. model_label and fileset_label live at
-                        # the same URI segment, so either key resolves it.
+                        # Keyed on the pushed artifact's `type`, not existing_type.
                         (
                             existing_meta.get("model_label")
                             or existing_meta.get("fileset_label")
@@ -1306,11 +1283,8 @@ def register(
                 )
                 ctx.exit(1)
 
-    # === URI decoding ===
-    # The store is derived from the URI scheme (lh:// or hf://); the two are
-    # decoded differently and only the Lakehouse branch has an "environment".
-    # Shared with `artifact push` via _resolve_uri so the parsing and
-    # mutual-exclusivity rules cannot drift between the two commands.
+    # --uri is syntactic sugar: _resolve_uri decodes the store and identity
+    # (shared with `artifact push`).
     uri_env = None
     if uri:
         resolved = _resolve_uri(
@@ -1366,8 +1340,7 @@ def register(
         )
         ctx.exit(1)
 
-    # Validate store type compatibility with artifact type
-    _validate_hf_store_type(ctx, store, type)
+    _validate_store_type(ctx, store, type, is_push=False)
 
     # === Type-specific handling ===
     # Prompts, tables, revisions and filesets/tables are all Lakehouse

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict
 
@@ -57,11 +58,11 @@ from gbcli.utils.utils import (
     validate_tags,
 )
 from gbcli.utils.versionutil import check_current_and_latest_versions
+from gbcommon.uri.hf import HfURI
 from gbcommon.uri.uri import URI
 from gbcommon.utils.hf_utils import (
     convert_hf_uri_to_url,
     is_enterprise_hf_org,
-    parse_hf_uri,
 )
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,165 @@ def _reject_resource_group_for_non_enterprise(exit_fn, org: str) -> None:
     exit_fn(1)
 
 
+@dataclass
+class ResolvedURI:
+    """The store and identity fields decoded from an artifact ``--uri``.
+
+    ``_resolve_uri`` turns an ``lh://`` or ``hf://`` URI into this flat set of
+    values so each command can unpack the subset it has flags for. ``uri_env``
+    and ``force`` are only meaningful for the Lakehouse path (``force`` is a
+    passthrough of the caller's seed, raised to ``True`` when a prod artifact is
+    registered in a non-prod environment).
+    """
+
+    store: str
+    type: str
+    hf_organization: str | None
+    label: str | None
+    revision: str | None
+    namespace: str | None
+    table: str | None
+    version: str | None
+    dataset: str | None
+    uri_env: str | None
+    force: bool
+
+
+def _resolve_uri(
+    ctx,
+    uri: str,
+    *,
+    store: str,
+    type: str | None,
+    hf_organization: str | None,
+    label: str | None,
+    revision: str | None,
+    namespace: str | None,
+    table: str | None,
+    version: str | None,
+    dataset: str | None,
+    force: bool,
+    hf_conflict_msg: str,
+    lh_conflict_msg: str,
+) -> ResolvedURI:
+    """Decode an artifact ``--uri`` into its store and identity fields.
+
+    ``--uri`` is syntactic sugar: the store is inferred from the scheme
+    (``lh://`` or ``hf://``) and the identity is encoded in the URI, so the
+    individual flags that would otherwise supply those are redundant and are
+    rejected outright. Shared by ``artifact push`` and ``artifact register`` so
+    the parsing and mutual-exclusivity rules cannot drift between them.
+
+    The two commands pass different ``*_conflict_msg`` strings because they do
+    not expose the same flags (push has no ``--revision``/``--namespace``/etc.);
+    those absent options are passed as ``None`` here so they can never trigger a
+    conflict.
+
+    Args:
+        ctx: The Click context (for ``get_parameter_source`` and ``exit``).
+        uri: The ``lh://`` or ``hf://`` URI.
+        store: The current ``--store`` value; an explicit one conflicts with a
+            URI (the scheme already determines the store).
+        type, hf_organization, label, revision, namespace, table, version,
+            dataset: The current values of the individual flags; any truthy one
+            conflicts with a URI.
+        force: The command's current ``--force`` seed (Lakehouse only).
+        hf_conflict_msg: Error shown when an hf:// URI is combined with an
+            identity flag; names only the calling command's flags.
+        lh_conflict_msg: Likewise for an lh:// URI.
+
+    Returns:
+        A :class:`ResolvedURI` with the decoded values.
+    """
+    # The URI already determines the store, so an explicit --store conflicts.
+    # COMMANDLINE is the only non-default source today because --store has no
+    # envvar or default-map entry; if one is ever added, use `!= DEFAULT` here
+    # so an env-set --store is also caught rather than silently overwritten.
+    if ctx.get_parameter_source("store") == ParameterSource.COMMANDLINE:
+        click.echo(
+            "❌ Error: --store cannot be combined with --uri; the store is inferred from the URI scheme (lh:// or hf://).",
+            err=True,
+        )
+        ctx.exit(1)
+
+    uri_env = None
+    if uri.startswith("hf://"):
+        store = "hf"
+        try:
+            metadata = URI.get_uri(uri).get_metadata()
+        except (ValueError, RuntimeError) as e:
+            # get_uri runs the URI through strict templating first: a bad
+            # template string raises ValueError, an undefined variable
+            # RuntimeError. Catch both so neither escapes as a traceback.
+            click.echo(f"❌ Error: invalid HuggingFace URI '{uri}': {e}", err=True)
+            ctx.exit(1)
+        # The type, owner, repo and (when applicable) revision are all
+        # encoded in the URI (hf:///[type/]owner/repo[/revision]), so the
+        # flags that would otherwise supply them are redundant and rejected
+        # outright. This mirrors the Lakehouse path, which likewise refuses
+        # any of these flags alongside a URI (see below), and sidesteps the
+        # ambiguity of an explicit "main" reading as "no revision given".
+        if type or hf_organization or label or revision:
+            click.echo(hf_conflict_msg, err=True)
+            ctx.exit(1)
+
+        type = str(metadata["hf_type"])
+        hf_organization = metadata["owner"]
+        label = metadata["repo"]
+        # Buckets decode to revision "" (no revision concept); None lets
+        # the service default it to "main" as the non-URI path does.
+        revision = metadata["revision"] or None
+    else:
+        store = "lh"
+        decoded_artifact = decode_uri(uri)
+
+        uri_env, cli_env = compare_env_uri(uri)
+
+        if uri_env == "prod" and cli_env != "prod":
+            click.echo(
+                f"⚠️{' '} Warning: You are registering a '{uri_env}' artifact in the '{cli_env}' environment."
+            )
+            force = True
+        elif uri_env != cli_env:
+            click.echo(
+                f"❌ The environment '{uri_env}' doesn't match the CLI environment '{cli_env}'. CLI doesn't support artifact register across environments except for 'prod' artifacts."
+            )
+            ctx.exit(1)
+
+        if type or table or label or revision or version or dataset or namespace:
+            click.echo(lh_conflict_msg)
+            ctx.exit(1)
+
+        type = decoded_artifact.type
+        namespace = decoded_artifact.namespace
+        table = decoded_artifact.table_name
+
+        if type == "model":
+            label = decoded_artifact.model_label
+            revision = decoded_artifact.model_revision
+
+        if type == "fileset":
+            label = decoded_artifact.fileset_label
+            version = decoded_artifact.fileset_version
+
+        if type == "dataset":
+            dataset = decoded_artifact.dataset_name
+
+    return ResolvedURI(
+        store=store,
+        type=type,
+        hf_organization=hf_organization,
+        label=label,
+        revision=revision,
+        namespace=namespace,
+        table=table,
+        version=version,
+        dataset=dataset,
+        uri_env=uri_env,
+        force=force,
+    )
+
+
 @click.group("artifact")
 @click.pass_context
 def cli(ctx):
@@ -138,8 +298,14 @@ def cli(ctx):
 )
 @click.option("--artifact-name", required=True, help="Artifact name to be registered.")
 @click.option(
+    "--uri",
+    help="Lakehouse (lh://) or HuggingFace (hf://) URI of the artifact destination. The store is inferred from the scheme, so --store must not be combined with --uri. The URI also encodes the artifact's identity, so --type, --hf-organization, --label/--repo and --table cannot be combined with it -- put them in the URI (for hf://: hf:///[type/]owner/repo).",
+)
+@click.option(
     "--label",
-    help="Label for model or fileset artifacts. If not provided, the artifact name will be used as the label.",
+    "--repo",
+    "label",
+    help="Label for model or fileset artifacts, aka --repo. If not provided, the artifact name will be used as the label. For a HuggingFace artifact it is the 'repo' portion of the owner/repo id.",
 )
 @click.option(
     "-t",
@@ -148,7 +314,6 @@ def cli(ctx):
         ["model", "table", "fileset", "dataset", "bucket"], case_sensitive=True
     ),
     help="Artifact type to be saved. Options: model, fileset, table, dataset, bucket",
-    required=True,
 )
 @click.option(
     "-s",
@@ -236,6 +401,7 @@ def push(
     from_local: str,
     format: str,
     artifact_name: str,
+    uri: str,
     label: str,
     type: str,
     size: str,
@@ -259,6 +425,50 @@ def push(
     quiet: bool,
 ):
     """A file (for a table) or a directory (for a model, fileset, dataset, or bucket) is uploaded and registered. Additional options will be required depending on the type of artifact."""
+
+    # === URI decoding ===
+    # --uri is syntactic sugar: the store and identity are decoded from the URI
+    # and drive the rest of the command exactly as the individual flags would.
+    # Shared with `artifact register` via _resolve_uri. push has no
+    # --revision/--namespace/--version/--dataset/--force flags, so those are
+    # passed as None/False here and the decoded lh-only extras are discarded
+    # (push overwrites revision/version and sends namespace=None downstream).
+    if uri:
+        resolved = _resolve_uri(
+            ctx,
+            uri,
+            store=store,
+            type=type,
+            hf_organization=hf_organization,
+            label=label,
+            revision=None,
+            namespace=None,
+            table=table,
+            version=None,
+            dataset=None,
+            force=False,
+            hf_conflict_msg=(
+                "❌ Error: --type, --hf-organization and --label/--repo cannot be "
+                "used with an hf:// URI; encode them in the URI itself "
+                "(hf:///[type/]owner/repo)."
+            ),
+            lh_conflict_msg=(
+                "❌ Error: artifact URI cannot be used along with type, label or "
+                "table arguments."
+            ),
+        )
+        store = resolved.store
+        type = resolved.type
+        hf_organization = resolved.hf_organization
+        label = resolved.label
+        table = resolved.table
+
+    if not uri and not type:
+        click.echo(
+            f"❌ Artifact type or artifact uri is required. Please try again.",
+            err=True,
+        )
+        ctx.exit(1)
 
     # Validate that --public is only used with HuggingFace
     if public and store != "hf":
@@ -303,16 +513,22 @@ def push(
         )
         ctx.exit(1)  # Exit with a non-zero status
 
+    # `and not uri` guards: with a URI the type/label are derived from the URI
+    # itself (e.g. an hf:// dataset/bucket URI legitimately sets label from the
+    # repo), and any user-supplied conflicting flag was already rejected in
+    # _resolve_uri. Only the non-URI, user-supplied combinations are invalid.
     if (
-        type == "model" or type == "fileset" or type == "dataset" or type == "bucket"
-    ) and table:
+        (type == "model" or type == "fileset" or type == "dataset" or type == "bucket")
+        and table
+        and not uri
+    ):
         click.echo(
             f"❌ The --table option is not valid for {type} artifacts. Please try again without the --table option.",
             err=True,
         )
         ctx.exit(1)
 
-    if (type == "table" or type == "dataset" or type == "bucket") and label:
+    if (type == "table" or type == "dataset" or type == "bucket") and label and not uri:
         click.echo(
             f"❌ The --label option is not valid for {type} artifacts. Please try again without the --label option.",
             err=True,
@@ -607,27 +823,43 @@ def push(
             # if existing artifact registration
             if existing_registration:
                 artifact_id = existing_registration.get("uuid")
+                # Decode the existing (Lakehouse) artifact's URI via the shared
+                # URI class rather than indexing raw "/"-split segments. This
+                # block only runs for store == "lh" (see the guard above), so
+                # the URI is always lh:// and the LhURI metadata carries the
+                # namespace/table/label/revision/version fields below.
+                existing_meta = URI.get_uri(
+                    existing_registration.get("uri")
+                ).get_metadata()
+                existing_type = existing_registration.get("type")
                 revision = (
-                    existing_registration.get("uri").split("/")[7]
-                    if existing_registration.get("type") == "model"
+                    existing_meta.get("model_revision")
+                    if existing_type == "model"
                     else None
                 )
                 version = (
-                    existing_registration.get("uri").split("/")[7]
-                    if existing_registration.get("type") == "fileset"
+                    existing_meta.get("fileset_version")
+                    if existing_type == "fileset"
                     else None
                 )
 
                 # check if artifact content exists in LH
                 artifact_existence = artifact_client.check_existence(
                     lh_token=lh_token,
-                    type=existing_registration.get("type"),
+                    type=existing_type,
                     space=space,
-                    namespace=existing_registration.get("uri").split("/")[3],
-                    table=existing_registration.get("uri").split("/")[5],
+                    namespace=existing_meta.get("namespace"),
+                    table=existing_meta.get("table_name"),
                     dataset=None,
                     label=(
-                        existing_registration.get("uri").split("/")[6]
+                        # NOTE: keyed on the outer `type` (the pushed artifact's
+                        # type), not existing_type — preserved from the original
+                        # split-based code. model_label and fileset_label live at
+                        # the same URI segment, so either key resolves it.
+                        (
+                            existing_meta.get("model_label")
+                            or existing_meta.get("fileset_label")
+                        )
                         if type in ("fileset", "model")
                         else None
                     ),
@@ -1050,87 +1282,44 @@ def register(
     # === URI decoding ===
     # The store is derived from the URI scheme (lh:// or hf://); the two are
     # decoded differently and only the Lakehouse branch has an "environment".
+    # Shared with `artifact push` via _resolve_uri so the parsing and
+    # mutual-exclusivity rules cannot drift between the two commands.
     uri_env = None
     if uri:
-        # The URI already determines the store, so an explicit --store conflicts.
-        # COMMANDLINE is the only non-default source today because --store has no
-        # envvar or default-map entry; if one is ever added, use `!= DEFAULT` here
-        # so an env-set --store is also caught rather than silently overwritten.
-        if ctx.get_parameter_source("store") == ParameterSource.COMMANDLINE:
-            click.echo(
-                "❌ Error: --store cannot be combined with --uri; the store is inferred from the URI scheme (lh:// or hf://).",
-                err=True,
-            )
-            ctx.exit(1)
-
-        if uri.startswith("hf://"):
-            store = "hf"
-            try:
-                metadata = URI.get_uri(uri).get_metadata()
-            except (ValueError, RuntimeError) as e:
-                # get_uri runs the URI through strict templating first: a bad
-                # template string raises ValueError, an undefined variable
-                # RuntimeError. Catch both so neither escapes as a traceback.
-                click.echo(f"❌ Error: invalid HuggingFace URI '{uri}': {e}", err=True)
-                ctx.exit(1)
-            # The type, owner, repo and (when applicable) revision are all
-            # encoded in the URI (hf:///[type/]owner/repo[/revision]), so the
-            # flags that would otherwise supply them are redundant and rejected
-            # outright. This mirrors the Lakehouse path, which likewise refuses
-            # any of these flags alongside a URI (see below), and sidesteps the
-            # ambiguity of an explicit "main" reading as "no revision given".
-            if type or hf_organization or label or revision:
-                click.echo(
-                    "❌ Error: --type, --hf-organization, --label/--repo and --revision "
-                    "cannot be used with an hf:// URI; encode them in the URI itself "
-                    "(hf:///[type/]owner/repo[/revision]).",
-                    err=True,
-                )
-                ctx.exit(1)
-
-            type = str(metadata["hf_type"])
-            hf_organization = metadata["owner"]
-            label = metadata["repo"]
-            # Buckets decode to revision "" (no revision concept); None lets
-            # the service default it to "main" as the non-URI path does.
-            revision = metadata["revision"] or None
-        else:
-            store = "lh"
-            decoded_artifact = decode_uri(uri)
-
-            uri_env, cli_env = compare_env_uri(uri)
-
-            if uri_env == "prod" and cli_env != "prod":
-                click.echo(
-                    f"⚠️{' '} Warning: You are registering a '{uri_env}' artifact in the '{cli_env}' environment."
-                )
-                force = True
-            elif uri_env != cli_env:
-                click.echo(
-                    f"❌ The environment '{uri_env}' doesn't match the CLI environment '{cli_env}'. CLI doesn't support artifact register across environments except for 'prod' artifacts."
-                )
-                ctx.exit(1)
-
-            if type or table or label or revision or version or dataset or namespace:
-                click.echo(
-                    f"❌ Error: artifact URI cannot be used along with type, namespace, table, label, revision, version or dataset arguments."
-                )
-                ctx.exit(1)
-
-            type = decoded_artifact.type
-            namespace = decoded_artifact.namespace
-            table = decoded_artifact.table_name
-
-            if type == "model":
-                label = decoded_artifact.model_label
-                revision = decoded_artifact.model_revision
-
-            if type == "fileset":
-                label = decoded_artifact.fileset_label
-                version = decoded_artifact.fileset_version
-
-            if type == "dataset":
-                dataset = decoded_artifact.dataset_name
+        resolved = _resolve_uri(
+            ctx,
+            uri,
+            store=store,
+            type=type,
+            hf_organization=hf_organization,
+            label=label,
+            revision=revision,
+            namespace=namespace,
+            table=table,
+            version=version,
+            dataset=dataset,
+            force=force,
+            hf_conflict_msg=(
+                "❌ Error: --type, --hf-organization, --label/--repo and --revision "
+                "cannot be used with an hf:// URI; encode them in the URI itself "
+                "(hf:///[type/]owner/repo[/revision])."
+            ),
+            lh_conflict_msg=(
+                "❌ Error: artifact URI cannot be used along with type, namespace, "
+                "table, label, revision, version or dataset arguments."
+            ),
+        )
+        store = resolved.store
+        type = resolved.type
+        hf_organization = resolved.hf_organization
+        label = resolved.label
+        revision = resolved.revision
+        namespace = resolved.namespace
+        table = resolved.table
+        version = resolved.version
+        dataset = resolved.dataset
+        uri_env = resolved.uri_env
+        force = resolved.force
 
     if not uri and not type:
         click.echo(
@@ -2001,9 +2190,11 @@ def download(
                 click.echo(f"\n❌ Error: artifact does not exist.", err=True)
                 ctx.exit(1)
 
-            # Detect if artifact is in HuggingFace or Lakehouse
+            # Detect if artifact is in HuggingFace or Lakehouse via the shared
+            # URI class rather than a raw scheme-prefix check.
             artifact_uri = artifact["uri"]
-            if artifact_uri.startswith("hf://"):
+            uri_obj = URI.get_uri(artifact_uri)
+            if isinstance(uri_obj, HfURI):
                 # === HF download path ===
                 hf_token_value = hf_token()
                 if not hf_token_value:
@@ -2013,8 +2204,8 @@ def download(
                     )
                     ctx.exit(1)
 
-                org, name, artifact_type, domain = parse_hf_uri(artifact_uri)
-                repo_id = f"{org}/{name}"
+                repo_id = f"{uri_obj.get_owner()}/{uri_obj.get_repo()}"
+                artifact_type = str(uri_obj.get_hf_type())
 
                 if not quiet:
                     click.echo(f"Downloading {artifact_type} from HuggingFace...")
@@ -2518,9 +2709,10 @@ def copy(
             uri = artifact["uri"]
             table_name = artifact_name
 
-            # Detect artifact source: HF or LH
+            # Detect artifact source: HF or LH via the shared URI class rather
+            # than a raw scheme-prefix check.
 
-            is_hf_artifact = uri.startswith("hf://")
+            is_hf_artifact = isinstance(URI.get_uri(uri), HfURI)
 
         if is_hf_artifact:
             click.echo(

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -217,9 +217,9 @@ def _resolve_uri(
         # Buckets decode to revision ""; None lets the service default to "main".
         revision = metadata["revision"] or None
     else:  # store == "lh"
-        # The Lakehouse environment is the lh://<env> host, used only for the
-        # prod-vs-non-prod guard below.
-        uri_env = uri_obj.uri.hostname
+        # The Lakehouse environment is the lh://<env> host, normalized to lower
+        # case once here and reused (it also flows to register_artifact lh_env).
+        uri_env = (uri_obj.uri.hostname or "").lower()
         cli_env = str(gb_environment_config().lakehouse_environment).lower()
 
         if uri_env == "prod" and cli_env != "prod":
@@ -859,13 +859,13 @@ def push(
                     table=existing_meta.get("table_name"),
                     dataset=None,
                     label=(
-                        # Keyed on the pushed artifact's `type`, not existing_type.
-                        (
-                            existing_meta.get("model_label")
-                            or existing_meta.get("fileset_label")
+                        existing_meta.get("model_label")
+                        if existing_type == "model"
+                        else (
+                            existing_meta.get("fileset_label")
+                            if existing_type == "fileset"
+                            else None
                         )
-                        if type in ("fileset", "model")
-                        else None
                     ),
                     revision=revision,
                     version=version,
@@ -2716,6 +2716,14 @@ def copy(
             uri_store = uri_obj.uri.scheme
             uri_metadata = uri_obj.get_metadata()
             is_hf_artifact = uri_store == "hf"
+        else:
+            # copy takes an artifact UUID or URI; a name-format identifier is
+            # unsupported (guarding the branch-local vars read below).
+            click.echo(
+                f"❌ Artifact identifier formatted incorrectly. Please try again with artifact UUID or URI.",
+                err=True,
+            )
+            sys.exit(1)  # Exit with a non-zero status
 
         if is_hf_artifact:
             click.echo(

--- a/src/gbcli/utils/utils.py
+++ b/src/gbcli/utils/utils.py
@@ -13,7 +13,6 @@ from typing import List, Optional
 import humanize
 import yaml
 from git import RemoteProgress
-from pydantic import BaseModel
 from rich.console import Console
 from rich.markdown import (
     ConsoleOptions,
@@ -48,9 +47,6 @@ from gbcli.utils.gbserver import get_artifacts, make_gbserver_call
 from gbcli.utils.gh_auth import get_user
 from gbcli.utils.spaceutil import resolve_space
 from gbcommon.types.constants import DEFAULT_GH_DOMAIN
-from gbcommon.types.gbenvconfig import gb_environment_config
-from gbcommon.uri.lh import LhURI
-from gbcommon.uri.uri import URI
 
 _KNOWN_GH_DOMAINS = list(
     dict.fromkeys([DEFAULT_GH_DOMAIN, "github.ibm.com", "github.com"])
@@ -312,47 +308,6 @@ def resolve_to_space_key(expression: str):
     return repo if repo else canonical_expression
 
 
-class DecodedURIResponse(BaseModel):
-    uri: str
-    namespace: str
-    table_name: str
-    type: str
-    model_label: Optional[str] = None
-    model_revision: Optional[str] = None
-    fileset_label: Optional[str] = None
-    fileset_version: Optional[str] = None
-    dataset_name: Optional[str] = None
-
-
-def __get_lh_decoded_uri_response(uri: LhURI) -> DecodedURIResponse:
-    metadata = uri.get_metadata()
-    response = DecodedURIResponse(**metadata)
-    return response
-
-
-def decode_uri(
-    uri_input: str,
-) -> DecodedURIResponse:
-    uri = URI.get_uri(uri_input)
-
-    if not isinstance(uri, LhURI):
-        raise Exception(f"Error: Artifact URI formatted incorrectly.")
-
-    assert isinstance(uri, LhURI)
-    response = __get_lh_decoded_uri_response(uri)
-    return response
-
-
-def compare_env_uri(uri: str):
-    # Read the Lakehouse environment (the lh://<env> host) through the shared
-    # URI class instead of indexing a raw "/"-split segment. get_lh_environment()
-    # returns the urlparse-normalized (lowercased) hostname.
-    return (
-        URI.get_uri(uri).get_lh_environment(),
-        str(gb_environment_config().lakehouse_environment).lower(),
-    )
-
-
 def format_artifact_tags(artifacts: list):
     formatted_artifacts = []
 
@@ -379,34 +334,6 @@ def is_official_artifact(artifact):
             else:
                 return False
     return False
-
-
-def get_artifact_formatted_name(decoded_artifact: DecodedURIResponse):
-    # table : <namespace_name>.<table_name>
-    # dataset : <dataset_name>|<namespace_name>.<table_name>
-    # model : <model_label>.<revision>|<namespace_name>.<table_name>
-    # fileset: <label>.<version>|<table_name>
-
-    type = decoded_artifact.type
-    namespace = decoded_artifact.namespace
-    table = decoded_artifact.table_name
-
-    match type:
-        case "dataset":
-            dataset = decoded_artifact.dataset_name
-            return f"{dataset}|{namespace}.{table}"
-        case "model":
-            model_name = decoded_artifact.model_label
-            revision = decoded_artifact.model_revision
-            return f"{model_name}.{revision}|{namespace}.{table}"
-        case "fileset":
-            label = decoded_artifact.fileset_label
-            version = decoded_artifact.fileset_version
-            return f"{label}.{version}|{namespace}.{table}"
-        case "table":
-            return f"{namespace}.{table}"
-        case _:
-            return None
 
 
 def parse_artifact_identifier(identifier: str):

--- a/src/gbcli/utils/utils.py
+++ b/src/gbcli/utils/utils.py
@@ -344,8 +344,11 @@ def decode_uri(
 
 
 def compare_env_uri(uri: str):
+    # Read the Lakehouse environment (the lh://<env> host) through the shared
+    # URI class instead of indexing a raw "/"-split segment. get_lh_environment()
+    # returns the urlparse-normalized (lowercased) hostname.
     return (
-        uri.split("/")[2],
+        URI.get_uri(uri).get_lh_environment(),
         str(gb_environment_config().lakehouse_environment).lower(),
     )
 

--- a/test/unit/gbcli/commands/test_artifact_copy.py
+++ b/test/unit/gbcli/commands/test_artifact_copy.py
@@ -104,3 +104,14 @@ def test_copy_lh_model_proceeds_to_copy_with_source_table(copy_env):
     assert args[2] == "model_shared"  # source_table (from URI table_name)
     assert args[4] == "my-model"  # model_label
     assert args[5] == "v3"  # revision
+
+
+def test_copy_name_identifier_clean_error(copy_env):
+    """A name-format identifier (not a UUID/URI) errors cleanly, not with a
+    traceback from an unbound is_hf_artifact."""
+    result = _invoke("ns.tbl")
+    assert result.exit_code != 0
+    assert "Artifact identifier formatted incorrectly" in result.output
+    copy_env.fetch_artifact.assert_not_called()
+    copy_env.fetch_artifact_uri.assert_not_called()
+    copy_env.artifact_copy.assert_not_called()

--- a/test/unit/gbcli/commands/test_artifact_copy.py
+++ b/test/unit/gbcli/commands/test_artifact_copy.py
@@ -14,11 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI-level tests for `gb artifact copy`, pinning the URI-class refactor.
+"""CLI-level tests for `gb artifact copy`.
 
-`copy` used to detect an HF source with `uri.startswith("hf://")`; it now uses
-`isinstance(URI.get_uri(uri), HfURI)`. These tests assert the HF source is still
-refused with the same message and the LH source still proceeds past the guard.
+`copy` detects the store from the URI scheme: an HF source is refused, and an LH
+model source proceeds to the Lakehouse copy path.
 """
 
 from unittest.mock import MagicMock, patch

--- a/test/unit/gbcli/commands/test_artifact_copy.py
+++ b/test/unit/gbcli/commands/test_artifact_copy.py
@@ -27,7 +27,6 @@ import pytest
 from click.testing import CliRunner
 
 from gbcli.commands.command_artifact import cli
-from gbcli.utils.utils import DecodedURIResponse
 
 
 def _artifact(uri):
@@ -81,26 +80,28 @@ def test_copy_hf_not_supported(copy_env):
     copy_env.artifact_copy.assert_not_called()
 
 
-def test_copy_lh_model_proceeds_past_guard(copy_env):
-    """An lh:// model source is detected as non-HF and proceeds past the guard."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/model_shared/my-model/v3",
-        namespace="ns",
-        table_name="model_shared",
-        type="model",
-        model_label="my-model",
-        model_revision="v3",
-    )
-    # A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>.
+def test_copy_lh_model_proceeds_to_copy_with_source_table(copy_env):
+    """An lh:// model source proceeds past the HF guard and copies with the
+    source table derived directly from the URI's table_name.
+
+    A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>. Here the
+    URI table is the shared model table, so source_table resolves to it.
+    """
     lh_uri = "lh://prod/ns/models/model_shared/my-model/v3"
     copy_env.fetch_artifact_uri.return_value = _artifact(lh_uri)
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.get_artifact_formatted_name",
-            return_value="x.model_shared",
-        ),
-    ):
-        result = _invoke(lh_uri)
-    # Should NOT be blocked by the HF guard (it may proceed to the LH copy path).
+    copy_response = MagicMock()
+    copy_response.status = "SUCCESS"
+    copy_env.artifact_copy.return_value = {
+        "copy_response": copy_response,
+        "target_table": "model",
+    }
+    copy_env.register_artifact.return_value = {"uuid": "uuid-1", "uri": lh_uri}
+    result = _invoke(lh_uri)
+    assert result.exit_code == 0, result.output
     assert "Copy is not supported for HuggingFace artifacts." not in result.output
+    # artifact_copy(lh_token, namespace, source_table, space_to, label, revision, cb)
+    args = copy_env.artifact_copy.call_args.args
+    assert args[1] == "ns"  # namespace
+    assert args[2] == "model_shared"  # source_table (from URI table_name)
+    assert args[4] == "my-model"  # model_label
+    assert args[5] == "v3"  # revision

--- a/test/unit/gbcli/commands/test_artifact_copy.py
+++ b/test/unit/gbcli/commands/test_artifact_copy.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI-level tests for `gb artifact copy`, pinning the URI-class refactor.
+
+`copy` used to detect an HF source with `uri.startswith("hf://")`; it now uses
+`isinstance(URI.get_uri(uri), HfURI)`. These tests assert the HF source is still
+refused with the same message and the LH source still proceeds past the guard.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gbcli.commands.command_artifact import cli
+from gbcli.utils.utils import DecodedURIResponse
+
+
+def _artifact(uri):
+    return {
+        "uri": uri,
+        "name": "my-model",
+        "description": "",
+        "checksum": "",
+        "origin_uris": [],
+        "tags": [],
+        "status": "success",
+        "certified_no_restrictions": True,
+    }
+
+
+@pytest.fixture
+def copy_env():
+    with (
+        patch("gbcli.commands.common_options.is_standalone", return_value=False),
+        patch(
+            "gbcli.commands.command_artifact.check_current_and_latest_versions",
+            return_value=None,
+        ),
+        patch("gbcli.commands.command_artifact.get_user_token", return_value="tok"),
+        patch("gbcli.commands.command_artifact.GBClient") as gbclient,
+    ):
+        artifact_client = MagicMock()
+        artifact_client.github_token = "tok"
+        gbclient.Artifact.return_value = artifact_client
+        gbclient.Auth.lakehouse_token_for_space.return_value = "lh-tok"
+        yield artifact_client
+
+
+def _invoke(artifact_id):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        ["copy", artifact_id, "--space-to", "dest", "--quiet"],
+        catch_exceptions=False,
+    )
+
+
+def test_copy_hf_not_supported(copy_env):
+    """An HF source is refused with the exact message; no copy attempted."""
+    copy_env.fetch_artifact_uri.return_value = _artifact(
+        "hf://huggingface.co/models/org/repo"
+    )
+    result = _invoke("hf://huggingface.co/models/org/repo")
+    assert result.exit_code != 0
+    assert "Copy is not supported for HuggingFace artifacts." in result.output
+    copy_env.artifact_copy.assert_not_called()
+
+
+def test_copy_lh_model_proceeds_past_guard(copy_env):
+    """An lh:// model source is detected as non-HF and proceeds past the guard."""
+    decoded = DecodedURIResponse(
+        uri="lh://prod/ns/model_shared/my-model/v3",
+        namespace="ns",
+        table_name="model_shared",
+        type="model",
+        model_label="my-model",
+        model_revision="v3",
+    )
+    # A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>.
+    lh_uri = "lh://prod/ns/models/model_shared/my-model/v3"
+    copy_env.fetch_artifact_uri.return_value = _artifact(lh_uri)
+    with (
+        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
+        patch(
+            "gbcli.commands.command_artifact.get_artifact_formatted_name",
+            return_value="x.model_shared",
+        ),
+    ):
+        result = _invoke(lh_uri)
+    # Should NOT be blocked by the HF guard (it may proceed to the LH copy path).
+    assert "Copy is not supported for HuggingFace artifacts." not in result.output

--- a/test/unit/gbcli/commands/test_artifact_download.py
+++ b/test/unit/gbcli/commands/test_artifact_download.py
@@ -30,7 +30,6 @@ import pytest
 from click.testing import CliRunner
 
 from gbcli.commands.command_artifact import cli
-from gbcli.utils.utils import DecodedURIResponse
 
 
 @pytest.fixture
@@ -103,22 +102,14 @@ def test_download_hf_missing_token(download_env, tmp_path):
 
 
 def test_download_lh_model_routes_with_decoded_fields(download_env, tmp_path):
-    """An lh:// model URI still routes to download_model with decoded fields."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/model_shared/my-model/v3",
-        namespace="ns",
-        table_name="model_shared",
-        type="model",
-        model_label="my-model",
-        model_revision="v3",
-    )
-    # A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>.
-    # The store dispatch parses this for real; decode_uri is patched so the
-    # downstream fields come from the decoded mock above.
+    """An lh:// model URI still routes to download_model with decoded fields.
+
+    A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>. The
+    shared LhURI class parses it for real (no decode_uri patch needed).
+    """
     lh_uri = "lh://prod/ns/models/model_shared/my-model/v3"
     download_env.fetch_artifact_uri.return_value = {"uri": lh_uri}
-    with patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded):
-        result = _invoke(tmp_path, lh_uri)
+    result = _invoke(tmp_path, lh_uri)
     assert result.exit_code == 0, result.output
     download_env.download_hf_artifact.assert_not_called()
     args = download_env.download_model.call_args.args

--- a/test/unit/gbcli/commands/test_artifact_download.py
+++ b/test/unit/gbcli/commands/test_artifact_download.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI-level tests for `gb artifact download`, pinning the URI-class refactor.
+"""CLI-level tests for `gb artifact download`.
 
-`download` used to detect the store with `artifact_uri.startswith("hf://")` and
-parse the HF repo with `parse_hf_uri`; it now dispatches on
-`isinstance(URI.get_uri(uri), HfURI)` and reads `get_owner()`/`get_repo()`/
-`str(get_hf_type())`. These tests assert the refactor is behavior-preserving: the
-HF path still passes a plain string `artifact_type` and `org/repo` repo_id to
-`download_hf_artifact`, and the LH path still routes through the decoded fields.
+`download` detects the store from the URI scheme. The HF path passes a
+plain-string `artifact_type` and an `org/repo` repo_id to `download_hf_artifact`;
+the LH path routes through the decoded namespace/table/label/revision.
 """
 
 from unittest.mock import MagicMock, patch

--- a/test/unit/gbcli/commands/test_artifact_download.py
+++ b/test/unit/gbcli/commands/test_artifact_download.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI-level tests for `gb artifact download`, pinning the URI-class refactor.
+
+`download` used to detect the store with `artifact_uri.startswith("hf://")` and
+parse the HF repo with `parse_hf_uri`; it now dispatches on
+`isinstance(URI.get_uri(uri), HfURI)` and reads `get_owner()`/`get_repo()`/
+`str(get_hf_type())`. These tests assert the refactor is behavior-preserving: the
+HF path still passes a plain string `artifact_type` and `org/repo` repo_id to
+`download_hf_artifact`, and the LH path still routes through the decoded fields.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gbcli.commands.command_artifact import cli
+from gbcli.utils.utils import DecodedURIResponse
+
+
+@pytest.fixture
+def download_env():
+    """Patch out infra collaborators and yield the mocked Artifact client."""
+    with (
+        patch("gbcli.commands.common_options.is_standalone", return_value=False),
+        patch(
+            "gbcli.commands.command_artifact.check_current_and_latest_versions",
+            return_value=None,
+        ),
+        patch("gbcli.commands.command_artifact.get_user_token", return_value="tok"),
+        patch("gbcli.commands.command_artifact.hf_token", return_value="hf-tok"),
+        patch("gbcli.commands.command_artifact.GBClient") as gbclient,
+    ):
+        artifact_client = MagicMock()
+        artifact_client.github_token = "tok"
+        artifact_client.download_hf_artifact.return_value = {
+            "download_dir": "/tmp/x",
+            "repo_id": "org/repo",
+            "artifact_type": "model",
+            "file_count": 1,
+            "total_size": 1,
+        }
+        gbclient.Artifact.return_value = artifact_client
+        gbclient.Auth.lakehouse_user_token.return_value = "lh-tok"
+        yield artifact_client
+
+
+def _invoke(tmp_path, artifact_id, extra=None):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        ["download", artifact_id, "-d", str(tmp_path), "--quiet", *(extra or [])],
+        catch_exceptions=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "uri,expected_repo,expected_type",
+    [
+        ("hf:///models/org/repo", "org/repo", "model"),
+        ("hf:///datasets/org/ds", "org/ds", "dataset"),
+        ("hf:///buckets/org/b", "org/b", "bucket"),
+        ("hf:///org/repo", "org/repo", "model"),  # implicit model
+    ],
+)
+def test_download_hf_passes_string_type(
+    download_env, tmp_path, uri, expected_repo, expected_type
+):
+    """HF download passes a plain-string artifact_type + org/repo repo_id."""
+    download_env.fetch_artifact_uri.return_value = {"uri": uri}
+    result = _invoke(tmp_path, uri)
+    assert result.exit_code == 0, result.output
+    args = download_env.download_hf_artifact.call_args.args
+    # download_hf_artifact(hf_token, repo_id, artifact_type, dir, revision, cb)
+    assert args[1] == expected_repo
+    assert args[2] == expected_type
+    assert isinstance(args[2], str)
+
+
+def test_download_hf_missing_token(download_env, tmp_path):
+    """A falsy HF token produces the exact 'token not found' error."""
+    download_env.fetch_artifact_uri.return_value = {"uri": "hf:///models/org/repo"}
+    with patch("gbcli.commands.command_artifact.hf_token", return_value=None):
+        result = _invoke(tmp_path, "hf:///models/org/repo")
+    assert result.exit_code != 0
+    assert "HuggingFace token not found" in result.output
+    download_env.download_hf_artifact.assert_not_called()
+
+
+def test_download_lh_model_routes_with_decoded_fields(download_env, tmp_path):
+    """An lh:// model URI still routes to download_model with decoded fields."""
+    decoded = DecodedURIResponse(
+        uri="lh://prod/ns/model_shared/my-model/v3",
+        namespace="ns",
+        table_name="model_shared",
+        type="model",
+        model_label="my-model",
+        model_revision="v3",
+    )
+    # A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>.
+    # The store dispatch parses this for real; decode_uri is patched so the
+    # downstream fields come from the decoded mock above.
+    lh_uri = "lh://prod/ns/models/model_shared/my-model/v3"
+    download_env.fetch_artifact_uri.return_value = {"uri": lh_uri}
+    with patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded):
+        result = _invoke(tmp_path, lh_uri)
+    assert result.exit_code == 0, result.output
+    download_env.download_hf_artifact.assert_not_called()
+    args = download_env.download_model.call_args.args
+    # download_model(lh_token, namespace, table, label, revision, dir, space, cb)
+    assert args[1] == "ns"
+    assert args[2] == "model_shared"
+    assert args[3] == "my-model"
+    assert args[4] == "v3"

--- a/test/unit/gbcli/commands/test_artifact_push.py
+++ b/test/unit/gbcli/commands/test_artifact_push.py
@@ -248,7 +248,7 @@ def test_hf_space_uri_rejected(push_env, tmp_path):
         tmp_path, ["--uri", "hf:///spaces/org/some-space", "--artifact-name", "x"]
     )
     assert result.exit_code != 0
-    assert "'model', 'dataset', and 'bucket'" in result.output
+    assert "'model', 'dataset', 'bucket'" in result.output
     push_env.push.assert_not_called()
 
 
@@ -306,7 +306,7 @@ def test_lh_uri_fileset_forwarded_to_push(push_env, tmp_path):
 
 
 def test_lh_uri_dataset_rejected(push_env, tmp_path):
-    """An lh:// dataset URI is rejected by the existing lh+dataset guard."""
+    """An lh:// dataset URI is rejected: push cannot push lh dataset content."""
     with patch(
         "gbcli.commands.command_artifact.gb_environment_config",
     ) as gb_env:
@@ -321,7 +321,7 @@ def test_lh_uri_dataset_rejected(push_env, tmp_path):
             ],
         )
     assert result.exit_code != 0
-    assert "does not support artifact type 'dataset'" in result.output
+    assert "store 'lh' is only allowed for artifact types" in result.output
     push_env.push.assert_not_called()
 
 
@@ -399,4 +399,14 @@ def test_missing_type_without_uri_errors(push_env, tmp_path):
     result = _invoke(tmp_path, ["--artifact-name", "x"])
     assert result.exit_code != 0
     assert "Artifact type or artifact uri is required" in result.output
+    push_env.push.assert_not_called()
+
+
+def test_lh_bucket_rejected(push_env, tmp_path):
+    """buckets are HF-only, so `--store lh -t bucket` is rejected."""
+    result = _invoke(
+        tmp_path, ["--store", "lh", "-t", "bucket", "--artifact-name", "x"]
+    )
+    assert result.exit_code != 0
+    assert "store 'lh' is only allowed for artifact types" in result.output
     push_env.push.assert_not_called()

--- a/test/unit/gbcli/commands/test_artifact_push.py
+++ b/test/unit/gbcli/commands/test_artifact_push.py
@@ -31,7 +31,6 @@ import pytest
 from click.testing import CliRunner
 
 from gbcli.commands.command_artifact import cli
-from gbcli.utils.utils import DecodedURIResponse
 
 # These tests exercise a @reject_standalone command; patch is_standalone -> False.
 
@@ -225,7 +224,7 @@ def test_uri_flags_rejected(push_env, tmp_path, extra_args):
 def test_malformed_hf_uri_clean_error(push_env, tmp_path):
     result = _invoke(tmp_path, ["--uri", "hf:///onlyowner", "--artifact-name", "x"])
     assert result.exit_code != 0
-    assert "invalid HuggingFace URI" in result.output
+    assert "invalid artifact URI" in result.output
     push_env.push.assert_not_called()
 
 
@@ -239,7 +238,7 @@ def test_hf_uri_undefined_template_var_clean_error(push_env, tmp_path):
     finally:
         logging.disable(logging.NOTSET)
     assert result.exit_code != 0
-    assert "invalid HuggingFace URI" in result.output
+    assert "invalid artifact URI" in result.output
     push_env.push.assert_not_called()
 
 
@@ -253,31 +252,24 @@ def test_hf_space_uri_rejected(push_env, tmp_path):
     push_env.push.assert_not_called()
 
 
-# --- lh:// paths (decode_uri + compare_env_uri patched for hermeticity) ----------
+# --- lh:// paths --------------------------------------------------------------
+#
+# Pass real, valid lh:// URIs so the shared URI class does the parsing; patch
+# `gb_environment_config` to control the CLI-side environment comparison.
+# Valid lh layout: lh://<env>/<ns>/<models|datasets|filesets>/<table>/...
 
 
 def test_lh_uri_model_forwarded_to_push(push_env, tmp_path):
     """`--uri lh://...` for a model forwards decoded type/label/table to push()."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/model_shared/my-model/v3",
-        namespace="ns",
-        table_name="model_shared",
-        type="model",
-        model_label="my-model",
-        model_revision="v3",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("prod", "prod"),
-        ),
-    ):
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "prod"
         result = _invoke(
             tmp_path,
             [
                 "--uri",
-                "lh://prod/ns/model_shared/my-model/v3",
+                "lh://prod/ns/models/model_shared/my-model/v3",
                 "--artifact-name",
                 "my-model",
             ],
@@ -292,26 +284,15 @@ def test_lh_uri_model_forwarded_to_push(push_env, tmp_path):
 
 
 def test_lh_uri_fileset_forwarded_to_push(push_env, tmp_path):
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/fileset_shared/my-fs/v1",
-        namespace="ns",
-        table_name="fileset_shared",
-        type="fileset",
-        fileset_label="my-fs",
-        fileset_version="v1",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("prod", "prod"),
-        ),
-    ):
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "prod"
         result = _invoke(
             tmp_path,
             [
                 "--uri",
-                "lh://prod/ns/fileset_shared/my-fs/v1",
+                "lh://prod/ns/filesets/fileset_shared/my-fs/v1",
                 "--artifact-name",
                 "my-fs",
             ],
@@ -326,23 +307,18 @@ def test_lh_uri_fileset_forwarded_to_push(push_env, tmp_path):
 
 def test_lh_uri_dataset_rejected(push_env, tmp_path):
     """An lh:// dataset URI is rejected by the existing lh+dataset guard."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/tbl/my-dataset",
-        namespace="ns",
-        table_name="tbl",
-        type="dataset",
-        dataset_name="my-dataset",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("prod", "prod"),
-        ),
-    ):
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "prod"
         result = _invoke(
             tmp_path,
-            ["--uri", "lh://prod/ns/tbl/my-dataset", "--artifact-name", "my-dataset"],
+            [
+                "--uri",
+                "lh://prod/ns/datasets/tbl/my-dataset",
+                "--artifact-name",
+                "my-dataset",
+            ],
         )
     assert result.exit_code != 0
     assert "does not support artifact type 'dataset'" in result.output
@@ -350,25 +326,23 @@ def test_lh_uri_dataset_rejected(push_env, tmp_path):
 
 
 def test_lh_uri_env_mismatch_rejected(push_env, tmp_path):
-    """A non-prod cross-environment lh:// URI is rejected."""
-    decoded = DecodedURIResponse(
-        uri="lh://staging/ns/model_shared/m/v1",
-        namespace="ns",
-        table_name="model_shared",
-        type="model",
-        model_label="m",
-        model_revision="v1",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("staging", "dev"),
-        ),
-    ):
+    """A non-prod cross-environment lh:// URI is rejected.
+
+    The URI host is 'staging'; the CLI env is 'dev', so the environments differ
+    and neither is the prod override case.
+    """
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "dev"
         result = _invoke(
             tmp_path,
-            ["--uri", "lh://staging/ns/model_shared/m/v1", "--artifact-name", "m"],
+            [
+                "--uri",
+                "lh://staging/ns/models/model_shared/m/v1",
+                "--artifact-name",
+                "m",
+            ],
         )
     assert result.exit_code != 0
     assert "doesn't match the CLI environment" in result.output
@@ -377,26 +351,15 @@ def test_lh_uri_env_mismatch_rejected(push_env, tmp_path):
 
 def test_lh_uri_conflict_flag_rejected(push_env, tmp_path):
     """`--uri lh://... --table t` is rejected by the lh conflict guard."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/model_shared/m/v1",
-        namespace="ns",
-        table_name="model_shared",
-        type="model",
-        model_label="m",
-        model_revision="v1",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("prod", "prod"),
-        ),
-    ):
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "prod"
         result = _invoke(
             tmp_path,
             [
                 "--uri",
-                "lh://prod/ns/model_shared/m/v1",
+                "lh://prod/ns/models/model_shared/m/v1",
                 "--table",
                 "t",
                 "--artifact-name",

--- a/test/unit/gbcli/commands/test_artifact_push.py
+++ b/test/unit/gbcli/commands/test_artifact_push.py
@@ -410,3 +410,49 @@ def test_lh_bucket_rejected(push_env, tmp_path):
     assert result.exit_code != 0
     assert "store 'lh' is only allowed for artifact types" in result.output
     push_env.push.assert_not_called()
+
+
+def test_checksum_collision_check_existence_label_keys_on_existing_type(
+    push_env, tmp_path
+):
+    """On a checksum collision, check_existence's label is derived from the
+    EXISTING artifact's type/URI (consistent with revision/version), not the
+    pushed --type."""
+    existing_uri = "lh://prod/ns/models/model_shared/found-model/v7"
+    push_env.existing_checksum_artifacts.return_value = {
+        "uuid": "existing-uuid",
+        "type": "model",
+        "uri": existing_uri,
+        "status": "success",
+    }
+    push_env.check_existence.return_value = {"success": False}
+    with patch(
+        "gbcli.commands.command_artifact.calculate_checksum_",
+        return_value="c" * 32,
+    ):
+        # Pushed type is model; --calculate-checksum triggers the collision path.
+        # size/variant/model-type are supplied so no interactive prompt fires.
+        _invoke(
+            tmp_path,
+            [
+                "--store",
+                "lh",
+                "-t",
+                "model",
+                "--size",
+                "8b",
+                "--variant",
+                "base",
+                "--model-type",
+                "granite",
+                "--calculate-checksum",
+                "--artifact-name",
+                "x",
+            ],
+        )
+    kwargs = push_env.check_existence.call_args.kwargs
+    assert kwargs["type"] == "model"
+    assert kwargs["namespace"] == "ns"
+    assert kwargs["table"] == "model_shared"
+    assert kwargs["label"] == "found-model"  # from the existing URI, not None
+    assert kwargs["revision"] == "v7"

--- a/test/unit/gbcli/commands/test_artifact_push.py
+++ b/test/unit/gbcli/commands/test_artifact_push.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI-level tests for `gb artifact push`, focused on the `--uri` option.
+
+`push` shares its `--uri` handling with `register` via `_resolve_uri`: the store
+is inferred from the scheme (lh:// or hf://), an explicit `--store` conflicts, and
+the identity flags (`--type`, `--hf-organization`, `--label`/`--repo`, `--table`)
+are rejected alongside a URI because the URI already encodes them. `push` supports
+both schemes. These tests mock every collaborator that would touch infrastructure
+so the command's argument handling is exercised in isolation.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gbcli.commands.command_artifact import cli
+from gbcli.utils.utils import DecodedURIResponse
+
+# These tests exercise a @reject_standalone command; patch is_standalone -> False.
+
+
+@pytest.fixture
+def push_env():
+    """Patch out infra collaborators and yield the mocked Artifact client.
+
+    Returns the MagicMock standing in for `GBClient.Artifact(...)` so tests can
+    assert on the arguments the command derived (esp. `push.call_args`).
+    """
+    with (
+        patch("gbcli.commands.common_options.is_standalone", return_value=False),
+        patch(
+            "gbcli.commands.command_artifact.check_current_and_latest_versions",
+            return_value=None,
+        ),
+        patch("gbcli.commands.command_artifact.get_user_token", return_value="tok"),
+        patch(
+            "gbcli.commands.command_artifact.validate_tags",
+            return_value=["sys-official"],
+        ),
+        patch("gbcli.commands.command_artifact.origins_from_local", return_value=[]),
+        # A non-enterprise org short-circuits resource-group resolution.
+        patch(
+            "gbcli.commands.command_artifact.is_enterprise_hf_org", return_value=False
+        ),
+        patch("gbcli.commands.command_artifact.GBClient") as gbclient,
+    ):
+        artifact_client = MagicMock()
+        artifact_client.github_token = "tok"
+        artifact_client.validate_origins.return_value = ["origin-1"]
+        artifact_client.existing_checksum_artifacts.return_value = None
+        artifact_client.register_artifact.return_value = {"uuid": "uuid-1"}
+        artifact_client.push.return_value = {"uuid": "uuid-1"}
+        artifact_client.update_artifact.return_value = {
+            "uuid": "uuid-1",
+            "uri": "hf://huggingface.co/models/org/repo",
+            "checksum": "",
+            "status": "success",
+        }
+        gbclient.Artifact.return_value = artifact_client
+        # Tokens must be truthy so the flow doesn't early-return.
+        gbclient.Auth.return_value.hf_token.return_value = "hf-tok"
+        gbclient.Auth.lakehouse_token_for_space.return_value = "lh-tok"
+        yield artifact_client
+
+
+def _invoke(tmp_path, args, stdin=""):
+    runner = CliRunner()
+    from_local = tmp_path / "artifact"
+    from_local.mkdir(exist_ok=True)
+    return runner.invoke(
+        cli,
+        [
+            "push",
+            "--from-local",
+            str(from_local),
+            "--certify-no-restrictions",
+            "--yes",
+            "--quiet",
+            *args,
+        ],
+        input=stdin,
+        catch_exceptions=False,
+    )
+
+
+# --- hf:// happy paths -----------------------------------------------------------
+
+
+def test_hf_uri_infers_store_type_org_and_label(push_env, tmp_path):
+    """`--uri hf:///org/repo` (no --store, no -t) → store=hf, type=model."""
+    result = _invoke(
+        tmp_path,
+        [
+            "--uri",
+            "hf:///ibm-granite/granite-4.2-3b",
+            "--artifact-name",
+            "granite-4.2-3b",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    kwargs = push_env.push.call_args.kwargs
+    args = push_env.push.call_args.args
+    # push() takes type/label positionally: (lh_token, from_local, type, label,
+    # artifact_name, size, variant, model_type, version, space, table, ...).
+    assert kwargs["store"] == "hf"
+    assert args[2] == "model"  # type
+    assert args[3] == "granite-4.2-3b"  # label (repo)
+    assert kwargs["hf_organization"] == "ibm-granite"
+
+
+def test_hf_uri_dataset(push_env, tmp_path):
+    result = _invoke(
+        tmp_path,
+        ["--uri", "hf:///datasets/org/my-dataset", "--artifact-name", "my-dataset"],
+    )
+    assert result.exit_code == 0, result.output
+    args = push_env.push.call_args.args
+    kwargs = push_env.push.call_args.kwargs
+    assert kwargs["store"] == "hf"
+    assert args[2] == "dataset"
+    assert kwargs["hf_organization"] == "org"
+
+
+def test_hf_uri_bucket(push_env, tmp_path):
+    result = _invoke(
+        tmp_path,
+        ["--uri", "hf:///buckets/org/my-bucket", "--artifact-name", "my-bucket"],
+    )
+    assert result.exit_code == 0, result.output
+    args = push_env.push.call_args.args
+    assert args[2] == "bucket"
+
+
+def test_hf_dataset_uri_does_not_trip_label_guard(push_env, tmp_path):
+    """A dataset URI sets label from the repo; the `and not uri` guard must not fire.
+
+    Without the guard, line "The --label option is not valid for dataset
+    artifacts" would falsely reject a URI-derived label.
+    """
+    result = _invoke(
+        tmp_path,
+        ["--uri", "hf:///datasets/org/ds", "--artifact-name", "ds"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "not valid for dataset" not in result.output
+    push_env.push.assert_called_once()
+
+
+def test_repo_synonym(push_env, tmp_path):
+    """`--repo` binds the same value as `--label` on push too."""
+    result = _invoke(
+        tmp_path,
+        [
+            "--store",
+            "hf",
+            "-t",
+            "model",
+            "--hf-organization",
+            "org",
+            "--repo",
+            "a",
+            "--artifact-name",
+            "x",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert push_env.push.call_args.args[3] == "a"  # label
+
+
+# --- hf:// rejections ------------------------------------------------------------
+
+
+def test_explicit_store_conflicts_with_uri(push_env, tmp_path):
+    result = _invoke(
+        tmp_path,
+        ["--store", "hf", "--uri", "hf:///org/repo", "--artifact-name", "repo"],
+    )
+    assert result.exit_code != 0
+    assert "--store cannot be combined with --uri" in result.output
+    push_env.push.assert_not_called()
+
+
+_URI_FLAG_REJECTED = "cannot be used with an hf:// URI"
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        pytest.param(["-t", "model"], id="type"),
+        pytest.param(["--hf-organization", "other-org"], id="org"),
+        pytest.param(["--repo", "other-repo"], id="repo"),
+    ],
+)
+def test_uri_flags_rejected(push_env, tmp_path, extra_args):
+    """--type/--hf-organization/--repo are rejected alongside an hf:// URI.
+
+    push has no --revision flag, so (unlike register) it is not parametrized here.
+    """
+    result = _invoke(
+        tmp_path,
+        ["--uri", "hf:///datasets/org/ds", "--artifact-name", "ds", *extra_args],
+    )
+    assert result.exit_code != 0
+    assert _URI_FLAG_REJECTED in result.output
+    push_env.push.assert_not_called()
+
+
+def test_malformed_hf_uri_clean_error(push_env, tmp_path):
+    result = _invoke(tmp_path, ["--uri", "hf:///onlyowner", "--artifact-name", "x"])
+    assert result.exit_code != 0
+    assert "invalid HuggingFace URI" in result.output
+    push_env.push.assert_not_called()
+
+
+def test_hf_uri_undefined_template_var_clean_error(push_env, tmp_path):
+    """An unresolved template var surfaces as a clean CLI error, not a traceback."""
+    logging.disable(logging.CRITICAL)
+    try:
+        result = _invoke(
+            tmp_path, ["--uri", "hf:///org/{{missing}}", "--artifact-name", "x"]
+        )
+    finally:
+        logging.disable(logging.NOTSET)
+    assert result.exit_code != 0
+    assert "invalid HuggingFace URI" in result.output
+    push_env.push.assert_not_called()
+
+
+def test_hf_space_uri_rejected(push_env, tmp_path):
+    """`hf:///spaces/...` decodes to type=space, rejected by the type-compat guard."""
+    result = _invoke(
+        tmp_path, ["--uri", "hf:///spaces/org/some-space", "--artifact-name", "x"]
+    )
+    assert result.exit_code != 0
+    assert "'model', 'dataset', and 'bucket'" in result.output
+    push_env.push.assert_not_called()
+
+
+# --- lh:// paths (decode_uri + compare_env_uri patched for hermeticity) ----------
+
+
+def test_lh_uri_model_forwarded_to_push(push_env, tmp_path):
+    """`--uri lh://...` for a model forwards decoded type/label/table to push()."""
+    decoded = DecodedURIResponse(
+        uri="lh://prod/ns/model_shared/my-model/v3",
+        namespace="ns",
+        table_name="model_shared",
+        type="model",
+        model_label="my-model",
+        model_revision="v3",
+    )
+    with (
+        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
+        patch(
+            "gbcli.commands.command_artifact.compare_env_uri",
+            return_value=("prod", "prod"),
+        ),
+    ):
+        result = _invoke(
+            tmp_path,
+            [
+                "--uri",
+                "lh://prod/ns/model_shared/my-model/v3",
+                "--artifact-name",
+                "my-model",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    args = push_env.push.call_args.args
+    kwargs = push_env.push.call_args.kwargs
+    assert kwargs["store"] == "lh"
+    assert args[2] == "model"  # type
+    assert args[3] == "my-model"  # label
+    assert args[10] == "model_shared"  # table
+
+
+def test_lh_uri_fileset_forwarded_to_push(push_env, tmp_path):
+    decoded = DecodedURIResponse(
+        uri="lh://prod/ns/fileset_shared/my-fs/v1",
+        namespace="ns",
+        table_name="fileset_shared",
+        type="fileset",
+        fileset_label="my-fs",
+        fileset_version="v1",
+    )
+    with (
+        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
+        patch(
+            "gbcli.commands.command_artifact.compare_env_uri",
+            return_value=("prod", "prod"),
+        ),
+    ):
+        result = _invoke(
+            tmp_path,
+            [
+                "--uri",
+                "lh://prod/ns/fileset_shared/my-fs/v1",
+                "--artifact-name",
+                "my-fs",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    args = push_env.push.call_args.args
+    assert push_env.push.call_args.kwargs["store"] == "lh"
+    assert args[2] == "fileset"
+    assert args[3] == "my-fs"
+    assert args[10] == "fileset_shared"
+
+
+def test_lh_uri_dataset_rejected(push_env, tmp_path):
+    """An lh:// dataset URI is rejected by the existing lh+dataset guard."""
+    decoded = DecodedURIResponse(
+        uri="lh://prod/ns/tbl/my-dataset",
+        namespace="ns",
+        table_name="tbl",
+        type="dataset",
+        dataset_name="my-dataset",
+    )
+    with (
+        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
+        patch(
+            "gbcli.commands.command_artifact.compare_env_uri",
+            return_value=("prod", "prod"),
+        ),
+    ):
+        result = _invoke(
+            tmp_path,
+            ["--uri", "lh://prod/ns/tbl/my-dataset", "--artifact-name", "my-dataset"],
+        )
+    assert result.exit_code != 0
+    assert "does not support artifact type 'dataset'" in result.output
+    push_env.push.assert_not_called()
+
+
+def test_lh_uri_env_mismatch_rejected(push_env, tmp_path):
+    """A non-prod cross-environment lh:// URI is rejected."""
+    decoded = DecodedURIResponse(
+        uri="lh://staging/ns/model_shared/m/v1",
+        namespace="ns",
+        table_name="model_shared",
+        type="model",
+        model_label="m",
+        model_revision="v1",
+    )
+    with (
+        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
+        patch(
+            "gbcli.commands.command_artifact.compare_env_uri",
+            return_value=("staging", "dev"),
+        ),
+    ):
+        result = _invoke(
+            tmp_path,
+            ["--uri", "lh://staging/ns/model_shared/m/v1", "--artifact-name", "m"],
+        )
+    assert result.exit_code != 0
+    assert "doesn't match the CLI environment" in result.output
+    push_env.push.assert_not_called()
+
+
+def test_lh_uri_conflict_flag_rejected(push_env, tmp_path):
+    """`--uri lh://... --table t` is rejected by the lh conflict guard."""
+    decoded = DecodedURIResponse(
+        uri="lh://prod/ns/model_shared/m/v1",
+        namespace="ns",
+        table_name="model_shared",
+        type="model",
+        model_label="m",
+        model_revision="v1",
+    )
+    with (
+        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
+        patch(
+            "gbcli.commands.command_artifact.compare_env_uri",
+            return_value=("prod", "prod"),
+        ),
+    ):
+        result = _invoke(
+            tmp_path,
+            [
+                "--uri",
+                "lh://prod/ns/model_shared/m/v1",
+                "--table",
+                "t",
+                "--artifact-name",
+                "m",
+            ],
+        )
+    assert result.exit_code != 0
+    assert "cannot be used along with type, label or table" in result.output
+    push_env.push.assert_not_called()
+
+
+# --- backward compatibility ------------------------------------------------------
+
+
+def test_plain_hf_model_push_unchanged(push_env, tmp_path):
+    """No --uri, explicit --store hf -t model still pushes as before."""
+    result = _invoke(
+        tmp_path,
+        [
+            "--store",
+            "hf",
+            "-t",
+            "model",
+            "--hf-organization",
+            "org",
+            "--artifact-name",
+            "x",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert push_env.push.call_args.kwargs["store"] == "hf"
+    assert push_env.push.call_args.args[2] == "model"
+
+
+def test_missing_type_without_uri_errors(push_env, tmp_path):
+    """No --uri and no -t → the relaxed 'type or uri required' error."""
+    result = _invoke(tmp_path, ["--artifact-name", "x"])
+    assert result.exit_code != 0
+    assert "Artifact type or artifact uri is required" in result.output
+    push_env.push.assert_not_called()

--- a/test/unit/gbcli/commands/test_artifact_register.py
+++ b/test/unit/gbcli/commands/test_artifact_register.py
@@ -312,7 +312,25 @@ def test_hf_space_uri_rejected(register_env):
         ]
     )
     assert result.exit_code != 0
-    assert "'model', 'dataset', and 'bucket'" in result.output
+    assert "'model', 'dataset', 'bucket'" in result.output
+    register_env.assert_not_called()
+
+
+def test_lh_bucket_rejected(register_env):
+    """buckets are HF-only, so `--store lh -t bucket` is rejected for register too."""
+    result = _invoke(
+        [
+            "--store",
+            "lh",
+            "-t",
+            "bucket",
+            "--artifact-name",
+            "x",
+            "--certify-no-restrictions",
+        ]
+    )
+    assert result.exit_code != 0
+    assert "store 'lh' is only allowed for artifact types" in result.output
     register_env.assert_not_called()
 
 

--- a/test/unit/gbcli/commands/test_artifact_register.py
+++ b/test/unit/gbcli/commands/test_artifact_register.py
@@ -31,7 +31,6 @@ import pytest
 from click.testing import CliRunner
 
 from gbcli.commands.command_artifact import cli
-from gbcli.utils.utils import DecodedURIResponse
 
 # These tests exercise a @reject_standalone command; patch is_standalone -> False.
 
@@ -254,7 +253,7 @@ def test_malformed_hf_uri_clean_error(register_env):
         ]
     )
     assert result.exit_code != 0
-    assert "invalid HuggingFace URI" in result.output
+    assert "invalid artifact URI" in result.output
     register_env.assert_not_called()
 
 
@@ -281,7 +280,7 @@ def test_hf_uri_undefined_template_var_clean_error(register_env):
     finally:
         logging.disable(logging.NOTSET)
     assert result.exit_code != 0
-    assert "invalid HuggingFace URI" in result.output
+    assert "invalid artifact URI" in result.output
     register_env.assert_not_called()
 
 
@@ -313,7 +312,7 @@ def test_hf_space_uri_rejected(register_env):
         ]
     )
     assert result.exit_code != 0
-    assert "'model', 'dataset' and 'bucket'" in result.output
+    assert "'model', 'dataset', and 'bucket'" in result.output
     register_env.assert_not_called()
 
 
@@ -449,36 +448,23 @@ def test_hf_uri_rejects_lakehouse_table_flag(register_env):
 
 # --- Lakehouse (lh://) regression coverage -------------------------------------
 #
-# This PR restructured the lh:// decode branch (moved it under the new `else`,
-# wrapped the type-handling block in `if store == "lh":`, and changed the model
-# label check from `if label == ""` to `if not label`). The HF path above is
-# well covered, but nothing exercises lh:// at the command level, so these two
-# tests pin that the decoded fields still reach `register_artifact` unchanged.
-# `decode_uri` and `compare_env_uri` are patched so the flow stays hermetic:
-# compare_env_uri returns matching environments so the mismatch branch is skipped.
+# The lh:// branch decodes the URI through the shared URI layer (URI.get_uri +
+# get_metadata in _resolve_uri). These tests pass real, valid lh:// URIs so the
+# URI class does the parsing, and patch `gb_environment_config` so the CLI env
+# matches the URI's environment and the cross-env mismatch branch is skipped.
+# Valid lh layout: lh://<env>/<ns>/<models|datasets|filesets>/<table>/...
 
 
 def test_lh_uri_model_decodes_through_to_register(register_env):
     """`--uri lh://...` for a model forwards the decoded type/namespace/table/label/revision."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/model_shared/my-model/v3",
-        namespace="ns",
-        table_name="model_shared",
-        type="model",
-        model_label="my-model",
-        model_revision="v3",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("prod", "prod"),
-        ),
-    ):
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "prod"
         result = _invoke(
             [
                 "--uri",
-                "lh://prod/ns/model_shared/my-model/v3",
+                "lh://prod/ns/models/model_shared/my-model/v3",
                 "--artifact-name",
                 "my-model",
                 "--certify-no-restrictions",
@@ -500,24 +486,14 @@ def test_lh_uri_model_decodes_through_to_register(register_env):
 
 def test_lh_uri_dataset_decodes_through_to_register(register_env):
     """`--uri lh://...` for a dataset forwards the decoded dataset/table and nulls model fields."""
-    decoded = DecodedURIResponse(
-        uri="lh://prod/ns/tbl/my-dataset",
-        namespace="ns",
-        table_name="tbl",
-        type="dataset",
-        dataset_name="my-dataset",
-    )
-    with (
-        patch("gbcli.commands.command_artifact.decode_uri", return_value=decoded),
-        patch(
-            "gbcli.commands.command_artifact.compare_env_uri",
-            return_value=("prod", "prod"),
-        ),
-    ):
+    with patch(
+        "gbcli.commands.command_artifact.gb_environment_config",
+    ) as gb_env:
+        gb_env.return_value.lakehouse_environment = "prod"
         result = _invoke(
             [
                 "--uri",
-                "lh://prod/ns/tbl/my-dataset",
+                "lh://prod/ns/datasets/tbl/my-dataset",
                 "--artifact-name",
                 "my-dataset",
                 "--certify-no-restrictions",

--- a/test/unit/gbcli/utils/test_utils.py
+++ b/test/unit/gbcli/utils/test_utils.py
@@ -25,7 +25,6 @@ import unittest
 import pytest
 
 from gbcli.utils.utils import (
-    compare_env_uri,
     generate_unique_id,
     remove_prefix,
     remove_suffix,
@@ -108,17 +107,3 @@ class TestUtils(unittest.TestCase):
                     case["url"], removeSuffix=True
                 )
                 self.assertEqual(result, case["expected"])
-
-    def test_compare_env_uri_reads_environment_via_uri(self):
-        """compare_env_uri returns the lh://<env> host as the first element.
-
-        The environment now comes from LhURI.get_lh_environment() (the shared
-        URI class) instead of a raw uri.split('/')[2]. That accessor returns the
-        urlparse-normalized (lowercased) hostname, so a mixed-case host is
-        normalized to lowercase.
-        """
-        # A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>.
-        assert compare_env_uri("lh://prod/ns/models/tbl/label/rev")[0] == "prod"
-        assert compare_env_uri("lh://staging/ns/models/tbl/label/rev")[0] == "staging"
-        # urlparse lowercases the host, so a mixed-case env normalizes.
-        assert compare_env_uri("lh://PROD/ns/models/tbl/label/rev")[0] == "prod"

--- a/test/unit/gbcli/utils/test_utils.py
+++ b/test/unit/gbcli/utils/test_utils.py
@@ -25,6 +25,7 @@ import unittest
 import pytest
 
 from gbcli.utils.utils import (
+    compare_env_uri,
     generate_unique_id,
     remove_prefix,
     remove_suffix,
@@ -107,3 +108,17 @@ class TestUtils(unittest.TestCase):
                     case["url"], removeSuffix=True
                 )
                 self.assertEqual(result, case["expected"])
+
+    def test_compare_env_uri_reads_environment_via_uri(self):
+        """compare_env_uri returns the lh://<env> host as the first element.
+
+        The environment now comes from LhURI.get_lh_environment() (the shared
+        URI class) instead of a raw uri.split('/')[2]. That accessor returns the
+        urlparse-normalized (lowercased) hostname, so a mixed-case host is
+        normalized to lowercase.
+        """
+        # A valid lh model URI: lh://<env>/<ns>/models/<table>/<label>/<rev>.
+        assert compare_env_uri("lh://prod/ns/models/tbl/label/rev")[0] == "prod"
+        assert compare_env_uri("lh://staging/ns/models/tbl/label/rev")[0] == "staging"
+        # urlparse lowercases the host, so a mixed-case env normalizes.
+        assert compare_env_uri("lh://PROD/ns/models/tbl/label/rev")[0] == "prod"


### PR DESCRIPTION
## Summary

- **`gb artifact push` now accepts `--uri`**, matching `gb artifact register`: a single `lh://` or `hf://` URI that infers the store from the scheme and encodes the artifact identity, mutually exclusive with the individual flags it supersedes. `--uri` is pure syntactic sugar — it is parsed into the same parameters push already accepts, so behavior without `--uri` is unchanged. Both schemes are supported.
- **Shared `_resolve_uri` helper** (returning a `ResolvedURI`) used by both `push` and `register`, so the URI parsing and mutual-exclusivity rules cannot drift. `register`'s observable behavior is unchanged apart from the message changes noted below.
- **All `lh://`/`hf://` parsing goes through `gbcommon.uri.uri.URI`.** Each site calls `URI.get_uri(uri)` once; the store is just `uri_obj.uri.scheme` and the identity fields come from `get_metadata()` — no `.startswith()` scheme checks, no `isinstance` on the concrete handler types, no raw `"/"`-split index math. This applies to `_resolve_uri`, `download`, `copy`, and push's existing-registration lookup.
- **Removed the gbcli-only URI helpers that predated the shared class**: `decode_uri`, `DecodedURIResponse`, `compare_env_uri`, and `get_artifact_formatted_name`. The Lakehouse environment (for the prod-vs-non-prod guard) is read inline from the URI host in the one spot that needs it. `copy` derives its source table directly from the URI's `table_name` instead of building a formatted name and splitting it.
- **Unified store/type validation** into one `_validate_store_type(ctx, store, type, is_push)` holding the full store→allowed-types matrix (using allow-lists): hf → `model/dataset/bucket`; lh → `model/table/fileset/dataset` for register, `model/table/fileset` for push (push cannot push dataset content). This folds in the previously separate push lh-dataset guard.
- Added the `--repo` alias to push's `--label` (matches register).

## Behavior changes (all intended)

- **`--store lh -t bucket` is now rejected** for both push and register. Buckets are a HuggingFace-only store concept; the CLI previously allowed the lh+bucket combination silently. No test or flow depended on it.
- **Invalid-URI error message is now scheme-agnostic** (`invalid artifact URI '<uri>': …`) — the scheme is only known after parsing, so a single message covers both.
- **The hf store/type message is unified** across push and register (`store 'hf' is only allowed for artifact types 'model', 'dataset', 'bucket'. Got type '<type>'.`); the two previously differed in wording.
- **Lakehouse environment is now compared case-insensitively.** The env host is read via `urlparse` (which lowercases), where the old `uri.split("/")[2]` did not. Identical for the real `prod`/`staging` hosts; a hand-typed mixed-case host (e.g. `lh://PROD/…`) now normalizes to lowercase rather than erroring on a spurious mismatch. System-generated LhURIs are already lowercase.
- For an `lh://` URI on `push`, the URI's namespace/revision are decoded but not consumed — push already forces `revision`/`version` and sends `namespace=None` regardless of how the parameters were supplied, so this matches push's existing behavior under the sugar model.

## Pre-existing issues left as-is (flagged, not fixed here)

- `copy`'s `is_hf_artifact` can be referenced unbound if the identifier is neither uuid nor uri (no `else`).
- push's existing-registration label extraction keys on the outer `type` while revision/version key on `existing_registration.get("type")`.

## Test plan

- New `test_artifact_push.py`: hf:// and lh:// happy paths, `--store`/`--uri` conflict, identity-flag rejection, malformed and undefined-template URIs, space-URI rejection, `--repo` synonym, env-mismatch, lh+bucket rejection, and backward-compat (plain flags, missing type).
- New `test_artifact_download.py` / `test_artifact_copy.py`: pin the URI-class dispatch — HF download still passes a plain-string `artifact_type` and `org/repo` repo_id; HF copy still refused; LH paths still route through the decoded fields; copy's `source_table` is derived from the URI.
- `test_artifact_register.py`: existing HF/LH coverage plus a new lh+bucket rejection; behavior otherwise unchanged.

```
PYTHONPATH="\$PWD/src" GB_ENVIRONMENT=STANDALONE python -m pytest \
  test/unit/gbcli/commands/test_artifact_register.py \
  test/unit/gbcli/commands/test_artifact_push.py \
  test/unit/gbcli/commands/test_artifact_download.py \
  test/unit/gbcli/commands/test_artifact_copy.py \
  test/unit/gbcli/utils/test_utils.py -q
# 60 passed
```

`black`/`isort` clean; `pylint src/gbcli/` passes (exit 0); `mypy` (non-blocking `continue-on-error` in CI) stays at the pre-refactor baseline.

Generated with [Claude Code](https://claude.com/claude-code)