### PR TITLE
hfpull lock: fix release/reclaim on mounts without atomic dir rename

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -127,6 +127,46 @@ into this.
 The dump is also useful when reproducing a customer's failure: it captures
 target/step state at the moment the assertion fired.
 
+## hfpull steps hang (concurrent pulls of the same model)
+
+When several targets pull the same `hf://` model into the shared cache, the
+pulls are serialized by a cross-process lock (a `mkdir` lock dir at
+`<cache>/<owner>/<repo>/.gb-hfpull-locks/<hash>.lock`, holding a `lock.info` of
+`host:...|pid:...` + a start timestamp). If one target finished but the others
+stay stuck — and the log repeats `breaking stale lock ...` — a holder failed to
+remove its lock. (This happened on object-store/AFM-backed caches where a
+directory rename fails; fixed in
+[#354](https://github.com/ibm-granite/granite.build/issues/354). Older images
+still hit it.)
+
+How reclaim works — worth knowing before you touch anything:
+
+- **Reclaim is passive**, driven by the *next* acquirer; there is no background
+  sweeper. A crashed holder's lock is broken by the next waiter once it is past
+  `GB_HFPULL_LOCK_TIMEOUT` (default **900s / 15 min**) with no writes under the
+  holder's HF scratch dir (`<hash>/.cache/huggingface/download/`). The window is
+  measured from the dead holder's *last write* and only elapses while a fresh
+  waiter is polling — so a crashed pull self-heals on the next pull. Routine
+  manual wiping is not required.
+- The `.gb-hfpull-locks/` **container** is never removed by design (removing it
+  races a peer creating a sibling lock), so one empty container dir persists per
+  `<owner>/<repo>/`. That is not a leak.
+
+To clear a stuck lock faster than the 15-min auto-recovery — **only when no
+hfpull is running for that repo**:
+
+```bash
+# 1. Confirm the recorded holder is dead (and, cross-node, nothing is writing
+#    under the sibling <hash>/.cache/huggingface/download/).
+cat <cache>/<owner>/<repo>/.gb-hfpull-locks/<hash>.lock/lock.info
+# 2. Then remove the lock (waiters grab it within ~1 poll):
+rm -rf <cache>/<owner>/<repo>/.gb-hfpull-locks/<hash>.lock
+```
+
+Deleting a *live* holder's lock reopens the corruption race from
+[#320](https://github.com/ibm-granite/granite.build/issues/320) — confirm the
+holder is dead first. Tune the window with `GB_HFPULL_LOCK_TIMEOUT` (seconds).
+
 ## Where to look when nothing else works
 
 - `gb build status <id>` — high-level state, errors per step.

--- a/src/gbcommon/utils/fs_lock.py
+++ b/src/gbcommon/utils/fs_lock.py
@@ -98,6 +98,31 @@ OWNERSHIP_READ_RETRY_INTERVAL_S = 0.2
 # breaker's and is reaped rather than left to wedge future breaks.
 BREAK_CLAIM_SUFFIX = ".breaking"
 
+# On mounts that cannot rename a directory the removal fallback is the *normal*
+# path, so a per-call WARNING would flood the log. Announce it once per process
+# at INFO (so an operator sees the fallback is in use) and drop to DEBUG after.
+_rename_fallback_logged = False
+
+
+def _note_rename_unsupported(lock_path: Path, err: OSError) -> None:
+    """Log the directory-rename removal fallback once per process, then DEBUG."""
+    global _rename_fallback_logged
+    if not _rename_fallback_logged:
+        _rename_fallback_logged = True
+        logger.info(
+            "SharedFileSystemLock: this filesystem cannot rename a directory "
+            "(%s); using the direct-delete fallback for lock removal. Expected on "
+            "object-store/AFM-backed caches; not logged again this process.",
+            err,
+        )
+    else:
+        logger.debug(
+            "SharedFileSystemLock: os.replace of %s failed (%s); using the "
+            "no-rename removal fallback",
+            lock_path,
+            err,
+        )
+
 
 def _has_recent_activity(root: Path, min_mtime: float) -> bool:
     """True if *root* or any file under it was modified at/after *min_mtime*.
@@ -223,6 +248,7 @@ class SharedFileSystemLock:
         deadline = None if self.timeout is None else time.monotonic() + self.timeout
         self._last_acquire_error = None
         self._next_stale_check = 0.0  # check on the first contended poll
+        announced_wait = False  # so the "waiting" INFO is logged once, not per poll
         # Create the container dir once up front rather than on every poll (a
         # contended wait can otherwise re-issue this mkdir hundreds of times).
         # The container is not removed on release, so nothing recreates it mid-
@@ -276,8 +302,23 @@ class SharedFileSystemLock:
                         pass
                     return False
                 self._held = True
+                logger.info(
+                    "SharedFileSystemLock: acquired %s (%s)",
+                    self.lock_path,
+                    self.identity,
+                )
                 return True
 
+            # Reached only when contended and about to wait (a successful acquire
+            # returns above; a successful stale-break `continue`s). Announce the
+            # wait once so the log shows who is blocked on whom, not every poll.
+            if not announced_wait:
+                announced_wait = True
+                logger.info(
+                    "SharedFileSystemLock: %s is held; waiting (%s)",
+                    self.lock_path,
+                    self.identity,
+                )
             if deadline is None:
                 time.sleep(self.poll_interval)
                 continue
@@ -299,6 +340,11 @@ class SharedFileSystemLock:
                 # whatever occupies the path, which may now be the peer's. If the
                 # captured dir is not ours, it is restored instead of removed.
                 self._move_aside_and_remove("released", verify_ours=True)
+                logger.info(
+                    "SharedFileSystemLock: released %s (%s)",
+                    self.lock_path,
+                    self.identity,
+                )
         except OSError:
             # Another process may have force-cleared a stale lock; don't crash
             # cleanup over it.
@@ -340,15 +386,10 @@ class SharedFileSystemLock:
             # The mount cannot rename a directory (object-store/AFM-backed FUSE:
             # os.mkdir works but os.replace does not), so the capture cannot run.
             # Fall back to a direct removal that keeps the same guarantees via
-            # os.mkdir -- the primitive verified atomic here (issue #354). Logged,
-            # not swallowed: silently dropping this is what let a leaked lock hang
-            # every waiter for the full ttl.
-            logger.warning(
-                "SharedFileSystemLock: os.replace of %s failed (%s); using the "
-                "no-rename removal fallback",
-                self.lock_path,
-                e,
-            )
+            # os.mkdir -- the primitive verified atomic here (issue #354). Logged
+            # (once per process, then DEBUG), not swallowed: silently dropping this
+            # is what let a leaked lock hang every waiter for the full ttl.
+            _note_rename_unsupported(self.lock_path, e)
             return self._remove_without_rename(verify_ours=verify_ours)
         if verify_ours and self._identity_at(graveyard / "lock.info") != self.identity:
             # Captured a dir a peer recreated in the check/act window -- restore

--- a/src/gbcommon/utils/fs_lock.py
+++ b/src/gbcommon/utils/fs_lock.py
@@ -52,6 +52,15 @@ rename cannot close; the on-acquire reaper cleans the orphan). This whole race i
 unreachable when a ``progress_path`` is set -- a releasing holder has just
 written, so a peer never declares it stale to begin with -- and only a
 ``ttl``-without-``progress_path`` caller can approach it.
+
+Some shared mounts (object-store/AFM-backed FUSE) support ``os.mkdir`` but *not*
+renaming a directory, so ``os.replace`` cannot run there at all -- left
+unhandled, that leaks every lock and hangs waiters for the full ``ttl`` (issue
+#354). When ``os.replace`` fails, removal falls back to a direct delete that
+keeps the same guarantees using ``os.mkdir``: release deletes only after
+re-confirming ownership, and the stale-break selects a single winner via an
+atomic ``mkdir`` of a ``<lock>.breaking`` claim (reaped if a crashed breaker
+leaves it behind).
 """
 
 import logging
@@ -79,6 +88,15 @@ DEFAULT_TIMEOUT_S = 10.0
 # reserved for the ambiguous transient-error case.
 OWNERSHIP_READ_RETRIES = 3
 OWNERSHIP_READ_RETRY_INTERVAL_S = 0.2
+
+# Suffix for the break-claim marker used by the dir-rename fallback (issue #354).
+# On mounts that do not support renaming a directory (object-store/AFM-backed
+# FUSE), ``os.replace`` cannot capture the lock dir, so the stale-break selects a
+# single winner by atomically ``mkdir``-ing ``<lock>.breaking`` instead -- the one
+# operation verified atomic there. The winner alone deletes the stale lock; the
+# marker is held only across that delete, so one older than ``ttl`` is a crashed
+# breaker's and is reaped rather than left to wedge future breaks.
+BREAK_CLAIM_SUFFIX = ".breaking"
 
 
 def _has_recent_activity(root: Path, min_mtime: float) -> bool:
@@ -313,8 +331,25 @@ class SharedFileSystemLock:
         )
         try:
             os.replace(self.lock_path, graveyard)
-        except OSError:
+        except FileNotFoundError:
+            # A racer already moved lock_path aside; we lost. (Distinct from the
+            # OSError below so a genuine handoff is not mistaken for a mount that
+            # cannot rename.)
             return False
+        except OSError as e:
+            # The mount cannot rename a directory (object-store/AFM-backed FUSE:
+            # os.mkdir works but os.replace does not), so the capture cannot run.
+            # Fall back to a direct removal that keeps the same guarantees via
+            # os.mkdir -- the primitive verified atomic here (issue #354). Logged,
+            # not swallowed: silently dropping this is what let a leaked lock hang
+            # every waiter for the full ttl.
+            logger.warning(
+                "SharedFileSystemLock: os.replace of %s failed (%s); using the "
+                "no-rename removal fallback",
+                self.lock_path,
+                e,
+            )
+            return self._remove_without_rename(verify_ours=verify_ours)
         if verify_ours and self._identity_at(graveyard / "lock.info") != self.identity:
             # Captured a dir a peer recreated in the check/act window -- restore
             # it rather than delete a live peer's lock.
@@ -325,6 +360,63 @@ class SharedFileSystemLock:
             return False
         shutil.rmtree(graveyard, ignore_errors=True)
         return True
+
+    def _remove_without_rename(self, *, verify_ours: bool) -> bool:
+        """Remove ``lock_path`` directly, for mounts without atomic dir rename.
+
+        Used only when :meth:`_move_aside_and_remove`'s ``os.replace`` capture is
+        unavailable (issue #354). Preserves the same guarantees using ``os.mkdir``
+        -- the one operation verified atomic/coherent on these shared mounts.
+        Returns whether ``lock_path`` is gone afterwards.
+
+        * release (``verify_ours=True``): re-confirm the on-disk lock still records
+          us immediately before deleting, so a peer that stale-broke and recreated
+          it is not destroyed; if it is no longer ours, leave it. (For hfpull this
+          check/act window is unreachable anyway -- a releasing holder has just
+          written under its ``progress_path``, so no peer declares it stale.)
+        * stale-break (``verify_ours=False``): atomically ``mkdir`` a
+          ``<lock>.breaking`` claim so exactly one waiter deletes the stale dir;
+          losers back off and just retry their ``mkdir`` of ``lock_path`` (itself
+          single-winner). A claim older than ``ttl`` is a crashed breaker's and is
+          reaped, so it cannot wedge the break.
+        """
+        if verify_ours:
+            if not self._owned_by_us():
+                return False
+            shutil.rmtree(self.lock_path, ignore_errors=True)
+            return not self.lock_path.exists()
+
+        claim = self.lock_path.with_name(self.lock_path.name + BREAK_CLAIM_SUFFIX)
+        try:
+            os.mkdir(claim)
+        except FileExistsError:
+            # Another waiter holds the break-claim. If it is an abandoned (aged)
+            # claim from a crashed breaker, reap it so a later poll can retry;
+            # otherwise a live breaker has it and we simply back off.
+            self._reap_if_abandoned(claim)
+            return False
+        except OSError:
+            return False
+        try:
+            shutil.rmtree(self.lock_path, ignore_errors=True)
+        finally:
+            shutil.rmtree(claim, ignore_errors=True)
+        return not self.lock_path.exists()
+
+    def _reap_if_abandoned(self, claim: Path) -> None:
+        """Reap a break-claim only if it is older than ``ttl`` (crashed breaker).
+
+        A live breaker holds the claim across a single ``rmtree`` (far younger
+        than any sensible ``ttl``), so an aged claim is abandoned. Without a
+        ``ttl`` the stale-break never runs, so no claim is ever created.
+        """
+        if self.ttl is None:
+            return
+        try:
+            if time.time() - claim.stat().st_mtime > self.ttl:
+                shutil.rmtree(claim, ignore_errors=True)
+        except OSError:
+            pass
 
     def _reap_graveyards(self) -> None:
         """Sweep leftover moved-aside lock dirs from the container (best-effort).

--- a/src/gbcommon/utils/fs_lock.py
+++ b/src/gbcommon/utils/fs_lock.py
@@ -339,12 +339,16 @@ class SharedFileSystemLock:
                 # would otherwise have its live dir deleted -- os.replace acts on
                 # whatever occupies the path, which may now be the peer's. If the
                 # captured dir is not ours, it is restored instead of removed.
-                self._move_aside_and_remove("released", verify_ours=True)
-                logger.info(
-                    "SharedFileSystemLock: released %s (%s)",
-                    self.lock_path,
-                    self.identity,
-                )
+                if self._move_aside_and_remove("released", verify_ours=True):
+                    # Log only on an actual removal -- not when the capture
+                    # restored a peer's dir it had recreated in the check/act
+                    # window (return False). That race is unreachable with a
+                    # progress_path set, as hfpull always does.
+                    logger.info(
+                        "SharedFileSystemLock: released %s (%s)",
+                        self.lock_path,
+                        self.identity,
+                    )
         except OSError:
             # Another process may have force-cleared a stale lock; don't crash
             # cleanup over it.

--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -178,6 +178,12 @@ hfpull_release_lock() {
         grave="${HFPULL_LOCK_DIR}.released.$$.${RANDOM}"
         if mv "${HFPULL_LOCK_DIR}" "${grave}" 2>/dev/null; then
             rm -rf "${grave}" 2>/dev/null || true
+        else
+            # Mount cannot rename a directory (mv fails, e.g. ENOTEMPTY on an
+            # object-store/AFM FUSE cache). Ownership is already confirmed, so
+            # delete our own lock directly (matches _remove_without_rename,
+            # verify_ours path).
+            rm -rf "${HFPULL_LOCK_DIR}" 2>/dev/null || true
         fi
     fi
     HFPULL_LOCK_DIR=""
@@ -201,12 +207,28 @@ hfpull_written_since() {
 
 # Break a stale lock by moving it aside atomically, then removing the moved
 # copy (single winner; matches _move_aside_and_remove). A loser's mv fails and
-# it simply retries mkdir.
+# it simply retries mkdir. Where the mount cannot rename a directory (mv fails
+# wholesale, e.g. ENOTEMPTY on object-store/AFM FUSE), fall back to a
+# single-winner delete: exactly one waiter claims the break via an atomic mkdir
+# of a .breaking marker, deletes the stale lock, then drops the claim; losers
+# skip and retry mkdir. An aged claim (older than ttl) is a crashed breaker's
+# and is reaped so it cannot wedge the break. Matches
+# SharedFileSystemLock._remove_without_rename / _reap_if_abandoned.
 hfpull_break_lock() {
-    local lockdir="$1" grave
+    local lockdir="$1" ttl="$2" grave claim cnow cmtime
     grave="${lockdir}.stale.$$.${RANDOM}"
     if mv "${lockdir}" "${grave}" 2>/dev/null; then
         rm -rf "${grave}" 2>/dev/null || true
+        return
+    fi
+    claim="${lockdir}.breaking"
+    if mkdir "${claim}" 2>/dev/null; then
+        rm -rf "${lockdir}" 2>/dev/null || true
+        rm -rf "${claim}" 2>/dev/null || true
+    else
+        cnow="$(date +%s)"
+        cmtime="$(stat -c %Y "${claim}" 2>/dev/null || echo "${cnow}")"
+        if (( cnow - cmtime > ttl )); then rm -rf "${claim}" 2>/dev/null || true; fi
     fi
 }
 
@@ -289,7 +311,7 @@ hfpull_acquire_lock() {
             if ! [[ "${created}" =~ ^[0-9]+$ ]]; then created=0; fi
             if (( now - created > ttl )) && ! hfpull_written_since "${scratch}" "$(( now - ttl ))"; then
                 echo "hfpull: reclaiming stale download lock ${lockdir} (no download progress in ${scratch} for >${ttl}s)" >&2
-                hfpull_break_lock "${lockdir}"
+                hfpull_break_lock "${lockdir}" "${ttl}"
                 continue
             fi
         fi

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -192,6 +192,12 @@ environment_configs:
                     grave="${HFPULL_LOCK_DIR}.released.$$.${RANDOM}"
                     if mv "${HFPULL_LOCK_DIR}" "${grave}" 2>/dev/null; then
                         rm -rf "${grave}" 2>/dev/null || true
+                    else
+                        # Mount cannot rename a directory (mv fails, e.g.
+                        # ENOTEMPTY on an object-store/AFM FUSE cache). Ownership
+                        # is already confirmed, so delete our own lock directly
+                        # (matches _remove_without_rename, verify_ours path).
+                        rm -rf "${HFPULL_LOCK_DIR}" 2>/dev/null || true
                     fi
                 fi
                 HFPULL_LOCK_DIR=""
@@ -218,10 +224,20 @@ environment_configs:
             # moved copy (single winner; matches _move_aside_and_remove). A loser's
             # mv fails and it simply retries mkdir.
             hfpull_break_lock() {
-                local lockdir="$1" grave
+                local lockdir="$1" ttl="$2" grave claim cnow cmtime
                 grave="${lockdir}.stale.$$.${RANDOM}"
                 if mv "${lockdir}" "${grave}" 2>/dev/null; then
                     rm -rf "${grave}" 2>/dev/null || true
+                    return
+                fi
+                claim="${lockdir}.breaking"
+                if mkdir "${claim}" 2>/dev/null; then
+                    rm -rf "${lockdir}" 2>/dev/null || true
+                    rm -rf "${claim}" 2>/dev/null || true
+                else
+                    cnow="$(date +%s)"
+                    cmtime="$(stat -c %Y "${claim}" 2>/dev/null || echo "${cnow}")"
+                    if (( cnow - cmtime > ttl )); then rm -rf "${claim}" 2>/dev/null || true; fi
                 fi
             }
 
@@ -310,7 +326,7 @@ environment_configs:
                         if ! [[ "${created}" =~ ^[0-9]+$ ]]; then created=0; fi
                         if (( now - created > ttl )) && ! hfpull_written_since "${scratch}" "$(( now - ttl ))"; then
                             echo "hfpull: reclaiming stale download lock ${lockdir} (no download progress in ${scratch} for >${ttl}s)" >&2
-                            hfpull_break_lock "${lockdir}"
+                            hfpull_break_lock "${lockdir}" "${ttl}"
                             continue
                         fi
                     fi

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -222,7 +222,14 @@ environment_configs:
 
             # Break a stale lock by moving it aside atomically, then removing the
             # moved copy (single winner; matches _move_aside_and_remove). A loser's
-            # mv fails and it simply retries mkdir.
+            # mv fails and it simply retries mkdir. Where the mount cannot rename a
+            # directory (mv fails wholesale, e.g. ENOTEMPTY on object-store/AFM
+            # FUSE), fall back to a single-winner delete: exactly one waiter claims
+            # the break via an atomic mkdir of a .breaking marker, deletes the
+            # stale lock, then drops the claim; losers skip and retry mkdir. An
+            # aged claim (older than ttl) is a crashed breaker's and is reaped so
+            # it cannot wedge the break. Matches
+            # SharedFileSystemLock._remove_without_rename / _reap_if_abandoned.
             hfpull_break_lock() {
                 local lockdir="$1" ttl="$2" grave claim cnow cmtime
                 grave="${lockdir}.stale.$$.${RANDOM}"

--- a/test/unit/environment/test_hfpull_shell_serialization.py
+++ b/test/unit/environment/test_hfpull_shell_serialization.py
@@ -42,6 +42,7 @@ _REQUIRED = [
     "--force-download",  # corrupt-cache self-heal retry
     ".cache/huggingface/download",  # scratch-cache clear on repeated corruption
     "Consistency check failed",  # recoverable-error classification
+    ".breaking",  # no-rename removal fallback: single-winner break claim (#354)
 ]
 
 

--- a/test/unit/utils/test_fs_lock.py
+++ b/test/unit/utils/test_fs_lock.py
@@ -399,6 +399,24 @@ def test_rename_unsupported_notice_logged_once_per_process(tmp_path, caplog):
     assert len(notices) == 1, f"expected one INFO notice, got {len(notices)}"
 
 
+def test_release_logs_released_only_when_it_actually_removed(tmp_path, caplog):
+    """release() logs 'released' only on an actual removal, not a peer-dir restore.
+
+    In the stale-break-then-recreate race, _move_aside_and_remove restores the
+    peer's recreated dir and returns False; release must not then claim the lock
+    was 'released' (misleading in the log). Gate the INFO on the return value.
+    """
+    lock = SharedFileSystemLock(tmp_path / "rel.lock", timeout=1)
+    assert lock.acquire() is True
+    with caplog.at_level(logging.INFO, logger="gbcommon.utils.fs_lock"):
+        with patch.object(lock, "_move_aside_and_remove", return_value=False):
+            lock.release()
+    # Match the message template (not the formatted path, which can contain the
+    # test name "...released...").
+    released = [r for r in caplog.records if "released" in str(r.msg)]
+    assert released == [], "must not log 'released' when the lock was not removed"
+
+
 def test_still_owned_reflects_on_disk_ownership(tmp_path):
     """still_owned() re-reads the FS, so it flips False once a peer reclaims us."""
     lock = SharedFileSystemLock(tmp_path / "s.lock", timeout=1)

--- a/test/unit/utils/test_fs_lock.py
+++ b/test/unit/utils/test_fs_lock.py
@@ -278,6 +278,101 @@ def test_timeout_none_reclaims_dead_holder_without_hanging(tmp_path):
     lock.release()
 
 
+# --- removal must survive a mount without atomic directory rename ----------
+#
+# The removal path (release and stale-break) renames the lock dir aside with
+# ``os.replace`` before deleting it, as a TOCTOU guard. But ``os.replace`` of a
+# directory is a rename, and the object-store/AFM-backed FUSE mounts these locks
+# target (see the module docstring) do not support renaming a directory: it
+# raises OSError there. ``mkdir`` (acquire) works on such a mount but
+# ``os.replace`` (removal) does not -- an asymmetry that leaks every lock. These
+# tests pin the observed production hang (build e87ceebb: a holder's release
+# left the lock behind and waiters re-logged "breaking stale lock" every poll
+# forever under ``timeout=None``) by simulating that rename failure.
+
+# ENOTSUP is what a directory rename raises on an object-store-backed FUSE mount.
+_DIR_RENAME_UNSUPPORTED = OSError(95, "Operation not supported")
+
+
+def test_release_removes_owned_lock_when_dir_rename_unsupported(tmp_path):
+    """Release must free an owned lock even where directory rename is unsupported.
+
+    Currently ``release`` removes the lock only via ``os.replace``; when that
+    raises it is swallowed and the lock dir is left behind (a leak that blocks
+    every waiter for the full ttl). Removal must fall back to a direct delete so
+    an owned lock is actually freed.
+    """
+    lock = SharedFileSystemLock(tmp_path / "rn.lock", timeout=1)
+    assert lock.acquire() is True
+
+    with patch("os.replace", side_effect=_DIR_RENAME_UNSUPPORTED):
+        lock.release()
+
+    assert lock.is_held is False
+    assert (
+        not lock.lock_path.exists()
+    ), "an owned lock must be freed even without dir rename"
+
+
+def test_stale_lock_reclaimed_when_dir_rename_unsupported(tmp_path):
+    """A dead holder's lock must be reclaimable where directory rename is unsupported.
+
+    Same mount limitation as release: if the stale-break's ``os.replace`` raises
+    and is swallowed, ``_clear_if_stale`` never clears the lock, so a waiter
+    (``timeout=None`` in hfpull) re-logs "breaking stale lock" every poll and
+    hangs forever. The break must fall back to a direct delete.
+    """
+    lock_path = tmp_path / "repo" / ".gb-hfpull-locks" / "rev.lock"
+    dest = tmp_path / "repo" / "rev"
+    dest.mkdir(parents=True)
+    old = time.time() - 1000
+    os.utime(dest, (old, old))  # no recent progress => holder looks dead
+    _stale_peer_lock(lock_path, age_s=1000)
+
+    lock = SharedFileSystemLock(
+        lock_path, timeout=1, poll_interval=0.02, ttl=1, progress_path=dest
+    )
+    with patch("os.replace", side_effect=_DIR_RENAME_UNSUPPORTED):
+        acquired = lock.acquire()
+
+    assert (
+        acquired is True
+    ), "a dead holder's lock must be reclaimed even without dir rename"
+    lock.release()
+
+
+def test_abandoned_break_claim_does_not_wedge_stale_reclaim(tmp_path):
+    """A crashed breaker's leftover claim must not deadlock future stale-breaks.
+
+    The dir-rename fallback picks a single break winner via an atomic ``mkdir``
+    of a ``<lock>.breaking`` marker. A breaker holds that marker only across one
+    ``rmtree``, so a marker older than the ttl is a crashed breaker's abandoned
+    claim; it must be reaped or every future waiter would block on it forever --
+    reintroducing the very hang #354 fixes.
+    """
+    lock_path = tmp_path / "repo" / ".gb-hfpull-locks" / "rev.lock"
+    dest = tmp_path / "repo" / "rev"
+    dest.mkdir(parents=True)
+    old = time.time() - 1000
+    os.utime(dest, (old, old))  # no recent progress => holder looks dead
+    _stale_peer_lock(lock_path, age_s=1000)
+    # A previous breaker crashed still holding the claim; make it clearly aged.
+    claim = lock_path.with_name(lock_path.name + ".breaking")
+    claim.mkdir()
+    os.utime(claim, (old, old))
+
+    lock = SharedFileSystemLock(
+        lock_path, timeout=2, poll_interval=0.02, ttl=1, progress_path=dest
+    )
+    with patch("os.replace", side_effect=_DIR_RENAME_UNSUPPORTED):
+        acquired = lock.acquire()
+
+    assert (
+        acquired is True
+    ), "an abandoned break-claim must be reaped, not deadlock the break"
+    lock.release()
+
+
 def test_still_owned_reflects_on_disk_ownership(tmp_path):
     """still_owned() re-reads the FS, so it flips False once a peer reclaims us."""
     lock = SharedFileSystemLock(tmp_path / "s.lock", timeout=1)

--- a/test/unit/utils/test_fs_lock.py
+++ b/test/unit/utils/test_fs_lock.py
@@ -16,6 +16,7 @@
 
 """Unit tests for ``SharedFileSystemLock`` (mkdir-based cross-node lock)."""
 
+import logging
 import os
 import time
 from pathlib import Path
@@ -371,6 +372,31 @@ def test_abandoned_break_claim_does_not_wedge_stale_reclaim(tmp_path):
         acquired is True
     ), "an abandoned break-claim must be reaped, not deadlock the break"
     lock.release()
+
+
+def test_rename_unsupported_notice_logged_once_per_process(tmp_path, caplog):
+    """The dir-rename fallback notice fires once per process, not per release.
+
+    On a mount without directory rename the fallback is the *normal* path, so a
+    per-release WARNING would flood logs and look like a recurring fault. The
+    "cannot rename" notice is emitted once at INFO; later fallbacks stay quiet
+    (DEBUG).
+    """
+    fs_lock._rename_fallback_logged = False  # reset the process-wide flag
+    with patch("os.replace", side_effect=OSError(39, "Directory not empty")):
+        with caplog.at_level(logging.INFO, logger="gbcommon.utils.fs_lock"):
+            for name in ("one.lock", "two.lock", "three.lock"):
+                lock = SharedFileSystemLock(tmp_path / name, timeout=1)
+                assert lock.acquire() is True
+                lock.release()
+                assert not lock.lock_path.exists()  # fallback still frees each lock
+
+    notices = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "cannot rename a directory" in r.getMessage()
+    ]
+    assert len(notices) == 1, f"expected one INFO notice, got {len(notices)}"
 
 
 def test_still_owned_reflects_on_disk_ownership(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #354 — `SharedFileSystemLock` (and its LSF/skypilot shell mirrors) could never remove a lock on caches whose filesystem cannot rename a directory (object-store/AFM-backed FUSE), because removal went only through a directory rename (`os.replace` / shell `mv`) whose failure was swallowed. The holder leaked its lock on release and waiters looped `breaking stale lock` for the full ttl (900s). Confirmed on DEV `vela_public` (`[Errno 39] Directory not empty`).

### k8s / Python path
- `_move_aside_and_remove` falls back to a direct delete when `os.replace` raises: **release** re-confirms ownership then `rmtree`s; **stale-break** selects a single winner via an atomic `mkdir` of a `<lock>.breaking` claim (an aged claim from a crashed breaker is reaped so it cannot wedge the break). The rename fast path (GPFS / normal FS) is unchanged.

### LSF + skypilot shell mirrors
- Same fallback mirrored in `hfpull_release_lock` (`rm -rf` of the owned lock when `mv` fails) and `hfpull_break_lock` (single-winner `mkdir <lock>.breaking` + aged-claim reap). Both shell copies stay byte-identical via the shared-shell sync guard; a new `.breaking` required-marker pins the removal mechanism so it can't silently drop. (LSF on GPFS renames fine; this mainly matters for object-store-backed mounts.)

### Logging
- INFO lifecycle logging — acquire, contended wait-start (once), release — each tagged with the lock `identity` (`host|pid`). The dir-rename fallback notice is logged once per process at INFO (DEBUG thereafter) rather than a per-call WARNING, so it does not flood the log on mounts where the fallback is the normal path.

### Docs
- `docs/help/troubleshooting.md` gains an hfpull-hang / lock section: passive reclaim by the next acquirer, the 900s-from-last-write window, the persistent `.gb-hfpull-locks` container, and the confirm-dead-first manual wipe.

## Test plan

- [x] `pytest test/unit/utils/test_fs_lock.py` — 32 passed (fallback, single-winner break, abandoned-claim reap, log-once).
- [x] `pytest test/unit/environment/test_hfpull_shell_serialization.py` — 4 passed (shell copies in sync; `.breaking` pinned).
- [x] `pytest test/unit/uri/test_hf_pull_lock.py` green; full `test/unit` = 2643 passed (2 unrelated live-github.ibm.com-API failures).
- [x] DEV: k8s path validated end-to-end (fallback fired, lock released). Shell (LSF/skypilot) paths pending DEV re-test.

Closes #354

Generated with [Claude Code](https://claude.com/claude-code)
