### PR TITLE
fix(k8s): retry transient apiserver errors (429/5xx) in monitoring

### DIFF
--- a/src/gbserver/monitoring/appwrapper_monitor.py
+++ b/src/gbserver/monitoring/appwrapper_monitor.py
@@ -49,6 +49,22 @@ logger = get_logger(__name__)
 # Timeout for Kubernetes API calls (in seconds)
 API_CALL_TIMEOUT = 30
 
+# Transient apiserver HTTP statuses fed to the grace-period machinery rather
+# than failing the build. Mirrors the set handled in _get_appwrapper_status;
+# the transport-retry layer already retries these, so reaching here means its
+# budget was exhausted.
+TRANSIENT_API_STATUS_CODES = frozenset({403, 408, 429, 500, 502, 503, 504})
+
+
+def _is_transient_api_exception(exc: Exception) -> bool:
+    """True for a k8s ApiException / aiohttp error worth tolerating transiently."""
+    if isinstance(exc, aiohttp.ClientError):
+        return True
+    if isinstance(exc, client.ApiException):
+        return exc.status in TRANSIENT_API_STATUS_CODES
+    return "Cannot connect to host" in str(exc)
+
+
 # "Normal" events that actually indicate problems
 PROBLEMATIC_NORMAL_EVENTS = {
     # Pod lifecycle issues
@@ -523,29 +539,50 @@ class AppWrapperMonitor(MonitorBase):
         return result
 
     async def _get_workload_status(self: Self) -> List:
-        """Return the status of the Workloads owned by this AppWrapper."""
-        appwrapper_workload_list = await self._workloads_for_appwrapper_by_ownerref(
-            self.name, self.ns
-        )
-        if not appwrapper_workload_list:
-            return []
-        workload_status_list = []
-        for workload in appwrapper_workload_list:
-            assert self.custom_api is not None, "CustomObjectsApi not initialized"
-            workload_status = await self.custom_api.get_namespaced_custom_object_status(
-                group="kueue.x-k8s.io",
-                version=os.getenv("K8S_WORKLOAD_VERSION", "v1beta1"),
-                namespace=self.ns,
-                plural="workloads",
-                name=workload,
+        """Return the status of the Workloads owned by this AppWrapper.
+
+        Runs while assembling a state-change payload, outside the monitor loop's
+        transient handling, so a transient apiserver error (e.g. a 429 that
+        outlived the transport-retry budget) is recorded and reported as empty
+        status for this poll rather than crashing the build. Others propagate.
+        """
+        try:
+            appwrapper_workload_list = await self._workloads_for_appwrapper_by_ownerref(
+                self.name, self.ns
             )
-            workload_status_list.append(
-                {
-                    "workload_name": workload,
-                    "workload_status": workload_status.get("status", {}),
-                }
-            )
-        return workload_status_list
+            if not appwrapper_workload_list:
+                return []
+            workload_status_list = []
+            for workload in appwrapper_workload_list:
+                assert self.custom_api is not None, "CustomObjectsApi not initialized"
+                workload_status = (
+                    await self.custom_api.get_namespaced_custom_object_status(
+                        group="kueue.x-k8s.io",
+                        version=os.getenv("K8S_WORKLOAD_VERSION", "v1beta1"),
+                        namespace=self.ns,
+                        plural="workloads",
+                        name=workload,
+                    )
+                )
+                workload_status_list.append(
+                    {
+                        "workload_name": workload,
+                        "workload_status": workload_status.get("status", {}),
+                    }
+                )
+            return workload_status_list
+        except Exception as e:
+            if _is_transient_api_exception(e):
+                logger.warning(
+                    "[AWMonitor launch_id %s] transient error fetching workload "
+                    "status for AppWrapper %s; reporting empty status this poll: %s",
+                    self.launch_id,
+                    self.name,
+                    e,
+                )
+                self._record_api_failure(e)
+                return []
+            raise
 
     async def _get_appwrapper_failed_pods(self: Self) -> None:
         """Update the dictionary of failed pods owned by this AppWrapper with their status and logs."""

--- a/src/gbserver/monitoring/appwrapper_monitor.py
+++ b/src/gbserver/monitoring/appwrapper_monitor.py
@@ -50,9 +50,9 @@ logger = get_logger(__name__)
 API_CALL_TIMEOUT = 30
 
 # Transient apiserver HTTP statuses fed to the grace-period machinery rather
-# than failing the build. Mirrors the set handled in _get_appwrapper_status;
-# the transport-retry layer already retries these, so reaching here means its
-# budget was exhausted.
+# than failing the build. Mirrors the set handled in _get_appwrapper_status.
+# The transport-retry layer retries the 429/5xx subset before we see it (403/408
+# it leaves alone), so these arrive here either post-retry or on first failure.
 TRANSIENT_API_STATUS_CODES = frozenset({403, 408, 429, 500, 502, 503, 504})
 
 

--- a/src/gbserver/resilience/transport_retry.py
+++ b/src/gbserver/resilience/transport_retry.py
@@ -259,8 +259,15 @@ def _retry_after_seconds(exc: BaseException) -> Optional[float]:
     return None
 
 
+# pylint: disable-next=too-few-public-methods
 class _WaitRetryAfterOrExponential(wait_base):
     """Honor a ``Retry-After`` hint (capped at MAX_DELAY), else exponential backoff."""
+
+    def __init__(self) -> None:
+        self._fallback = wait_random_exponential(
+            multiplier=TRANSPORT_RETRY_BASE_DELAY,
+            max=TRANSPORT_RETRY_MAX_DELAY,
+        )
 
     def __call__(self, retry_state: "RetryCallState") -> float:
         exc = retry_state.outcome.exception() if retry_state.outcome else None
@@ -268,11 +275,7 @@ class _WaitRetryAfterOrExponential(wait_base):
             hinted = _retry_after_seconds(exc)
             if hinted is not None:
                 return max(0.0, min(hinted, TRANSPORT_RETRY_MAX_DELAY))
-        fallback = wait_random_exponential(
-            multiplier=TRANSPORT_RETRY_BASE_DELAY,
-            max=TRANSPORT_RETRY_MAX_DELAY,
-        )
-        return fallback(retry_state)
+        return self._fallback(retry_state)
 
 
 def _install_k8s_request_retry() -> None:

--- a/src/gbserver/resilience/transport_retry.py
+++ b/src/gbserver/resilience/transport_retry.py
@@ -48,6 +48,8 @@ subcommand.
 import asyncio
 import functools
 import json
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Callable, Optional
 
 from tenacity import (
@@ -68,12 +70,20 @@ from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Kubernetes apiserver HTTP status codes that are transient and worth retrying:
-# 429 (throttled / "storage is (re)initializing"), and the 5xx family that
-# surfaces during apiserver rollouts, etcd blips, or LB failovers. Non-transient
-# statuses (401, 403, 404, 409, 422, ...) are deliberately excluded so real API
-# errors still surface promptly with their decoded body.
-RETRYABLE_K8S_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+# Transient apiserver HTTP statuses worth retrying. 429 (throttled / "storage
+# is (re)initializing") is safe to retry for any verb. The 5xx family (apiserver
+# rollouts, etcd blips, LB failovers) is only retried for idempotent read verbs:
+# a 5xx on a write may mean the request reached etcd and mutated state before the
+# response was lost, so a blind retry could duplicate a create or re-apply a
+# patch. Non-transient statuses (401, 403, 404, 409, 422, ...) are excluded so
+# real API errors surface promptly with their decoded body.
+RETRYABLE_ANY_VERB_STATUS_CODES = frozenset({429})
+RETRYABLE_READ_VERB_STATUS_CODES = frozenset({500, 502, 503, 504})
+RETRYABLE_K8S_STATUS_CODES = (
+    RETRYABLE_ANY_VERB_STATUS_CODES | RETRYABLE_READ_VERB_STATUS_CODES
+)
+# HTTP verbs safe to retry on a 5xx (no state mutation on the server).
+IDEMPOTENT_READ_VERBS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 # Marker attribute stamped on wrapped methods so re-installation is a no-op.
 _WRAPPED_MARKER = "_gbserver_transport_retry_wrapped"
@@ -213,28 +223,64 @@ def _is_retryable_connector_error(exc: BaseException) -> bool:
     return isinstance(exc, ClientConnectorError)
 
 
-def _is_retryable_api_status(exc: BaseException) -> bool:
-    """Retry transient apiserver HTTP errors (429 / 5xx); let the rest propagate.
+def _is_retryable_api_status(exc: BaseException, method: Optional[str] = None) -> bool:
+    """Retry transient apiserver HTTP errors; let the rest propagate.
 
     The connector seam only retries connection-level failures and lets every
     ``ApiException`` through, so an HTTP throttle (429 "storage is
     (re)initializing") or a transient 5xx was never retried and would fail an
-    otherwise-healthy build. ``kubernetes_asyncio`` is in the optional ``ibm``
-    extra, so its exception type is imported lazily.
+    otherwise-healthy build.
+
+    429 is retried for any verb. 5xx is retried only for idempotent read verbs
+    (``method`` in :data:`IDEMPOTENT_READ_VERBS`), since a 5xx on a write may
+    have already mutated state. ``method=None`` means "verb unknown" and permits
+    the full transient set — the install site always passes the real verb, so
+    write-gating holds there; None is for classification without a request.
+
+    ``kubernetes_asyncio`` is in the optional ``ibm`` extra, so its exception
+    type is imported lazily.
     """
     try:
         # pylint: disable-next=import-outside-toplevel
         from kubernetes_asyncio.client.exceptions import ApiException
     except ImportError:
         return False
-    return isinstance(exc, ApiException) and exc.status in RETRYABLE_K8S_STATUS_CODES
+    if not isinstance(exc, ApiException):
+        return False
+    if exc.status in RETRYABLE_ANY_VERB_STATUS_CODES:
+        return True
+    if exc.status in RETRYABLE_READ_VERB_STATUS_CODES:
+        return method is None or method.upper() in IDEMPOTENT_READ_VERBS
+    return False
+
+
+def _parse_retry_after(value: str) -> Optional[float]:
+    """Parse a ``Retry-After`` value (RFC 7231): delay-seconds or HTTP-date.
+
+    Returns non-negative seconds, or None if unparseable. The k8s apiserver only
+    emits delay-seconds, but a proxy in front of it could send the date form, so
+    we handle both rather than silently backing off.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        pass
+    try:
+        when = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
 
 
 def _retry_after_seconds(exc: BaseException) -> Optional[float]:
     """Server-advised retry delay for an ApiException, else None.
 
-    Prefers the ``Retry-After`` header, then the Status body's
-    ``details.retryAfterSeconds``; ignores a malformed value.
+    Prefers the ``Retry-After`` header (delay-seconds or HTTP-date), then the
+    Status body's ``details.retryAfterSeconds``; ignores a malformed value.
     """
     headers = getattr(exc, "headers", None)
     if headers is not None:
@@ -243,10 +289,9 @@ def _retry_after_seconds(exc: BaseException) -> Optional[float]:
         except AttributeError:
             retry_after = None
         if retry_after:
-            try:
-                return float(retry_after)
-            except (TypeError, ValueError):
-                pass
+            parsed = _parse_retry_after(retry_after)
+            if parsed is not None:
+                return parsed
     body = getattr(exc, "body", None)
     if body:
         try:
@@ -287,14 +332,17 @@ def _install_k8s_request_retry() -> None:
     if getattr(original, _WRAPPED_MARKER, False):
         return
 
-    def _is_retryable_k8s_error(exc: BaseException) -> bool:
-        # Connection-level failures OR transient apiserver HTTP statuses.
-        return _is_retryable_connector_error(exc) or _is_retryable_api_status(exc)
-
     @functools.wraps(original)
-    async def _request_with_retry(self, *args, **kwargs):
+    async def _request_with_retry(self, method, *args, **kwargs):
+        # request(self, method, url, ...): retry connection errors for any verb,
+        # 429 for any verb, and 5xx only for idempotent reads (see predicate).
+        def _predicate(exc: BaseException) -> bool:
+            return _is_retryable_connector_error(exc) or _is_retryable_api_status(
+                exc, method
+            )
+
         async for attempt in _make_retrying(
-            _is_retryable_k8s_error,
+            _predicate,
             "kubernetes_asyncio request",
             wait=_WaitRetryAfterOrExponential(),
         ):
@@ -302,7 +350,7 @@ def _install_k8s_request_retry() -> None:
                 # Upstream ApiClient.request is a sync def that returns a
                 # coroutine (it dispatches to async RESTClient methods), so the
                 # original call must be awaited.
-                return await original(self, *args, **kwargs)
+                return await original(self, method, *args, **kwargs)
         # Unreachable: tenacity either returns a value or re-raises.
         raise RuntimeError("transport k8s request retry exhausted without result")
 

--- a/src/gbserver/resilience/transport_retry.py
+++ b/src/gbserver/resilience/transport_retry.py
@@ -47,7 +47,8 @@ subcommand.
 
 import asyncio
 import functools
-from typing import Callable
+import json
+from typing import Callable, Optional
 
 from tenacity import (
     AsyncRetrying,
@@ -56,6 +57,7 @@ from tenacity import (
     stop_after_attempt,
     wait_random_exponential,
 )
+from tenacity.wait import wait_base
 
 from gbserver.types.constants import (
     TRANSPORT_RETRY_BASE_DELAY,
@@ -65,6 +67,13 @@ from gbserver.types.constants import (
 from gbserver.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Kubernetes apiserver HTTP status codes that are transient and worth retrying:
+# 429 (throttled / "storage is (re)initializing"), and the 5xx family that
+# surfaces during apiserver rollouts, etcd blips, or LB failovers. Non-transient
+# statuses (401, 403, 404, 409, 422, ...) are deliberately excluded so real API
+# errors still surface promptly with their decoded body.
+RETRYABLE_K8S_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 # Marker attribute stamped on wrapped methods so re-installation is a no-op.
 _WRAPPED_MARKER = "_gbserver_transport_retry_wrapped"
@@ -98,20 +107,27 @@ def _make_before_sleep(label: str) -> Callable[["RetryCallState"], None]:
 
 
 def _make_retrying(
-    predicate: Callable[[BaseException], bool], label: str
+    predicate: Callable[[BaseException], bool],
+    label: str,
+    wait: Optional[wait_base] = None,
 ) -> AsyncRetrying:
     """Build an AsyncRetrying with the shared transport retry policy.
 
     Mirrors the tenacity structure used elsewhere (see ``utils/git_retry.py``):
     capped exponential backoff with jitter, retrying only when ``predicate``
     returns True, and re-raising the original exception once attempts are
-    exhausted. ``label`` names the seam in the retry logs.
+    exhausted. ``label`` names the seam in the retry logs. ``wait`` overrides the
+    default backoff (used by the k8s seam to honor ``Retry-After``).
     """
     return AsyncRetrying(
         stop=stop_after_attempt(TRANSPORT_RETRY_MAX_ATTEMPTS),
-        wait=wait_random_exponential(
-            multiplier=TRANSPORT_RETRY_BASE_DELAY,
-            max=TRANSPORT_RETRY_MAX_DELAY,
+        wait=(
+            wait
+            if wait is not None
+            else wait_random_exponential(
+                multiplier=TRANSPORT_RETRY_BASE_DELAY,
+                max=TRANSPORT_RETRY_MAX_DELAY,
+            )
         ),
         retry=retry_if_exception(predicate),
         before_sleep=_make_before_sleep(label),
@@ -197,6 +213,68 @@ def _is_retryable_connector_error(exc: BaseException) -> bool:
     return isinstance(exc, ClientConnectorError)
 
 
+def _is_retryable_api_status(exc: BaseException) -> bool:
+    """Retry transient apiserver HTTP errors (429 / 5xx); let the rest propagate.
+
+    The connector seam only retries connection-level failures and lets every
+    ``ApiException`` through, so an HTTP throttle (429 "storage is
+    (re)initializing") or a transient 5xx was never retried and would fail an
+    otherwise-healthy build. ``kubernetes_asyncio`` is in the optional ``ibm``
+    extra, so its exception type is imported lazily.
+    """
+    try:
+        # pylint: disable-next=import-outside-toplevel
+        from kubernetes_asyncio.client.exceptions import ApiException
+    except ImportError:
+        return False
+    return isinstance(exc, ApiException) and exc.status in RETRYABLE_K8S_STATUS_CODES
+
+
+def _retry_after_seconds(exc: BaseException) -> Optional[float]:
+    """Server-advised retry delay for an ApiException, else None.
+
+    Prefers the ``Retry-After`` header, then the Status body's
+    ``details.retryAfterSeconds``; ignores a malformed value.
+    """
+    headers = getattr(exc, "headers", None)
+    if headers is not None:
+        try:
+            retry_after = headers.get("Retry-After") or headers.get("retry-after")
+        except AttributeError:
+            retry_after = None
+        if retry_after:
+            try:
+                return float(retry_after)
+            except (TypeError, ValueError):
+                pass
+    body = getattr(exc, "body", None)
+    if body:
+        try:
+            details = json.loads(body).get("details", {}) or {}
+            seconds = details.get("retryAfterSeconds")
+            if seconds is not None:
+                return float(seconds)
+        except (ValueError, TypeError, AttributeError):
+            pass
+    return None
+
+
+class _WaitRetryAfterOrExponential(wait_base):
+    """Honor a ``Retry-After`` hint (capped at MAX_DELAY), else exponential backoff."""
+
+    def __call__(self, retry_state: "RetryCallState") -> float:
+        exc = retry_state.outcome.exception() if retry_state.outcome else None
+        if exc is not None:
+            hinted = _retry_after_seconds(exc)
+            if hinted is not None:
+                return max(0.0, min(hinted, TRANSPORT_RETRY_MAX_DELAY))
+        fallback = wait_random_exponential(
+            multiplier=TRANSPORT_RETRY_BASE_DELAY,
+            max=TRANSPORT_RETRY_MAX_DELAY,
+        )
+        return fallback(retry_state)
+
+
 def _install_k8s_request_retry() -> None:
     """Wrap ``ApiClient.request`` with the transport retry policy."""
     # pylint: disable-next=import-outside-toplevel
@@ -206,10 +284,16 @@ def _install_k8s_request_retry() -> None:
     if getattr(original, _WRAPPED_MARKER, False):
         return
 
+    def _is_retryable_k8s_error(exc: BaseException) -> bool:
+        # Connection-level failures OR transient apiserver HTTP statuses.
+        return _is_retryable_connector_error(exc) or _is_retryable_api_status(exc)
+
     @functools.wraps(original)
     async def _request_with_retry(self, *args, **kwargs):
         async for attempt in _make_retrying(
-            _is_retryable_connector_error, "kubernetes_asyncio request"
+            _is_retryable_k8s_error,
+            "kubernetes_asyncio request",
+            wait=_WaitRetryAfterOrExponential(),
         ):
             with attempt:
                 # Upstream ApiClient.request is a sync def that returns a

--- a/test/unit/monitoring/test_appwrapper_monitor.py
+++ b/test/unit/monitoring/test_appwrapper_monitor.py
@@ -7,6 +7,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from kubernetes_asyncio import client
 
 from gbserver.monitoring.appwrapper_monitor import AppWrapperMonitor
 from gbserver.types.buildevent import BuildEventType, EntityRunMetadata
@@ -176,3 +177,67 @@ class TestPodLivenessCheck:
         # Call _check_pod_liveness and verify it returns True
         result = await monitor._check_pod_liveness()
         assert result is True
+
+
+class TestWorkloadStatusTransientErrors:
+    """_get_workload_status tolerates transient apiserver errors.
+
+    This runs while assembling a state-change payload, outside the monitor
+    loop's transient handling. A 429/5xx that outlived the transport-retry
+    budget must not crash the build: it is recorded as an API failure and
+    reported as empty status for that poll, rather than propagating.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transient_429_returns_empty_and_records_failure(self):
+        """A 429 on the workload list is tolerated, not raised."""
+        monitor, _, _ = _make_monitor()
+        monitor.custom_api = MagicMock()
+        monitor.custom_api.list_namespaced_custom_object = AsyncMock(
+            side_effect=client.ApiException(status=429, reason="Too Many Requests")
+        )
+        result = await monitor._get_workload_status()
+        assert result == []
+        assert monitor._api_failure_start_time is not None
+
+    @pytest.mark.asyncio
+    async def test_transient_503_on_status_call_is_tolerated(self):
+        """A 503 while fetching per-workload status is tolerated too."""
+        monitor, _, _ = _make_monitor()
+        monitor.custom_api = MagicMock()
+        # List succeeds and returns one owned workload...
+        monitor.custom_api.list_namespaced_custom_object = AsyncMock(
+            return_value={
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "wl-1",
+                            "ownerReferences": [
+                                {
+                                    "apiVersion": "workload.codeflare.dev/v1beta2",
+                                    "name": monitor.name,
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        )
+        # ...but the per-workload status call is throttled.
+        monitor.custom_api.get_namespaced_custom_object_status = AsyncMock(
+            side_effect=client.ApiException(status=503, reason="Service Unavailable")
+        )
+        result = await monitor._get_workload_status()
+        assert result == []
+        assert monitor._api_failure_start_time is not None
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_propagates(self):
+        """A non-transient ApiException (e.g. 401) still propagates."""
+        monitor, _, _ = _make_monitor()
+        monitor.custom_api = MagicMock()
+        monitor.custom_api.list_namespaced_custom_object = AsyncMock(
+            side_effect=client.ApiException(status=401, reason="Unauthorized")
+        )
+        with pytest.raises(client.ApiException):
+            await monitor._get_workload_status()

--- a/test/unit/resilience/test_transport_retry.py
+++ b/test/unit/resilience/test_transport_retry.py
@@ -22,6 +22,8 @@ and the retry predicates that decide which transport errors are transient.
 """
 
 import asyncio
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from typing import Self
 
 import pytest
@@ -184,7 +186,8 @@ class TestApiStatusPredicate:
     """The apiserver-status predicate retries transient HTTP codes only."""
 
     @requires_k8s
-    def test_retries_transient_statuses(self: Self) -> None:
+    def test_retries_transient_statuses_when_verb_unknown(self: Self) -> None:
+        # method=None permits the full transient set (classification without a verb).
         for status in (429, 500, 502, 503, 504):
             assert _is_retryable_api_status(ApiException(status=status)) is True
 
@@ -192,6 +195,26 @@ class TestApiStatusPredicate:
     def test_does_not_retry_non_transient_statuses(self: Self) -> None:
         for status in (400, 401, 403, 404, 409, 422):
             assert _is_retryable_api_status(ApiException(status=status)) is False
+
+    @requires_k8s
+    def test_429_retries_for_any_verb(self: Self) -> None:
+        for method in ("GET", "POST", "PATCH", "DELETE"):
+            assert _is_retryable_api_status(ApiException(status=429), method) is True
+
+    @requires_k8s
+    def test_5xx_retries_only_for_read_verbs(self: Self) -> None:
+        # 5xx on a write may have mutated state before the response was lost, so
+        # only idempotent reads are retried.
+        for status in (500, 502, 503, 504):
+            for read in ("GET", "HEAD", "OPTIONS", "get"):
+                assert (
+                    _is_retryable_api_status(ApiException(status=status), read) is True
+                )
+            for write in ("POST", "PUT", "PATCH", "DELETE"):
+                assert (
+                    _is_retryable_api_status(ApiException(status=status), write)
+                    is False
+                )
 
     def test_non_api_exception_is_not_retryable(self: Self) -> None:
         # Non-ApiException (and the missing-library case) must not match.
@@ -217,6 +240,18 @@ class TestRetryAfterWait:
     def test_malformed_header_ignored(self: Self) -> None:
         exc = _FakeApiExc(status=429, headers={"Retry-After": "soon"})
         assert _retry_after_seconds(exc) is None
+
+    def test_retry_after_http_date_future(self: Self) -> None:
+        # RFC 7231 allows an HTTP-date; parse it to a positive delay.
+        future = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=30))
+        exc = _FakeApiExc(status=429, headers={"Retry-After": future})
+        delay = _retry_after_seconds(exc)
+        assert delay is not None and 20.0 <= delay <= 31.0
+
+    def test_retry_after_http_date_past_clamps_to_zero(self: Self) -> None:
+        past = format_datetime(datetime.now(timezone.utc) - timedelta(seconds=30))
+        exc = _FakeApiExc(status=429, headers={"Retry-After": past})
+        assert _retry_after_seconds(exc) == 0.0
 
     def test_wait_honors_hint_capped(
         self: Self, monkeypatch: pytest.MonkeyPatch
@@ -356,32 +391,31 @@ class TestRetryDriver:
 class TestK8sSeamRetries:
     """The installed ApiClient.request wrapper retries transient HTTP statuses."""
 
+    @staticmethod
+    def _install_fake_base(monkeypatch: pytest.MonkeyPatch, fake_request) -> None:
+        # fresh_install already wrapped ApiClient.request. Swap the *original*
+        # base for our fake (marker-less, so re-install wraps it) and re-install.
+        monkeypatch.setattr(ApiClient, "request", fake_request, raising=True)
+        tr._INSTALLED = False
+        install_transport_retries()
+
     @requires_k8s
     @pytest.mark.asyncio
     async def test_installed_wrapper_retries_429_then_succeeds(
         self: Self, fresh_install, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # fresh_install already wrapped ApiClient.request with fast (no-wait)
-        # retries. Replace the *original* underlying request so the wrapper
-        # drives it: fail twice with 429, then succeed.
         calls = {"n": 0}
 
-        async def flaky_request(self, *args, **kwargs):
+        async def flaky_request(self, method, *args, **kwargs):
             calls["n"] += 1
             if calls["n"] < 3:
                 raise ApiException(status=429, reason="Too Many Requests")
             return "ok"
 
-        # Point the wrapped method's captured `original` at our fake by patching
-        # at the class level beneath the wrapper via the closure is not directly
-        # reachable; instead re-install over a patched base.
-        monkeypatch.setattr(ApiClient, "request", flaky_request, raising=True)
-        tr._INSTALLED = False
-        # Clear the wrap marker so re-install wraps our fake base.
-        install_transport_retries()
-
+        self._install_fake_base(monkeypatch, flaky_request)
         client_obj = ApiClient.__new__(ApiClient)
-        result = await ApiClient.request(client_obj)
+        # 429 retries even on a write verb.
+        result = await ApiClient.request(client_obj, "POST")
         assert result == "ok"
         assert calls["n"] == 3
 
@@ -392,15 +426,49 @@ class TestK8sSeamRetries:
     ) -> None:
         calls = {"n": 0}
 
-        async def not_found_request(self, *args, **kwargs):
+        async def not_found_request(self, method, *args, **kwargs):
             calls["n"] += 1
             raise ApiException(status=404, reason="Not Found")
 
-        monkeypatch.setattr(ApiClient, "request", not_found_request, raising=True)
-        tr._INSTALLED = False
-        install_transport_retries()
-
+        self._install_fake_base(monkeypatch, not_found_request)
         client_obj = ApiClient.__new__(ApiClient)
         with pytest.raises(ApiException):
-            await ApiClient.request(client_obj)
+            await ApiClient.request(client_obj, "GET")
+        assert calls["n"] == 1
+
+    @requires_k8s
+    @pytest.mark.asyncio
+    async def test_installed_wrapper_retries_5xx_on_read_verb(
+        self: Self, fresh_install, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = {"n": 0}
+
+        async def flaky_request(self, method, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ApiException(status=503, reason="Service Unavailable")
+            return "ok"
+
+        self._install_fake_base(monkeypatch, flaky_request)
+        client_obj = ApiClient.__new__(ApiClient)
+        result = await ApiClient.request(client_obj, "GET")
+        assert result == "ok"
+        assert calls["n"] == 3
+
+    @requires_k8s
+    @pytest.mark.asyncio
+    async def test_installed_wrapper_does_not_retry_5xx_on_write_verb(
+        self: Self, fresh_install, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A 5xx on a write may have mutated state; must not be blindly retried.
+        calls = {"n": 0}
+
+        async def failing_write(self, method, *args, **kwargs):
+            calls["n"] += 1
+            raise ApiException(status=503, reason="Service Unavailable")
+
+        self._install_fake_base(monkeypatch, failing_write)
+        client_obj = ApiClient.__new__(ApiClient)
+        with pytest.raises(ApiException):
+            await ApiClient.request(client_obj, "POST")
         assert calls["n"] == 1

--- a/test/unit/resilience/test_transport_retry.py
+++ b/test/unit/resilience/test_transport_retry.py
@@ -45,9 +45,12 @@ from libgbtest.constants import HAS_K8S, requires_k8s
 import gbserver.resilience.transport_retry as tr
 from gbserver.resilience.transport_retry import (
     _WRAPPED_MARKER,
+    _WaitRetryAfterOrExponential,
+    _is_retryable_api_status,
     _is_retryable_connector_error,
     _is_retryable_dns_error,
     _make_retrying,
+    _retry_after_seconds,
     install_transport_retries,
 )
 
@@ -172,8 +175,104 @@ class TestPredicates:
 
     @requires_k8s
     def test_connector_does_not_retry_api_exception(self: Self) -> None:
-        # ApiException must propagate so callers see real API errors.
+        # The connector predicate never matches ApiException; retryable HTTP
+        # statuses are handled by _is_retryable_api_status instead.
         assert _is_retryable_connector_error(ApiException(status=500)) is False
+
+
+class TestApiStatusPredicate:
+    """The apiserver-status predicate retries transient HTTP codes only."""
+
+    @requires_k8s
+    def test_retries_transient_statuses(self: Self) -> None:
+        for status in (429, 500, 502, 503, 504):
+            assert _is_retryable_api_status(ApiException(status=status)) is True
+
+    @requires_k8s
+    def test_does_not_retry_non_transient_statuses(self: Self) -> None:
+        for status in (400, 401, 403, 404, 409, 422):
+            assert _is_retryable_api_status(ApiException(status=status)) is False
+
+    def test_non_api_exception_is_not_retryable(self: Self) -> None:
+        # Non-ApiException (and the missing-library case) must not match.
+        assert _is_retryable_api_status(ValueError("nope")) is False
+        assert _is_retryable_api_status(OSError("x")) is False
+
+
+class TestRetryAfterWait:
+    """The k8s wait honors Retry-After hints, capped, else falls back."""
+
+    def test_retry_after_header_seconds(self: Self) -> None:
+        exc = _FakeApiExc(status=429, headers={"Retry-After": "2"})
+        assert _retry_after_seconds(exc) == 2.0
+
+    def test_retry_after_body_details(self: Self) -> None:
+        exc = _FakeApiExc(status=429, body='{"details": {"retryAfterSeconds": 3}}')
+        assert _retry_after_seconds(exc) == 3.0
+
+    def test_no_hint_returns_none(self: Self) -> None:
+        assert _retry_after_seconds(_FakeApiExc(status=500)) is None
+        assert _retry_after_seconds(ValueError("x")) is None
+
+    def test_malformed_header_ignored(self: Self) -> None:
+        exc = _FakeApiExc(status=429, headers={"Retry-After": "soon"})
+        assert _retry_after_seconds(exc) is None
+
+    def test_wait_honors_hint_capped(
+        self: Self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tr, "TRANSPORT_RETRY_MAX_DELAY", 15.0)
+        wait = _WaitRetryAfterOrExponential()
+        # Server asks for 2s -> honored.
+        assert (
+            wait(_FakeRetryState(_FakeApiExc(status=429, headers={"Retry-After": "2"})))
+            == 2.0
+        )
+        # Server asks for a huge delay -> capped at MAX_DELAY.
+        assert (
+            wait(
+                _FakeRetryState(
+                    _FakeApiExc(status=429, headers={"Retry-After": "9999"})
+                )
+            )
+            == 15.0
+        )
+
+    def test_wait_falls_back_to_backoff(
+        self: Self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No hint -> exponential backoff (bounded by MAX_DELAY, non-negative).
+        monkeypatch.setattr(tr, "TRANSPORT_RETRY_BASE_DELAY", 1.0)
+        monkeypatch.setattr(tr, "TRANSPORT_RETRY_MAX_DELAY", 15.0)
+        wait = _WaitRetryAfterOrExponential()
+        delay = wait(_FakeRetryState(OSError("x")))
+        assert 0.0 <= delay <= 15.0
+
+
+class _FakeApiExc(Exception):
+    """Stand-in for kubernetes_asyncio ApiException (status/headers/body only)."""
+
+    def __init__(self, status: int, headers=None, body=None) -> None:
+        super().__init__(f"({status})")
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+
+class _FakeOutcome:
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def exception(self) -> BaseException:
+        return self._exc
+
+
+class _FakeRetryState:
+    """Minimal tenacity RetryCallState carrying a failed outcome."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self.outcome = _FakeOutcome(exc)
+        self.attempt_number = 1
 
 
 class _FakeKey:
@@ -252,3 +351,56 @@ class TestRetryDriver:
         with pytest.raises(OSError):
             await always_fail()
         assert calls["n"] == 3
+
+
+class TestK8sSeamRetries:
+    """The installed ApiClient.request wrapper retries transient HTTP statuses."""
+
+    @requires_k8s
+    @pytest.mark.asyncio
+    async def test_installed_wrapper_retries_429_then_succeeds(
+        self: Self, fresh_install, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # fresh_install already wrapped ApiClient.request with fast (no-wait)
+        # retries. Replace the *original* underlying request so the wrapper
+        # drives it: fail twice with 429, then succeed.
+        calls = {"n": 0}
+
+        async def flaky_request(self, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ApiException(status=429, reason="Too Many Requests")
+            return "ok"
+
+        # Point the wrapped method's captured `original` at our fake by patching
+        # at the class level beneath the wrapper via the closure is not directly
+        # reachable; instead re-install over a patched base.
+        monkeypatch.setattr(ApiClient, "request", flaky_request, raising=True)
+        tr._INSTALLED = False
+        # Clear the wrap marker so re-install wraps our fake base.
+        install_transport_retries()
+
+        client_obj = ApiClient.__new__(ApiClient)
+        result = await ApiClient.request(client_obj)
+        assert result == "ok"
+        assert calls["n"] == 3
+
+    @requires_k8s
+    @pytest.mark.asyncio
+    async def test_installed_wrapper_does_not_retry_404(
+        self: Self, fresh_install, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = {"n": 0}
+
+        async def not_found_request(self, *args, **kwargs):
+            calls["n"] += 1
+            raise ApiException(status=404, reason="Not Found")
+
+        monkeypatch.setattr(ApiClient, "request", not_found_request, raising=True)
+        tr._INSTALLED = False
+        install_transport_retries()
+
+        client_obj = ApiClient.__new__(ApiClient)
+        with pytest.raises(ApiException):
+            await ApiClient.request(client_obj)
+        assert calls["n"] == 1

--- a/test/unit/resilience/test_transport_retry.py
+++ b/test/unit/resilience/test_transport_retry.py
@@ -45,12 +45,12 @@ from libgbtest.constants import HAS_K8S, requires_k8s
 import gbserver.resilience.transport_retry as tr
 from gbserver.resilience.transport_retry import (
     _WRAPPED_MARKER,
-    _WaitRetryAfterOrExponential,
     _is_retryable_api_status,
     _is_retryable_connector_error,
     _is_retryable_dns_error,
     _make_retrying,
     _retry_after_seconds,
+    _WaitRetryAfterOrExponential,
     install_transport_retries,
 )
 


### PR DESCRIPTION
## Problem

An integration build failed with the build ending in `FAILED` instead of `SUCCESS`. The root cause was a **transient Kubernetes apiserver `429 Too Many Requests`** (body `storage is (re)initializing`, `Retry-After: 1`) during a workload-status poll:

```
appwrapper_monitor._publish_state_change
 → _get_state_change → _get_workload_status
   → _workloads_for_appwrapper_by_ownerref → list_namespaced_custom_object(...)
     → kubernetes_asyncio ApiException(429)
```

The 429 propagated as an unhandled `ExceptionGroup` → `RunFailed`, failing an otherwise-healthy build (the pod was still `Pending`, starting normally).

### Why the existing safeguards didn't catch it

There were already **two** mechanisms intended to absorb exactly this kind of transient apiserver error, and this 429 slipped through the seam between them — each had a blind spot that only lined up on this specific call path:

1. **Transport-layer retry** (`transport_retry.py`) wraps *every* `kubernetes_asyncio` `ApiClient.request` and is the general-purpose "survive transient cluster blips" layer. But its predicate retried only **connection-level** failures (`ClientConnectorError`, DNS) and **deliberately let every `ApiException` propagate** — the original intent was that an `ApiException` carries a decoded HTTP error the caller should see. That design conflated "HTTP error the caller must handle" (401/404/409…) with "HTTP error that is purely transient" (429 throttle, 5xx during an apiserver rollout). So an HTTP-level 429/5xx was **never** retried here, even though it's the textbook transient case.

2. **Application-layer tolerance** in the monitor already treats transient statuses as non-fatal — but only on the **primary** poll, `_get_appwrapper_status`, which catches `ApiException` with `status in {403,408,429,500,502,503,504}` and feeds it to the grace-period machinery. The failing call, `_get_workload_status`, runs on a **different** path: it's invoked while *assembling a state-change payload* (`_get_state_change`), which executes **outside** the monitor loop's `try/except`. That path made raw k8s calls with no transient guard at all — so the same 429 that `_get_appwrapper_status` would have shrugged off was fatal when it happened one method over.

In short: the transport layer skipped it *by policy* (ApiException always propagates), and the monitor's transient handling didn't cover *this* code path *by omission*. The fix closes both.

## Fix (defense-in-depth, both layers)

**`src/gbserver/resilience/transport_retry.py`** (primary — covers every k8s call in the process)
- Add `_is_retryable_api_status` and broaden the k8s seam predicate to `connector-error OR retryable-status`. The transient set is **verb-aware**: `429` retries for any verb; `5xx` (`500/502/503/504`) retries only for idempotent read verbs (`GET/HEAD/OPTIONS`), since a 5xx on a write may have reached etcd and mutated state before the response was lost. Non-transient statuses (401/403/404/409/422) still surface immediately — the ApiException-propagates intent is preserved for the codes where it matters.
- Add a `Retry-After`-aware wait (`_WaitRetryAfterOrExponential`): honor the response header (delay-seconds **or** RFC 7231 HTTP-date), then the Status body's `details.retryAfterSeconds`, capped at `TRANSPORT_RETRY_MAX_DELAY`; fall back to the existing capped exponential backoff.

**`src/gbserver/monitoring/appwrapper_monitor.py`** (defense-in-depth)
- `_get_workload_status` now funnels a transient `ApiException`/`aiohttp.ClientError` through the existing `_record_api_failure` grace-period machinery and returns empty status for that poll instead of raising; non-transient errors still propagate. This brings the state-change-payload path in line with the tolerance `_get_appwrapper_status` already had.

## Self-review

**Design**
- Primary fix is at the transport seam's true source, so it protects **all** k8s calls, not just this call site. The monitor guard is a backstop for when the retry budget is exhausted (or disabled via `GBSERVER_TRANSPORT_RETRY_MAX_ATTEMPTS=1`), where the grace-period + pod-liveness logic then decides fatality.
- Retryable status set is intentionally narrow. 401/403/404/409/422 still fail fast with their decoded body — no masking of real API errors. (The monitor's `TRANSIENT_API_STATUS_CODES` additionally includes 403/408, matching the pre-existing set in `_get_appwrapper_status` rather than introducing a new policy; the transport layer retries only the 429/5xx subset, leaving 403/408 to fail fast.)
- `Retry-After` is bounded by `TRANSPORT_RETRY_MAX_DELAY` (15s) × `TRANSPORT_RETRY_MAX_ATTEMPTS` (10), so a persistently-throttling apiserver still fails in bounded time rather than hanging.
- **Operator note:** under sustained throttling a single k8s call can now take up to ~150s (`MAX_DELAY 15s × MAX_ATTEMPTS 10`) before it finally fails, versus failing immediately before. Both knobs are env-tunable (`GBSERVER_TRANSPORT_RETRY_MAX_DELAY` / `_MAX_ATTEMPTS`); set `_MAX_ATTEMPTS=1` to disable retries entirely.

**Blast radius**
- The transport wrap is an idempotent global monkeypatch applied once from the CLI root callback; broadening its predicate is the intended behavior change. Existing DNS/connector retry behavior is unchanged.
- `_get_workload_status` returning `[]` on a transient blip only affects the diagnostic `workload_status` field of one state-change payload — no control-flow impact.

**Tests** (`test/unit/resilience/test_transport_retry.py`, `test/unit/monitoring/test_appwrapper_monitor.py`)
- Predicate: 429 retries for any verb; 5xx retries only for read verbs (`GET/HEAD/OPTIONS`), not writes (`POST/PUT/PATCH/DELETE`); non-transient `{400,401,403,404,409,422}` and non-`ApiException` never match.
- `Retry-After` parsing: delay-seconds, HTTP-date (future → positive delay, past → clamped to 0), body `details.retryAfterSeconds`, malformed value ignored, no-hint → `None`; capped wait honors the hint and clamps a huge value.
- End-to-end (installed wrapper): retries a 429 on POST twice then succeeds; retries a 503 on GET; does **not** retry a 503 on POST; does **not** retry a 404.
- Monitor: 429 on list and 503 on the per-workload status call both yield `[]` + record the failure; 401 propagates.
- k8s-dependent tests are gated by `requires_k8s`/`HAS_K8S` (optional `ibm` extra), matching the existing file convention. `isort`/`black`/`pylint`/`mypy` clean for the changed code.

**Verification note**
The original failure relied on a live-cluster 429, so the deterministic proof is the unit tests above rather than a re-run of `TestBuildRunner1StepCPU.test_runner`.

**Updates from review** (thanks @klwuibm)
- 5xx retry is now gated to idempotent read verbs so writes aren't blindly retried after a possible state mutation.
- `Retry-After` now parses the RFC 7231 HTTP-date form in addition to delay-seconds.
- Added the per-poll latency-ceiling note above for operators.
- The `403` in the monitor's `TRANSIENT_API_STATUS_CODES` is pre-existing parity with `_get_appwrapper_status`, not introduced here — left as-is to avoid scope creep.


