### PR TITLE
fix(lsf): resilient SSH tunnel setup and runtime self-heal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ standalone = [
 ]
 # Tier 2: Third-party open-source — installable from PyPI, testable in GH Actions
 thirdparty = [
+    "asyncssh",	# SSH tunnel util (also in [ibm]); here so non-ibm CI can test it
     "docker>=7.0.0",
     "kubernetes<36.0.0",	# Avoids missing watch import created in kubernetes==36.0.0
     "skypilot[kubernetes,slurm,aws] @ git+https://github.com/cmadam/skypilot.git@gb-sky-v1-stable",  # Integration branch (granite-build): LSF cloud driver + thinkahead AWS host-AMI-override + LsfCommandRunner rsync timeout fix. gb-sky-v1-stable is a moving alias for the recommended v1-line commit (re-pointed as the fork advances, like a docker minor tag); a breaking jump gets a new tag. Fresh installs re-resolve it; cached clones need `git fetch --tags --force`.

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -92,6 +92,9 @@ JOB_LOG_STDERR_FILENAME = "job_log.err"
 LSF_SCRIPTS = "lsf_scripts"
 JOB_SUB_SH = "llmb_lsf_jobsub.sh"
 REPLACE_THIS_PREFIX = "LLMB_LSF_REPLACE_THIS_"
+# Bounded drain at teardown: wait this long for an in-flight transfer to
+# release the tunnel before closing anyway.
+SSH_TEARDOWN_DRAIN_S = 30.0
 
 # Builtin step names auto-injected by this module's pullasset/pushasset
 # handlers.  Each resolves via SpaceURI to the LSF env-keyed copy under
@@ -1080,11 +1083,12 @@ class Lsf(Environment):
 
         ssh_tunnel = self._ssh_tunnel
         if ssh_tunnel is not None:
-            # Force-close (not close_when_idle): teardown runs after the build
-            # is done or cancelled, so draining in-flight transfers is pointless
-            # and would risk hanging teardown behind a stuck operation. The key
-            # file is deleted just below regardless, so the tunnel is unusable.
-            await ssh_tunnel.close()
+            # Drain briefly so we don't tear the tunnel out from under an
+            # in-flight asset copy / job launch on cancellation, but bounded so
+            # a stuck operation can't wedge teardown. The key file is deleted
+            # just below regardless, so the tunnel is unusable afterwards.
+            with contextlib.suppress(Exception):
+                await ssh_tunnel.close_when_idle(timeout=SSH_TEARDOWN_DRAIN_S)
             self._ssh_tunnel = None
         key_file_path = self._key_file_path
         self._key_file_path = None

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Self, Tuple, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Self, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -219,20 +219,30 @@ class Lsf(Environment):
         # Superseded tunnels being closed once their in-flight uses drain; kept
         # referenced so the GC tasks aren't collected mid-close.
         self._retired_tunnel_tasks: set[asyncio.Task] = set()
-        self.ssh_connect_budget_s = int(
-            authentication.get(
-                "ssh_connect_budget_s", GBSERVER_LSF_SSH_CONNECT_BUDGET_S
-            )
+        # Floored against operator misconfig via authentication: a negative
+        # budget would raise on the first failure; a negative max backoff would
+        # feed a negative delay into asyncio.sleep (which raises). Base is
+        # floored to >=1 at use so a zero base can't busy-loop.
+        self.ssh_connect_budget_s = max(
+            0,
+            int(
+                authentication.get(
+                    "ssh_connect_budget_s", GBSERVER_LSF_SSH_CONNECT_BUDGET_S
+                )
+            ),
         )
         self.ssh_connect_base_backoff_s = int(
             authentication.get(
                 "ssh_connect_base_backoff_s", GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S
             )
         )
-        self.ssh_connect_max_backoff_s = int(
-            authentication.get(
-                "ssh_connect_max_backoff_s", GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S
-            )
+        self.ssh_connect_max_backoff_s = max(
+            1,
+            int(
+                authentication.get(
+                    "ssh_connect_max_backoff_s", GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S
+                )
+            ),
         )
         if self.use_ssh:
             assert (
@@ -586,11 +596,10 @@ class Lsf(Environment):
                 **kwargs,
             )
             logger.info("using ssh, copying the asset into the env")
-            ssh_tunnel = await self._ensure_ssh_tunnel()
             logger.info("copying %s to %s", asset_dir, final_asset_dir)
             # Hold the tunnel in-use for the whole copy so a rebuild elsewhere
             # can't retire it out from under the transfer.
-            async with ssh_tunnel.use():
+            async with self.ensure_and_use() as ssh_tunnel:
                 logger.info("creating remote directory %s via tunnel", final_asset_dir)
                 await ssh_tunnel.run_remote_with_retries(
                     f"mkdir -p {final_asset_dir} || true"
@@ -808,13 +817,12 @@ class Lsf(Environment):
         secret_env_keys = self._get_secret_env_keys(kwargs.get("config", {}))
         try:
             if self.use_ssh:
-                ssh_tunnel = await self._ensure_ssh_tunnel()
                 remote_cmd, redacted_cmd = self._build_cmd_to_run_with_ssh(
                     final_jobsub_path, env_vars, secret_env_keys
                 )
                 msg = f"⚡ Launching LSF job with command:\n```\n{redacted_cmd}\n```"
                 self._send_message(msg=msg, **kwargs)
-                async with ssh_tunnel.use():
+                async with self.ensure_and_use() as ssh_tunnel:
                     _, stdout, stderr = await ssh_tunnel.run_remote_with_retries(
                         command=remote_cmd, redacted_command=redacted_cmd
                     )
@@ -921,6 +929,22 @@ class Lsf(Environment):
         self._retired_tunnel_tasks.add(task)
         task.add_done_callback(self._retired_tunnel_tasks.discard)
 
+    @contextlib.asynccontextmanager
+    async def ensure_and_use(
+        self: Self, setup_id: str = "runtime"
+    ) -> AsyncIterator[SshTunnel]:
+        """Ensure a healthy tunnel and hold it in-use for the enclosed block.
+
+        Atomic against the retire path: the returned tunnel is marked in-use
+        (``use()``) before ``_ensure_ssh_tunnel``'s lock is released, closing the
+        window where a concurrent rebuild could retire it between ensure and use.
+        Runtime SSH callers should prefer this over calling ``_ensure_ssh_tunnel``
+        then ``tunnel.use()`` as separate statements.
+        """
+        tunnel = await self._ensure_ssh_tunnel(setup_id=setup_id)
+        async with tunnel.use():
+            yield tunnel
+
     async def _ensure_ssh_tunnel(self: Self, setup_id: str = "runtime") -> SshTunnel:
         """Return a healthy persistent SshTunnel, (re)establishing it if needed.
 
@@ -930,11 +954,21 @@ class Lsf(Environment):
         backoff+jitter for up to ``ssh_connect_budget_s`` before raising
         ``SshTunnelError``. ``_tunnel_lock`` serializes rebuilds so concurrent
         callers don't each open a tunnel.
+
+        Callers that immediately transfer over the tunnel should use
+        :meth:`ensure_and_use` instead, which holds the tunnel in-use before
+        releasing the lock and so is atomic against the retire path.
         """
         assert (
             self._key_file_path
         ), "SSH key file must be set up before opening a tunnel"
+        # Fast path: a healthy tunnel needs no rebuild, so skip the lock — a burst
+        # of concurrent transfers shouldn't serialize on it when it's already up.
+        existing = self._ssh_tunnel
+        if existing is not None and existing.is_healthy():
+            return existing
         async with self._tunnel_lock:
+            # Re-check under the lock: another coroutine may have just rebuilt.
             existing = self._ssh_tunnel
             if existing is not None and existing.is_healthy():
                 return existing
@@ -955,7 +989,12 @@ class Lsf(Environment):
             last_err: Optional[Exception] = None
             while True:
                 attempt += 1
-                # Fresh view each sweep so a recovered node gets retried.
+                # Fresh view each sweep so a recovered node gets retried. Note:
+                # this list is otherwise guarded by node_search_lock, not
+                # _tunnel_lock — the two aren't mutually excluded, so a concurrent
+                # node search could observe a mid-clear list. Harmless in CPython
+                # (no corruption; worst case a node is re-probed), but a latent
+                # hazard if either lock's scope changes.
                 self.unreachable_ssh_nodes.clear()
                 tunnel: Optional[SshTunnel] = None
                 try:
@@ -1041,6 +1080,10 @@ class Lsf(Environment):
 
         ssh_tunnel = self._ssh_tunnel
         if ssh_tunnel is not None:
+            # Force-close (not close_when_idle): teardown runs after the build
+            # is done or cancelled, so draining in-flight transfers is pointless
+            # and would risk hanging teardown behind a stuck operation. The key
+            # file is deleted just below regardless, so the tunnel is unusable.
             await ssh_tunnel.close()
             self._ssh_tunnel = None
         key_file_path = self._key_file_path
@@ -1920,8 +1963,9 @@ class Lsf(Environment):
             src: Source directory path.
             dest: Destination directory path on the remote host.
             add_slashes: Whether to ensure trailing slashes on src/dest.
-            ssh_tunnel: Tunnel to build the command against; the caller passes the
-                one it holds in-use so we don't fetch (and race) a different one.
+            ssh_tunnel: Tunnel to build the command against; required when
+                use_ssh is set. The caller passes the one it holds in-use so we
+                don't fetch (and race) a different one.
 
         Returns:
             List of command tokens for the SCP invocation.
@@ -1932,8 +1976,9 @@ class Lsf(Environment):
         scp_cmd.extend(["-i", key_file_path])
         scp_cmd.extend(self.ssh_no_verification_flags())
         if self.use_ssh:
-            if ssh_tunnel is None:
-                ssh_tunnel = await self._ensure_ssh_tunnel()
+            # Caller must pass the tunnel it holds in-use; re-ensuring here could
+            # build the command against a different tunnel than the caller holds.
+            assert ssh_tunnel is not None, "ssh_tunnel is required when use_ssh is set"
             ssh_dest = self.__get_ssh_destination(node="localhost")
             local_port = ssh_tunnel.get_local_port(ssh_tunnel.host, self.ssh_port)
             assert (
@@ -1969,8 +2014,9 @@ class Lsf(Environment):
         ssh_t2 = cmd_safe_join(ssh_t1)
         rsync_ssh = f"ssh -i {key_file_path} {ssh_t2}"
         if self.use_ssh:
-            if ssh_tunnel is None:
-                ssh_tunnel = await self._ensure_ssh_tunnel()
+            # Caller must pass the tunnel it holds in-use; re-ensuring here could
+            # build the command against a different tunnel than the caller holds.
+            assert ssh_tunnel is not None, "ssh_tunnel is required when use_ssh is set"
             ssh_dest = self.__get_ssh_destination(
                 node="localhost"
             )  # localhost because of the port forwarding

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -25,6 +25,7 @@ import random
 import re
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Self, Tuple, Union
 
@@ -59,6 +60,9 @@ from gbserver.types.constants import (
     DEFAULT_ROOT_WORKSPACE_DIR,
     ENABLE_SSH_HOST_KEY_VERIFICATION,
     GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT,
+    GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S,
+    GBSERVER_LSF_SSH_CONNECT_BUDGET_S,
+    GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S,
     LSF_USE_ASPERA,
     STEP_FILE_NAME,
 )
@@ -78,7 +82,7 @@ from gbserver.utils.launch import (
 from gbserver.utils.logger import get_logger
 from gbserver.utils.redaction import REDACTED, SENSITIVE_KEY_RE, scrub_url_credentials
 from gbserver.utils.ssh_keys import write_private_key_file
-from gbserver.utils.ssh_tunnel import SshTunnel
+from gbserver.utils.ssh_tunnel import SshTunnel, SshTunnelError
 from gbserver.utils.utils import cmd_safe_join, get_uuid, short_alphanumeric_lower_hash
 
 logger = get_logger(__name__)
@@ -210,6 +214,26 @@ class Lsf(Environment):
         self.ssh_timeout = int(authentication.get("ssh_timeout", "5"))
         self.node_search_lock = asyncio.Lock()
         self.unreachable_ssh_nodes = []  # type: ignore[var-annotated]
+        # Resilient SSH-tunnel establishment (see _ensure_ssh_tunnel).
+        self._tunnel_lock = asyncio.Lock()
+        # Superseded tunnels being closed once their in-flight uses drain; kept
+        # referenced so the GC tasks aren't collected mid-close.
+        self._retired_tunnel_tasks: set[asyncio.Task] = set()
+        self.ssh_connect_budget_s = int(
+            authentication.get(
+                "ssh_connect_budget_s", GBSERVER_LSF_SSH_CONNECT_BUDGET_S
+            )
+        )
+        self.ssh_connect_base_backoff_s = int(
+            authentication.get(
+                "ssh_connect_base_backoff_s", GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S
+            )
+        )
+        self.ssh_connect_max_backoff_s = int(
+            authentication.get(
+                "ssh_connect_max_backoff_s", GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S
+            )
+        )
         if self.use_ssh:
             assert (
                 self.ssh_key_secret_name
@@ -562,32 +586,35 @@ class Lsf(Environment):
                 **kwargs,
             )
             logger.info("using ssh, copying the asset into the env")
-            ssh_tunnel = self._ssh_tunnel
-            assert ssh_tunnel
+            ssh_tunnel = await self._ensure_ssh_tunnel()
             logger.info("copying %s to %s", asset_dir, final_asset_dir)
-            # Create remote destination directory via tunnel
-            logger.info("creating remote directory %s via tunnel", final_asset_dir)
-            await ssh_tunnel.run_remote_with_retries(
-                f"mkdir -p {final_asset_dir} || true"
-            )
-            # Copy assets to remote host (local-to-remote transfer)
-            if self.copy_method == "rsync":
-                copy_cmd = await self._create_rsync_cmd(
-                    launch_id=launch_id,
-                    src=str(asset_dir),
-                    dest=str(final_asset_dir),
+            # Hold the tunnel in-use for the whole copy so a rebuild elsewhere
+            # can't retire it out from under the transfer.
+            async with ssh_tunnel.use():
+                logger.info("creating remote directory %s via tunnel", final_asset_dir)
+                await ssh_tunnel.run_remote_with_retries(
+                    f"mkdir -p {final_asset_dir} || true"
                 )
-            else:
-                copy_cmd = await self._create_scp_cmd(
+                # Copy assets to remote host (local-to-remote transfer)
+                if self.copy_method == "rsync":
+                    copy_cmd = await self._create_rsync_cmd(
+                        launch_id=launch_id,
+                        src=str(asset_dir),
+                        dest=str(final_asset_dir),
+                        ssh_tunnel=ssh_tunnel,
+                    )
+                else:
+                    copy_cmd = await self._create_scp_cmd(
+                        launch_id=launch_id,
+                        src=str(asset_dir),
+                        dest=str(final_asset_dir),
+                        ssh_tunnel=ssh_tunnel,
+                    )
+                logger.info("copy command (%s): %s", self.copy_method, copy_cmd)
+                returncode, stdout, stderr = await ssh_tunnel.run_local_with_retries(
+                    command=copy_cmd,
                     launch_id=launch_id,
-                    src=str(asset_dir),
-                    dest=str(final_asset_dir),
                 )
-            logger.info("copy command (%s): %s", self.copy_method, copy_cmd)
-            returncode, stdout, stderr = await ssh_tunnel.run_local_with_retries(
-                command=copy_cmd,
-                launch_id=launch_id,
-            )
             logger.info(
                 "copy command returncode %s stdout %s stderr %s",
                 returncode,
@@ -781,16 +808,16 @@ class Lsf(Environment):
         secret_env_keys = self._get_secret_env_keys(kwargs.get("config", {}))
         try:
             if self.use_ssh:
-                ssh_tunnel = self._ssh_tunnel
-                assert ssh_tunnel
+                ssh_tunnel = await self._ensure_ssh_tunnel()
                 remote_cmd, redacted_cmd = self._build_cmd_to_run_with_ssh(
                     final_jobsub_path, env_vars, secret_env_keys
                 )
                 msg = f"⚡ Launching LSF job with command:\n```\n{redacted_cmd}\n```"
                 self._send_message(msg=msg, **kwargs)
-                _, stdout, stderr = await ssh_tunnel.run_remote_with_retries(
-                    command=remote_cmd, redacted_command=redacted_cmd
-                )
+                async with ssh_tunnel.use():
+                    _, stdout, stderr = await ssh_tunnel.run_remote_with_retries(
+                        command=remote_cmd, redacted_command=redacted_cmd
+                    )
             else:
                 command, redacted_command_str = self._get_local_bsub_command(
                     launch_id=launch_id,
@@ -877,21 +904,113 @@ class Lsf(Environment):
         self: Self,
         setup_id: str,
     ) -> None:
+        """Open the persistent SshTunnel during target setup.
+
+        Thin wrapper around the resilient :meth:`_ensure_ssh_tunnel`.
         """
-        Resolve the SSH key from space_secrets, write it to a temp file,
-        and open a persistent SshTunnel.  Returns the key file path.
+        await self._ensure_ssh_tunnel(setup_id=setup_id)
+
+    def _retire_tunnel(self: Self, tunnel: SshTunnel) -> None:
+        """Close a superseded tunnel once its in-flight uses drain (background)."""
+
+        async def _gc() -> None:
+            with contextlib.suppress(Exception):
+                await tunnel.close_when_idle()
+
+        task = asyncio.create_task(_gc())
+        self._retired_tunnel_tasks.add(task)
+        task.add_done_callback(self._retired_tunnel_tasks.discard)
+
+    async def _ensure_ssh_tunnel(self: Self, setup_id: str = "runtime") -> SshTunnel:
+        """Return a healthy persistent SshTunnel, (re)establishing it if needed.
+
+        The single entry point for both target setup and every runtime SSH
+        command, so a login node that dies mid-build is transparently replaced.
+        Reuses a live tunnel; otherwise sweeps the login nodes with failover and
+        backoff+jitter for up to ``ssh_connect_budget_s`` before raising
+        ``SshTunnelError``. ``_tunnel_lock`` serializes rebuilds so concurrent
+        callers don't each open a tunnel.
         """
-        login_node = await self._get_reachable_ssh_node()
-        self._ssh_tunnel = SshTunnel(
-            host=login_node,
-            username=self.username,
-            key_file=self._key_file_path,
-            host_key_verification=self.ssh_host_key_verification,
-            port_forwards=[(0, login_node, self.ssh_port)],
-            max_sessions=self.ssh_max_sessions,
-        )
-        await self._ssh_tunnel.open()
-        logger.info("setup_id: %s SSH tunnel opened to %s", setup_id, login_node)
+        assert (
+            self._key_file_path
+        ), "SSH key file must be set up before opening a tunnel"
+        async with self._tunnel_lock:
+            existing = self._ssh_tunnel
+            if existing is not None and existing.is_healthy():
+                return existing
+            # Retire a stale / half-open tunnel before rebuilding. Don't force
+            # close it — another coroutine may be mid scp/rsync on it; retire it
+            # so it closes once its in-flight uses drain.
+            if existing is not None:
+                logger.warning(
+                    "setup_id: %s existing SSH tunnel to %s is unhealthy; rebuilding",
+                    setup_id,
+                    existing.host,
+                )
+                self._retire_tunnel(existing)
+                self._ssh_tunnel = None
+
+            deadline = time.monotonic() + self.ssh_connect_budget_s
+            attempt = 0
+            last_err: Optional[Exception] = None
+            while True:
+                attempt += 1
+                # Fresh view each sweep so a recovered node gets retried.
+                self.unreachable_ssh_nodes.clear()
+                tunnel: Optional[SshTunnel] = None
+                try:
+                    login_node = await self._get_reachable_ssh_node()
+                    tunnel = SshTunnel(
+                        host=login_node,
+                        username=self.username,
+                        key_file=self._key_file_path,
+                        host_key_verification=self.ssh_host_key_verification,
+                        port_forwards=[(0, login_node, self.ssh_port)],
+                        max_sessions=self.ssh_max_sessions,
+                    )
+                    await tunnel.open()
+                    # A node can open a connection yet not execute commands; prove
+                    # it works before committing, so that mode fails over too.
+                    await tunnel.run_remote("echo tunnel-ready")
+                    self._ssh_tunnel = tunnel
+                    logger.info(
+                        "setup_id: %s SSH tunnel opened to %s (attempt %d)",
+                        setup_id,
+                        login_node,
+                        attempt,
+                    )
+                    return tunnel
+                except Exception as e:  # noqa: BLE001 — any failure => try next node
+                    last_err = e
+                    if tunnel is not None:
+                        with contextlib.suppress(Exception):
+                            await tunnel.close()
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise SshTunnelError(
+                            f"Could not establish an SSH tunnel to any login node "
+                            f"{self.login_nodes} after {attempt} sweeps over "
+                            f"{self.ssh_connect_budget_s}s"
+                        ) from last_err
+                    # Floor at 1s so a misconfigured base backoff of 0 can't spin.
+                    base = max(1, self.ssh_connect_base_backoff_s)
+                    delay = min(
+                        self.ssh_connect_max_backoff_s,
+                        base * (2 ** min(attempt - 1, 6)),
+                    )
+                    delay += random.uniform(0, delay * 0.25)  # jitter
+                    delay = min(delay, remaining)
+                    logger.warning(
+                        "setup_id: %s SSH tunnel establish attempt %d failed (%s); "
+                        "retrying in %.0fs (%.0fs of %ds budget left)",
+                        setup_id,
+                        attempt,
+                        e,
+                        delay,
+                        remaining,
+                        self.ssh_connect_budget_s,
+                    )
+                    await asyncio.sleep(delay)
 
     async def _cleanup_asset_dirs(self) -> None:
         # Delete all launch dirs now that all pipeline steps are done.
@@ -1787,7 +1906,12 @@ class Lsf(Environment):
         return ssh_cmd
 
     async def _create_scp_cmd(
-        self: Self, launch_id: str, src: str, dest: str, add_slashes: bool = True
+        self: Self,
+        launch_id: str,
+        src: str,
+        dest: str,
+        add_slashes: bool = True,
+        ssh_tunnel: Optional[SshTunnel] = None,
     ) -> List[str]:
         """Create an SCP command for copying assets to the remote LSF node.
 
@@ -1796,6 +1920,8 @@ class Lsf(Environment):
             src: Source directory path.
             dest: Destination directory path on the remote host.
             add_slashes: Whether to ensure trailing slashes on src/dest.
+            ssh_tunnel: Tunnel to build the command against; the caller passes the
+                one it holds in-use so we don't fetch (and race) a different one.
 
         Returns:
             List of command tokens for the SCP invocation.
@@ -1806,8 +1932,8 @@ class Lsf(Environment):
         scp_cmd.extend(["-i", key_file_path])
         scp_cmd.extend(self.ssh_no_verification_flags())
         if self.use_ssh:
-            ssh_tunnel = self._ssh_tunnel
-            assert ssh_tunnel
+            if ssh_tunnel is None:
+                ssh_tunnel = await self._ensure_ssh_tunnel()
             ssh_dest = self.__get_ssh_destination(node="localhost")
             local_port = ssh_tunnel.get_local_port(ssh_tunnel.host, self.ssh_port)
             assert (
@@ -1826,7 +1952,12 @@ class Lsf(Environment):
         return scp_cmd
 
     async def _create_rsync_cmd(
-        self: Self, launch_id: str, src: str, dest: str, add_slashes: bool = True
+        self: Self,
+        launch_id: str,
+        src: str,
+        dest: str,
+        add_slashes: bool = True,
+        ssh_tunnel: Optional[SshTunnel] = None,
     ) -> List[str]:
         scp_cmd = [
             "rsync",
@@ -1838,8 +1969,8 @@ class Lsf(Environment):
         ssh_t2 = cmd_safe_join(ssh_t1)
         rsync_ssh = f"ssh -i {key_file_path} {ssh_t2}"
         if self.use_ssh:
-            ssh_tunnel = self._ssh_tunnel
-            assert ssh_tunnel
+            if ssh_tunnel is None:
+                ssh_tunnel = await self._ensure_ssh_tunnel()
             ssh_dest = self.__get_ssh_destination(
                 node="localhost"
             )  # localhost because of the port forwarding
@@ -2018,32 +2149,45 @@ class Lsf(Environment):
 
         try:
             if self.use_ssh:
+                # Best-effort: reuse a live tunnel but don't trigger the multi-hour
+                # reconnect just to bkill — if it's gone, so is the job's session.
                 ssh_tunnel = self._ssh_tunnel
-                assert ssh_tunnel
+                if ssh_tunnel is None or not ssh_tunnel.is_healthy():
+                    logger.warning(
+                        "no healthy SSH tunnel for bkill of job %s; skipping remote kill",
+                        job_id,
+                    )
+                    return
                 logger.info("running cleanup command via tunnel: bkill %s", job_id)
                 max_attempts = 3
-                for attempt in range(1, max_attempts + 1):
-                    try:
-                        rc, stdout, stderr = await ssh_tunnel.run_remote(
-                            f"bkill {job_id}", raise_on_error=False
-                        )
-                        break
-                    except TimeoutError:
-                        if attempt < max_attempts:
-                            logger.warning(
-                                "bkill %s timed out (attempt %d/%d), retrying",
-                                job_id,
-                                attempt,
-                                max_attempts,
-                            )
-                            await asyncio.sleep(attempt * 2)
-                        else:
-                            logger.error(
-                                "bkill %s timed out after %d attempts",
-                                job_id,
-                                max_attempts,
-                            )
-                            raise
+                try:
+                    async with ssh_tunnel.use():
+                        for attempt in range(1, max_attempts + 1):
+                            try:
+                                rc, stdout, stderr = await ssh_tunnel.run_remote(
+                                    f"bkill {job_id}", raise_on_error=False
+                                )
+                                break
+                            except TimeoutError:
+                                if attempt < max_attempts:
+                                    logger.warning(
+                                        "bkill %s timed out (attempt %d/%d), retrying",
+                                        job_id,
+                                        attempt,
+                                        max_attempts,
+                                    )
+                                    await asyncio.sleep(attempt * 2)
+                                else:
+                                    raise
+                except Exception as e:  # noqa: BLE001 — cleanup is best-effort
+                    # Tunnel dropped between the health check and the kill (or the
+                    # kill kept timing out); skip rather than fail teardown.
+                    logger.warning(
+                        "best-effort bkill of job %s via tunnel failed, skipping: %s",
+                        job_id,
+                        e,
+                    )
+                    return
             else:
                 command = ["bkill", job_id]
                 logger.info("running cleanup command: %s", cmd_safe_join(command))

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -812,6 +812,20 @@ GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT = int(
     ),
     base=10,
 )
+# Time budget (seconds) for establishing an SSH tunnel to an LSF login node,
+# sweeping all nodes with backoff before failing the build. Login nodes can be
+# unreachable for hours. Governs both setup and mid-build reconnect. Default 4h.
+GBSERVER_LSF_SSH_CONNECT_BUDGET_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_BUDGET_S", "14400"), base=10
+)
+# Base delay (seconds) for the backoff between SSH-establish sweeps.
+GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_BASE_BACKOFF_S", "2"), base=10
+)
+# Cap (seconds) on the per-sweep backoff so a long outage keeps a steady cadence.
+GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_MAX_BACKOFF_S", "60"), base=10
+)
 # Used by the build framework monitoring to allow the consumption of all the events
 GBSERVER_MONITORING_GRACE_PERIOD = int(
     os.getenv(ENV_VAR_PREFIX + "_MONITORING_GRACE_PERIOD", "30"), base=10

--- a/src/gbserver/utils/ssh_tunnel.py
+++ b/src/gbserver/utils/ssh_tunnel.py
@@ -101,6 +101,9 @@ class SshTunnel:
         self._inflight = 0
         self._idle = asyncio.Event()
         self._idle.set()
+        # Set once retirement/close begins, so use() fails fast instead of
+        # running against a connection about to drop.
+        self._closing = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -158,6 +161,8 @@ class SshTunnel:
         A True result doesn't guarantee the next command succeeds; callers must
         still handle a command failing and re-establish.
         """
+        if self._closing:
+            return False
         conn = self._conn
         if conn is None:
             return False
@@ -180,7 +185,15 @@ class SshTunnel:
         A tunnel with in-flight uses won't be closed by ``close_when_idle`` (see
         the retire path in the LSF environment), so a rebuild elsewhere can't tear
         down the connection or port forward mid-transfer.
+
+        Raises ``SshTunnelError`` if the tunnel is already closing/closed, so a
+        caller that raced the retire path fails fast and re-establishes rather
+        than running against a dead connection.
         """
+        if self._closing or self._conn is None:
+            raise SshTunnelError(
+                f"[SshTunnel] Cannot use tunnel to {self.host}: it is closing or closed"
+            )
         self._inflight += 1
         self._idle.clear()
         try:
@@ -193,11 +206,14 @@ class SshTunnel:
 
     async def close_when_idle(self) -> None:
         """Wait for in-flight uses to drain, then close. Used to retire a tunnel."""
+        # Block new use() entrants immediately so the refcount can reach zero.
+        self._closing = True
         await self._idle.wait()
         await self.close()
 
     async def close(self) -> None:
         """Close all port-forward listeners and the SSH connection."""
+        self._closing = True
         for listener in self._listeners:
             listener.close()
             await listener.wait_closed()

--- a/src/gbserver/utils/ssh_tunnel.py
+++ b/src/gbserver/utils/ssh_tunnel.py
@@ -204,11 +204,22 @@ class SshTunnel:
                 self._inflight = 0
                 self._idle.set()
 
-    async def close_when_idle(self) -> None:
-        """Wait for in-flight uses to drain, then close. Used to retire a tunnel."""
+    async def close_when_idle(self, timeout: Optional[float] = None) -> None:
+        """Wait for in-flight uses to drain, then close. Used to retire a tunnel.
+
+        With ``timeout`` (seconds), close anyway once it elapses so a stuck
+        operation can't wedge the caller (e.g. teardown) indefinitely.
+        """
         # Block new use() entrants immediately so the refcount can reach zero.
         self._closing = True
-        await self._idle.wait()
+        try:
+            await asyncio.wait_for(self._idle.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[SshTunnel] %s still in use after %.0fs; closing anyway",
+                self.host,
+                timeout,
+            )
         await self.close()
 
     async def close(self) -> None:

--- a/src/gbserver/utils/ssh_tunnel.py
+++ b/src/gbserver/utils/ssh_tunnel.py
@@ -33,7 +33,8 @@ Usage::
 """
 
 import asyncio
-from typing import List, Optional, Tuple
+import contextlib
+from typing import AsyncIterator, List, Optional, Tuple
 
 from gbserver.utils.optional_imports import HAS_ASYNCSSH
 
@@ -95,6 +96,11 @@ class SshTunnel:
         self._listeners: List[asyncssh.SSHListener] = []
         self._actual_local_ports: List[int] = []
         self._semaphore = asyncio.Semaphore(max_sessions)
+        # In-flight operation refcount, so a superseded tunnel is closed only
+        # once nothing is still using its connection or port forward.
+        self._inflight = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
 
     # ------------------------------------------------------------------
     # Public API
@@ -145,6 +151,50 @@ class SshTunnel:
                 ) from e
 
         logger.info("[SshTunnel] Connected to %s", self.host)
+
+    def is_healthy(self) -> bool:
+        """Best-effort, non-throwing check that the connection is open.
+
+        A True result doesn't guarantee the next command succeeds; callers must
+        still handle a command failing and re-establish.
+        """
+        conn = self._conn
+        if conn is None:
+            return False
+        try:
+            if conn.is_closed():
+                return False
+        except Exception:  # noqa: BLE001 — introspection must never raise
+            return False
+        # A live control connection is not enough: a lost port forward would let
+        # commands run but break scp/rsync. Require every configured forward to
+        # still have a listener (close() clears these). asyncssh exposes no
+        # per-listener liveness, so this catches teardown, not a silently dropped
+        # forward — the caller's own command failure is the backstop for that.
+        return len(self._listeners) == len(self.port_forwards)
+
+    @contextlib.asynccontextmanager
+    async def use(self) -> AsyncIterator["SshTunnel"]:
+        """Mark this tunnel in-use for the duration of an operation.
+
+        A tunnel with in-flight uses won't be closed by ``close_when_idle`` (see
+        the retire path in the LSF environment), so a rebuild elsewhere can't tear
+        down the connection or port forward mid-transfer.
+        """
+        self._inflight += 1
+        self._idle.clear()
+        try:
+            yield self
+        finally:
+            self._inflight -= 1
+            if self._inflight <= 0:
+                self._inflight = 0
+                self._idle.set()
+
+    async def close_when_idle(self) -> None:
+        """Wait for in-flight uses to drain, then close. Used to retire a tunnel."""
+        await self._idle.wait()
+        await self.close()
 
     async def close(self) -> None:
         """Close all port-forward listeners and the SSH connection."""

--- a/test/unit/environment/test_lsf_cleanup.py
+++ b/test/unit/environment/test_lsf_cleanup.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import asyncio
+import contextlib
 from typing import Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +23,19 @@ import pytest
 
 from gbserver.environment.lsf import Lsf
 from gbserver.types.errors import WorkloadFailedException
+
+
+def _mock_tunnel() -> AsyncMock:
+    """A mock SshTunnel whose is_healthy() is truthy and use() is an async CM."""
+    tunnel = AsyncMock()
+    tunnel.is_healthy = MagicMock(return_value=True)
+
+    @contextlib.asynccontextmanager
+    async def _use():
+        yield tunnel
+
+    tunnel.use = _use
+    return tunnel
 
 
 def _make_lsf(use_ssh: bool = True) -> Lsf:
@@ -32,7 +46,7 @@ def _make_lsf(use_ssh: bool = True) -> Lsf:
     lsf.use_ssh = use_ssh
     lsf._launched_jobs = {}
     lsf._existing_jobids = {}
-    lsf._ssh_tunnel = AsyncMock() if use_ssh else None
+    lsf._ssh_tunnel = _mock_tunnel() if use_ssh else None
     lsf._send_message = MagicMock()
     lsf._dispatch_event = MagicMock()
     return lsf
@@ -126,21 +140,26 @@ class TestCleanupBsub:
         assert "Killed LSF job 12345" in msg
 
     @pytest.mark.asyncio
-    async def test_timeout_exhausts_retries(self: Self) -> None:
-        """After 3 timeout failures, should raise TimeoutError."""
+    async def test_timeout_exhausts_retries_is_best_effort(self: Self) -> None:
+        """After 3 timeout failures, bkill is skipped (best-effort), not raised.
+
+        Failing teardown on a flaky tunnel is worse than a leaked bkill, so the
+        exhausted-retry case now logs-and-returns rather than raising RuntimeError.
+        """
         lsf = _make_lsf(use_ssh=True)
         lsf._launched_jobs["launch-1"] = "12345"
         lsf._ssh_tunnel.run_remote = AsyncMock(
             side_effect=TimeoutError("ssh timed out")
         )
 
-        with pytest.raises(RuntimeError):
-            await lsf.cleanup_bsub(
-                launch_id="launch-1",
-                run_metadata={"build_id": "b1"},
-            )
+        # No exception propagates.
+        await lsf.cleanup_bsub(
+            launch_id="launch-1",
+            run_metadata={"build_id": "b1"},
+        )
 
         assert lsf._ssh_tunnel.run_remote.call_count == 3
+        lsf._send_message.assert_not_called()
 
 
 class TestRetryPendingAfterMonitor:

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+
+# Copyright LLM.build Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the resilient SSH-tunnel establishment path (issue #368).
+
+Covers ``Lsf._ensure_ssh_tunnel`` (reuse/rebuild/failover/budget) and the
+``SshTunnel.is_healthy`` predicate it relies on.
+"""
+
+import asyncio
+from typing import List, Self
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gbserver.environment.lsf import Lsf
+from gbserver.utils.ssh_tunnel import SshTunnel, SshTunnelError
+
+
+def _make_lsf(login_nodes: List[str]) -> Lsf:
+    """Minimal Lsf instance with just the state ``_ensure_ssh_tunnel`` touches."""
+    with patch.object(Lsf, "__init__", lambda self, **kw: None):
+        lsf = Lsf.__new__(Lsf)
+    lsf.use_ssh = True
+    lsf.login_nodes = list(login_nodes)
+    lsf.login_node_idx = 0
+    lsf.unreachable_ssh_nodes = []
+    lsf.node_search_lock = asyncio.Lock()
+    lsf._tunnel_lock = asyncio.Lock()
+    lsf._retired_tunnel_tasks = set()
+    lsf._ssh_tunnel = None
+    lsf._key_file_path = "/tmp/fake_key"
+    lsf.username = "tester"
+    lsf.ssh_host_key_verification = False
+    lsf.ssh_port = 22
+    lsf.ssh_max_sessions = 10
+    lsf.ssh_timeout = 5
+    # Short budget + backoff so a failing test fails fast rather than hanging.
+    lsf.ssh_connect_budget_s = 3600
+    lsf.ssh_connect_base_backoff_s = 1
+    lsf.ssh_connect_max_backoff_s = 4
+    return lsf
+
+
+def _healthy_tunnel(host: str = "node") -> MagicMock:
+    """A stand-in SshTunnel that is alive and whose open()/echo succeed."""
+    t = MagicMock(spec=SshTunnel)
+    t.host = host
+    t.is_healthy.return_value = True
+    t.open = AsyncMock()
+    t.run_remote = AsyncMock(return_value=(0, "tunnel-ready", ""))
+    t.close = AsyncMock()
+    t.close_when_idle = AsyncMock()
+    return t
+
+
+class TestEnsureSshTunnel:
+    """Behavior of the idempotent, self-healing establish loop."""
+
+    @pytest.mark.asyncio
+    async def test_reuses_healthy_tunnel_without_rebuilding(self: Self) -> None:
+        lsf = _make_lsf(["a", "b"])
+        existing = _healthy_tunnel("a")
+        lsf._ssh_tunnel = existing
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel") as tunnel_cls,
+            patch.object(lsf, "_get_reachable_ssh_node", new=AsyncMock()) as get_node,
+        ):
+            result = await lsf._ensure_ssh_tunnel()
+
+        assert result is existing
+        tunnel_cls.assert_not_called()  # no rebuild
+        get_node.assert_not_awaited()  # no node search
+        existing.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rebuilds_when_existing_tunnel_unhealthy(self: Self) -> None:
+        lsf = _make_lsf(["a", "b"])
+        stale = _healthy_tunnel("a")
+        stale.is_healthy.return_value = False  # dead connection
+        lsf._ssh_tunnel = stale
+        fresh = _healthy_tunnel("b")
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", return_value=fresh),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(return_value="b")
+            ),
+        ):
+            result = await lsf._ensure_ssh_tunnel()
+            # Let the background retirement GC task run.
+            await asyncio.sleep(0)
+
+        assert result is fresh
+        assert lsf._ssh_tunnel is fresh
+        # Stale tunnel is retired (drained then closed), not force-closed.
+        stale.close_when_idle.assert_awaited()
+        stale.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fails_over_when_open_fails_then_succeeds(self: Self) -> None:
+        """First candidate's open() raises; the next sweep must succeed."""
+        lsf = _make_lsf(["a", "b"])
+        bad = _healthy_tunnel("a")
+        bad.open = AsyncMock(side_effect=SshTunnelError("connect refused"))
+        good = _healthy_tunnel("b")
+        built: List[MagicMock] = [bad, good]
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", side_effect=built),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(side_effect=["a", "b"])
+            ),
+            patch("gbserver.environment.lsf.asyncio.sleep", new=AsyncMock()) as sleep,
+        ):
+            result = await lsf._ensure_ssh_tunnel()
+
+        assert result is good
+        bad.close.assert_awaited()  # half-open attempt torn down
+        sleep.assert_awaited()  # backed off between sweeps
+
+    @pytest.mark.asyncio
+    async def test_fails_over_when_open_ok_but_command_fails(self: Self) -> None:
+        """A node that connects but can't execute must be rejected (echo probe)."""
+        lsf = _make_lsf(["a", "b"])
+        cannot_exec = _healthy_tunnel("a")
+        cannot_exec.run_remote = AsyncMock(side_effect=Exception("no exec"))
+        good = _healthy_tunnel("b")
+
+        with (
+            patch(
+                "gbserver.environment.lsf.SshTunnel", side_effect=[cannot_exec, good]
+            ),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(side_effect=["a", "b"])
+            ),
+            patch("gbserver.environment.lsf.asyncio.sleep", new=AsyncMock()),
+        ):
+            result = await lsf._ensure_ssh_tunnel()
+
+        assert result is good
+        cannot_exec.close.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_raises_only_after_budget_exhausted(self: Self) -> None:
+        """No reachable node ever: keep retrying until the budget elapses, then raise."""
+        lsf = _make_lsf(["a"])
+        lsf.ssh_connect_budget_s = 100
+
+        # Simulated clock advances by 40s per backoff sleep, so the budget is
+        # exhausted after a few sweeps without any real waiting.
+        clock = {"t": 0.0}
+
+        def fake_monotonic() -> float:
+            return clock["t"]
+
+        async def fake_sleep(_delay: float) -> None:
+            clock["t"] += 40.0
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel"),
+            patch.object(
+                lsf,
+                "_get_reachable_ssh_node",
+                new=AsyncMock(side_effect=RuntimeError("no reachable node")),
+            ),
+            patch(
+                "gbserver.environment.lsf.time.monotonic", side_effect=fake_monotonic
+            ),
+            patch("gbserver.environment.lsf.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            with pytest.raises(SshTunnelError) as excinfo:
+                await lsf._ensure_ssh_tunnel()
+
+        # Original cause preserved for debugging.
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_clears_unreachable_nodes_each_sweep(self: Self) -> None:
+        """A node marked unreachable on a prior sweep is retried on the next."""
+        lsf = _make_lsf(["a", "b"])
+        lsf.unreachable_ssh_nodes = ["a", "b"]  # stale from a previous outage
+        good = _healthy_tunnel("a")
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", return_value=good),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(return_value="a")
+            ),
+        ):
+            result = await lsf._ensure_ssh_tunnel()
+
+        assert result is good
+        assert lsf.unreachable_ssh_nodes == []  # reset before the sweep
+
+    @pytest.mark.asyncio
+    async def test_open_ssh_tunnel_delegates_and_sets_tunnel(self: Self) -> None:
+        """setup path (_open_ssh_tunnel) still populates self._ssh_tunnel."""
+        lsf = _make_lsf(["a"])
+        good = _healthy_tunnel("a")
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", return_value=good),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(return_value="a")
+            ),
+        ):
+            await lsf._open_ssh_tunnel(setup_id="setup-1")
+
+        assert lsf._ssh_tunnel is good
+
+
+class TestSshTunnelIsHealthy:
+    """The cheap, non-throwing liveness predicate."""
+
+    def test_unopened_tunnel_is_not_healthy(self: Self) -> None:
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        assert t.is_healthy() is False
+
+    def test_open_connection_is_healthy(self: Self) -> None:
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        conn = MagicMock()
+        conn.is_closed.return_value = False
+        t._conn = conn
+        assert t.is_healthy() is True
+
+    def test_closed_connection_is_not_healthy(self: Self) -> None:
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        conn = MagicMock()
+        conn.is_closed.return_value = True
+        t._conn = conn
+        assert t.is_healthy() is False
+
+    def test_introspection_error_is_not_healthy(self: Self) -> None:
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        conn = MagicMock()
+        conn.is_closed.side_effect = RuntimeError("boom")
+        t._conn = conn
+        assert t.is_healthy() is False  # never raises
+
+    def test_missing_port_forward_is_not_healthy(self: Self) -> None:
+        """Live control connection but a lost port forward => not healthy."""
+        t = SshTunnel(
+            host="h", username="u", key_file="/tmp/k", port_forwards=[(0, "h", 22)]
+        )
+        conn = MagicMock()
+        conn.is_closed.return_value = False
+        t._conn = conn
+        t._listeners = []  # forward never came up / was torn down
+        assert t.is_healthy() is False
+
+
+class TestSshTunnelRefcount:
+    """use()/close_when_idle: a retired tunnel closes only once uses drain."""
+
+    @pytest.mark.asyncio
+    async def test_close_when_idle_waits_for_inflight_use(self: Self) -> None:
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        t.close = AsyncMock()  # type: ignore[method-assign]
+
+        release = asyncio.Event()
+
+        async def _hold() -> None:
+            async with t.use():
+                await release.wait()
+
+        holder = asyncio.create_task(_hold())
+        await asyncio.sleep(0)  # let _hold enter the use() block
+
+        gc = asyncio.create_task(t.close_when_idle())
+        await asyncio.sleep(0)
+        # Still in use — must not have closed yet.
+        t.close.assert_not_awaited()
+
+        release.set()
+        await holder
+        await gc
+        t.close.assert_awaited_once()  # closed once the use drained

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -409,3 +409,26 @@ class TestSshTunnelRefcount:
         t._conn = conn
         t._closing = True
         assert t.is_healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_close_when_idle_timeout_closes_anyway(self: Self) -> None:
+        """A stuck in-flight use can't wedge close_when_idle past its timeout."""
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        t._conn = MagicMock()  # opened tunnel, so use() is valid
+        t.close = AsyncMock()  # type: ignore[method-assign]
+
+        never = asyncio.Event()  # holder never releases
+
+        async def _hold() -> None:
+            async with t.use():
+                await never.wait()
+
+        holder = asyncio.create_task(_hold())
+        await asyncio.sleep(0)  # enter the use() block
+
+        # timeout=0 elapses immediately; close happens despite the in-flight use.
+        await t.close_when_idle(timeout=0)
+        t.close.assert_awaited_once()
+
+        never.set()
+        await holder

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -223,6 +223,97 @@ class TestEnsureSshTunnel:
 
         assert lsf._ssh_tunnel is good
 
+    @pytest.mark.asyncio
+    async def test_healthy_fast_path_skips_lock(self: Self) -> None:
+        """A healthy tunnel is returned without ever taking _tunnel_lock."""
+        lsf = _make_lsf(["a"])
+        existing = _healthy_tunnel("a")
+        lsf._ssh_tunnel = existing
+        # A held lock would deadlock if the fast path tried to acquire it.
+        await lsf._tunnel_lock.acquire()
+        try:
+            result = await asyncio.wait_for(lsf._ensure_ssh_tunnel(), timeout=1)
+        finally:
+            lsf._tunnel_lock.release()
+        assert result is existing
+
+
+class TestEnsureSshTunnelConcurrency:
+    """The crux of the PR: rebuilds serialize and retire is transfer-safe."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_callers_rebuild_once(self: Self) -> None:
+        """Under contention, exactly one rebuild happens; all callers share it."""
+        lsf = _make_lsf(["a", "b"])
+        fresh = _healthy_tunnel("a")
+        builds = 0
+
+        def _build(*_args: object, **_kwargs: object) -> MagicMock:
+            nonlocal builds
+            builds += 1
+            return fresh
+
+        async def _slow_node() -> str:
+            await asyncio.sleep(0)  # yield so callers pile up on the lock
+            return "a"
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", side_effect=_build),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(wraps=_slow_node)
+            ),
+        ):
+            results = await asyncio.gather(
+                *(lsf._ensure_ssh_tunnel() for _ in range(5))
+            )
+
+        assert builds == 1  # lock serialized; re-check under lock reused the build
+        assert all(r is fresh for r in results)
+
+    @pytest.mark.asyncio
+    async def test_ensure_and_use_holds_tunnel_across_retire(self: Self) -> None:
+        """A concurrent rebuild retires the old tunnel but can't close it while a
+        caller holds it via ensure_and_use (the retire-window fix)."""
+        lsf = _make_lsf(["a", "b"])
+        # Real SshTunnel so use()/close_when_idle refcounting is exercised.
+        first = SshTunnel(host="a", username="u", key_file="/tmp/k")
+        first._conn = MagicMock()
+        first._conn.is_closed.return_value = False
+        first.close = AsyncMock()  # type: ignore[method-assign]
+        lsf._ssh_tunnel = first
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _hold() -> None:
+            async with lsf.ensure_and_use():
+                entered.set()
+                await release.wait()
+
+        holder = asyncio.create_task(_hold())
+        await entered.wait()  # caller now holds `first` in-use
+
+        # Force a rebuild: mark first unhealthy, then ensure again.
+        first._conn.is_closed.return_value = True
+        second = _healthy_tunnel("b")
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", return_value=second),
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(return_value="b")
+            ),
+        ):
+            rebuilt = await lsf._ensure_ssh_tunnel()
+            await asyncio.sleep(0)  # let the retire GC task run
+
+        assert rebuilt is second
+        # first is retired but NOT yet closed — the holder still has it in-use.
+        first.close.assert_not_awaited()
+
+        release.set()
+        await holder
+        await asyncio.sleep(0)  # let close_when_idle drain and close
+        first.close.assert_awaited()  # closed once the in-flight use drained
+
 
 class TestSshTunnelIsHealthy:
     """The cheap, non-throwing liveness predicate."""
@@ -270,6 +361,7 @@ class TestSshTunnelRefcount:
     @pytest.mark.asyncio
     async def test_close_when_idle_waits_for_inflight_use(self: Self) -> None:
         t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        t._conn = MagicMock()  # opened tunnel, so use() is valid
         t.close = AsyncMock()  # type: ignore[method-assign]
 
         release = asyncio.Event()
@@ -290,3 +382,30 @@ class TestSshTunnelRefcount:
         await holder
         await gc
         t.close.assert_awaited_once()  # closed once the use drained
+
+    @pytest.mark.asyncio
+    async def test_use_rejects_closing_tunnel(self: Self) -> None:
+        """use() on a tunnel already being retired fails fast (retire window)."""
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        t._conn = MagicMock()  # otherwise use() rejects on conn is None
+        t._closing = True
+        with pytest.raises(SshTunnelError):
+            async with t.use():
+                pass  # pragma: no cover
+
+    @pytest.mark.asyncio
+    async def test_use_rejects_unopened_tunnel(self: Self) -> None:
+        """use() before open() (no connection) fails fast rather than silently."""
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        with pytest.raises(SshTunnelError):
+            async with t.use():
+                pass  # pragma: no cover
+
+    def test_is_healthy_false_while_closing(self: Self) -> None:
+        """A tunnel being retired must not be reused as healthy."""
+        t = SshTunnel(host="h", username="u", key_file="/tmp/k")
+        conn = MagicMock()
+        conn.is_closed.return_value = False
+        t._conn = conn
+        t._closing = True
+        assert t.is_healthy() is False


### PR DESCRIPTION
## Summary

LSF login nodes can be intermittently unreachable — no connect, auth failure, or "connects but won't execute the command" — for minutes to hours. The old path probed each login node at most twice back-to-back and then raised `RuntimeError`, so any outage longer than a few seconds failed the build at target setup. A tunnel that dropped mid-build was never rebuilt.

This makes both setup and runtime SSH resilient:

- **`Lsf._ensure_ssh_tunnel()`** — single idempotent, self-healing entry point. Returns the live tunnel if healthy; otherwise rebuilds it, sweeping all login nodes with failover and exponential backoff+jitter for up to a configurable budget (default 4h) before raising `SshTunnelError`. Clears the sticky unreachable-node set each sweep (a recovered node is retried) and runs an `echo` probe after `open()` so a node that connects but can't execute also fails over. `_tunnel_lock` serializes concurrent rebuilds.
- **Setup and runtime both route through it.** `_open_ssh_tunnel` (target setup) delegates to it, and every runtime SSH caller (asset copy, job launch, scp/rsync command build) now calls it — so a login node that dies mid-build is transparently replaced.
- **Shared-tunnel safety under concurrency.** `SshTunnel` gains in-flight refcounting (`use()` / `close_when_idle()`): a superseded tunnel is *retired* — closed only once its in-flight scp/rsync/commands drain — instead of being force-closed out from under them. Runtime operations wrap their work in `async with tunnel.use()`.
- **`SshTunnel.is_healthy()`** — cheap, non-throwing liveness check; also verifies the port forward is still up, not just the control connection.
- **Best-effort `bkill`** reuses an already-healthy tunnel and skips (rather than failing teardown) if the tunnel drops mid-kill; it does not trigger the multi-hour reconnect budget.
- Three `GBSERVER_LSF_SSH_CONNECT_*` tunables (budget / base / max backoff), also overridable per-environment via the `authentication:` block. Backoff is floored so a zero base delay can't busy-loop.

Closes ibm-granite/granite.build#368

## Design notes / scope

- Retry budget is bounded (default 4h) rather than truly indefinite, so a genuinely dead cluster eventually fails the build instead of hanging forever. Tunable via `GBSERVER_LSF_SSH_CONNECT_BUDGET_S`.
- Deliberately small-footprint (confined to `lsf.py`, `ssh_tunnel.py`, `constants.py`) given the likely move toward the SkyPilot-based connection path.
- Known residual: there is a narrow window between `_ensure_ssh_tunnel()` returning a tunnel and the caller entering `use()` where a concurrent rebuild could retire it. In practice the caller enters `use()` as the next statement; this is far smaller than the original tear-down-mid-transfer bug. Flagged for reviewer awareness.

## Test plan

- New `test/unit/environment/test_lsf_ssh_resilience.py`: reuse-when-healthy, rebuild-on-unhealthy (via retire, not force-close), failover on `open()` failure and on post-open command failure, budget exhaustion, per-sweep unreachable-node reset, setup delegation, `is_healthy()` cases (including missing port forward), and refcount (`close_when_idle` waits for in-flight `use()`).
- Updated `test_lsf_cleanup.py` for the new best-effort `bkill` (exhausted retries now skip rather than raise).
- Full `test/unit/environment/` + `test/unit/utils/` mock suite passes (608 tests); black/isort clean; no new mypy findings on changed files.