### PR TITLE
Support host-supplied identity headers on both Agent Chat call paths

### DIFF
--- a/frontend/apps/standalone/tests/chat-headers.test.js
+++ b/frontend/apps/standalone/tests/chat-headers.test.js
@@ -1,0 +1,134 @@
+/**
+ * Verifies every outbound chat request can carry host-supplied headers.
+ *
+ * Usage: node --test tests/chat-headers.test.js
+ *
+ * Why static checks rather than behavioural ones: this workspace's test setup is plain
+ * `node --test` with no DOM or module transpiler, so exercising an axios interceptor and a
+ * native fetch against TypeScript source is not available here. The failure mode worth
+ * guarding is structural anyway — a *new* chat call path that forgets the headers — and a
+ * source-level check catches that, where a behavioural test of the existing two would not.
+ *
+ * Chat is the one API client a host app cannot reach with its own axios interceptor: three
+ * routes go through this module's private `statusClient`, and /chat/stream uses native fetch
+ * because axios does not stream cleanly in-browser. If a request escapes both hooks it
+ * arrives unidentified, and the backend's resolve_identity() collapses every user into one
+ * shared "standalone" identity — merging the per-identity rate limit into a single bucket and
+ * merging the session scoping that stops one user resolving another's pending confirm_action.
+ *
+ * Like source-cleanup.test.js, these read from UI_CORE_ROOT, not APP_ROOT — chat.ts lives in
+ * the sibling packages/ui-core workspace. The first test exists so that a moved or renamed
+ * file fails loudly here instead of making every "source contains ..." check below pass
+ * vacuously against an empty string.
+ */
+
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('fs')
+const path = require('path')
+
+const UI_CORE_ROOT = path.join(__dirname, '..', '..', '..', 'packages', 'ui-core')
+const CHAT_TS = path.join(UI_CORE_ROOT, 'api', 'chat.ts')
+
+function chatSource() {
+  return fs.readFileSync(CHAT_TS, 'utf8')
+}
+
+function countOccurrences(haystack, needle) {
+  return haystack.split(needle).length - 1
+}
+
+/**
+ * The source of the balanced (...) argument list that follows `marker`.
+ *
+ * Scoping matters more than it looks: an earlier version of the interceptor check matched
+ * /use\(async \(config\) => \{[\s\S]*?resolveChatHeaders\(\)/ against the whole file, which
+ * passed as long as resolveChatHeaders() appeared *anywhere* later — including in the
+ * unrelated fetch path further down. It therefore still passed against an interceptor whose
+ * body had been gutted. Matching only within the call's own parentheses is what makes the
+ * check mean what it says.
+ */
+function callArgumentSource(src, marker) {
+  const start = src.indexOf(marker)
+  if (start === -1) return ''
+  let i = src.indexOf('(', start + marker.length - 1)
+  if (i === -1) return ''
+  let depth = 0
+  const from = i
+  for (; i < src.length; i += 1) {
+    if (src[i] === '(') depth += 1
+    else if (src[i] === ')') {
+      depth -= 1
+      if (depth === 0) return src.slice(from, i + 1)
+    }
+  }
+  return ''
+}
+
+describe('chat header provider', () => {
+  it('api/chat.ts is where these checks expect it', () => {
+    assert.ok(
+      fs.existsSync(CHAT_TS),
+      `packages/ui-core/api/chat.ts not found at ${CHAT_TS} — if it moved, update this test; ` +
+        'otherwise every check below would pass against an empty string',
+    )
+    assert.ok(chatSource().length > 500, 'api/chat.ts is unexpectedly small — wrong file?')
+  })
+
+  it('exposes a settable header provider', () => {
+    const src = chatSource()
+    assert.match(src, /export function setChatHeaderProvider\(/)
+    assert.match(src, /export type ChatHeaderProvider/)
+  })
+
+  it('applies the provider to the statusClient path', () => {
+    const src = chatSource()
+    assert.match(
+      src,
+      /statusClient\.interceptors\.request\.use\(/,
+      'statusClient has no request interceptor, so /chat/status, /chat/stop and ' +
+        '/chat/confirm cannot carry host headers',
+    )
+    const body = callArgumentSource(src, 'statusClient.interceptors.request.use')
+    assert.ok(body.length > 0, 'could not parse the interceptor call — has its shape changed?')
+    assert.ok(
+      body.includes('resolveChatHeaders()'),
+      "statusClient's request interceptor does not call resolveChatHeaders(), so the three " +
+        'routes behind statusClient would arrive unidentified',
+    )
+  })
+
+  it('applies the provider to the streaming fetch path', () => {
+    const src = chatSource()
+    assert.ok(
+      /headers: \{\s*\.\.\.\(await resolveChatHeaders\(\)\)/.test(src),
+      'the /chat/stream fetch does not spread resolveChatHeaders() into its headers',
+    )
+  })
+
+  it('keeps Content-Type authoritative on the streaming body', () => {
+    // A provider returning its own Content-Type must not change how the JSON body is read,
+    // so the literal has to come after the spread rather than before it.
+    const src = chatSource()
+    const spreadAt = src.indexOf('...(await resolveChatHeaders())')
+    const contentTypeAt = src.indexOf("'Content-Type': 'application/json'", spreadAt)
+    assert.ok(spreadAt !== -1 && contentTypeAt > spreadAt, 'Content-Type must be set after the spread')
+  })
+
+  it('has no chat request path that bypasses both hooks', () => {
+    // The guard that actually earns its keep: a third call path added later.
+    const src = chatSource()
+    assert.equal(
+      countOccurrences(src, 'axios.create('),
+      1,
+      'a second axios instance was added to chat.ts — it needs the same request interceptor, ' +
+        'or its calls will arrive unidentified',
+    )
+    assert.equal(
+      countOccurrences(src, 'fetch('),
+      1,
+      'chat.ts makes more than one direct fetch() call — each needs resolveChatHeaders() ' +
+        'spread into its headers',
+    )
+  })
+})

--- a/frontend/packages/ui-core/api/chat.ts
+++ b/frontend/packages/ui-core/api/chat.ts
@@ -28,7 +28,67 @@ export interface ChatEvent {
   confirmation_id?: string
 }
 
+/**
+ * Extra request headers to attach to every chat call, supplied by the host app.
+ *
+ * Chat is the one API client here that a host cannot reach with its own axios
+ * interceptor. Deployments whose per-user identity does not come from gbserver's
+ * AuthMiddleware identify the caller with request headers instead (gb-ui's
+ * sidecar, for one, sends an Authorization bearer token plus X-User-Email) and
+ * normally attach them by interceptor on their own axios instance. This module
+ * uses neither that instance nor, for streaming, axios at all: /chat/status,
+ * /chat/stop and /chat/confirm go through the module-private `statusClient`
+ * below, and /chat/stream uses native fetch because axios does not stream
+ * cleanly in-browser.
+ *
+ * So without a hook here, every chat request arrives unidentified no matter what
+ * the host configures, and the backend's resolve_identity() falls back to one
+ * shared "standalone" identity for everybody — collapsing the per-identity rate
+ * limit into a single bucket and, more seriously, collapsing the session scoping
+ * that stops one user resolving another user's pending confirm_action.
+ *
+ * Call setChatHeaderProvider once during app startup; pass null to clear it. The
+ * provider runs per request rather than once, so it always sees current
+ * credentials, and it may be async for hosts that refresh a token first.
+ */
+export type ChatHeaderProvider = () =>
+  | Record<string, string>
+  | Promise<Record<string, string>>
+
+let chatHeaderProvider: ChatHeaderProvider | null = null
+
+export function setChatHeaderProvider(provider: ChatHeaderProvider | null): void {
+  chatHeaderProvider = provider
+}
+
+/**
+ * Resolves the host-supplied headers for a single request.
+ *
+ * A provider that throws or rejects contributes no headers rather than failing
+ * the call: that degrades chat to exactly the unidentified behaviour it has when
+ * no provider is installed, whereas propagating the error would take the whole
+ * widget down over something like a transient token read.
+ */
+async function resolveChatHeaders(): Promise<Record<string, string>> {
+  if (!chatHeaderProvider) return {}
+  try {
+    return (await chatHeaderProvider()) ?? {}
+  } catch {
+    return {}
+  }
+}
+
 const statusClient = axios.create({ baseURL: apiBase('/api/analytics') })
+
+// One interceptor covers /chat/status, /chat/stop and /chat/confirm. axios awaits
+// async request interceptors, so a provider that refreshes a token still works.
+statusClient.interceptors.request.use(async (config) => {
+  const extra = await resolveChatHeaders()
+  for (const [name, value] of Object.entries(extra)) {
+    config.headers.set(name, value)
+  }
+  return config
+})
 
 export interface ChatStatus {
   enabled: boolean
@@ -118,7 +178,12 @@ export async function* streamChat(
 ): AsyncGenerator<ChatEvent> {
   const res = await fetch(apiBase('/api/analytics/chat/stream'), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      ...(await resolveChatHeaders()),
+      // Set last on purpose: the body below is always JSON, so a host provider
+      // must not be able to change how the server reads it.
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({
       session_id: sessionId,
       message,


### PR DESCRIPTION
## Description

Chat is the only API client in `ui-core` that a host application cannot reach with its own
axios interceptor. Three of its four routes (`/chat/status`, `/chat/stop`, `/chat/confirm`) go
through the module-private `statusClient` instance, and `/chat/stream` uses native `fetch`
because axios does not stream cleanly in-browser.

For deployments whose per-user identity does not come from gbserver's `AuthMiddleware`, that
is not cosmetic. Such a host identifies the caller with request headers instead — gb-ui's
sidecar sends an `Authorization` bearer token plus `X-User-Email` — and attaches them by
interceptor on its own axios client. Neither chat path sees that interceptor, so every chat
request arrives unidentified and `resolve_identity()` falls back to a single shared
`"standalone"` identity for all users. That merges the per-identity rate limit into one bucket
and, more seriously, merges the `_scoped_session_id` namespace, so one user can resolve another
user's pending `confirm_action`.

This adds `setChatHeaderProvider()`, applied to both paths: a request interceptor on
`statusClient` covers the three non-streaming routes, and `streamChat()` spreads the resolved
headers into its fetch options.

Design notes:

- The provider runs **per request** rather than once, so it always sees current credentials,
  and it may be async for hosts that refresh a token first.
- A provider that throws contributes no headers rather than failing the call. That leaves chat
  exactly as unidentified as it is with no provider installed, instead of taking the whole
  widget down over something like a transient token read.
- `Content-Type` is set *after* the spread so a provider cannot change how the server reads the
  JSON body.

**Existing behaviour is unchanged when no provider is installed, which is every current
caller.** This is the enabling half only — no caller in this repo installs a provider.

`tests/chat-headers.test.js` guards the invariant that no chat request path bypasses both
hooks; the failure mode worth guarding is a *new* call path added later that forgets the
headers. The checks are static because this workspace's test setup is plain `node --test` with
no DOM or transpiler, so exercising an axios interceptor and a native fetch against TypeScript
source isn't available here. They are scoped to the interceptor call's own parentheses — an
earlier whole-file regex still passed against an interceptor whose body had been gutted, which
is why the test does real brace matching.

## Checklist

- [ ] Tests pass (`pytest -m "not ibm" -s test`) — not run; frontend-only change, no Python touched
- [ ] Code formatted (`make xformat`) — not run; targets Python
- [ ] Linting passes (`make xcheck`) — not run; targets Python
- [x] No IBM-internal references introduced
- [x] Documentation updated (if applicable) — the exported hook carries its full rationale as TSDoc

CI's `frontend` job is the relevant gate here. Both of its steps were run locally against this
branch: `yarn build` succeeds and `yarn test` passes 36/36 (30 pre-existing + 6 new).
`tsc --noEmit` on `packages/ui-core` is clean, against a baseline verified clean beforehand.
