### PR TITLE
Publish ui-core as a rolling branch, not just per-release tags

### DIFF
--- a/.github/workflows/sync-ui-core-branch.yml
+++ b/.github/workflows/sync-ui-core-branch.yml
@@ -1,0 +1,59 @@
+name: Sync ui-core Branch
+
+# Republishes frontend/packages/ui-core as the root of a rolling `ui-core` branch, so
+# external consumers can track main instead of only tagged releases. Needed because
+# Yarn Classic v1 can't consume a subdirectory of a git dependency and this repo's
+# root is a Python project — see scripts/sync-ui-core-branch.sh's header.
+#
+# Complements scripts/publish-ui-core.sh, which cuts an immutable ui-core-<tag> at
+# release time via tag-main.sh. Tags for pinned releases; this branch for "current".
+#
+# NOTE: GitHub only runs `schedule` triggers on the default branch, so the scheduled
+# run always splits main. Use `workflow_dispatch` to run it on demand from any branch.
+
+on:
+  schedule:
+    # Every 2 hours. The off-the-hour minute avoids the congestion that delays
+    # scheduled runs queued on the hour (same rationale as nightly-tests.yml).
+    - cron: "17 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Ref to split. Forks validating this workflow should pass upstream/main."
+        required: false
+        default: "main"
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    # Scheduled runs are restricted to the canonical repo — scheduled workflows also
+    # fire on a fork's own default branch, and a fork republishing its (possibly
+    # stale) main as `ui-core` would mislead anyone who pinned to it. Manual dispatch
+    # stays available everywhere so a fork can validate the script end-to-end before
+    # these changes are proposed here.
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'ibm-granite/granite.build'
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 — `git subtree split` walks the full history of the prefix.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Only forks need this: they split upstream's main rather than their own, so the
+      # content published is upstream's regardless of how stale the fork is. Skipped
+      # on the canonical repo, where `main` is already the right source.
+      - name: Add upstream remote (forks only)
+        if: github.repository != 'ibm-granite/granite.build'
+        run: |
+          git remote add upstream https://github.com/ibm-granite/granite.build.git
+          git fetch upstream main
+
+      - name: Sync ui-core branch
+        run: scripts/sync-ui-core-branch.sh "${{ inputs.source_ref || 'main' }}" ui-core origin

--- a/scripts/sync-ui-core-branch.sh
+++ b/scripts/sync-ui-core-branch.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Keeps a rolling `ui-core` branch in sync with frontend/packages/ui-core's current
+# contents, so external consumers can depend on the package as it is on main rather
+# than only at tagged releases.
+#
+# Usage: scripts/sync-ui-core-branch.sh [<source-ref>] [<target-branch>] [<remote>]
+#   Defaults: main ui-core origin
+#   A fork validating this script before proposing changes upstream should pass
+#   `upstream/main` as <source-ref> (see .github/workflows/sync-ui-core-branch.yml).
+#
+# Why a subtree split is needed at all: Yarn Classic v1 has no subdirectory support
+# for git dependencies — it clones the whole repo and expects package.json at the
+# root, but this repo's root is a Python project. `git subtree split` produces a ref
+# whose *root* is the package, which Yarn can consume:
+#   "@granite-build/ui-core": "ibm-granite/granite.build#ui-core"
+#
+# Relationship to publish-ui-core.sh: that script does the same split but emits an
+# immutable per-release tag (ui-core-v0.3.4), invoked by tag-main.sh at release time.
+# The two are complementary and coexist — tags for pinned releases, this branch for
+# "current". Neither replaces the other.
+set -euo pipefail
+
+source_ref=${1:-main}
+target_branch=${2:-ui-core}
+remote=${3:-origin}
+
+prefix="frontend/packages/ui-core"
+tmp_branch="dist/ui-core-sync-tmp"
+remote_ref="refs/remotes/${remote}/${target_branch}"
+
+if ! git rev-parse -q --verify "$source_ref" >/dev/null; then
+    echo "error: source ref '$source_ref' not found" >&2
+    exit 1
+fi
+
+if [ -z "$(git ls-tree -d --name-only "$source_ref" "$prefix")" ]; then
+    echo "error: '$prefix' does not exist in '$source_ref'" >&2
+    exit 1
+fi
+
+# Fetch the target branch so its current tree can be compared below. Tolerates
+# failure: on the first ever run the branch doesn't exist yet, which is not an error.
+git fetch --quiet "$remote" "+refs/heads/${target_branch}:${remote_ref}" 2>/dev/null || true
+
+# Clear any stray temp branch left behind by a prior failed run, so this run doesn't
+# fail on `git subtree split -b` before even getting started.
+git branch -D "$tmp_branch" >/dev/null 2>&1 || true
+trap 'git branch -D "$tmp_branch" >/dev/null 2>&1 || true' EXIT
+
+# --quiet suppresses the per-commit progress counter, which is one line per commit
+# walked (~225 and growing) and pure noise in a CI log. Real errors still surface,
+# and `set -e` aborts on a non-zero exit either way.
+# stdout is just the resulting SHA, which is reported explicitly below.
+git subtree split --quiet --prefix="$prefix" "$source_ref" -b "$tmp_branch" >/dev/null
+
+new_tree=$(git rev-parse "${tmp_branch}^{tree}")
+
+# Skip the push when the content is byte-identical to what's already published.
+# Not just tidiness: yarn resolves and caches git dependencies by commit SHA, so a
+# force-push that changed the SHA without changing the tree — which is exactly what
+# an upstream rebase or an amended commit produces — would invalidate every
+# consumer's resolved dependency for no reason.
+if git rev-parse -q --verify "$remote_ref" >/dev/null; then
+    if [ "$new_tree" = "$(git rev-parse "${remote_ref}^{tree}")" ]; then
+        echo "$target_branch is already up to date (tree $new_tree) — nothing to push"
+        exit 0
+    fi
+fi
+
+# --force because each split rewrites history from scratch: the commits are derived
+# from the source ref's history, not appended to whatever the branch held before.
+git push --force "$remote" "${tmp_branch}:refs/heads/${target_branch}"
+
+echo "Pushed $prefix ($source_ref) to $remote/$target_branch"
+echo "  commit: $(git rev-parse "$tmp_branch")"
+echo "  tree:   $new_tree"


### PR DESCRIPTION
## Description

`scripts/publish-ui-core.sh` already republishes `frontend/packages/ui-core` as a ref whose *root* is the package, because Yarn Classic v1 has no subdirectory support for git dependencies and this repo's root is a Python project. But it only ever emits an immutable `ui-core-<tag>`, cut by hand from `tag-main.sh` at release time — so an external consumer's only options are "a tagged release" or "a local `file:` path into a sibling checkout".

This adds a rolling `ui-core` branch as a third option, so consumers can track `main` between releases. The two mechanisms are complementary and coexist: **tags for pinned releases, this branch for current.**

### `scripts/sync-ui-core-branch.sh`

Performs the same `git subtree split` as `publish-ui-core.sh`, but is parameterized (`[source-ref] [target-branch] [remote]`) rather than tied to the release flow, and **skips the push entirely when the resulting tree matches what's already published.**

That guard is load-bearing rather than cosmetic: yarn resolves and caches git dependencies by commit SHA, so a force-push that changed the SHA without changing the tree — precisely what a rebase or an amended commit produces — would invalidate every consumer's resolved dependency for nothing. Reuses `publish-ui-core.sh`'s trap-based temp-branch cleanup.

### `.github/workflows/sync-ui-core-branch.yml`

One file that behaves correctly in both places. Scheduled runs are guarded to this repo, mirroring `nightly-tests.yml` — schedules also fire on a fork's own default branch, and a fork republishing its possibly-stale `main` as `ui-core` would mislead anyone pinned to it. `workflow_dispatch` stays available anywhere, with a `source_ref` input, so a fork can
validate the script end-to-end before proposing changes here. Both fork-shaped pieces are inert on this repo, so there's no separate variant to keep in sync.

## Verification

Dry-run against a scratch bare remote:

- **First run** pushes, and the branch's root tree is byte-identical to `main:frontend/packages/ui-core` (`eeeb833a15c1d44ec22cce3eca63de2eb08d4621`), with `package.json` at the root naming `@granite-build/ui-core`.
- **Second run**, no upstream change, prints `already up to date` and leaves the remote SHA untouched.
- Consumer side proven once and reverted: Yarn v1 resolves the split ref as a dependency.

## Checklist

- [x] `make xformat` leaves the tree clean (no Python files touched)
- [x] `make xcheck` (no Python files touched)
- [x] `bash -n` on the new script; workflow YAML parses; executable bit set
- [x] No IBM-internal references introduced
- [x] DCO sign-off

## Worth raising in review

**A rolling branch propagates breakage.** Because it tracks `main` rather than a release, a broken commit on `main` reaches consumers within the cron interval. A tag can't do that. The mitigation is the frontend CI job proposed in the companion PR — it makes such breakage visible here *before* it propagates. The two reinforce each other but merge
independently, in any order (no file overlap).

**An alternative you may prefer:** publishing `ui-core` to a registry (npm or GitHub Packages) is arguably the real fix. It's a much bigger ask — registry auth, release cadence, a private-consumption story — and this repo already committed to the
subtree-split approach via `publish-ui-core.sh`, so this is the incremental change consistent with what's here. Happy to go the other way if you'd rather.

## Schedule

Part of a sequence to let an external consumer (an internal deployment repo) depend on this repo's subpackages from real git refs instead of local paths:

1. This PR + the companion frontend-CI/chat PR — **independent, mergeable in any order**
2. Merging this one is what starts the cron: `schedule` only fires from the default branch, after which the `ui-core` branch appears within ~2h
3. A release tag containing the companion PR
4. The consumer then repoints its pins at `#ui-core` and the tag

Nothing downstream is blocked by review timing here — the consumer's current work merges
independently with local paths intact.