### PR TITLE
fix(hfpull): avoid ${#var} in skypilot step template (Jinja comment token)

### DIFF
--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -87,7 +87,7 @@ hf_env_flag() {
 HFPULL_LOCK_TTL_DEFAULT=900
 HFPULL_LOCK_TTL_MAX=31536000
 hfpull_lock_ttl() {
-    local raw="${GB_HFPULL_LOCK_TIMEOUT:-}" intpart secs
+    local raw="${GB_HFPULL_LOCK_TIMEOUT:-}" intpart secs ndigits
     if [[ -z "${raw// }" ]]; then echo "${HFPULL_LOCK_TTL_DEFAULT}"; return; fi
     if [[ "${raw}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
         intpart="${raw%%.*}"
@@ -95,8 +95,13 @@ hfpull_lock_ttl() {
         # magnitude (all-zeros -> empty -> 0).
         intpart="${intpart#"${intpart%%[!0]*}"}"; [[ -z "${intpart}" ]] && intpart=0
         # >8 significant digits necessarily exceeds the 1-year cap and would risk
-        # overflowing bash arithmetic, so clamp before computing.
-        if (( ${#intpart} > 8 )); then
+        # overflowing bash arithmetic, so clamp before computing. The digit count
+        # is taken with `wc -c` rather than ${#intpart}: the skypilot copy of this
+        # block is rendered through Jinja, which reads the `{#` in ${#...} as a
+        # comment-open and fails to compile the whole step (nightly regression).
+        # intpart is pure digits here, so a byte count equals the digit count.
+        ndigits="$(printf %s "${intpart}" | wc -c)"
+        if (( ndigits > 8 )); then
             secs="${HFPULL_LOCK_TTL_MAX}"
         else
             secs=$(( 10#${intpart} ))  # base 10 so a leading zero is not octal

--- a/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
+++ b/src/gbserver/builtins/steps/skypilot/hfpull/step.yaml
@@ -94,7 +94,7 @@ environment_configs:
             HFPULL_LOCK_TTL_DEFAULT=900
             HFPULL_LOCK_TTL_MAX=31536000
             hfpull_lock_ttl() {
-                local raw="${GB_HFPULL_LOCK_TIMEOUT:-}" intpart secs
+                local raw="${GB_HFPULL_LOCK_TIMEOUT:-}" intpart secs ndigits
                 if [[ -z "${raw// }" ]]; then echo "${HFPULL_LOCK_TTL_DEFAULT}"; return; fi
                 if [[ "${raw}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
                     intpart="${raw%%.*}"
@@ -103,7 +103,13 @@ environment_configs:
                     intpart="${intpart#"${intpart%%[!0]*}"}"; [[ -z "${intpart}" ]] && intpart=0
                     # >8 significant digits necessarily exceeds the 1-year cap and
                     # would risk overflowing bash arithmetic, so clamp before it.
-                    if (( ${#intpart} > 8 )); then
+                    # The digit count is taken with `wc -c` rather than a bash
+                    # length expansion: this block is rendered through Jinja,
+                    # which reads a brace-then-hash sequence as a comment-open and
+                    # fails to compile the whole step. intpart is pure digits
+                    # here, so a byte count equals the digit count.
+                    ndigits="$(printf %s "${intpart}" | wc -c)"
+                    if (( ndigits > 8 )); then
                         secs="${HFPULL_LOCK_TTL_MAX}"
                     else
                         secs=$(( 10#${intpart} ))  # base 10 so a leading zero is not octal

--- a/test/unit/environment/test_hfpull_shell_serialization.py
+++ b/test/unit/environment/test_hfpull_shell_serialization.py
@@ -26,6 +26,9 @@ of silently regressing the shared-cache race back to the #320 behavior.
 import re
 from pathlib import Path
 
+import yaml
+from jinja2 import Environment
+
 import gbserver
 
 _STEPS = Path(gbserver.__file__).parent / "builtins" / "steps"
@@ -116,3 +119,47 @@ def test_shell_recoverable_regex_matches_python_source_of_truth():
         "HF_RECOVERABLE_CACHE_ERROR_RE; the shell workers would classify "
         "recoverable errors differently than HfURI.pull"
     )
+
+
+def _template_strings(node):
+    """Yield every string field anywhere in a parsed step.yaml.
+
+    Mirrors the render surface of ``traverse_obj`` / ``fill_objtemplate``, which
+    fills *every* string in the launcher config as a Jinja template -- not just
+    the ``run:`` block. Walking the same surface means a Jinja-hostile bash
+    construct (e.g. ``${#var}``) is caught wherever it lands, not only under
+    ``run:``.
+    """
+    if isinstance(node, dict):
+        for v in node.values():
+            yield from _template_strings(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _template_strings(item)
+    elif isinstance(node, str):
+        yield node
+
+
+def test_skypilot_hfpull_step_compiles_under_jinja():
+    """Every string in the skypilot hfpull step must be a valid Jinja template.
+
+    Unlike the LSF ``command.sh`` (shipped to the worker verbatim), the skypilot
+    step embeds its script inline and is rendered through Jinja at build creation
+    (``fill_objtemplate`` in gbserver.utils.template fills every string field, not
+    only ``run:``). Any construct Jinja reads as markup breaks that render and
+    fails the step "on creation" before it ever launches -- exactly what a bash
+    length expansion (``${#var}``) did, since its ``{#`` reads as a Jinja
+    comment-open with no closing ``#}`` (nightly SkyPilot SLURM regression).
+    Compile the same string surface the renderer does so any such construct fails
+    here, in a fast unit test, instead of only at night.
+    """
+    doc = yaml.safe_load(_SKY_HFPULL.read_text())
+    env = Environment()
+    strings = list(_template_strings(doc))
+    assert any(
+        "hfpull start" in s for s in strings
+    ), "expected the hfpull run block among the step's strings"
+    for s in strings:
+        # Raises jinja2.TemplateSyntaxError if the string contains a stray Jinja
+        # token (e.g. the {# from a ${#var} bash length expansion).
+        env.from_string(s)


### PR DESCRIPTION
## Summary

The nightly Extended Tests failed on `main` ([run 33830023320](https://github.com/ibm-granite/granite.build/actions/runs/33830023320)) with two failures in the SkyPilot SLURM integration suite (`test_skypilot_1step.py::test_runner` and `::test_runner_cancellation`). This was **not** a flake, HF error, or infra issue — it was a template-rendering regression.

- The SkyPilot hfpull step embeds its shell script inline in the launcher `run:` block, which is rendered through **Jinja** at build creation (`fill_objtemplate`).
- The bash length expansion `${#intpart}` added in #322 contains `{#`, which Jinja parses as a comment-open with no matching `#}`, so the whole step fails to render:
  ```
  jinja2.exceptions.TemplateSyntaxError: Missing end of comment tag
  ```
- The hfpull step therefore failed **"on creation"**, before ever launching on SLURM. Regular PR CI stayed green because only the extended/nightly suite runs this path.

### Fix
- Replace `${#intpart}` with `ndigits="$(printf %s "${intpart}" | wc -c)"` in **both** hfpull shell copies (`skypilot/hfpull/step.yaml` and `lsf/hfpull/lsf_scripts/hfpull/command.sh`), kept byte-identical per the shared-shell parity test. `intpart` is pure digits at that point, so a byte count equals the digit count and the `>8`-digit overflow guard is unchanged.
- Add `test_skypilot_hfpull_step_compiles_under_jinja`, which compiles every string field of the step the way the renderer does (matching `traverse_obj`/`fill_objtemplate`'s render surface, not just `run:`), so this class of stray-Jinja-token bug fails in a fast unit test instead of only in the nightly run.

## Test plan
- `pytest test/unit/environment/test_hfpull_shell_serialization.py` — all 5 pass, including the new guard and the LSF/skypilot in-sync parity check. Verified the new test **fails** when `${#intpart}` is reintroduced and **passes** after the fix.
- Ran the real `fill_objtemplate` over the actual skypilot hfpull launcher config (the exact `targetsteprun.py` call that threw in the nightly) — now renders cleanly.
- Live Docker SLURM run of the two failing tests: the nightly signatures (`Missing end of comment tag`, `the template is invalid`, `failed on creation`) are gone (0 occurrences) and the hfpull step reaches `RUNNING` (past creation).
- Verified all 12 `hfpull_lock_ttl` edge cases (empty, 0, 0.0, 0.5 to 1, leading zeros, exactly-cap, 8/9-digit clamp, huge-no-overflow, invalid, scientific) behave identically before/after.

Generated with [Claude Code](https://claude.com/claude-code)
