### PR TITLE
Replace HF push `private: false` with `public: true` (default false)

### DIFF
--- a/docs/builds/build-yaml-reference.md
+++ b/docs/builds/build-yaml-reference.md
@@ -102,11 +102,7 @@ outputs:
     uri: file:workspace/checkpoint
   model:
     uri: hf://huggingface.co/my-org/my-model
-    store_push:
-      mode: hf_push 
-      config:
-        hf:
-          private: false
+    public: true                     # HF-only: publish the repo (default private)
   server_url:
     uri: "mem://server_url"          # opaque value passed to a downstream target (no type/store_push)
 ```
@@ -114,6 +110,7 @@ outputs:
 | Field             | Type    | Required | Default | Notes |
 |-------------------|---------|----------|---------|-------|
 | `uri`             | string  | no       | —       | Output URI. Supports Jinja templating, e.g. `hf://huggingface.co/datasets/.../{{ run_metadata.targetsteprun_id \| short_hash }}`. |
+| `public`          | bool    | no       | `false` | HuggingFace-only convenience flag: publish the pushed repo. Default (private) needs no key. Only valid on `hf://` outputs. See [`hf-push.md`](hf-push.md#making-an-output-public). |
 | `store_push`      | object  | no       | —       | Push to a remote store after the step writes the artifact. See [`hf-push.md`](hf-push.md) for the HF case. |
 | `event_selectors` | list    | no       | `[]`    | Event-payload matchers used by downstream `inputs.event` triggers. |
 
@@ -154,8 +151,8 @@ and [Asset stores — In-memory](../asset-stores/README.md#store-types-and-uri-s
 
 | Field    | Type   | Required | Notes |
 |----------|--------|----------|-------|
-| `mode`   | string | yes      | `hfstore`, `lhstore`, `cosstore`, etc. |
-| `config` | object | no       | Mode-specific (e.g. `hf.private`, `hf.resource_group_id`, `hf.resource_group_name`, `hf.use_resource_group`). |
+| `mode`   | string | no       | Rarely needed — the store is inferred from the output `uri` scheme. Honored only by k8s; ignored (deprecation warning) elsewhere. |
+| `config` | object | no       | Store-specific (e.g. `hf.public`, `hf.resource_group_id`, `hf.resource_group_name`, `hf.use_resource_group`). |
 
 For HuggingFace specifically, see [`hf-push.md`](hf-push.md) — it documents
 the full URI format, resource-group resolution, the Enterprise vs

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -10,8 +10,8 @@ This document covers two related things:
 > **TL;DR:** You almost never need `store_push`. An `hf://` URI on the output is
 > enough — the environment's asset store and the active g.b space supply the
 > defaults (private repo, and — for HF Enterprise orgs — a space-derived
-> resource group). Only reach for `store_push` when you need a per-output
-> override.
+> resource group). To publish a single output, add `public: true` next to its
+> `uri`. Reach for the full `store_push` block only for resource-group overrides.
 
 ---
 
@@ -95,7 +95,56 @@ With the above, the framework will:
 
 ---
 
+## Making an output public
+
+Outputs are private by default. To publish one, set `public: true` on the output
+— no `store_push` block, no `mode`:
+
+```yaml
+outputs:
+  download_file:
+    uri: hf://huggingface.co/datasets/myaccount/my-dataset-{{ binding.path | short_hash }}
+    public: true
+```
+
+`public` is a boolean, **default `false`** (private). Only an explicit truthy
+value (`true`/`yes`/`on`/`1`, quoted or not) publishes; anything else — omitted,
+`false`, an empty/`null` value, or an unrecognized typo — keeps the repo private.
+That fail-closed rule is deliberate: HuggingFace's own `create_repo` defaults to
+*public*, so a mis-set flag must never silently publish an artifact.
+
+`public` may also be written inside the push config, next to the resource-group
+keys, if you are already using a `store_push` block. Both forms mean the same thing:
+
+```yaml
+public: true                          # top-level (preferred)
+store_push: { config: { hf: { public: true } } }
+```
+
+Setting both on the same output with **conflicting** values is an error (it is
+almost always a copy-paste mistake); equal values are fine.
+
+> `public` is HuggingFace-only. Setting it (or any `store_push.config.hf.*` key)
+> on a non-`hf://` output — `lh://`, `env://`, `file://`, `cos://` — fails
+> validation at load time, since those stores have no notion of repo visibility.
+
+### `public` vs HuggingFace's `private`
+
+granite.build's surface flag is `public` (default false); HuggingFace's API uses
+`private` (`create_repo(private=...)`, `hf upload --private`). The two are the
+same setting inverted, and the inversion happens at exactly one place —
+[`_private_from_hf_cfg`](../../src/gbserver/spaces/hf_push_config.py), where the
+merged push config is resolved. Everything below that point (the resolver's
+return value, the emitted step config, the LSF/Helm/SkyPilot worker templates,
+and `gbcommon.uri.hf`) speaks `private`, matching the HF API; everything you
+write in `build.yaml`/`store.yaml` speaks `public`. You never write `private`.
+
+---
+
 ## The optional `store_push` block
+
+The full block is only needed for resource-group overrides (for `public`, prefer
+the top-level form above):
 
 ```yaml
 llm.build:
@@ -104,14 +153,17 @@ llm.build:
       outputs:
         <output-name>:
           uri: hf://huggingface.co/datasets/<org>/<repo>
+          public: true                            # optional; publishes the repo
           store_push:                # <-- optional, omit when defaults suffice
-            mode: "hfstore"
             config:
               hf:
-                private: false
                 resource_group_id: "abc123..."        # or use resource_group_name
                 resource_group_name: "gbspace-public"
 ```
+
+`mode` may be set but is not needed — the store is inferred from the `hf://` URI
+scheme, and `mode` is honored only by k8s (ignored, with a deprecation warning,
+elsewhere).
 
 `store_push` is evaluated per-output and **takes precedence** over any equivalent
 settings in `environment.yaml` (see [Relationship with `environment.yaml`](#relationship-with-environmentyaml)).
@@ -120,20 +172,21 @@ settings in `environment.yaml` (see [Relationship with `environment.yaml`](#rela
 
 #### `mode`
 
-| Value | Description |
-|-------|-------------|
-| `"hfstore"` | Push the output artifact to HuggingFace Hub. This is the only supported mode. |
+Optional and rarely needed. The store is inferred from the output `uri` scheme
+(`hf://` → the HF store); `mode` is honored only by the k8s environment and
+ignored — with a deprecation warning — everywhere else. Prefer omitting it (or
+`"default"`).
 
 If `store_push` is absent the environment-level push configuration from `environment.yaml`
 is used instead (see the [environments overview](../environments/README.md)).
 
-#### `config.hf`
+#### `config` and `config.hf`
 
 All fields are optional.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `private` | bool | `true` | Whether the HuggingFace repository should be **private**. Set to `false` to create or update a public repository. |
+| `public` | bool | `false` | Whether the HuggingFace repository should be **public**. Default (and any non-truthy/unrecognized value) → private. May be written as top-level `public` or `config.hf.public` — see [Making an output public](#making-an-output-public). |
 | `resource_group_id` | string | — | Pre-resolved HF Enterprise resource group id. When provided, no HF API lookup is performed — the id is used as-is. Enterprise orgs only — supplying it for a non-Enterprise org is an error. |
 | `resource_group_name` | string | — | Resource group name. Resolved to an id via the HF API at push time. Enterprise orgs only. |
 | `use_resource_group` | bool | `true` | Set to `false` to push to an Enterprise org **without** a resource group. Cannot be combined with `resource_group_id`/`resource_group_name`. See [Enterprise vs non-Enterprise organizations](#enterprise-vs-non-enterprise-organizations). |
@@ -262,7 +315,7 @@ If none of the above yield a value, no resource group is attached to the push.
 > re-verified at runtime.
 
 The space-table lookup + HF fallback + write-back is implemented in
-[`resolve_space_resource_group_id`](../../src/gbserver/spaces/resource_group.py),
+[`resolve_space_resource_group_id`](../../src/gbserver/spaces/hf_push_config.py),
 which wraps the HF-only resolver
 [`HfURI.resolve_resource_group_id_for_org`](../../src/gbcommon/uri/hf.py). It is
 called from the K8s, LSF, and SkyPilot push paths (and the CLI-facing
@@ -278,12 +331,11 @@ called from the K8s, LSF, and SkyPilot push paths (and the CLI-facing
 outputs:
   download_file:
     uri: hf://huggingface.co/datasets/my-org/my-dataset-{{ binding.path | short_hash }}
-    store_push:
-      mode: "hfstore"
-      config:
-        hf:
-          private: false
+    public: true
 ```
+
+See [Making an output public](#making-an-output-public) for the other accepted
+forms.
 
 ### Pin a specific resource group name (ignore the space default)
 
@@ -326,12 +378,15 @@ assetstores:
     pull:
       - mode: default
     push:
-      - mode: default
-        config:
+      - config:
           hf:
-            private: true
+            public: false            # the default; shown for illustration
             resource_group_name: "default-group"
 ```
+
+`public` at the environment level is written as `config.hf.public` (there is no
+output-level field here); it defaults to `false` (private), so you only set it to
+opt a whole environment's pushes into public.
 
 Fields in `build.yaml`'s `store_push` **override** the corresponding fields from the
 environment-level push config.  Any field not set in `build.yaml` falls back to the

--- a/docs/builds/hf-push.md
+++ b/docs/builds/hf-push.md
@@ -139,6 +139,10 @@ return value, the emitted step config, the LSF/Helm/SkyPilot worker templates,
 and `gbcommon.uri.hf`) speaks `private`, matching the HF API; everything you
 write in `build.yaml`/`store.yaml` speaks `public`. You never write `private`.
 
+The former `store_push.config.hf.private` key is retired: it is rejected at load
+time with an error pointing to `public` (`private: false` becomes `public: true`),
+so an old config fails loudly rather than silently reverting to private.
+
 ---
 
 ## The optional `store_push` block

--- a/src/gbcli/commands/command_artifact.py
+++ b/src/gbcli/commands/command_artifact.py
@@ -87,7 +87,7 @@ def _reject_resource_group_for_non_enterprise(exit_fn, org: str) -> None:
     anything. Shared by ``artifact push`` and ``artifact register`` so the
     two user-facing messages cannot drift. Worded for the CLI flag; the
     server-side build.yaml equivalent is
-    :func:`gbserver.spaces.resource_group._non_enterprise_rg_error`.
+    :func:`gbserver.spaces.hf_push_config._non_enterprise_rg_error`.
 
     Args:
         exit_fn: The command's exit callable (``sys.exit`` or ``ctx.exit``).

--- a/src/gbcommon/types/gbenvconfig.py
+++ b/src/gbcommon/types/gbenvconfig.py
@@ -33,21 +33,25 @@ _FALSY_TOKENS = frozenset({"false", "null", "undefined", "no", "off", "0", ""})
 _TRUTHY_TOKENS = frozenset({"true", "yes", "on", "1"})
 
 
-def parse_boolean(value: object | None, default: bool = False) -> bool:
-    """Parse an env-var-style string (or an already-typed value) into a boolean.
+def parse_boolean(
+    value: object | None, default: bool = False, *, strict: bool = False
+) -> bool:
+    """Parse an env-var-style string (or already-typed value) into a boolean.
 
-    ``None`` (unset) → ``default``. Otherwise the value is stringified,
-    lower-cased and compared against the falsy token set (see ``_FALSY_TOKENS``);
-    a match is ``False``, anything else set is ``True``. A non-falsy value that
-    also isn't a recognized truthy token (a likely typo, e.g. ``on-prod``) is
-    still treated as ``True`` but logs a warning. This never raises — the single
-    place the string→bool rule is defined, shared by ``getenv_boolean`` and any
-    other caller that already has the string in hand.
+    ``None`` (unset) → ``default``. Otherwise falsy tokens (``_FALSY_TOKENS``) →
+    ``False``. For any other set value the two modes differ:
 
-    Accepts non-string input because YAML/JSON configs yield real ``bool`` (and
-    occasionally ``int``) values: ``str()`` maps those onto the same token sets
-    (``False``→``"false"``, ``0``→``"0"``), so a config value and its quoted
-    form resolve identically.
+    - lenient (default): anything not falsy → ``True``; an unrecognized value (a
+      likely typo, e.g. ``on-prod``) still → ``True`` but logs a warning.
+    - ``strict=True``: only a recognized truthy token → ``True``; an unrecognized
+      value → ``False`` with no warning. Use when a typo must fail *closed* — a
+      flag whose safe default and safe failure mode are both ``False`` (e.g. an
+      opt-in like making a HuggingFace repo ``public``).
+
+    Accepts non-string input because YAML/JSON yields real ``bool``/``int``;
+    ``str()`` maps those onto the same token sets, so a value and its quoted form
+    resolve identically. Never raises — the single place the string→bool rule
+    lives, shared by ``getenv_boolean`` and any caller holding the value.
     """
     if value is None:
         return default
@@ -55,8 +59,10 @@ def parse_boolean(value: object | None, default: bool = False) -> bool:
     if normalized in _FALSY_TOKENS:
         return False
     if normalized not in _TRUTHY_TOKENS:
+        if strict:
+            return False
         logger.warning(
-            "Unrecognized boolean value %r — treating as true; " "use one of %s / %s",
+            "Unrecognized boolean value %r — treating as true; use one of %s / %s",
             value,
             sorted(_TRUTHY_TOKENS),
             sorted(_FALSY_TOKENS),

--- a/src/gbserver/api/artifacts.py
+++ b/src/gbserver/api/artifacts.py
@@ -34,7 +34,7 @@ from gbserver.api.utils import (
     split_tags,
 )
 from gbserver.lineage.jobstats import get_lineage_store
-from gbserver.spaces.resource_group import resolve_space_resource_group_id
+from gbserver.spaces.hf_push_config import resolve_space_resource_group_id
 from gbserver.storage.artifact_registration import (
     ArtifactRegistration,
     ArtifactRegistrationStatus,

--- a/src/gbserver/environment/k8s.py
+++ b/src/gbserver/environment/k8s.py
@@ -74,7 +74,7 @@ from gbserver.environment.environment import (
     Environment,
     EventLogLineParserConfig,
 )
-from gbserver.spaces.resource_group import (
+from gbserver.spaces.hf_push_config import (
     apply_hf_step_overlay,
     resolve_hfpush_resource_group_id,
 )

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from gbserver.spaces.resource_group import (
+from gbserver.spaces.hf_push_config import (
     HfPushConfigError,
     resolve_hfpush_private,
     resolve_hfpush_resource_group_id,
@@ -148,7 +148,7 @@ def push_asset_hfstore(
         run_metadata: EntityRunMetadata with ``build_id`` and ``target_name``.
         storepush_config: Environment-level ``store_push`` (environment.yaml)
             supplying ``config.hf`` (``resource_group_id`` /
-            ``resource_group_name`` / ``use_resource_group`` / ``private``).
+            ``resource_group_name`` / ``use_resource_group`` / ``public``).
         output_config: Per-output config whose ``store_push`` (build.yaml)
             overrides the environment level.
 

--- a/src/gbserver/environment/local_assets.py
+++ b/src/gbserver/environment/local_assets.py
@@ -244,9 +244,9 @@ def push_asset_hfstore(
         from gbserver.types.constants import get_hf_token
 
         # Resource groups cannot be classified without Hfstore's Enterprise org
-        # list, but `private` is store-independent: read it from the same merged
-        # config levels so an explicit `private: false` is honored here too
-        # (default stays True). Only the resource-group resolution below differs
+        # list, but the visibility flag is store-independent: read it from the same
+        # merged config levels so an explicit `public: true` is honored here too
+        # (default stays private). Only the resource-group resolution below differs
         # between the two branches.
         private = resolve_hfpush_private(
             storepush_config=storepush_config,

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -50,7 +50,7 @@ from gbserver.monitoring.lsf_bsub_monitor import LSFBsubMonitor
 from gbserver.monitoring.streams.log_stream_base import LogStreamSource
 from gbserver.monitoring.streams.stream_factory import make_stream
 from gbserver.resilience.strategies.aspera_failure import AsperaRetryStrategy
-from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 from gbserver.types.buildconfig import BuildTargetOutputConfig, BuildTargetStepConfig
 from gbserver.types.buildevent import (
     EntityRunMetadata,

--- a/src/gbserver/environment/skypilot.py
+++ b/src/gbserver/environment/skypilot.py
@@ -39,7 +39,7 @@ from tenacity import (
 
 from gbcommon.uri.uri import URI
 from gbserver.environment.environment import Environment, EventLogLineParserConfig
-from gbserver.spaces.resource_group import (
+from gbserver.spaces.hf_push_config import (
     apply_hf_step_overlay,
     resolve_hfpush_resource_group_id,
 )

--- a/src/gbserver/spaces/hf_push_config.py
+++ b/src/gbserver/spaces/hf_push_config.py
@@ -205,20 +205,44 @@ def _extract_hf(config: Optional[dict], top_public: object = None) -> dict:
     level, where there is no output field). ``top_public`` carries the output's
     top-level field (``None`` at the environment level); it is folded into the
     returned ``hf`` block so downstream reads one location. Setting both on the
-    same output with conflicting values raises; equal values collapse.
+    same output with conflicting values raises; equal values collapse. A yaml null
+    is "unset" on either form. The retired ``private`` key raises (see
+    :func:`_reject_retired_private`).
     """
     config = config or {}
     hf_cfg = config.get("hf") or {}
     hf_cfg = dict(hf_cfg) if isinstance(hf_cfg, dict) else {}
-    if top_public is not None:
-        if PUBLIC_KEY in hf_cfg and _differ(hf_cfg[PUBLIC_KEY], top_public):
-            raise HfPushConfigError(
-                f"conflicting public settings for one push "
-                f"('config.hf.{PUBLIC_KEY}: {hf_cfg[PUBLIC_KEY]}' vs "
-                f"'public: {top_public}') — keep one."
-            )
-        hf_cfg.setdefault(PUBLIC_KEY, top_public)
+    _reject_retired_private(hf_cfg)
+    hf_public = hf_cfg.get(PUBLIC_KEY)
+    if (
+        hf_public is not None
+        and top_public is not None
+        and _differ(hf_public, top_public)
+    ):
+        raise HfPushConfigError(
+            f"conflicting public settings for one push "
+            f"('config.hf.{PUBLIC_KEY}: {hf_public}' vs "
+            f"'public: {top_public}') — keep one."
+        )
+    if hf_public is None and top_public is not None:
+        hf_cfg[PUBLIC_KEY] = top_public
     return hf_cfg
+
+
+def _reject_retired_private(hf_cfg: dict) -> None:
+    """Reject the retired ``private`` key with a message pointing to ``public``.
+
+    ``private`` was replaced by ``public`` (inverted, default False). An old
+    ``config.hf.private`` reaching here would otherwise be ignored and silently
+    make the repo private, so fail loudly instead. Raised at load time via
+    :func:`validate_output_push` and defensively at resolve time.
+    """
+    if "private" in hf_cfg:
+        raise HfPushConfigError(
+            "`store_push.config.hf.private` is no longer supported; use `public` "
+            f"(inverted, default False) instead — e.g. `private: false` → "
+            f"`public: true`. Got `private: {hf_cfg['private']}`."
+        )
 
 
 def _hf_push_config_levels(
@@ -283,14 +307,15 @@ def validate_output_push(
 ) -> Optional[str]:
     """Validate an output's HuggingFace push config at load time; else ``None``.
 
-    Two load-time checks, so both fail fast with the output named:
+    Fails fast with the output named on:
 
     - non-``hf://`` guard: ``public`` and any ``store_push.config.hf.*`` key are
       HuggingFace-only (no other store reads ``store_push``), so on an ``lh://``/
       ``env://``/``file://``/``cos://`` output they are a misconfiguration that
       would otherwise be silently ignored.
-    - same-level ``public`` conflict: caught by folding the forms via
-      :func:`_hf_push_config_levels` (the single place the fold rule lives).
+    - the retired ``config.hf.private`` key, and a same-level ``public`` conflict:
+      both caught by folding the forms via :func:`_hf_push_config_levels` (the
+      single place those rules live).
 
     Returns an error string for the generic build validator to collect. Kept here
     so ``buildconfig`` stays generic.

--- a/src/gbserver/spaces/hf_push_config.py
+++ b/src/gbserver/spaces/hf_push_config.py
@@ -14,7 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Server-side resolution of HuggingFace Enterprise resource group ids.
+"""Server-side resolution of a HuggingFace push's configuration.
+
+The single home for turning the ``public``/``store_push`` config written in
+build.yaml and store.yaml/environment.yaml into the concrete values a push needs:
+
+- the public→private flip (:func:`_private_from_hf_cfg`) — the one boundary
+  between granite.build's surface ``public`` and the HF-API ``private``;
+- the cross-level config merge and the load-time output guard
+  (:func:`validate_output_push`);
+- Enterprise resource group id resolution (below).
+
+## Resource group resolution
 
 HF Enterprise access control keys repository/bucket creation on a resource
 group *id* (an internal HF identifier). There is no non-admin HF API to map a
@@ -44,7 +55,7 @@ id. The table read/write lives here.
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from gbcommon.types.gbenvconfig import parse_boolean
-from gbcommon.uri.hf import HF_HOST, HfURI
+from gbcommon.uri.hf import HF_HOST, HF_URI_SCHEME, HfURI
 from gbcommon.utils.hf_utils import is_enterprise_hf_org
 from gbserver.storage.singleton_storage import get_admin_storage
 from gbserver.utils.logger import get_logger
@@ -60,6 +71,11 @@ logger = get_logger(__name__)
 # resource groups. Consumed here and stripped before the config reaches a
 # worker step template.
 USE_RESOURCE_GROUP_KEY = "use_resource_group"
+
+# The granite.build surface key at both exposed interfaces (build.yaml and
+# store.yaml/environment.yaml). Flipped to the HF-API ``private`` at one place,
+# :func:`_private_from_hf_cfg`; everything below that boundary speaks ``private``.
+PUBLIC_KEY = "public"
 
 
 class HfPushConfigError(ValueError):
@@ -181,6 +197,30 @@ def _merge_hf_levels(levels: Tuple[dict, dict]) -> dict:
     return merged
 
 
+def _extract_hf(config: Optional[dict], top_public: object = None) -> dict:
+    """The ``hf`` block for one config level, with a top-level ``public`` folded in.
+
+    ``public`` may be written two ways: the ergonomic output-level top ``public``,
+    or the store-namespaced ``config.hf.public`` (the only form at the environment
+    level, where there is no output field). ``top_public`` carries the output's
+    top-level field (``None`` at the environment level); it is folded into the
+    returned ``hf`` block so downstream reads one location. Setting both on the
+    same output with conflicting values raises; equal values collapse.
+    """
+    config = config or {}
+    hf_cfg = config.get("hf") or {}
+    hf_cfg = dict(hf_cfg) if isinstance(hf_cfg, dict) else {}
+    if top_public is not None:
+        if PUBLIC_KEY in hf_cfg and _differ(hf_cfg[PUBLIC_KEY], top_public):
+            raise HfPushConfigError(
+                f"conflicting public settings for one push "
+                f"('config.hf.{PUBLIC_KEY}: {hf_cfg[PUBLIC_KEY]}' vs "
+                f"'public: {top_public}') — keep one."
+            )
+        hf_cfg.setdefault(PUBLIC_KEY, top_public)
+    return hf_cfg
+
+
 def _hf_push_config_levels(
     storepush_config: Optional["StorePush"] = None,
     output_config: Optional["BuildTargetOutputConfig"] = None,
@@ -189,31 +229,91 @@ def _hf_push_config_levels(
 
     ``(environment_level, output_level)``. Kept distinct from the merged view so
     a per-output setting can be told apart from one inherited from the
-    environment — see the ``use_resource_group`` handling in
+    environment — see ``use_resource_group`` in
     :func:`resolve_hfpush_resource_group_id`.
     """
-
-    def _hf(config: Optional[dict]) -> dict:
-        hf_cfg = (config or {}).get("hf") or {}
-        return hf_cfg if isinstance(hf_cfg, dict) else {}
-
-    env_level = _hf(storepush_config.config) if storepush_config is not None else {}
-    output_level = (
-        _hf(output_config.store_push.config)
-        if output_config is not None and output_config.store_push is not None
-        else {}
+    env_level = (
+        _extract_hf(storepush_config.config) if storepush_config is not None else {}
     )
+    output_level = {}
+    if output_config is not None:
+        push = output_config.store_push
+        output_level = _extract_hf(
+            push.config if push is not None else None,
+            top_public=output_config.public,
+        )
     return env_level, output_level
 
 
-def _private_from_hf_cfg(hf_cfg: dict) -> bool:
-    """Apply the ``private`` default to an already-merged ``hf`` config block.
+def _differ(a: object, b: object) -> bool:
+    """Whether two ``public`` values disagree in meaning (strict, like the flip)."""
+    return _is_public(a) != _is_public(b)
 
-    The single definition of the rule, shared by
-    :func:`resolve_hfpush_resource_group_id` (which has the merged block in hand)
-    and :func:`resolve_hfpush_private` (which merges it first).
+
+def _is_public(value: object) -> bool:
+    """Resolve a surface ``public`` value, failing closed (a typo → private)."""
+    return parse_boolean(value, strict=True)
+
+
+def _private_from_hf_cfg(hf_cfg: dict) -> bool:
+    """Flip the surface ``public`` flag to the internal ``private`` bool.
+
+    THE public→private boundary: the one place granite.build's ``public`` (default
+    False) becomes the HF-API ``private`` (default True) used everywhere below.
+    Fails closed via :func:`_is_public` — an unset/null/typo value stays private,
+    so no ``.get(default)``/``hasKey`` gymnastics are needed (unlike the old
+    ``private`` key, whose safe default was True).
     """
-    return parse_boolean(hf_cfg.get("private"), True)
+    return not _is_public(hf_cfg.get(PUBLIC_KEY))
+
+
+def _uri_scheme(uri: Optional[str]) -> Optional[str]:
+    """Scheme of a (possibly Jinja-templated) URI by prefix, or ``None``.
+
+    An output ``uri`` is a template at load time (``hf:///org/repo-{{ x }}``), so
+    split on ``://`` rather than parsing — both ``hf://`` and ``hf:///`` match.
+    """
+    if not uri or "://" not in uri:
+        return None
+    return uri.split("://", 1)[0].lower() or None
+
+
+def validate_output_push(
+    output_name: str, output_config: "BuildTargetOutputConfig"
+) -> Optional[str]:
+    """Validate an output's HuggingFace push config at load time; else ``None``.
+
+    Two load-time checks, so both fail fast with the output named:
+
+    - non-``hf://`` guard: ``public`` and any ``store_push.config.hf.*`` key are
+      HuggingFace-only (no other store reads ``store_push``), so on an ``lh://``/
+      ``env://``/``file://``/``cos://`` output they are a misconfiguration that
+      would otherwise be silently ignored.
+    - same-level ``public`` conflict: caught by folding the forms via
+      :func:`_hf_push_config_levels` (the single place the fold rule lives).
+
+    Returns an error string for the generic build validator to collect. Kept here
+    so ``buildconfig`` stays generic.
+    """
+    labels = []
+    if getattr(output_config, PUBLIC_KEY, None) is not None:
+        labels.append(f"`{PUBLIC_KEY}`")
+    push = output_config.store_push
+    cfg = push.config if push is not None else None
+    if isinstance(cfg, dict) and isinstance(cfg.get("hf"), dict) and cfg["hf"]:
+        labels.append("`store_push.config.hf.*`")
+    if not labels:
+        return None
+    if _uri_scheme(output_config.uri) != HF_URI_SCHEME:
+        return (
+            f"Output `{output_name}`: {', '.join(labels)} is a HuggingFace push "
+            f"option, only valid on an hf:// output; got uri '{output_config.uri}'."
+        )
+    try:
+        _hf_push_config_levels(output_config=output_config)
+    except HfPushConfigError as e:
+        return f"Output `{output_name}`: {e}"
+    return None
 
 
 def _level_pin(level: dict) -> Optional[str]:
@@ -225,12 +325,15 @@ def resolve_hfpush_private(
     storepush_config: Optional["StorePush"] = None,
     output_config: Optional["BuildTargetOutputConfig"] = None,
 ) -> bool:
-    """Resolve the ``private`` flag for an HF push from the merged push config.
+    """Resolve the internal ``private`` flag for an HF push from the push config.
 
-    Artifacts are private by default: HuggingFace's own ``create_repo`` default is
-    PUBLIC, so an unset/omitted value must resolve to ``True`` here to keep a user
-    from unintentionally publishing a model. Only an explicit falsy value
-    (``false``/``no``/``off``/``0``, quoted or not) opts into a public repo.
+    Artifacts are private by default. The surface flag is ``public`` (default
+    False); this returns the flipped internal ``private`` via the
+    :func:`_private_from_hf_cfg` boundary, so an unset/omitted ``public`` yields a
+    private repo and only an explicit truthy ``public`` (``true``/``yes``/``1``,
+    quoted or not) opts into a public one. HuggingFace's own ``create_repo``
+    defaults to PUBLIC, which is exactly why the safe granite.build default is
+    ``public: false``.
 
     Split out of :func:`resolve_hfpush_resource_group_id` so a caller that cannot
     classify the org (no ``Hfstore``, hence no Enterprise org list) can still honor
@@ -249,13 +352,20 @@ def resolve_hfpush_private(
     return _private_from_hf_cfg(hf_cfg)
 
 
+_RESOLUTION_ONLY_HF_KEYS = frozenset({USE_RESOURCE_GROUP_KEY, PUBLIC_KEY})
+
+
 def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
     """Drop keys that must never reach a worker step's ``hfpush_config``.
 
-    ``use_resource_group`` is consumed during resolution (it opts an Enterprise
-    org out of resource groups); leaking it verbatim into the emitted step
-    config would hand the LSF/Helm/SkyPilot templates a key they do not
-    understand.
+    Both keys are consumed during *resolution*, not by the worker template, so
+    leaking them verbatim into the emitted step config would hand the
+    LSF/Helm/SkyPilot templates keys they do not understand:
+
+    - ``use_resource_group`` opts an Enterprise org out of resource groups.
+    - ``public`` is the surface flag flipped to the flat ``private`` step key by
+      :func:`_private_from_hf_cfg`; the templates read ``hfpush_config.private``,
+      never ``hf.public``, so a leftover ``hf.public`` would be dead weight.
 
     Args:
         hf_cfg: An ``hf`` config dict from a push configuration.
@@ -263,7 +373,9 @@ def sanitize_hf_step_overlay(hf_cfg: dict) -> dict:
     Returns:
         A copy without the resolution-only keys.
     """
-    return {k: v for k, v in (hf_cfg or {}).items() if k != USE_RESOURCE_GROUP_KEY}
+    return {
+        k: v for k, v in (hf_cfg or {}).items() if k not in _RESOLUTION_ONLY_HF_KEYS
+    }
 
 
 def apply_hf_step_overlay(
@@ -329,11 +441,9 @@ def resolve_hfpush_resource_group_id(
     hf_cfg = _merge_hf_levels(levels)
     resource_group_id = hf_cfg.get("resource_group_id") or None
     resource_group_name = hf_cfg.get("resource_group_name") or None
-    # parse_boolean, not .get(key, default): a yaml null is a *present* key, so
-    # .get's default would not apply and a None reaching a worker template
-    # stringifies as "None". parse_boolean also folds the quoted forms
-    # ("false"/"no"/"off"/"0") onto False, so `private: "false"` means what it
-    # says instead of being truthy as a non-empty string.
+    # The public→private flip. `private` below is the HF-API vocabulary; the
+    # surface key is `public` (default False → private), so the safe default is
+    # the flag's zero value and no unset/null special-casing is needed here.
     private = _private_from_hf_cfg(hf_cfg)
     use_resource_group = parse_boolean(hf_cfg.get(USE_RESOURCE_GROUP_KEY), True)
 

--- a/src/gbserver/storage/stored_space.py
+++ b/src/gbserver/storage/stored_space.py
@@ -40,7 +40,7 @@ class StoredSpace(BaseStoredItem):
     # Cached HuggingFace Enterprise resource group id for this space's DEFAULT
     # resource group (the ``gbspace-<space>`` group derived from the space name).
     # Populated from create-spaces YAML or lazily written back after a successful
-    # HF API lookup (see gbserver.spaces.resource_group). Only the default group's
+    # HF API lookup (see gbserver.spaces.hf_push_config). Only the default group's
     # id is cached here; an explicitly-requested non-default group is never stored.
     # Stored inside the existing ``json`` column, so no schema migration / new SQL
     # column is required.

--- a/src/gbserver/types/buildconfig.py
+++ b/src/gbserver/types/buildconfig.py
@@ -103,8 +103,10 @@ class BuildTargetOutputPushConfig(Config):
     """Push configuration for an output artifact (build.yaml ``store_push`` block).
 
     Attributes:
-        mode: The push mode (e.g. ``"hfstore"``).
-        config: Mode-specific push configuration (e.g. ``{"hf": {"private": false}}``).
+        mode: The push mode. Optional and rarely needed — the store is inferred
+            from the output ``uri`` scheme.
+        config: Store-specific push configuration, keyed by store (e.g. the
+            ``hf`` block for HuggingFace). Interpreted by the store's push path.
     """
 
     mode: Optional[str] = None
@@ -120,6 +122,10 @@ class BuildTargetOutputConfig(Config):
             Applied to the registered artifact when the store pushes inline (no
             push step emits one), e.g. the ``env_local`` store. Defaults to
             ``UNDEFINED`` when omitted.
+        public: Store-specific push visibility flag (currently HuggingFace only:
+            publish the pushed repo). Convenience alias for the store's own
+            ``store_push`` visibility key; interpreted by the store's push path,
+            which also validates it against the ``uri`` scheme.
         event_selectors: Event selector rules for matching artifact events.
         store_push: Optional per-output push configuration from build.yaml.
         space_name: Build space name; set at runtime, not parsed from build.yaml.
@@ -127,6 +133,7 @@ class BuildTargetOutputConfig(Config):
 
     uri: Optional[str] = None
     type: Optional[ArtifactType] = None
+    public: Optional[bool] = None
     event_selectors: List[BuildTargetOutputEventSelectorsConfig] = Field(
         default_factory=list
     )
@@ -376,6 +383,23 @@ class BuildConfig(Config):
                     )
         return errors
 
+    def __validate_output_push(self: Self) -> GBValidationErrors:
+        """Validate each output's push config via the owning store's own rules.
+
+        Store-specific push rules live with the store, not here — this only walks
+        the outputs and collects what each store's validator reports (currently
+        only the HF push guard). Lazily imported to avoid a types→spaces cycle.
+        """
+        from gbserver.spaces.hf_push_config import validate_output_push
+
+        errors = GBValidationErrors()
+        for target_name, target in self.targets.items():
+            for output_name, output in (target.outputs or {}).items():
+                err = validate_output_push(output_name, output)
+                if err:
+                    errors.add(f"Target `{target_name}`: {err}")
+        return errors
+
     def my_validate(self: Self) -> GBValidationErrors:
         """Validate the build config."""
         logger.info("validating the build config")
@@ -386,6 +410,7 @@ class BuildConfig(Config):
         errors.add(self.__validate_step_uris())
         errors.add(self.__validate_target_inputs())
         errors.add(self.__validate_env_uris())
+        errors.add(self.__validate_output_push())
         logger.info("validated the build config and found %d errors", len(errors))
         return errors
 

--- a/test/unit/api/test_hf_resource_group.py
+++ b/test/unit/api/test_hf_resource_group.py
@@ -17,10 +17,10 @@
 """Unit tests for GET /hf/resource-group endpoint (mocked, no HF API calls).
 
 The endpoint delegates resolution to
-``gbserver.spaces.resource_group.resolve_space_resource_group_id`` (table-first
+``gbserver.spaces.hf_push_config.resolve_space_resource_group_id`` (table-first
 with HF API fallback + write-back). These tests patch that helper so they only
 exercise the endpoint's request/response contract; the helper's own logic is
-covered in ``test/unit/spaces/test_resource_group.py``.
+covered in ``test/unit/spaces/test_hf_push_config.py``.
 """
 
 from unittest.mock import patch

--- a/test/unit/environment/test_docker_hfstore.py
+++ b/test/unit/environment/test_docker_hfstore.py
@@ -630,7 +630,7 @@ async def test_push_asset_hfstore_honors_store_push_use_resource_group(tmp_path)
     uri = HfURI.from_parts(owner="org", repo="repo", hf_type=HfType.MODEL)
     with (
         patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="should-not-be-used",
         ) as mock_resolve,
         patch.object(HfURI, "push", return_value=True) as mock_push,
@@ -654,7 +654,7 @@ async def test_docker_pushasset_forwards_push_configs(docker_env, tmp_path):
     src.write_bytes(b"w")
     storepush_config = MagicMock()
     storepush_config.mode = "default"
-    storepush_config.config = {"hf": {"private": False}}
+    storepush_config.config = {"hf": {"public": True}}
     output_config = MagicMock()
     output_config.store_push = MagicMock()
     output_config.store_push.config = {"hf": {"resource_group_id": "rg-out"}}
@@ -704,7 +704,7 @@ async def test_push_asset_hfstore_uses_the_resolved_space_name(tmp_path):
             URI, "get_space_config", return_value={"space": {"name": "my-team-space"}}
         ),
         patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="rg-id",
         ) as mock_resolve,
         patch.object(HfURI, "push", return_value=True),

--- a/test/unit/environment/test_local_assets_besteffort.py
+++ b/test/unit/environment/test_local_assets_besteffort.py
@@ -42,7 +42,7 @@ from gbcommon.uri.hf import HfURI
 from gbcommon.uri.uri import URI
 from gbserver.asset.hfstore import Hfstore
 from gbserver.environment.local_assets import push_asset_hfstore
-from gbserver.spaces.resource_group import HfPushConfigError
+from gbserver.spaces.hf_push_config import HfPushConfigError
 
 
 @pytest.fixture
@@ -147,7 +147,7 @@ def test_miss_from_the_real_resolver_chain_still_pushes(
         patch.object(HfURI, "_resolve_resource_group_id", return_value=None),
         patch("gbcommon.uri.hf.HfApi"),
         patch("gbcommon.uri.hf.is_hf_mocked", return_value=False),
-        patch("gbserver.spaces.resource_group.get_admin_storage") as get_storage,
+        patch("gbserver.spaces.hf_push_config.get_admin_storage") as get_storage,
     ):
         get_storage.return_value.space_storage.get_by_name.return_value = None
         _run(src=src_dir, hfuri=hfuri, assetstore=enterprise_store)

--- a/test/unit/environment/test_local_assets_private.py
+++ b/test/unit/environment/test_local_assets_private.py
@@ -18,10 +18,11 @@
 
 These environments have no hfpush step directory, so they call
 ``push_asset_hfstore`` directly instead of rendering a worker template. The
-resolved ``private`` value was previously discarded here, and
-``HfApi.create_repo``'s own default is PUBLIC — so a dropped ``private``
-publishes the artifact rather than failing loudly. Every test below asserts on
-the ``private`` kwarg that actually reaches ``HfURI.push``.
+surface flag is ``public`` (default false); it is flipped to the internal
+``private`` at the resolver boundary. ``HfApi.create_repo``'s own default is
+PUBLIC — so a dropped/mis-resolved value must fail closed to private rather than
+publishing. Every test below feeds a ``public`` config and asserts on the
+``private`` kwarg that actually reaches ``HfURI.push``.
 
 The tests exercise the real ``push_asset_hfstore`` (only ``HfURI.push`` and the
 resource-group lookup are mocked); mocking ``push_asset_hfstore`` itself, as the
@@ -87,6 +88,7 @@ def _run(hfuri, src, assetstore, output_config=None, storepush_config=None):
 def _output_config(hf_cfg):
     """A BuildTargetOutputConfig double carrying an ``hf`` push config."""
     output_config = MagicMock()
+    output_config.public = None  # no top-level public (real output defaults to None)
     output_config.store_push.config = {"hf": hf_cfg}
     return output_config
 
@@ -107,26 +109,26 @@ def test_no_config_defaults_to_private(src_dir, hfstore):
     assert _run(hfuri, src_dir, hfstore) is True
 
 
-def test_explicit_private_true_is_not_discarded(src_dir, hfstore):
-    """(3) A redundant explicit ``private: true`` must survive to HF."""
+def test_explicit_public_false_is_not_discarded(src_dir, hfstore):
+    """(3) A redundant explicit ``public: false`` must survive to HF as private."""
     hfuri = _hfuri()
-    assert _run(hfuri, src_dir, hfstore, _output_config({"private": True})) is True
+    assert _run(hfuri, src_dir, hfstore, _output_config({"public": False})) is True
 
 
-def test_explicit_private_false_is_honored(src_dir, hfstore):
-    """(2) Public is opt-in: only an explicit ``private: false`` gets it."""
+def test_explicit_public_true_is_honored(src_dir, hfstore):
+    """(2) Public is opt-in: only an explicit ``public: true`` gets it."""
     hfuri = _hfuri()
-    assert _run(hfuri, src_dir, hfstore, _output_config({"private": False})) is False
+    assert _run(hfuri, src_dir, hfstore, _output_config({"public": True})) is False
 
 
-def test_yaml_null_private_does_not_publish(src_dir, hfstore):
-    """A bare ``private:`` (yaml null) must not be read as "public".
+def test_yaml_null_public_does_not_publish(src_dir, hfstore):
+    """A bare ``public:`` (yaml null) must not be read as "public".
 
-    ``None`` is *present* as a key, so a ``.get("private", True)`` would return
-    None and HuggingFace would default the repo to public.
+    ``None`` is *present* as a key; the flip treats it (and any non-truthy value)
+    as private, so a bare ``public:`` keeps the repo private.
     """
     hfuri = _hfuri()
-    assert _run(hfuri, src_dir, hfstore, _output_config({"private": None})) is True
+    assert _run(hfuri, src_dir, hfstore, _output_config({"public": None})) is True
 
 
 def test_non_hfstore_assetstore_still_pushes_private(src_dir):
@@ -160,31 +162,30 @@ def test_resolver_failure_still_pushes_private(src_dir, hfstore):
         assert _run(hfuri, src_dir, hfstore) is True
 
 
-def test_quoted_private_false_is_honored(src_dir, hfstore):
-    """``private: "false"`` (quoted in yaml) must mean public, not truthy.
+def test_quoted_public_true_is_honored(src_dir, hfstore):
+    """``public: "true"`` (quoted in yaml) must mean public, not a truthy string.
 
-    A bare ``bool("false")`` is ``True``, so a quoted value used to silently
-    invert the user's intent. Resolution goes through ``parse_boolean``, which
-    folds the quoted falsy forms onto ``False``.
+    A bare ``bool("true")`` would also be ``True``, but the fail-closed flip only
+    honors *recognized* truthy tokens, folded case- and whitespace-insensitively.
     """
     hfuri = _hfuri()
-    assert _run(hfuri, src_dir, hfstore, _output_config({"private": "false"})) is False
+    assert _run(hfuri, src_dir, hfstore, _output_config({"public": "true"})) is False
 
 
-@pytest.mark.parametrize("value", ["no", "off", "0", "False", " false "])
-def test_quoted_falsy_forms_are_honored(src_dir, hfstore, value):
-    """The whole falsy token set works, case- and whitespace-insensitively."""
+@pytest.mark.parametrize("value", ["yes", "on", "1", "True", " true "])
+def test_quoted_truthy_forms_are_honored(src_dir, hfstore, value):
+    """The whole truthy token set works, case- and whitespace-insensitively."""
     hfuri = _hfuri()
-    assert _run(hfuri, src_dir, hfstore, _output_config({"private": value})) is False
+    assert _run(hfuri, src_dir, hfstore, _output_config({"public": value})) is False
 
 
-def test_unparseable_private_falls_back_to_private(src_dir, hfstore):
-    """A typo must fail *safe*: unrecognized means private, not public."""
+def test_unparseable_public_falls_back_to_private(src_dir, hfstore):
+    """A typo must fail *safe*: unrecognized ``public`` means private, not public."""
     hfuri = _hfuri()
-    assert _run(hfuri, src_dir, hfstore, _output_config({"private": "flase"})) is True
+    assert _run(hfuri, src_dir, hfstore, _output_config({"public": "treu"})) is True
 
 
-def test_output_level_private_overrides_environment_level(src_dir, hfstore):
+def test_output_level_public_overrides_environment_level(src_dir, hfstore):
     """build.yaml outranks environment.yaml, so a per-output opt-in wins.
 
     The intended usage: the environment keeps everything private, and a single
@@ -192,25 +193,25 @@ def test_output_level_private_overrides_environment_level(src_dir, hfstore):
     """
     hfuri = _hfuri()
     storepush_config = MagicMock()
-    storepush_config.config = {"hf": {"private": True}}
+    storepush_config.config = {"hf": {"public": False}}
     assert (
         _run(
             hfuri,
             src_dir,
             hfstore,
-            output_config=_output_config({"private": False}),
+            output_config=_output_config({"public": True}),
             storepush_config=storepush_config,
         )
         is False
     )
 
 
-def test_non_hfstore_honors_explicit_private_false(src_dir):
-    """The non-Hfstore branch must honor an explicit ``private: false`` too.
+def test_non_hfstore_honors_explicit_public_true(src_dir):
+    """The non-Hfstore branch must honor an explicit ``public: true`` too.
 
     It cannot classify the org (no Enterprise list without an ``Hfstore``), but
-    ``private`` is store-independent: hardcoding ``True`` here would silently
-    ignore a config the Hfstore branch obeys.
+    the public/private flag is store-independent: hardcoding ``private=True`` here
+    would silently ignore a config the Hfstore branch obeys.
     """
     hfuri = _hfuri()
     plain_store = MagicMock()  # not an Hfstore
@@ -221,6 +222,5 @@ def test_non_hfstore_honors_explicit_private_false(src_dir):
         return_value=None,
     ):
         assert (
-            _run(hfuri, src_dir, plain_store, _output_config({"private": False}))
-            is False
+            _run(hfuri, src_dir, plain_store, _output_config({"public": True})) is False
         )

--- a/test/unit/environment/test_lsf_hfstore.py
+++ b/test/unit/environment/test_lsf_hfstore.py
@@ -63,7 +63,7 @@ def mock_resolve_rg():
     """Patch the resource group resolution used by pushasset_hfstore.
 
     Resolution is delegated to
-    ``gbserver.spaces.resource_group.resolve_hfpush_resource_group_id`` (imported
+    ``gbserver.spaces.hf_push_config.resolve_hfpush_resource_group_id`` (imported
     into the lsf env module); patch it there so tests never touch storage or the
     HF API. It returns ``(resource_group_id, private, hf_config)``; the default
     here mirrors a push with no resource group and the default private=True.
@@ -251,11 +251,12 @@ class TestPushassetHfstore:
     async def test_private_flag_from_storepush_config(
         self, lsf_env, mock_hfuri, mock_hf_metadata
     ):
-        """pushasset_hfstore picks up private=False from storepush_config.
+        """pushasset_hfstore picks up public=True (=> private=False) from storepush_config.
 
         Uses the real resolver (not ``mock_resolve_rg``) so the env-level
-        ``private`` actually flows through resolve_hfpush_resource_group_id.
-        The org is non-Enterprise here, so no HF API call is made.
+        ``public`` actually flows through resolve_hfpush_resource_group_id and is
+        flipped to the internal ``private``. The org is non-Enterprise here, so no
+        HF API call is made.
         """
         from gbserver.asset.hfstore import Hfstore
 
@@ -264,7 +265,7 @@ class TestPushassetHfstore:
         assetstore.get_enterprise_organizations.return_value = ["some-other-org"]
         storepush_config = MagicMock()
         storepush_config.mode = "default"
-        storepush_config.config = {"hf": {"private": False}}
+        storepush_config.config = {"hf": {"public": True}}
 
         with (
             patch("gbserver.environment.lsf.Asset") as mock_asset_cls,

--- a/test/unit/environment/test_skypilot_hfstore.py
+++ b/test/unit/environment/test_skypilot_hfstore.py
@@ -50,7 +50,7 @@ def mock_resolve_rg():
     mock so tests can tune the return value / assert call behavior.
     """
     with patch(
-        "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+        "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
         return_value=None,
     ) as mock:
         yield mock
@@ -366,13 +366,14 @@ class TestPushassetHfstore:
     async def test_private_flag_from_output_config(
         self, skypilot_env, mock_hfuri, mock_resolve_rg
     ):
-        """pushasset_hfstore picks up private=False from output_config.store_push."""
+        """pushasset_hfstore picks up public=True (=> private=False) from output_config.store_push."""
         assetstore = _hfstore_mock()
 
         output_config = MagicMock()
+        output_config.public = None  # no top-level public
         output_config.space_name = None
         output_config.store_push = MagicMock()
-        output_config.store_push.config = {"hf": {"private": False}}
+        output_config.store_push.config = {"hf": {"public": True}}
 
         step_config = await skypilot_env.pushasset_hfstore(
             binding={"path": "/workspace/output/model"},

--- a/test/unit/gbtypes/test_buildconfig.py
+++ b/test/unit/gbtypes/test_buildconfig.py
@@ -78,3 +78,77 @@ class TestBuildConfig:
         build_config = BuildConfig.from_yaml(build_config_path)
         expected = get_expected_buildconfig(matched_base_key="granite.build")
         assert build_config == expected
+
+
+class TestOutputPublicField:
+    """The generic `public` field on an output.
+
+    `buildconfig` stays store-agnostic: it holds `public` as a plain optional
+    bool and does not interpret it. The three-form fold, the public→private flip,
+    and the HF-only guard all live with the HF push path
+    (`gbserver.spaces.hf_push_config`) and are tested there.
+    """
+
+    def test_public_is_stored_verbatim(self):
+        from gbserver.types.buildconfig import BuildTargetOutputConfig
+
+        o = BuildTargetOutputConfig(uri="hf:///org/repo", public=True)
+        assert o.public is True
+        # No parse-time mutation into store_push: buildconfig doesn't interpret it.
+        assert o.store_push is None
+
+    def test_public_defaults_to_none(self):
+        from gbserver.types.buildconfig import BuildTargetOutputConfig
+
+        assert BuildTargetOutputConfig(uri="hf:///org/repo").public is None
+
+
+class TestOutputPushHfOnlyGuard:
+    """`public` / `store_push.config.hf.*` are HuggingFace-only push options.
+
+    End-to-end through `BuildConfig.my_validate`, which delegates to the HF push
+    path's validator. Fold/flip/conflict semantics are tested in
+    `test/unit/spaces/test_hf_push_config.py`.
+    """
+
+    @staticmethod
+    def _build(uri, output_extra):
+        return BuildConfig.model_validate(
+            {
+                "targets": {
+                    "t1": {
+                        "environment_uri": "space://env/default",
+                        "outputs": {"out": {"uri": uri, **output_extra}},
+                        "steps": [{"step_uri": ""}],
+                    }
+                }
+            }
+        )
+
+    def _push_errors(self, uri, output_extra):
+        errs = self._build(uri, output_extra).my_validate()
+        return [e for e in errs.errors if "HuggingFace push option" in e.error]
+
+    @pytest.mark.parametrize("uri", ["file:///tmp/x", "lh://a/b", "env:///abs/p"])
+    def test_public_on_non_hf_output_errors(self, uri):
+        assert len(self._push_errors(uri, {"public": True})) == 1
+
+    @pytest.mark.parametrize("uri", ["lh://a/b", "cos://bucket/key"])
+    def test_hf_block_on_non_hf_output_errors(self, uri):
+        errs = self._push_errors(
+            uri, {"store_push": {"config": {"hf": {"resource_group_name": "x"}}}}
+        )
+        assert len(errs) == 1
+
+    def test_public_on_templated_hf_output_is_allowed(self):
+        # The uri is a Jinja template at load time — the guard checks the prefix.
+        assert (
+            self._push_errors("hf:///org/repo-{{ binding.path }}", {"public": True})
+            == []
+        )
+
+    def test_public_on_plain_hf_output_is_allowed(self):
+        assert (
+            self._push_errors("hf://huggingface.co/datasets/o/r", {"public": True})
+            == []
+        )

--- a/test/unit/gbtypes/test_gbenvconfig.py
+++ b/test/unit/gbtypes/test_gbenvconfig.py
@@ -257,3 +257,30 @@ class TestResolvedValues:
                 "build_start_via_github"
                 not in _GB_ENVIRONMENT_CONFIGS[env].feature_flags
             )
+
+
+class TestParseBooleanStrict:
+    """``strict=True`` fails closed: only a recognized truthy value → True.
+
+    Unlike lenient mode (unrecognized non-falsy → True), strict returns True only
+    for a real ``True`` or a recognized truthy token. Backs the HF ``public``
+    flag, where a typo must never silently opt into a public repo.
+    """
+
+    @pytest.mark.parametrize(
+        "value", [True, "true", "yes", "on", "1", "True", " true "]
+    )
+    def test_recognized_truthy_is_true(self, value):
+        assert gbenvconfig.parse_boolean(value, strict=True) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, False, "false", "no", "off", "0", "", "null", "treu", "on-prod", "2"],
+    )
+    def test_everything_else_is_false(self, value):
+        assert gbenvconfig.parse_boolean(value, strict=True) is False
+
+    def test_strict_differs_from_lenient_on_a_typo(self):
+        """The whole point: an unrecognized value goes opposite ways."""
+        assert gbenvconfig.parse_boolean("treu") is True  # lenient default
+        assert gbenvconfig.parse_boolean("treu", strict=True) is False  # fail closed

--- a/test/unit/spaces/test_hf_push_config.py
+++ b/test/unit/spaces/test_hf_push_config.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gbcommon.uri.hf import HfURI
-from gbserver.spaces.resource_group import (
+from gbserver.spaces.hf_push_config import (
     apply_hf_step_overlay,
     resolve_hfpush_resource_group_id,
     resolve_space_resource_group_id,
@@ -51,9 +51,9 @@ class TestResolveSpaceResourceGroupId:
         admin = MagicMock(return_value=storage)
 
         with (
-            patch("gbserver.spaces.resource_group.get_admin_storage", admin),
+            patch("gbserver.spaces.hf_push_config.get_admin_storage", admin),
             patch(
-                "gbserver.spaces.resource_group.HfURI.resolve_resource_group_id_for_org"
+                "gbserver.spaces.hf_push_config.HfURI.resolve_resource_group_id_for_org"
             ) as mock_hf,
         ):
             result = resolve_space_resource_group_id(
@@ -74,11 +74,11 @@ class TestResolveSpaceResourceGroupId:
 
         with (
             patch(
-                "gbserver.spaces.resource_group.get_admin_storage",
+                "gbserver.spaces.hf_push_config.get_admin_storage",
                 return_value=storage,
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.resolve_resource_group_id_for_org",
+                "gbserver.spaces.hf_push_config.HfURI.resolve_resource_group_id_for_org",
                 return_value="resolved-id",
             ) as mock_hf,
         ):
@@ -101,11 +101,11 @@ class TestResolveSpaceResourceGroupId:
 
         with (
             patch(
-                "gbserver.spaces.resource_group.get_admin_storage",
+                "gbserver.spaces.hf_push_config.get_admin_storage",
                 return_value=storage,
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.resolve_resource_group_id_for_org",
+                "gbserver.spaces.hf_push_config.HfURI.resolve_resource_group_id_for_org",
                 return_value="resolved-id",
             ),
         ):
@@ -126,11 +126,11 @@ class TestResolveSpaceResourceGroupId:
 
         with (
             patch(
-                "gbserver.spaces.resource_group.get_admin_storage",
+                "gbserver.spaces.hf_push_config.get_admin_storage",
                 return_value=storage,
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.resolve_resource_group_id_for_org",
+                "gbserver.spaces.hf_push_config.HfURI.resolve_resource_group_id_for_org",
                 return_value=None,
             ),
         ):
@@ -157,15 +157,15 @@ class TestResolveSpaceResourceGroupId:
 
         with (
             patch(
-                "gbserver.spaces.resource_group.get_admin_storage",
+                "gbserver.spaces.hf_push_config.get_admin_storage",
                 return_value=storage,
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.space_name_to_resource_group_name",
+                "gbserver.spaces.hf_push_config.HfURI.space_name_to_resource_group_name",
                 return_value="gbspace-public",
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.resolve_resource_group_id_for_org",
+                "gbserver.spaces.hf_push_config.HfURI.resolve_resource_group_id_for_org",
                 return_value="non-default-id",
             ) as mock_hf,
         ):
@@ -191,15 +191,15 @@ class TestResolveSpaceResourceGroupId:
 
         with (
             patch(
-                "gbserver.spaces.resource_group.get_admin_storage",
+                "gbserver.spaces.hf_push_config.get_admin_storage",
                 return_value=storage,
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.space_name_to_resource_group_name",
+                "gbserver.spaces.hf_push_config.HfURI.space_name_to_resource_group_name",
                 return_value="gbspace-public",
             ),
             patch(
-                "gbserver.spaces.resource_group.HfURI.resolve_resource_group_id_for_org"
+                "gbserver.spaces.hf_push_config.HfURI.resolve_resource_group_id_for_org"
             ) as mock_hf,
         ):
             result = resolve_space_resource_group_id(
@@ -229,6 +229,7 @@ def _make_hfuri(owner="ibm-research", repo="my-model"):
 def _output_config(hf_cfg):
     """BuildTargetOutputConfig-alike carrying a store_push hf block."""
     cfg = MagicMock()
+    cfg.public = None  # no top-level public (a real output defaults it to None)
     cfg.store_push = MagicMock()
     cfg.store_push.config = {"hf": hf_cfg}
     return cfg
@@ -245,7 +246,7 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
 
     def test_non_enterprise_skips_resolution(self):
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, private, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="my-user"),
@@ -278,7 +279,7 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
     def test_absent_enterprise_list_keeps_legacy_behavior(self):
         """None (key absent) => every org is Enterprise, so resolution still runs."""
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="resolved-id",
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
@@ -294,7 +295,7 @@ class TestResolveHfpushResourceGroupIdNonEnterprise:
 class TestResolveHfpushResourceGroupIdEnterprise:
     def test_enterprise_resolves_via_space(self):
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="space-id",
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
@@ -309,7 +310,7 @@ class TestResolveHfpushResourceGroupIdEnterprise:
 
     def test_pinned_id_used_verbatim_without_resolver(self):
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -324,7 +325,7 @@ class TestResolveHfpushResourceGroupIdEnterprise:
     def test_use_resource_group_false_opts_out(self):
         """An Enterprise org can opt out with use_resource_group: false."""
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -353,7 +354,7 @@ class TestResolveHfpushConfigPrecedence:
 
     def test_env_level_store_push_is_honored(self):
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="ignored",
         ) as mock_resolve:
             _, private, _ = resolve_hfpush_resource_group_id(
@@ -361,7 +362,7 @@ class TestResolveHfpushConfigPrecedence:
                 assetstore=_make_assetstore(["ibm-research"]),
                 space_name="public",
                 storepush_config=_storepush_config(
-                    {"resource_group_name": "env-group", "private": False}
+                    {"resource_group_name": "env-group", "public": True}
                 ),
             )
 
@@ -370,14 +371,14 @@ class TestResolveHfpushConfigPrecedence:
 
     def test_build_yaml_overrides_environment(self):
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, private, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
                 assetstore=_make_assetstore(["ibm-research"]),
                 space_name="public",
                 storepush_config=_storepush_config(
-                    {"resource_group_id": "env-id", "private": False}
+                    {"resource_group_id": "env-id", "public": True}
                 ),
                 output_config=_output_config({"resource_group_id": "build-id"}),
             )
@@ -388,10 +389,12 @@ class TestResolveHfpushConfigPrecedence:
 
 
 class TestSanitizeHfStepOverlay:
-    def test_strips_use_resource_group(self):
+    def test_strips_resolution_only_keys(self):
+        # ``use_resource_group`` and ``public`` are consumed during resolution and
+        # must never leak into the worker step's ``hf`` block; other keys stay.
         assert sanitize_hf_step_overlay(
-            {"private": True, "use_resource_group": False}
-        ) == {"private": True}
+            {"type": "model", "use_resource_group": False, "public": True}
+        ) == {"type": "model"}
 
     def test_handles_empty_and_none(self):
         assert sanitize_hf_step_overlay({}) == {}
@@ -444,7 +447,7 @@ class TestUseResourceGroupAcrossLevels:
 
     def test_output_opt_out_overrides_inherited_group(self):
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -489,10 +492,10 @@ class TestUseResourceGroupAcrossLevels:
         explicit output-level `resource_group_id` — inverting the documented
         precedence and dropping a pinned group with no error.
         """
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -508,10 +511,10 @@ class TestUseResourceGroupAcrossLevels:
 
     def test_output_pinned_name_overrides_environment_opt_out(self):
         """Same for a pinned name, which does go through the resolver."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="rg-from-name",
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
@@ -527,10 +530,10 @@ class TestUseResourceGroupAcrossLevels:
 
     def test_environment_pin_does_not_override_output_opt_out(self):
         """The reverse: a lower-level pin must not defeat a higher-level opt-out."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -544,10 +547,10 @@ class TestUseResourceGroupAcrossLevels:
         mock_resolve.assert_not_called()
 
     def test_opt_out_at_both_levels_still_opts_out(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id"
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id"
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
                 hfuri=_make_hfuri(owner="ibm-research"),
@@ -563,7 +566,7 @@ class TestUseResourceGroupAcrossLevels:
     def test_environment_opt_out_is_overridable_by_output(self):
         """The reverse direction: an output can turn resource groups back on."""
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="rg-on",
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
@@ -581,30 +584,30 @@ class TestUseResourceGroupAcrossLevels:
 class TestNullConfigValuesTreatedAsUnset:
     """An explicit yaml null means "not set here", not "override with None".
 
-    A bare `private:` in build.yaml parses as None. Merging it wholesale would
-    erase a value inherited from environment.yaml, and a None reaching the step
-    config renders as the string "None" in the worker templates — failing their
-    `== "True"` test, so a repo meant to be private would be created public.
+    A bare `public:` in build.yaml parses as None. Merging it wholesale would
+    erase a value inherited from environment.yaml. The resolver returns the
+    internal ``private`` bool (``public`` flipped): ``public`` unset/null → the
+    safe default, a private repo (``private is True``).
     """
 
     @pytest.mark.parametrize(
         "env_hf,output_hf,expected",
         [
             # A null at the output level must not erase the environment value.
-            ({"private": False}, {"private": None}, False),
+            ({"public": True}, {"public": None}, False),
             # A real value at the output level still wins.
-            ({"private": False}, {"private": True}, True),
-            # A null with nothing to inherit falls back to the default (True).
-            (None, {"private": None}, True),
-            ({"private": None}, {"private": None}, True),
+            ({"public": True}, {"public": False}, True),
+            # A null with nothing to inherit falls back to the default (private).
+            (None, {"public": None}, True),
+            ({"public": None}, {"public": None}, True),
             # Unchanged behavior for values that are actually set.
-            (None, {"private": False}, False),
-            ({"private": False}, None, False),
+            (None, {"public": True}, False),
+            ({"public": True}, None, False),
             (None, None, True),
         ],
     )
     def test_private_resolution(self, env_hf, output_hf, expected):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         _, private, _ = resolve_hfpush_resource_group_id(
             hfuri=_make_hfuri(owner="my-user"),
@@ -618,23 +621,23 @@ class TestNullConfigValuesTreatedAsUnset:
 
     def test_private_is_always_a_bool(self):
         """Never a None: the worker templates stringify whatever they are given."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         _, private, _ = resolve_hfpush_resource_group_id(
             hfuri=_make_hfuri(owner="my-user"),
             assetstore=_make_assetstore([]),
             space_name="public",
-            output_config=_output_config({"private": None}),
+            output_config=_output_config({"public": None}),
         )
 
         assert isinstance(private, bool)
 
     def test_null_use_resource_group_does_not_disable_resolution(self):
         """`use_resource_group:` with no value must not read as an opt-out."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="rg",
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
@@ -649,7 +652,7 @@ class TestNullConfigValuesTreatedAsUnset:
 
     def test_null_resource_group_id_does_not_pin(self):
         """A null id must not count as a pinned group on a non-Enterprise org."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         rg_id, _, _ = resolve_hfpush_resource_group_id(
             hfuri=_make_hfuri(owner="my-user"),
@@ -671,15 +674,15 @@ class TestQuotedBooleanForms:
     being truthy. Before that, a quoted value silently inverted the user's intent.
     """
 
-    @pytest.mark.parametrize("value", ["false", "no", "off", "0", "False", " false "])
-    def test_quoted_private_is_public(self, value):
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+    @pytest.mark.parametrize("value", ["true", "yes", "on", "1", "True", " true "])
+    def test_quoted_public_is_public(self, value):
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         _, private, _ = resolve_hfpush_resource_group_id(
             hfuri=_make_hfuri(owner="my-user"),
             assetstore=_make_assetstore([]),
             space_name="public",
-            output_config=_output_config({"private": value}),
+            output_config=_output_config({"public": value}),
         )
 
         assert private is False
@@ -687,10 +690,10 @@ class TestQuotedBooleanForms:
     @pytest.mark.parametrize("value", ["false", "no", "off", "0"])
     def test_quoted_use_resource_group_opts_out(self, value):
         """A quoted opt-out must actually skip resolution."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         with patch(
-            "gbserver.spaces.resource_group.resolve_space_resource_group_id",
+            "gbserver.spaces.hf_push_config.resolve_space_resource_group_id",
             return_value="rg",
         ) as mock_resolve:
             rg_id, _, _ = resolve_hfpush_resource_group_id(
@@ -703,15 +706,15 @@ class TestQuotedBooleanForms:
         assert rg_id is None
         mock_resolve.assert_not_called()
 
-    def test_unrecognized_private_stays_private(self):
+    def test_unrecognized_public_stays_private(self):
         """A typo fails safe: unparseable means private, never public."""
-        from gbserver.spaces.resource_group import resolve_hfpush_resource_group_id
+        from gbserver.spaces.hf_push_config import resolve_hfpush_resource_group_id
 
         _, private, _ = resolve_hfpush_resource_group_id(
             hfuri=_make_hfuri(owner="my-user"),
             assetstore=_make_assetstore([]),
             space_name="public",
-            output_config=_output_config({"private": "flase"}),
+            output_config=_output_config({"public": "treu"}),
         )
 
         assert private is True
@@ -727,12 +730,12 @@ class TestHfPushConfigError:
     """
 
     def test_is_a_valueerror_subclass(self):
-        from gbserver.spaces.resource_group import HfPushConfigError
+        from gbserver.spaces.hf_push_config import HfPushConfigError
 
         assert issubclass(HfPushConfigError, ValueError)
 
     def test_non_enterprise_pin_raises_the_subtype(self):
-        from gbserver.spaces.resource_group import (
+        from gbserver.spaces.hf_push_config import (
             HfPushConfigError,
             resolve_hfpush_resource_group_id,
         )
@@ -746,7 +749,7 @@ class TestHfPushConfigError:
             )
 
     def test_same_level_contradiction_raises_the_subtype(self):
-        from gbserver.spaces.resource_group import (
+        from gbserver.spaces.hf_push_config import (
             HfPushConfigError,
             resolve_hfpush_resource_group_id,
         )
@@ -766,43 +769,43 @@ class TestResolveHfpushPrivate:
     """The standalone ``private`` resolver used by the non-Hfstore push branch."""
 
     def test_defaults_to_private(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_private
+        from gbserver.spaces.hf_push_config import resolve_hfpush_private
 
         assert resolve_hfpush_private() is True
 
-    def test_honors_explicit_false(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_private
+    def test_honors_explicit_public(self):
+        from gbserver.spaces.hf_push_config import resolve_hfpush_private
 
         assert (
-            resolve_hfpush_private(output_config=_output_config({"private": False}))
+            resolve_hfpush_private(output_config=_output_config({"public": True}))
             is False
         )
 
     def test_output_overrides_environment(self):
-        from gbserver.spaces.resource_group import resolve_hfpush_private
+        from gbserver.spaces.hf_push_config import resolve_hfpush_private
 
         assert (
             resolve_hfpush_private(
-                storepush_config=_storepush_config({"private": True}),
-                output_config=_output_config({"private": False}),
+                storepush_config=_storepush_config({"public": False}),
+                output_config=_output_config({"public": True}),
             )
             is False
         )
 
     def test_agrees_with_the_full_resolver(self):
         """Same rule, so the two entry points must never diverge."""
-        from gbserver.spaces.resource_group import (
+        from gbserver.spaces.hf_push_config import (
             resolve_hfpush_private,
             resolve_hfpush_resource_group_id,
         )
 
         for hf_cfg in (
             {},
-            {"private": True},
-            {"private": False},
-            {"private": None},
-            {"private": "false"},
-            {"private": "flase"},
+            {"public": False},
+            {"public": True},
+            {"public": None},
+            {"public": "true"},
+            {"public": "treu"},
         ):
             output_config = _output_config(hf_cfg)
             _, from_full, _ = resolve_hfpush_resource_group_id(
@@ -812,3 +815,132 @@ class TestResolveHfpushPrivate:
                 output_config=output_config,
             )
             assert resolve_hfpush_private(output_config=output_config) is from_full
+
+
+class TestEnvLevelPublic:
+    """At the environment level `public` is written as `config.hf.public`.
+
+    Environment/store.yaml push config has no output field, so `config.hf.public`
+    is the only form; the resolver flips it to the internal `private`.
+    """
+
+    def _storepush(self, config):
+        cfg = MagicMock()
+        cfg.config = config
+        return cfg
+
+    def test_env_config_hf_public_makes_public(self):
+        from gbserver.spaces.hf_push_config import resolve_hfpush_private
+
+        assert (
+            resolve_hfpush_private(
+                storepush_config=self._storepush({"hf": {"public": True}})
+            )
+            is False
+        )
+
+    def test_env_default_is_private(self):
+        from gbserver.spaces.hf_push_config import resolve_hfpush_private
+
+        assert resolve_hfpush_private(storepush_config=self._storepush({})) is True
+
+
+class TestOutputPublicForms:
+    """The two `public` forms on a build.yaml output, folded + flipped here.
+
+    `public` is granite.build's surface vocabulary (default false → private),
+    written top-level or as `config.hf.public`. The resolver folds them to one and
+    flips to the internal `private`; `buildconfig` itself stays store-agnostic (it
+    just carries the field).
+    """
+
+    @staticmethod
+    def _output(**kwargs):
+        from gbserver.types.buildconfig import BuildTargetOutputConfig
+
+        return BuildTargetOutputConfig(**kwargs)
+
+    def _private(self, **kwargs):
+        from gbserver.spaces.hf_push_config import resolve_hfpush_private
+
+        return resolve_hfpush_private(output_config=self._output(**kwargs))
+
+    def test_top_level_public(self):
+        assert self._private(uri="hf:///o/r-{{ x }}", public=True) is False
+
+    def test_config_hf_public(self):
+        assert (
+            self._private(
+                uri="hf:///o/r", store_push={"config": {"hf": {"public": True}}}
+            )
+            is False
+        )
+
+    def test_omitted_is_private(self):
+        assert self._private(uri="hf:///o/r") is True
+
+    def test_equal_forms_collapse(self):
+        assert (
+            self._private(
+                uri="hf:///o/r",
+                public=True,
+                store_push={"config": {"hf": {"public": True}}},
+            )
+            is False
+        )
+
+    def test_conflicting_forms_raise(self):
+        from gbserver.spaces.hf_push_config import (
+            HfPushConfigError,
+            resolve_hfpush_private,
+        )
+
+        o = self._output(
+            uri="hf:///o/r",
+            public=True,
+            store_push={"config": {"hf": {"public": False}}},
+        )
+        with pytest.raises(HfPushConfigError, match="conflict"):
+            resolve_hfpush_private(output_config=o)
+
+
+class TestValidateOutputPush:
+    """The load-time HF push guard, kept in the HF module (buildconfig delegates)."""
+
+    @staticmethod
+    def _output(**kwargs):
+        from gbserver.types.buildconfig import BuildTargetOutputConfig
+
+        return BuildTargetOutputConfig(**kwargs)
+
+    def _check(self, **kwargs):
+        from gbserver.spaces.hf_push_config import validate_output_push
+
+        return validate_output_push("out", self._output(**kwargs))
+
+    @pytest.mark.parametrize(
+        "uri", ["file:///t", "lh://a/b", "env:///abs", "cos://b/k"]
+    )
+    def test_public_on_non_hf_output_errors(self, uri):
+        assert self._check(uri=uri, public=True) is not None
+
+    def test_hf_block_on_non_hf_output_errors(self):
+        err = self._check(
+            uri="lh://a/b",
+            store_push={"config": {"hf": {"resource_group_name": "x"}}},
+        )
+        assert err is not None
+
+    def test_public_on_templated_hf_output_ok(self):
+        assert self._check(uri="hf:///o/r-{{ binding.path }}", public=True) is None
+
+    def test_no_push_options_ok(self):
+        assert self._check(uri="file:///t") is None
+
+    def test_same_level_conflict_surfaces_at_validate(self):
+        err = self._check(
+            uri="hf:///o/r",
+            public=True,
+            store_push={"config": {"hf": {"public": False}}},
+        )
+        assert err is not None and "conflict" in err.lower()

--- a/test/unit/spaces/test_hf_push_config.py
+++ b/test/unit/spaces/test_hf_push_config.py
@@ -903,6 +903,18 @@ class TestOutputPublicForms:
         with pytest.raises(HfPushConfigError, match="conflict"):
             resolve_hfpush_private(output_config=o)
 
+    def test_null_hf_public_is_unset_not_a_conflict(self):
+        # A bare `config.hf.public:` (yaml null) is "unset", so a top-level
+        # `public: true` fills it rather than clashing.
+        assert (
+            self._private(
+                uri="hf:///o/r",
+                public=True,
+                store_push={"config": {"hf": {"public": None}}},
+            )
+            is False
+        )
+
 
 class TestValidateOutputPush:
     """The load-time HF push guard, kept in the HF module (buildconfig delegates)."""
@@ -944,3 +956,20 @@ class TestValidateOutputPush:
             store_push={"config": {"hf": {"public": False}}},
         )
         assert err is not None and "conflict" in err.lower()
+
+    @pytest.mark.parametrize("private_val", [False, True, "false", None])
+    def test_retired_private_key_errors_loudly(self, private_val):
+        # The old `config.hf.private` key is no longer supported; instead of
+        # silently making the repo private, it must fail loudly pointing to `public`.
+        err = self._check(
+            uri="hf:///o/r",
+            store_push={"config": {"hf": {"private": private_val}}},
+        )
+        assert err is not None and "no longer supported" in err
+
+    def test_retired_private_key_on_non_hf_output_errors(self):
+        err = self._check(
+            uri="lh://a/b",
+            store_push={"config": {"hf": {"private": False}}},
+        )
+        assert err is not None


### PR DESCRIPTION
## Summary

Replaces the awkward `store_push.config.hf.private: false` surface for publishing a HuggingFace push with a `public` flag (default false) at both exposed interfaces (`build.yaml` and `store.yaml`/`environment.yaml`).

- **Why:** the old `private` flag defaulted to `true`, so its *safe* default (private) was the flag's *true* value — forcing defensive "unset vs false vs null" handling across the resolver and every worker template. With `public` (default false), the safe default is the boolean's zero value and that special-casing collapses.
- **Two equivalent forms** on an output — top-level `public`, or `store_push.config.hf.public` (next to the resource-group keys) — folded to one at the resolver boundary. Setting both with conflicting values is a load-time error; equal values collapse. At the environment level (no output field) only `config.hf.public` applies.
- **One flip point:** `public` → HF-API `private` happens only in `_private_from_hf_cfg`. Everything below — the step config, the LSF/Helm/SkyPilot worker templates, `gbcommon.uri.hf`, and HF's `create_repo` — is untouched and still speaks `private`, matching `hf upload --private`.
- **`parse_boolean` gains a `strict=` kwarg** (fail-closed): a `public` typo stays private rather than silently publishing.
- **New load-time guard:** `public` / `store_push.config.hf.*` on a non-`hf://` output (`lh://`, `env://`, `file://`, `cos://`) now fails validation (previously silently ignored).
- **Architecture:** HF push-config logic (flip, form fold, output guard) lives with the HF push path; `buildconfig` stays store-agnostic and delegates. `spaces/resource_group.py` renamed to `spaces/hf_push_config.py` to match its now-broader scope.
- **No back-compat** for the old `config.hf.private` key (hard replace).
- Docs (`hf-push.md`, `build-yaml-reference.md`) updated.

## Test plan

- `test/unit/spaces/test_hf_push_config.py` — flip, two-form fold, conflict, guard, cross-level override, quoted/typo fail-closed cases.
- `test/unit/gbtypes/test_gbenvconfig.py` — `parse_boolean(strict=True)` semantics.
- `test/unit/gbtypes/test_buildconfig.py` — generic `public` field + delegated HF-only guard end-to-end.
- `test/unit/environment/test_{lsf,skypilot,docker,bash,k8s}_hfstore.py`, `test_local_assets_private.py`, `test/unit/asset/test_hfstore.py` — migrated to `public`; internal `private` assertions unchanged.
- Full `test/unit/` sweep passes (the only failures are a pre-existing, unrelated flake in `test/unit/lineage/test_lineage_watch_command.py`, which fails identically on clean `main`).
- Worker templates and `gbcommon/uri/hf.py` verified untouched.

Generated with [Claude Code](https://claude.com/claude-code)