### PR TITLE
fix(hfpull): avoid ${#var} token in lsf command.sh comment (Jinja comment-open)

### DIFF
--- a/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
+++ b/src/gbserver/builtins/steps/lsf/hfpull/lsf_scripts/hfpull/command.sh
@@ -94,12 +94,12 @@ hfpull_lock_ttl() {
         # Strip leading zeros so the digit-count guard below is on the true
         # magnitude (all-zeros -> empty -> 0).
         intpart="${intpart#"${intpart%%[!0]*}"}"; [[ -z "${intpart}" ]] && intpart=0
-        # >8 significant digits necessarily exceeds the 1-year cap and would risk
-        # overflowing bash arithmetic, so clamp before computing. The digit count
-        # is taken with `wc -c` rather than ${#intpart}: the skypilot copy of this
-        # block is rendered through Jinja, which reads the `{#` in ${#...} as a
-        # comment-open and fails to compile the whole step (nightly regression).
-        # intpart is pure digits here, so a byte count equals the digit count.
+        # >8 significant digits exceeds the 1-year cap and risks overflowing bash
+        # arithmetic, so clamp before computing. Count digits with `wc -c`, not
+        # the bash length expansion: this script is rendered through Jinja, and
+        # that expansion's `brace-hash` opens a Jinja comment (no close) and fails
+        # the render (nightly regression) -- so this comment must avoid it too.
+        # intpart is pure digits, so byte count == digit count.
         ndigits="$(printf %s "${intpart}" | wc -c)"
         if (( ndigits > 8 )); then
             secs="${HFPULL_LOCK_TTL_MAX}"

--- a/test/unit/environment/test_hfpull_shell_serialization.py
+++ b/test/unit/environment/test_hfpull_shell_serialization.py
@@ -143,15 +143,14 @@ def _template_strings(node):
 def test_skypilot_hfpull_step_compiles_under_jinja():
     """Every string in the skypilot hfpull step must be a valid Jinja template.
 
-    Unlike the LSF ``command.sh`` (shipped to the worker verbatim), the skypilot
-    step embeds its script inline and is rendered through Jinja at build creation
-    (``fill_objtemplate`` in gbserver.utils.template fills every string field, not
-    only ``run:``). Any construct Jinja reads as markup breaks that render and
-    fails the step "on creation" before it ever launches -- exactly what a bash
-    length expansion (``${#var}``) did, since its ``{#`` reads as a Jinja
-    comment-open with no closing ``#}`` (nightly SkyPilot SLURM regression).
-    Compile the same string surface the renderer does so any such construct fails
-    here, in a fast unit test, instead of only at night.
+    The skypilot step embeds its script inline and is rendered through Jinja at
+    build creation (``fill_objtemplate`` in gbserver.utils.template fills every
+    string field, not only ``run:``). Any construct Jinja reads as markup breaks
+    that render and fails the step "on creation" before it ever launches --
+    exactly what a bash length expansion (``${#var}``) did, since its ``{#``
+    reads as a Jinja comment-open with no closing ``#}`` (nightly SkyPilot SLURM
+    regression). Compile the same string surface the renderer does so any such
+    construct fails here, in a fast unit test, instead of only at night.
     """
     doc = yaml.safe_load(_SKY_HFPULL.read_text())
     env = Environment()
@@ -163,3 +162,19 @@ def test_skypilot_hfpull_step_compiles_under_jinja():
         # Raises jinja2.TemplateSyntaxError if the string contains a stray Jinja
         # token (e.g. the {# from a ${#var} bash length expansion).
         env.from_string(s)
+
+
+def test_lsf_hfpull_command_compiles_under_jinja():
+    """The LSF hfpull ``command.sh`` must be a valid Jinja template.
+
+    ``fill_templates_in_dir`` renders it through Jinja before it ships to the
+    worker, so the same ``${#var}`` hazard as the skypilot copy applies -- a
+    stray ``{#`` (even in a shell comment, which Jinja still parses) fails the
+    step "on creation" with "Missing end of comment tag". This copy had no such
+    test, so a ``${#intpart}`` left in a comment only surfaced in the nightly
+    bluevela run; compile it here to catch that in a fast unit test.
+    """
+    env = Environment()
+    # Raises jinja2.TemplateSyntaxError on any stray Jinja token (e.g. the {#
+    # from a ${#var} bash length expansion, even within a shell comment).
+    env.from_string(_LSF_HFPULL.read_text())


### PR DESCRIPTION
## Summary

The LSF hfpull `command.sh` is rendered through Jinja by `fill_templates_in_dir` before it ships to the worker. Jinja reads `{#` as a comment-open needing a matching `#}`, and it parses shell comments too. Commit a9df96c5 replaced the executable `${#intpart}` with `wc -c`, but left the literal `${#...}` tokens in the explanatory comment — so the step still failed on creation with `TemplateSyntaxError: Missing end of comment tag` (nightly bluevela regression, `test_buildrunner_1step_bluevela`).

- Reword the comment on lines 97–104 to describe the bash length sigil in prose instead of writing the literal `${#...}` token. Executable logic is unchanged, so the lsf↔skypilot parity test (which strips comments) is unaffected.
- Add `test_lsf_hfpull_command_compiles_under_jinja`, mirroring the skypilot compile test, so this class of regression is caught in a fast unit test rather than only in the nightly run. The prior test's docstring wrongly assumed the LSF copy was "shipped verbatim" (it is Jinja-rendered) — corrected.

## Test plan

- `pytest test/unit/environment/test_hfpull_shell_serialization.py` — 6 passed.
- Verified the new test **fails** with `TemplateSyntaxError` at line 99 when `${#intpart}` is reintroduced into the comment, and **passes** with the fix.
- Confirmed the LSF and skypilot hfpull templates all compile under a bare Jinja `Environment`.

Generated with [Claude Code](https://claude.com/claude-code)