### PR TITLE
Fix Agent Chat for installs without gbmcp; add frontend build/test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,40 @@ jobs:
           mypy --disable-error-code=import-untyped --ignore-missing-imports src/gbcli/
           mypy --disable-error-code=import-untyped --ignore-missing-imports src/gbcommon/
 
+  # The frontend workspace (frontend/packages/ui-core + frontend/apps/standalone) had
+  # no CI coverage, so a change that broke `yarn build` or the standalone tests still
+  # reported green. Matters more now that ui-core is consumed externally as a git
+  # dependency: breakage here propagates to consumers.
+  frontend:
+    if: ${{ !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # No Node version is pinned anywhere in the repo (no .nvmrc/.node-version, no
+      # engines field), so this is a fresh choice: 22 is the active LTS, and 20 went
+      # end-of-life in April 2026.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: yarn install --frozen-lockfile
+
+      # Build before test, not merely conventionally: standalone's `test` script globs
+      # tests/*.test.js, which includes build-output.test.js — it asserts against the
+      # contents of out/ and fails if no build has run.
+      - name: Build
+        working-directory: frontend
+        run: yarn build
+
+      - name: Test
+        working-directory: frontend
+        run: yarn test
+
   test:
     if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ __pycache__/
 .Python
 develop-eggs/
 dist/
+# Anchored, NOT a bare `build/`: src/gbserver/build/ is a real tracked package
+# (gbserver.build), and a bare rule would silently stop new files there from being
+# tracked. This one path is setuptools' output when building src/gb_ui_backend's own
+# nested pyproject.toml (e.g. `pip install ./src/gb_ui_backend`), which nests
+# recursively on repeat builds because that manifest uses `where = [".."]`.
+/src/gb_ui_backend/build/
 downloads/
 eggs/
 .eggs/

--- a/src/gb_ui_backend/pyproject.toml
+++ b/src/gb_ui_backend/pyproject.toml
@@ -17,6 +17,26 @@ dependencies = [
     "aiosqlite>=0.19",
 ]
 
+[project.optional-dependencies]
+# Agent Chat's read-only dashboard tools (services/chat_agents/dashboard_tools.py).
+# Everything else they need — httpx, sqlalchemy — is already a base dependency
+# above; `regex` is the only addition.
+#
+# Deliberately does NOT pull in `mcp`: the gbmcp tool surface (build_start,
+# secret_*, build_status, ...) additionally needs the `gbmcp` console script, which
+# is coupled to gbcli's full client layer and so can't be shipped from this
+# distribution without dragging in most of the top-level one — which is the very
+# thing this distribution exists to avoid. Chat detects that at startup and runs on
+# the dashboard tools alone (see tool_loop_backend._gbmcp_available). Install the
+# top-level granite.build distribution with its own [chat] extra for the full set.
+chat = [
+    # search_build_yaml matches model-chosen regex against build.yaml content, and
+    # stdlib re never releases the GIL during a match — so a catastrophically
+    # backtracking pattern would freeze the whole single-threaded server. The regex
+    # package's timeout= is a hard bound enforced inside its own matching loop.
+    "regex",
+]
+
 [project.scripts]
 gb-ui-backend = "gb_ui_backend.__main__:main"
 

--- a/src/gb_ui_backend/services/chat_agents/tool_loop_backend.py
+++ b/src/gb_ui_backend/services/chat_agents/tool_loop_backend.py
@@ -16,7 +16,7 @@ import sys
 import time
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 from urllib.parse import urlparse
 
 from gb_ui_backend.config import (
@@ -67,16 +67,35 @@ _ROUTE_MAP_TEXT = "\n".join(
 )
 
 
-def _build_system_prompt(cloud_logs_available: bool) -> str:
-    log_search_line = (
-        "- `search_build_logs`: search a build's logs (prefer this over `build_log` when the "
-        "user wants to search history, not just the latest log)\n"
-        if cloud_logs_available
-        else ""
-    )
-    return f"""You are the granite.build dashboard assistant.
-You help users understand their builds, spaces, and artifacts using the tools available to
-you. Most tools are read-only. A few genuinely change state:
+def _gbmcp_available() -> bool:
+    """Whether the gbmcp tool surface can be used in this install.
+
+    Requires both the `mcp` client library and the `gbmcp` console script. Both
+    ship with the top-level granite.build distribution, but an external consumer
+    installing only `granite-build-analytics` (src/gb_ui_backend's own
+    pyproject.toml) has neither — gbmcp is coupled to gbcli's full client surface,
+    so bundling it there would defeat that distribution's purpose.
+
+    Chat still works without them, on the dashboard tools alone; see
+    ToolLoopBackend._run_session_owner.
+    """
+    if not _MCP_AVAILABLE:
+        return False
+    try:
+        _resolve_gbmcp_bin()
+        return True
+    except RuntimeError:
+        return False
+
+
+def _build_system_prompt(
+    cloud_logs_available: bool, gbmcp_available: bool = True
+) -> str:
+    # Every tool named in this block is a gbmcp tool. Describing them when gbmcp
+    # isn't running would have the model announce capabilities it has no tool for,
+    # then confabulate results — worse than not mentioning them at all.
+    gbmcp_tools_guidance = (
+        """Most tools are read-only. A few genuinely change state:
 
 - `secret_list`/`secret_get`/`secret_create`/`secret_update` run immediately, no
   confirmation needed. But `secret_get`/`secret_create`/`secret_update` never hand you (or
@@ -90,19 +109,49 @@ you. Most tools are read-only. A few genuinely change state:
   approve it, you'll see a note about the outcome the next time they message you. Say
   plainly that you're asking for confirmation — never claim the build started or gbserver
   stopped just because you called the tool.
-- Cancelling a build works differently: call `{NAVIGATION_TOOL_NAME}` with `build_detail`
-  (see below) to send the user to the build's own page, where the real Cancel button and its
-  own confirmation dialog live — there is no `build_cancel` tool available to you directly.
 - Deleting a secret has no tool at all — decline and explain that it happens via the
   granite.build CLI (`gb`) outside this dashboard.
-
+- Cancelling a build works differently: call `{nav}` with `build_detail` (see below) to send
+  the user to the build's own page, where the real Cancel button and its own confirmation
+  dialog live — there is no `build_cancel` tool available to you directly.
+""".format(nav=NAVIGATION_TOOL_NAME)
+        if gbmcp_available
+        # Stated as one paragraph rather than a bullet list of absent tools: naming
+        # them individually invites the model to treat them as things it might still
+        # attempt. Cancellation is called out because there IS something useful to do
+        # (navigate the user there), unlike the rest.
+        else """All of your tools are read-only. You cannot change any state in this
+deployment — you cannot start, stop or cancel builds, and you have no access to secrets at
+all. When a user asks for any of that, say so plainly and never imply you attempted it. For
+cancelling specifically, call `{nav}` with `build_detail` (see below) to send them to the
+build's own page, where the real Cancel button lives; anything else happens through the
+granite.build CLI (`gb`) outside this dashboard.
+""".format(nav=NAVIGATION_TOOL_NAME)
+    )
+    single_build_line = (
+        "  Use `build_status`/`build_describe`/`build_log` for a single build you already have the ID for.\n"
+        if gbmcp_available
+        else ""
+    )
+    log_search_line = (
+        (
+            "- `search_build_logs`: search a build's logs (prefer this over `build_log` when the "
+            "user wants to search history, not just the latest log)\n"
+            if gbmcp_available
+            else "- `search_build_logs`: search a build's logs\n"
+        )
+        if cloud_logs_available
+        else ""
+    )
+    return f"""You are the granite.build dashboard assistant.
+You help users understand their builds, spaces, and artifacts using the tools available to
+you. {gbmcp_tools_guidance}
 Tool selection guidance:
 - Use `search_builds` for anything filtered or bulk (by user, date range, status, space).
-  Use `build_status`/`build_describe`/`build_log` for a single build you already have the ID for.
-{log_search_line}- `search_build_yaml` / `search_build_errors` scan many builds at once — mention the cost
+{single_build_line}{log_search_line}- `search_build_yaml` / `search_build_errors` scan many builds at once — mention the cost
   (they scan a bounded recent window) if the user asks for something very broad.
-- For a deep investigation of one build (failure, root cause), combine `get_ai_analysis`,
-  `build_log`, and `search_build_errors` yourself — there is no separate "investigate" tool.
+- For a deep investigation of one build (failure, root cause), combine `get_ai_analysis`
+  and `search_build_errors` yourself — there is no separate "investigate" tool.
 - `search_docs` answers "how do I..." / "what is..." questions about granite.build itself
   (build.yaml syntax, CLI usage, spaces, secrets, environments) — prefer it over guessing.
 
@@ -254,7 +303,12 @@ class _Session:
 
     def __init__(
         self,
-        mcp_session: "ClientSession",
+        # None when gbmcp isn't available and this session runs on the dashboard
+        # tools alone. Only ever dereferenced by confirm_action(), which is
+        # unreachable in that mode: pending_confirmations is populated solely by
+        # build_confirmable_gbmcp_tools()'s handlers, so it stays empty and
+        # confirm_action() returns {"found": False} before touching this.
+        mcp_session: Optional["ClientSession"],
         tools: list[ToolSpec],
         event_queue: "asyncio.Queue[NormalizedEvent]",
         pending_confirmations: dict[str, dict],
@@ -288,10 +342,13 @@ class _Session:
 
 class ToolLoopBackend(ChatAgentBackend):
     def __init__(self, config: Config) -> None:
-        if not _MCP_AVAILABLE:
-            raise RuntimeError(
-                "mcp is not installed. Install it with `pip install -e '.[chat]'`."
-            )
+        # gbmcp is optional rather than required. An external consumer installing
+        # only granite-build-analytics has neither `mcp` nor the `gbmcp` script (see
+        # _gbmcp_available), and previously that raised here — so chat was reachable
+        # via /chat/status, reported itself enabled, and then failed on the first
+        # message. It now degrades to the dashboard tools, which are pure-Python and
+        # need no subprocess.
+        self._gbmcp_enabled = _gbmcp_available()
         self._config = config
         self._sessions: dict[str, _Session] = {}
         self._lock = asyncio.Lock()
@@ -301,8 +358,13 @@ class ToolLoopBackend(ChatAgentBackend):
         # backend-wide config); per-session state (history, tools, the gbmcp
         # connection) lives on _Session instead.
         self._provider = _build_provider(
-            config, _build_system_prompt(cloud_logs_available)
+            config, _build_system_prompt(cloud_logs_available, self._gbmcp_enabled)
         )
+        if not self._gbmcp_enabled:
+            logger.info(
+                "Chat starting without gbmcp — read-only dashboard tools only. Install the "
+                "granite.build distribution with the [chat] extra to enable the gbmcp tools."
+            )
         # Also backend-wide, not per session, for the same reason as
         # self._provider above: build_dashboard_tools() is a pure function
         # of config — every session would otherwise reconstruct the same
@@ -328,8 +390,28 @@ class ToolLoopBackend(ChatAgentBackend):
         subprocess), this task enters the stack, publishes the constructed
         _Session via `holder`, then blocks on `close_event` until told to
         shut down — and closes the stack itself, right here, when it does.
+
+        When gbmcp isn't available there is no subprocess and no stack to own, but
+        this task still owns the session's lifetime so the create/evict plumbing in
+        _get_or_create_session and _evict_idle_sessions_locked is identical either way.
         """
+        # Declared once for both paths below. In the gbmcp-less path
+        # pending_confirmations stays empty — no confirmable tools exist to populate
+        # it — but it's still passed so _Session's shape doesn't vary by mode.
+        event_queue: "asyncio.Queue[NormalizedEvent]" = asyncio.Queue()
+        pending_confirmations: dict[str, dict] = {}
         try:
+            if not self._gbmcp_enabled:
+                holder["session"] = _Session(
+                    mcp_session=None,
+                    tools=[build_navigation_tool(event_queue)] + self._dashboard_tools,
+                    event_queue=event_queue,
+                    pending_confirmations=pending_confirmations,
+                )
+                ready_event.set()
+                await close_event.wait()
+                return
+
             async with AsyncExitStack() as stack:
                 params = StdioServerParameters(
                     command=_resolve_gbmcp_bin(),
@@ -342,8 +424,6 @@ class ToolLoopBackend(ChatAgentBackend):
                 )
                 await mcp_session.initialize()
 
-                event_queue: "asyncio.Queue[NormalizedEvent]" = asyncio.Queue()
-                pending_confirmations: dict[str, dict] = {}
                 listed_tools = (await mcp_session.list_tools()).tools
                 tools = (
                     build_gbmcp_tools(mcp_session, listed_tools)
@@ -481,6 +561,15 @@ class ToolLoopBackend(ChatAgentBackend):
                 return {"found": True, "approved": False}
 
             try:
+                if session.mcp_session is None:
+                    # Unreachable in the dashboard-tools-only mode: pending_confirmations
+                    # is populated solely by build_confirmable_gbmcp_tools()'s handlers,
+                    # which aren't built when gbmcp is unavailable, so the pop above
+                    # already returned {"found": False}. Raised rather than asserted so
+                    # that if some future caller does populate it, the failure is
+                    # reported back through the same path below instead of surfacing as
+                    # an AttributeError on None.
+                    raise RuntimeError("gbmcp is not available in this deployment")
                 result = await session.mcp_session.call_tool(action, pending["args"])
                 text = _extract_mcp_result_text(result)
                 is_error = result.isError

--- a/src/gb_ui_backend/services/chat_agents/tool_loop_backend.py
+++ b/src/gb_ui_backend/services/chat_agents/tool_loop_backend.py
@@ -367,9 +367,12 @@ class ToolLoopBackend(ChatAgentBackend):
             )
         # Also backend-wide, not per session, for the same reason as
         # self._provider above: build_dashboard_tools() is a pure function
-        # of config — every session would otherwise reconstruct the same
-        # ToolSpecs (same descriptions, same JSON schemas) from scratch.
-        self._dashboard_tools = build_dashboard_tools(config)
+        # of config (and of self._gbmcp_enabled, fixed for the backend's life) —
+        # every session would otherwise reconstruct the same ToolSpecs (same
+        # descriptions, same JSON schemas) from scratch.
+        self._dashboard_tools = build_dashboard_tools(
+            config, gbmcp_available=self._gbmcp_enabled
+        )
 
     async def _run_session_owner(
         self,

--- a/src/gb_ui_backend/services/chat_agents/tool_registry.py
+++ b/src/gb_ui_backend/services/chat_agents/tool_registry.py
@@ -17,9 +17,15 @@ import inspect
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol
 
-from mcp import ClientSession
+# Import-time optional: `mcp` ships with the top-level granite.build distribution's
+# [chat] extra, but not with granite-build-analytics, where chat runs on the
+# dashboard tools alone (see tool_loop_backend._gbmcp_available). ClientSession is
+# only referenced in annotations on the two gbmcp-only builders below, and
+# `from __future__ import annotations` means those are never evaluated at runtime.
+if TYPE_CHECKING:
+    from mcp import ClientSession
 
 from gb_ui_backend.config import Config
 from gb_ui_backend.services.chat_agents import dashboard_tools

--- a/src/gb_ui_backend/services/chat_agents/tool_registry.py
+++ b/src/gb_ui_backend/services/chat_agents/tool_registry.py
@@ -374,10 +374,21 @@ def _wrap(
     )
 
 
-def build_dashboard_tools(config: Config) -> list[ToolSpec]:
+def build_dashboard_tools(
+    config: Config, *, gbmcp_available: bool = True
+) -> list[ToolSpec]:
     """Ports the same tool descriptions/schemas used previously — already
     framework-agnostic, just re-declared as ToolSpecs instead of via a
-    Claude-Agent-SDK-specific @tool decorator."""
+    Claude-Agent-SDK-specific @tool decorator.
+
+    `gbmcp_available` gates the cross-references these descriptions make to gbmcp
+    tools (`build_status`/`build_describe`/`build_log`). Descriptions go to the model
+    just as the system prompt does, so pointing at a tool that isn't in this
+    deployment's tool list has the same failure mode _build_system_prompt() guards
+    against: the model announces a capability it has no tool for, then confabulates
+    a result. Only the cross-reference clauses vary — names, schemas and handlers are
+    identical either way.
+    """
     specs = [
         _wrap(
             "search_docs",
@@ -399,7 +410,14 @@ def build_dashboard_tools(config: Config) -> list[ToolSpec]:
         _wrap(
             "search_builds",
             "Search/filter builds by text, status, user, space, and/or date range. Use this for "
-            "anything bulk or filtered; use build_status/build_describe for a single known build ID.",
+            + (
+                "anything bulk or filtered; use build_status/build_describe for a single known build ID."
+                if gbmcp_available
+                # No substitute pointer here: `query` matches build *name* only (see
+                # dashboard_tools.search_builds), so it is not a build-ID lookup, and
+                # this deployment has no single-build tool to redirect to.
+                else "anything bulk or filtered."
+            ),
             {
                 "type": "object",
                 "properties": {
@@ -533,8 +551,13 @@ def build_dashboard_tools(config: Config) -> list[ToolSpec]:
         specs.append(
             _wrap(
                 "search_build_logs",
-                "Search a build's logs for a substring across its recent history. Prefer this over "
-                "build_log when the user wants to search, not just see the latest log.",
+                "Search a build's logs for a substring across its recent history."
+                + (
+                    " Prefer this over build_log when the user wants to search, not just see "
+                    "the latest log."
+                    if gbmcp_available
+                    else ""
+                ),
                 {
                     "type": "object",
                     "properties": {

--- a/test/unit/gb_ui_backend/test_gbmcp_optional.py
+++ b/test/unit/gb_ui_backend/test_gbmcp_optional.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for chat's gbmcp-less (degraded) mode.
+
+`ToolLoopBackend` used to require gbmcp: __init__ raised RuntimeError without
+`mcp`, and _resolve_gbmcp_bin() ran unconditionally at session start. Both ship
+with the top-level granite.build distribution but NOT with
+granite-build-analytics (src/gb_ui_backend's own pyproject.toml), so a consumer
+installing only that distribution got a chat feature that advertised itself as
+enabled via /chat/status — which only checks LLM config — and then failed on the
+very first message. Chat now detects availability once and falls back to the
+dashboard tools, which are pure Python and need no subprocess.
+
+Why this file exists at all: **this repo's own CI always has gbmcp on PATH**, so
+no other test in the suite can ever exercise that fallback. Every assertion here
+covers an install shape our CI never reaches, which is exactly the shape an
+external consumer runs. Without it, a future refactor re-breaks that consumer
+silently and we hear about it from the consumer rather than from a red build.
+
+Deliberately NOT in test_session_lifecycle.py, whose `backend` fixture patches
+stdio_client/ClientSession/build_gbmcp_tools — that fixture builds the
+gbmcp-*enabled* shape. The fixture here touches none of those names, so these
+tests also pass in a venv where `mcp` isn't importable at all (where patching
+`tool_loop_backend.stdio_client` would itself raise AttributeError).
+
+Four things are covered, matching the four moving parts of the fallback:
+
+  1. _gbmcp_available()'s own branches, including that it short-circuits before
+     probing for the binary when `mcp` is missing.
+  2. The mcp_session=None session-owner path: what it serves, that a real turn
+     runs on it, that it closes without leaking its owner task, and both of
+     confirm_action()'s degraded outcomes — the reachable one (pop returns
+     not-found first) and the Optional-deref guard behind it, which needs an
+     injected confirmation to reach at all.
+  3. The conditional system prompt, both ways, across the cloud-logs matrix.
+  4. Import safety with `mcp` genuinely absent (subprocess), plus a sweep
+     proving no gbmcp tool name reaches the model through *either* channel —
+     the system prompt or a tool description.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import textwrap
+from typing import Any, AsyncIterator
+
+import pytest
+
+from gb_ui_backend.config import Config
+from gb_ui_backend.services.chat_agents import tool_loop_backend
+from gb_ui_backend.services.chat_agents.gbmcp_policy import ALL_GBMCP_TOOLS
+from gb_ui_backend.services.chat_agents.tool_loop_backend import (
+    NAVIGATION_TOOL_NAME,
+    ToolLoopBackend,
+)
+from gb_ui_backend.services.chat_agents.tool_registry import build_dashboard_tools
+
+# The gbmcp tools the enabled system prompt names explicitly. Kept separate from
+# ALL_GBMCP_TOOLS so the prompt assertions below test both directions: these must
+# be absent when degraded and present when enabled. (ALL_GBMCP_TOOLS is the right
+# set for the leak sweep, but the prompt never mentions all 18.)
+_PROMPT_NAMED_GBMCP_TOOLS = (
+    "secret_list",
+    "secret_get",
+    "secret_create",
+    "secret_update",
+    "build_start",
+    "gbserver_stop",
+    "build_status",
+    "build_describe",
+    "build_log",
+)
+
+
+def _names_in(text: str, names) -> set[str]:
+    """Which of `names` appear in `text` as whole words.
+
+    Word-boundary matching rather than a plain substring test, because
+    `search_build_logs` — a *dashboard* tool, present even when degraded —
+    contains `build_log`. A naive `"build_log" not in text` assertion passes only
+    while cloud logs are unconfigured and silently starts failing the moment the
+    matrix below covers cloud_logs_available=True. `_` is a \\w character, so
+    \\bbuild_log\\b correctly does not match inside search_build_logs.
+    """
+    return {n for n in names if re.search(rf"\b{re.escape(n)}\b", text)}
+
+
+class _StubProvider:
+    """Minimal provider: echoes the user message back through history so a full
+    stream_turn can be driven with no LLM credentials and no model round-trip."""
+
+    PROVIDER_NAME = "stub"
+
+    def __init__(self) -> None:
+        self.model = "stub-model"
+        self.tools_seen: list[list[Any]] = []
+
+    async def run_turn(
+        self,
+        history: list[Any],
+        tools: list[Any],
+        user_message: str,
+        event_queue: Any,
+        interrupt_event: Any,
+    ) -> AsyncIterator[dict]:
+        # Recorded so a test can assert on exactly the tool list the model was
+        # offered, which is the thing that actually matters here.
+        self.tools_seen.append(list(tools))
+        history.append({"role": "user", "content": user_message})
+        reply = f"echo: {user_message}"
+        history.append({"role": "assistant", "content": reply})
+        yield {"type": "text_delta", "text": reply}
+
+
+@pytest.fixture
+def degraded_backend(monkeypatch):
+    """A backend that believes gbmcp is unavailable.
+
+    Patches only _gbmcp_available (read as a module global in __init__) and
+    _build_provider. Notably absent: stdio_client/ClientSession/build_gbmcp_tools
+    — see this module's docstring.
+    """
+    stub_provider = _StubProvider()
+    monkeypatch.setattr(tool_loop_backend, "_gbmcp_available", lambda: False)
+    monkeypatch.setattr(
+        tool_loop_backend, "_build_provider", lambda config, prompt: stub_provider
+    )
+    backend = ToolLoopBackend(Config(_env_file=None))
+    backend._stub_provider = stub_provider  # type: ignore[attr-defined]
+    return backend
+
+
+class TestGbmcpAvailabilityDetection:
+    """_gbmcp_available() needs both the `mcp` client library and the gbmcp
+    console script; either one missing means degraded."""
+
+    def test_missing_mcp_short_circuits_before_probing_for_the_binary(
+        self, monkeypatch
+    ):
+        """Order matters: without `mcp` there is nothing to talk to gbmcp over,
+        so the binary probe (a filesystem stat plus a PATH scan) must not run."""
+
+        def _must_not_be_called() -> str:
+            raise AssertionError(
+                "_resolve_gbmcp_bin() must not be probed when mcp is unavailable"
+            )
+
+        monkeypatch.setattr(tool_loop_backend, "_MCP_AVAILABLE", False)
+        monkeypatch.setattr(
+            tool_loop_backend, "_resolve_gbmcp_bin", _must_not_be_called
+        )
+
+        assert tool_loop_backend._gbmcp_available() is False
+
+    def test_unresolvable_gbmcp_script_means_unavailable(self, monkeypatch):
+        """`mcp` present but no gbmcp script — the granite-build-analytics
+        install shape once its [chat] extra pulls in `mcp`."""
+
+        def _raise() -> str:
+            raise RuntimeError("gbmcp console script not found")
+
+        monkeypatch.setattr(tool_loop_backend, "_MCP_AVAILABLE", True)
+        monkeypatch.setattr(tool_loop_backend, "_resolve_gbmcp_bin", _raise)
+
+        assert tool_loop_backend._gbmcp_available() is False
+
+    def test_both_present_means_available(self, monkeypatch):
+        monkeypatch.setattr(tool_loop_backend, "_MCP_AVAILABLE", True)
+        monkeypatch.setattr(
+            tool_loop_backend, "_resolve_gbmcp_bin", lambda: "/venv/bin/gbmcp"
+        )
+
+        assert tool_loop_backend._gbmcp_available() is True
+
+
+@pytest.mark.asyncio
+class TestDegradedSessionServesReadOnlyToolsOnly:
+    async def test_backend_constructs_without_gbmcp(self, degraded_backend):
+        """The original bug: this raised RuntimeError in __init__."""
+        assert degraded_backend._gbmcp_enabled is False
+        assert degraded_backend.describe()["provider"] == "stub"
+
+    async def test_session_has_no_mcp_session_and_only_read_only_tools(
+        self, degraded_backend
+    ):
+        session = await degraded_backend._get_or_create_session("s1")
+
+        assert session.mcp_session is None
+
+        names = {t.name for t in session.tools}
+        # suggest_navigation + the dashboard tools, and nothing else. Asserted as
+        # equality rather than a few `in` checks so a gbmcp tool leaking into this
+        # path fails here even if it isn't one of the names spelled out below.
+        expected = {NAVIGATION_TOOL_NAME} | {
+            t.name
+            for t in build_dashboard_tools(
+                degraded_backend._config, gbmcp_available=False
+            )
+        }
+        assert names == expected
+        assert NAVIGATION_TOOL_NAME in names
+        assert not names & set(ALL_GBMCP_TOOLS)
+
+        # Nothing can populate this without the confirmable-gbmcp handlers, which
+        # is the premise confirm_action()'s None guard relies on.
+        assert session.pending_confirmations == {}
+
+    async def test_confirm_action_reports_not_found_instead_of_raising(
+        self, degraded_backend
+    ):
+        """The normal degraded path through confirm_action(): pending_confirmations
+        can never be populated (only build_confirmable_gbmcp_tools' handlers write
+        to it, and those aren't built here), so the pop returns first and the
+        Optional mcp_session is never reached.
+
+        Note this asserts the *observable* safety, not the None-guard itself — the
+        guard is unreachable from here by construction, and deleting it leaves this
+        test passing. See
+        test_confirm_action_on_an_injected_confirmation_reports_gbmcp_is_absent for
+        coverage of the guard.
+        """
+        await degraded_backend._get_or_create_session("s1")
+
+        for approved in (True, False):
+            assert await degraded_backend.confirm_action(
+                "s1", "bogus-confirmation-id", approved=approved
+            ) == {"found": False}
+
+    async def test_confirm_action_on_an_injected_confirmation_reports_gbmcp_is_absent(
+        self, degraded_backend
+    ):
+        """Exercises the mcp_session None-guard directly, by being the "future
+        caller that populates pending_confirmations some other way" the guard exists
+        for. Injecting the entry is the only way to reach it — which is the point:
+        the guard is defense-in-depth, so without this the suite would pass with it
+        deleted.
+
+        Both with and without the guard the failure is caught by confirm_action's
+        except and reported rather than raised, so the assertion is on *which*
+        failure: a deliberate "gbmcp is not available" message, not an
+        AttributeError on None that happened to land in the generic handler.
+        """
+        session = await degraded_backend._get_or_create_session("s1")
+        session.pending_confirmations["injected-id"] = {
+            "action": "build_start",
+            "args": {},
+        }
+
+        result = await degraded_backend.confirm_action(
+            "s1", "injected-id", approved=True
+        )
+
+        assert result["found"] is True
+        assert result["is_error"] is True
+        assert "gbmcp is not available" in result["result"]
+        # The tell-tale of an unguarded None deref reaching the generic handler.
+        assert "NoneType" not in result["result"]
+
+    async def test_unknown_session_is_reported_not_found(self, degraded_backend):
+        assert await degraded_backend.confirm_action("nope", "any-id", True) == {
+            "found": False
+        }
+
+    async def test_a_full_turn_completes(self, degraded_backend):
+        """Constructing the session isn't enough — the original failure was on the
+        first *message*, so drive one all the way through."""
+        events = [
+            event
+            async for event in degraded_backend.stream_turn("s1", "hello", None, None)
+        ]
+
+        assert any(e.get("type") == "text_delta" for e in events)
+        assert degraded_backend._sessions["s1"].history == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "echo: hello"},
+        ]
+
+        # The tool list the model was actually offered on a real turn.
+        offered = {t.name for t in degraded_backend._stub_provider.tools_seen[0]}
+        assert not offered & set(ALL_GBMCP_TOOLS)
+
+    async def test_close_session_leaves_no_owner_task_behind(self, degraded_backend):
+        session = await degraded_backend._get_or_create_session("s1")
+        assert not session.owner_task.done()
+
+        await degraded_backend.close_session("s1")
+
+        assert "s1" not in degraded_backend._sessions
+        assert session.owner_task.done()
+        # _close_session_owner swallows and logs, so a failing owner task would
+        # otherwise close "successfully" and hide the breakage.
+        assert session.owner_task.exception() is None
+
+
+class TestSystemPromptIsConditional:
+    """Every tool the enabled prompt names is a gbmcp tool. Describing them with
+    no such tool available has the model announce capabilities it cannot perform
+    and then confabulate results, so the degraded prompt must not name them."""
+
+    @pytest.mark.parametrize("cloud_logs_available", [False, True])
+    def test_degraded_prompt_names_no_gbmcp_tools(self, cloud_logs_available):
+        prompt = tool_loop_backend._build_system_prompt(
+            cloud_logs_available=cloud_logs_available, gbmcp_available=False
+        )
+
+        leaked = _names_in(prompt, ALL_GBMCP_TOOLS)
+        assert leaked == set(), f"degraded prompt names gbmcp tools: {sorted(leaked)}"
+
+    @pytest.mark.parametrize("cloud_logs_available", [False, True])
+    def test_degraded_prompt_states_it_is_read_only(self, cloud_logs_available):
+        prompt = tool_loop_backend._build_system_prompt(
+            cloud_logs_available=cloud_logs_available, gbmcp_available=False
+        )
+
+        assert "read-only" in prompt.lower()
+        # Cancellation still has somewhere useful to send the user, so the prompt
+        # must keep pointing there instead of only refusing.
+        assert NAVIGATION_TOOL_NAME in prompt
+        assert "build_detail" in prompt
+
+    @pytest.mark.parametrize("cloud_logs_available", [False, True])
+    def test_enabled_prompt_still_names_them(self, cloud_logs_available):
+        """The other direction — without this, deleting the whole block would
+        also pass the degraded assertions above."""
+        prompt = tool_loop_backend._build_system_prompt(
+            cloud_logs_available=cloud_logs_available, gbmcp_available=True
+        )
+
+        named = _names_in(prompt, _PROMPT_NAMED_GBMCP_TOOLS)
+        assert named == set(_PROMPT_NAMED_GBMCP_TOOLS)
+
+    def test_search_build_logs_tracks_cloud_logs_not_gbmcp(self):
+        """search_build_logs is a dashboard tool gated on cloud-logs config, not on
+        gbmcp — so it survives in the degraded prompt. Only its "prefer this over
+        build_log" comparison drops, since build_log is the gbmcp-only half."""
+        degraded = tool_loop_backend._build_system_prompt(
+            cloud_logs_available=True, gbmcp_available=False
+        )
+        enabled = tool_loop_backend._build_system_prompt(
+            cloud_logs_available=True, gbmcp_available=True
+        )
+
+        assert "search_build_logs" in degraded
+        assert "search_build_logs" in enabled
+        assert _names_in(degraded, ["build_log"]) == set()
+        assert _names_in(enabled, ["build_log"]) == {"build_log"}
+
+        for prompt in (
+            tool_loop_backend._build_system_prompt(
+                cloud_logs_available=False, gbmcp_available=False
+            ),
+            tool_loop_backend._build_system_prompt(
+                cloud_logs_available=False, gbmcp_available=True
+            ),
+        ):
+            assert "search_build_logs" not in prompt
+
+
+class TestNoGbmcpToolNamesReachTheModelAtAll:
+    """The prompt is only one of the two channels that describe tools to the
+    model — every ToolSpec's own description is sent too. Both must be clean, or
+    the model is told to reach for a tool that isn't in its tool list."""
+
+    def test_degraded_tool_descriptions_name_no_gbmcp_tools(self):
+        for cloud_logs_available in (False, True):
+            config = Config(
+                _env_file=None,
+                **(
+                    {
+                        "cloud_logs_url": "https://logs.example.com",
+                        "cloud_logs_api_key": "x",
+                    }
+                    if cloud_logs_available
+                    else {}
+                ),
+            )
+            for tool in build_dashboard_tools(config, gbmcp_available=False):
+                leaked = _names_in(tool.description, ALL_GBMCP_TOOLS)
+                assert leaked == set(), (
+                    f"{tool.name}'s description names gbmcp tools "
+                    f"{sorted(leaked)} in a deployment that has none"
+                )
+
+    def test_enabled_tool_descriptions_still_cross_reference_gbmcp(self):
+        """The cross-references are useful when the tools exist — the degraded
+        variant drops them rather than deleting them outright."""
+        config = Config(
+            _env_file=None,
+            cloud_logs_url="https://logs.example.com",
+            cloud_logs_api_key="x",
+        )
+        descriptions = {
+            t.name: t.description
+            for t in build_dashboard_tools(config, gbmcp_available=True)
+        }
+
+        assert _names_in(descriptions["search_builds"], ALL_GBMCP_TOOLS) == {
+            "build_status",
+            "build_describe",
+        }
+        assert _names_in(descriptions["search_build_logs"], ALL_GBMCP_TOOLS) == {
+            "build_log"
+        }
+
+    def test_tool_names_and_schemas_do_not_vary_by_mode(self):
+        """Only description prose is conditional. Names and JSON schemas must be
+        identical, so nothing downstream (the ToolSpec sharing asserted in
+        test_chat_page_context.py, or a provider's schema handling) shifts."""
+        config = Config(_env_file=None)
+        enabled = build_dashboard_tools(config, gbmcp_available=True)
+        degraded = build_dashboard_tools(config, gbmcp_available=False)
+
+        assert [t.name for t in enabled] == [t.name for t in degraded]
+        assert [t.parameters for t in enabled] == [t.parameters for t in degraded]
+
+    def test_default_is_the_gbmcp_enabled_wording(self):
+        """The kwarg defaults to True so the one production call site is the only
+        thing that decides, and existing callers/tests keep today's behavior."""
+        config = Config(_env_file=None)
+        assert [t.description for t in build_dashboard_tools(config)] == [
+            t.description for t in build_dashboard_tools(config, gbmcp_available=True)
+        ]
+
+
+# Runs in a subprocess: `mcp` is importable in this repo's venv, and blocking it
+# in-process would need importlib.reload, which creates a second module object
+# while every other module keeps referring to the first. Precedent for shelling
+# out: test/unit/standalone/test_gbcli_entry_points.py.
+_MCP_ABSENT_SCRIPT = textwrap.dedent('''
+    import sys
+
+
+    class _BlockMcp:
+        """Raises on any attempt to import mcp, mimicking a venv without it."""
+
+        def find_spec(self, name, path=None, target=None):
+            if name == "mcp" or name.startswith("mcp."):
+                raise ImportError(f"{name} is blocked by this test")
+            return None
+
+
+    sys.meta_path.insert(0, _BlockMcp())
+
+    from gb_ui_backend.config import Config
+    from gb_ui_backend.services.chat_agents import tool_loop_backend, tool_registry
+
+    assert tool_loop_backend._MCP_AVAILABLE is False, "_MCP_AVAILABLE should be False"
+    assert tool_loop_backend._gbmcp_available() is False, "should report unavailable"
+    assert "mcp" not in sys.modules, "something imported mcp at runtime"
+
+    # tool_registry keeps ClientSession under TYPE_CHECKING; if that import moved
+    # back to module scope, importing it above would already have raised.
+    assert callable(tool_registry.build_gbmcp_tools)
+    assert callable(tool_registry.build_confirmable_gbmcp_tools)
+
+    tools = tool_registry.build_dashboard_tools(
+        Config(_env_file=None), gbmcp_available=False
+    )
+    assert len(tools) == 9, f"expected 9 dashboard tools, got {len(tools)}"
+
+    print("MCP_ABSENT_OK")
+    ''')
+
+
+class TestImportsSurviveMcpBeingAbsent:
+    def test_modules_import_and_report_unavailable_without_mcp(self):
+        """The only test here that exercises the real install shape rather than
+        simulating it with monkeypatch."""
+        result = subprocess.run(
+            [sys.executable, "-c", _MCP_ABSENT_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        assert result.returncode == 0, (
+            f"importing chat modules without mcp failed\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "MCP_ABSENT_OK" in result.stdout


### PR DESCRIPTION
## Description

Two changes for external consumers of this repo's subpackages.

### 1. CI builds and tests the frontend workspace

`ci.yml` ran only Python jobs (`lint`, `test`, `demo-cpu`), none of which touch `frontend/`. A change that broke `yarn build` or the standalone tests reported green. Requested during review of #307.

Node 22 rather than 20: nothing here pins a version (no `.nvmrc`, no `.node-version`, no `engines` field), so this is a fresh choice, and Node 20 reached end-of-life in April 2026.

**Build runs before test deliberately** — `standalone`'s `test` script globs `tests/*.test.js`, which includes `build-output.test.js`, and that asserts against the contents of `out/`, which is gitignored. On a fresh checkout the test fails unless a build produced it first.

`yarn lint` is deliberately not included: it delegates to `next lint`, which Next 15 deprecates and which prompts interactively with no ESLint config present. Wiring a linter for this workspace is a separate change.

### 2. Agent Chat degrades gracefully without gbmcp

`ToolLoopBackend.__init__` raised `RuntimeError` without `mcp`, and `_resolve_gbmcp_bin()` was called unconditionally at session start. Both ship with this repo's top-level distribution, but **not** with `granite-build-analytics` (`src/gb_ui_backend`'s own `pyproject.toml`). So a consumer installing only that distribution got a chat feature that
reported itself enabled via `/chat/status` — which only checks LLM config — and then failed on the very first message.

**Bundling gbmcp there is not a viable fix.** `gbmcp/server.py` needs `fastmcp` plus `gbcli.client.client.GBClient`, which pulls in all 54 `gbcli` files and `fastmcp`/`GitPython`/`jinja2`/`openai`/`portalocker`/`pydantic`/`requests`/`toml`/`yaml`/`packaging`. That distribution exists precisely so consumers can install it *without* the whole granite.build distribution, so bundling would defeat its purpose.

The dashboard tools have no such coupling — `build_dashboard_tools()` was already a pure function of config, computed in `__init__` independently of any gbmcp session. So availability is now detected once (`_gbmcp_available`: `mcp` importable **and** the `gbmcp` script resolvable) and the session owner takes a subprocess-free path when it's absent,
serving `suggest_navigation` plus the 9–10 dashboard tools. `regex` is the only new dependency, added as a `chat` extra.

Supporting changes:

- `mcp`'s import in `tool_registry.py` moves under `TYPE_CHECKING` — `ClientSession`  appears only in annotations on the two gbmcp-only builders, and the module already has `from __future__ import annotations`.
- **The system prompt is now conditional.** It named `secret_*`, `build_start`, `gbserver_stop`, `build_status`, `build_describe` and `build_log` — all gbmcp tools. Describing them with no such tool available would have the model announce capabilities it cannot perform and then confabulate results, so the degraded prompt states plainly that every tool is read-only.
- `_Session.mcp_session` becomes `Optional`. It's dereferenced in exactly one place, `confirm_action()`, which is unreachable in this mode: `pending_confirmations` is populated solely by `build_confirmable_gbmcp_tools()`'s handlers, so it stays empty and `confirm_action()` returns `{"found": False}` first. Verified rather than reasoned about  — a bogus confirmation id returns `{"found": False}` with no `AttributeError`. The `None` branch still raises inside the existing `try/except` so a future caller that populates it some other way reports through the same path instead of hitting a `None` deref.
- An anchored `/src/gb_ui_backend/build/` gitignore entry. Deliberately **not** a bare `build/` — `src/gbserver/build/` is a real tracked package and a bare rule would silently stop new files there from being tracked. This one path is setuptools' output when  building the nested `pyproject.toml`, which nests recursively on repeat builds because  that manifest uses `where = [".."]`.

**Added after review:** the conditional prompt covers only one of the two channels that
describe tools to the model — each `ToolSpec`'s own description is sent too, and
`search_builds` / `search_build_logs` still named `build_status`/`build_describe`/`build_log`
unconditionally. `build_dashboard_tools()` now takes `gbmcp_available` (default `True`); only
the cross-reference prose varies, names and schemas are identical in both modes.

**Side effect worth noting if you're reviewing the chat authorization surface:** in this mode `build_start`, `gbserver_start` and `gbserver_stop` are simply absent, so a deployment without gbmcp exposes no state-changing chat tools at all.

## Verification

- Frontend job's exact commands on Node v22.20.0 → 11 routes built, 30/30 tests passing
- `test/unit/gb_ui_backend`: **160/160**. The 138 pre-existing tests are unchanged from
  baseline — confirms the gbmcp path still works — plus 22 new ones in
  `test_gbmcp_optional.py` covering the gbmcp-less path (added in review; this repo's CI
  always has gbmcp on PATH, so nothing else in the suite can reach it)
- Each new assertion checked against a deliberately reintroduced regression, to confirm it
  fails when it should
- Real `git+…#subdirectory` install of `granite-build-analytics[chat]` ships only  `gb_ui_backend` + `gbcommon` + `regex` — no `gbmcp`, `gbcli`, `pandas`, `pyarrow` or  `huggingface-hub` - In that install: backend constructs, session yields 10 read-only tools with `mcp_session=None`, owner task closes without leaking, and no absent tool names appear in the prompt

## Checklist

- [x] `make xformat` leaves the tree clean
- [x] `make xcheck` — adds **no** new errors
- [x] `pytest test/unit/gb_ui_backend` — 160/160 (138 pre-existing + 22 new)
- [x] No IBM-internal references introduced
- [x] DCO sign-off

**One note on `make xcheck`:** two errors remain in `tool_loop_backend.py` — `close_event`/`owner_task` `union-attr` and `arg-type`. Both are **pre-existing on `main`**, confirmed by running mypy against `main`'s copy of the file. This PR adds none and doesn't fix them either, to keep the diff scoped.

## Schedule

Part of a sequence to let an external consumer depend on this repo's subpackages from real git refs instead of local paths:

1. This PR + the companion [rolling-`ui-core`-branch PR](https://github.com/ibm-granite/granite.build/pull/359) — **independent, mergeable in any order** (no file overlap). The frontend job here is also the safety net that keeps that rolling branch from propagating breakage to consumers
2. A release tag cut **after** this merges — tagging first would hand consumers the pre-merge code that raises RuntimeError` on the first chat message
3. The consumer then repoints its pins and mounts chat behind an off-by-default gate

## Known follow-up, not in this PR

Chat is usable but should ship **disabled** for now: `resolve_identity()` falls back to `"standalone"` because `ui-core`'s `api/chat.ts` builds its own axios instance and uses native `fetch`, so it can't pick up a consumer's auth-header interceptor. That voids `_scoped_session_id`, which exists precisely so two identities can't collide on one backend session key, and collapses the per-identity rate limit into a shared bucket. Giving `api/chat.ts` a settable auth-header hook is a small separate change — happy to open it if you'd like it bundled.

