### PR TITLE
hfpull (shell): bound the lock-acquire wait when stale reclaim is disabled (#352)

### DIFF
--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -225,8 +225,8 @@ hfpull_acquire_lock() {
     # once, but the dest walk is not repeated every second. Matches
     # SharedFileSystemLock._stale_check_interval.
     interval=$(( ttl / 4 )); (( interval < 1 )) && interval=1; (( interval > 30 )) && interval=30
-    # The liveness probe needs GNU find's -newermt (the workers ship GNU
-    # findutils/coreutils; we already rely on `stat -c`). Probe it once: if it is
+    # The liveness probe needs find's -newermt (the workers' find supports it;
+    # we already rely on `stat -c`). Probe it once: if it is
     # unsupported (BSD/busybox find), the probe would silently return "no
     # activity" and every past-ttl lock would look dead -> peers would break LIVE
     # holders mid-download and re-induce the corruption this guards against. So
@@ -235,7 +235,7 @@ hfpull_acquire_lock() {
     have_newermt=1
     if ! find "${HFPULL_LAST_OUT}" -newermt "@0" >/dev/null 2>&1; then
         have_newermt=0
-        echo "hfpull: 'find -newermt' unsupported (GNU findutils required); will wait for the lock holder without reclaiming stale locks, to avoid breaking a live download" >&2
+        echo "hfpull: this find lacks '-newermt'; will wait for the lock holder without reclaiming stale locks, to avoid breaking a live download" >&2
     fi
     if ! mkdir -p "${container}" 2>/dev/null; then
         echo "hfpull: cannot create lock container ${container}; proceeding without lock" >&2
@@ -266,16 +266,16 @@ hfpull_acquire_lock() {
             return 0
         fi
         now="$(date +%s)"
-        # Without GNU find the reclaim branch below is disabled, so a crashed
-        # holder's lock would never be reclaimed and this loop would spin
+        # Without -newermt support the reclaim branch below is disabled, so a
+        # crashed holder's lock would never be reclaimed and this loop would spin
         # forever. Bound the wait by the ttl window, then proceed unlocked (HF's
         # per-file locks + self-heal are the backstop), matching the
         # infra-failure fall-through above. The Python path reclaims a dead
         # holder via ttl on every platform; the shell can only approximate that
         # here by giving up the wait. A live holder legitimately exceeding ttl
-        # on such a worker is the accepted cost of a missing GNU find.
+        # on such a worker is the accepted cost of a find without -newermt.
         if (( ! have_newermt )) && (( now - start >= ttl )); then
-            echo "hfpull: waited ${ttl}s for download lock ${lockdir} with no liveness probe (GNU find required to reclaim a dead holder); proceeding without lock" >&2
+            echo "hfpull: waited ${ttl}s for download lock ${lockdir} with no liveness probe (find -newermt required to reclaim a dead holder); proceeding without lock" >&2
             return 0
         fi
         if (( have_newermt )) && (( now - last_check >= interval )); then

--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -211,7 +211,7 @@ hfpull_break_lock() {
 }
 
 hfpull_acquire_lock() {
-    local dest="$1" container lockdir ttl created now interval last_check scratch have_newermt
+    local dest="$1" container lockdir ttl created now interval last_check scratch have_newermt start
     container="$(dirname "${dest}")/.gb-hfpull-locks"
     lockdir="${container}/$(basename "${dest}").lock"
     # Liveness watches HF's internal scratch dir (where the download's own writes
@@ -245,6 +245,7 @@ hfpull_acquire_lock() {
     # persistent container (matches fs_lock._reap_graveyards).
     rm -rf "${container}"/*.stale.* "${container}"/*.released.* 2>/dev/null || true
     last_check=0
+    start="$(date +%s)"
     while :; do
         if mkdir "${lockdir}" 2>/dev/null; then
             if printf '%s\n%s\n' "${HFPULL_IDENTITY}" "$(date +%s)" > "${lockdir}/lock.info" 2>/dev/null; then
@@ -265,6 +266,18 @@ hfpull_acquire_lock() {
             return 0
         fi
         now="$(date +%s)"
+        # Without GNU find the reclaim branch below is disabled, so a crashed
+        # holder's lock would never be reclaimed and this loop would spin
+        # forever. Bound the wait by the ttl window, then proceed unlocked (HF's
+        # per-file locks + self-heal are the backstop), matching the
+        # infra-failure fall-through above. The Python path reclaims a dead
+        # holder via ttl on every platform; the shell can only approximate that
+        # here by giving up the wait. A live holder legitimately exceeding ttl
+        # on such a worker is the accepted cost of a missing GNU find.
+        if (( ! have_newermt )) && (( now - start >= ttl )); then
+            echo "hfpull: waited ${ttl}s for download lock ${lockdir} with no liveness probe (GNU find required to reclaim a dead holder); proceeding without lock" >&2
+            return 0
+        fi
         if (( have_newermt )) && (( now - last_check >= interval )); then
             last_check="${now}"
             # A peer holds it. Reclaim only if past the ttl AND the scratch dir

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -226,7 +226,7 @@ environment_configs:
             }
 
             hfpull_acquire_lock() {
-                local dest="$1" container lockdir ttl created now interval last_check scratch have_newermt
+                local dest="$1" container lockdir ttl created now interval last_check scratch have_newermt start
                 container="$(dirname "${dest}")/.gb-hfpull-locks"
                 lockdir="${container}/$(basename "${dest}").lock"
                 # Liveness watches HF's internal scratch dir (where the download's
@@ -263,6 +263,7 @@ environment_configs:
                 # the persistent container (matches fs_lock._reap_graveyards).
                 rm -rf "${container}"/*.stale.* "${container}"/*.released.* 2>/dev/null || true
                 last_check=0
+                start="$(date +%s)"
                 while :; do
                     if mkdir "${lockdir}" 2>/dev/null; then
                         if printf '%s\n%s\n' "${HFPULL_IDENTITY}" "$(date +%s)" > "${lockdir}/lock.info" 2>/dev/null; then
@@ -284,6 +285,19 @@ environment_configs:
                         return 0
                     fi
                     now="$(date +%s)"
+                    # Without GNU find the reclaim branch below is disabled, so a
+                    # crashed holder's lock would never be reclaimed and this loop
+                    # would spin forever. Bound the wait by the ttl window, then
+                    # proceed unlocked (HF's per-file locks + self-heal are the
+                    # backstop), matching the infra-failure fall-through above. The
+                    # Python path reclaims a dead holder via ttl on every platform;
+                    # the shell can only approximate that here by giving up the
+                    # wait. A live holder legitimately exceeding ttl on such a
+                    # worker is the accepted cost of a missing GNU find.
+                    if (( ! have_newermt )) && (( now - start >= ttl )); then
+                        echo "hfpull: waited ${ttl}s for download lock ${lockdir} with no liveness probe (GNU find required to reclaim a dead holder); proceeding without lock" >&2
+                        return 0
+                    fi
                     if (( have_newermt )) && (( now - last_check >= interval )); then
                         last_check="${now}"
                         # A peer holds it. Reclaim only if past the ttl AND the

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -242,8 +242,8 @@ environment_configs:
                 # repeated every second. Matches
                 # SharedFileSystemLock._stale_check_interval.
                 interval=$(( ttl / 4 )); (( interval < 1 )) && interval=1; (( interval > 30 )) && interval=30
-                # The liveness probe needs GNU find's -newermt (the workers ship
-                # GNU findutils/coreutils; we already rely on `stat -c`). Probe it
+                # The liveness probe needs find's -newermt (the workers' find
+                # supports it; we already rely on `stat -c`). Probe it
                 # once: if it is unsupported (BSD/busybox find), the probe would
                 # silently return "no activity" and every past-ttl lock would look
                 # dead -> peers would break LIVE holders mid-download and re-induce
@@ -253,7 +253,7 @@ environment_configs:
                 have_newermt=1
                 if ! find "${HFPULL_LAST_OUT}" -newermt "@0" >/dev/null 2>&1; then
                     have_newermt=0
-                    echo "hfpull: 'find -newermt' unsupported (GNU findutils required); will wait for the lock holder without reclaiming stale locks, to avoid breaking a live download" >&2
+                    echo "hfpull: this find lacks '-newermt'; will wait for the lock holder without reclaiming stale locks, to avoid breaking a live download" >&2
                 fi
                 if ! mkdir -p "${container}" 2>/dev/null; then
                     echo "hfpull: cannot create lock container ${container}; proceeding without lock" >&2
@@ -285,17 +285,17 @@ environment_configs:
                         return 0
                     fi
                     now="$(date +%s)"
-                    # Without GNU find the reclaim branch below is disabled, so a
-                    # crashed holder's lock would never be reclaimed and this loop
-                    # would spin forever. Bound the wait by the ttl window, then
-                    # proceed unlocked (HF's per-file locks + self-heal are the
-                    # backstop), matching the infra-failure fall-through above. The
-                    # Python path reclaims a dead holder via ttl on every platform;
-                    # the shell can only approximate that here by giving up the
-                    # wait. A live holder legitimately exceeding ttl on such a
-                    # worker is the accepted cost of a missing GNU find.
+                    # Without -newermt support the reclaim branch below is
+                    # disabled, so a crashed holder's lock would never be reclaimed
+                    # and this loop would spin forever. Bound the wait by the ttl
+                    # window, then proceed unlocked (HF's per-file locks + self-heal
+                    # are the backstop), matching the infra-failure fall-through
+                    # above. The Python path reclaims a dead holder via ttl on every
+                    # platform; the shell can only approximate that here by giving
+                    # up the wait. A live holder legitimately exceeding ttl on such
+                    # a worker is the accepted cost of a find without -newermt.
                     if (( ! have_newermt )) && (( now - start >= ttl )); then
-                        echo "hfpull: waited ${ttl}s for download lock ${lockdir} with no liveness probe (GNU find required to reclaim a dead holder); proceeding without lock" >&2
+                        echo "hfpull: waited ${ttl}s for download lock ${lockdir} with no liveness probe (find -newermt required to reclaim a dead holder); proceeding without lock" >&2
                         return 0
                     fi
                     if (( have_newermt )) && (( now - last_check >= interval )); then


### PR DESCRIPTION
## Summary

Follow-up to #322 (round-8 review, finding A). Fixes an unbounded-wait hang in the LSF/skypilot shell hfpull steps on workers whose `find` lacks `-newermt`.

`hfpull_acquire_lock` waits for the cross-process download lock in an unbounded `while :; do … sleep 1; done` loop. Its stale-holder reclaim is gated behind a `find -newermt` capability probe — a #322 fail-safe so a *missing* liveness probe can't break a **live** holder mid-download (re-inducing #320). On a worker whose `find` lacks `-newermt` (BSD/busybox), reclaim is disabled, so a **crashed** holder's lock is never reclaimed *and* never times out → every peer sharing that destination loops forever.

The Python path (`SharedFileSystemLock`) is unaffected: its liveness probe uses `os.walk`/`os.stat` (no `find`), so ttl reclaim of a dead holder works on every platform.

**Fix:** add a wall-clock deadline that applies **only** when the `find -newermt` probe failed (`have_newermt=0`): bound the wait to the ttl window (`GB_HFPULL_LOCK_TIMEOUT`, default 900s), then fall through *unlocked* — relying on HF's per-file locks + the corrupt-cache self-heal, matching the existing infra-failure fall-through. When the probe succeeds, behavior is unchanged (indefinite wait + progress-based reclaim, matching Python).

Reusing the ttl window as the cap avoids a new tuning knob: with `-newermt`, a dead holder is reclaimed after `ttl` of no progress, so without a progress probe, waiting `ttl` then proceeding unlocked is the closest bounded analogue. A *live* holder legitimately exceeding ttl on such a worker is the accepted, documented cost (self-heal backstops any overlap).

Applied identically to `command.sh` (LSF) and `step.yaml` (skypilot); the `test_hfpull_shell_serialization` parity test keeps the two copies in lockstep. No Python change.

## Test plan

- [x] Shell parity: LSF and skypilot shared-shell blocks remain byte-identical in executable lines (200 lines each, in sync).
- [x] `bash -n` clean on both shared-shell blocks.
- [x] Functional (isolated, real `hfpull_acquire_lock` sourced from the file): with the `-newermt` probe forced to fail and a peer holding the lock, acquire falls through **unlocked** after ~ttl (`rc=0`, no lock held) and leaves the peer's lock intact — instead of looping forever.
- [x] Verified by inspection that the new deadline is gated on `(( ! have_newermt ))`, so the `-newermt` path (indefinite wait + reclaim) is unchanged.

Fixes #352
