### PR TITLE
fix(lsf): bound slow SSH session/exec setup; make bkill reconnect

### DIFF
--- a/src/gbserver/api/lsf_tunnel.py
+++ b/src/gbserver/api/lsf_tunnel.py
@@ -38,7 +38,6 @@ import shlex
 import stat
 import tempfile
 import time
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncIterator, Dict, List, Optional
 
@@ -48,6 +47,7 @@ from gbserver.environment.environment import Environment
 from gbserver.types.constants import (
     ENABLE_SSH_HOST_KEY_VERIFICATION,
     GBSERVER_LSF_FILE_API_SSH_BUDGET_S,
+    GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S,
     GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S,
     GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
     GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
@@ -210,7 +210,7 @@ def _write_key_file(key_material: str) -> str:
     return path
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def open_lsf_tunnel(
     space_name: str,
     environment_uri: str,
@@ -268,6 +268,7 @@ async def open_lsf_tunnel(
                 login_timeout=GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
                 keepalive_interval=GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
                 keepalive_count_max=GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
+                command_timeout=GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S,
             )
             logger.info(
                 "[build-files] opening tunnel: space=%s node=%s key_file=%s",

--- a/src/gbserver/api/lsf_tunnel.py
+++ b/src/gbserver/api/lsf_tunnel.py
@@ -31,11 +31,13 @@ request time.
 """
 
 import asyncio
+import contextlib
 import os
 import random
 import shlex
 import stat
 import tempfile
+import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncIterator, Dict, List, Optional
@@ -43,7 +45,14 @@ from typing import AsyncIterator, Dict, List, Optional
 from fastapi import HTTPException, status
 
 from gbserver.environment.environment import Environment
-from gbserver.types.constants import ENABLE_SSH_HOST_KEY_VERIFICATION
+from gbserver.types.constants import (
+    ENABLE_SSH_HOST_KEY_VERIFICATION,
+    GBSERVER_LSF_FILE_API_SSH_BUDGET_S,
+    GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S,
+    GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
+    GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
+    GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
+)
 from gbserver.utils.logger import get_logger
 from gbserver.utils.ssh_tunnel import SshTunnel, SshTunnelError
 
@@ -227,12 +236,38 @@ async def open_lsf_tunnel(
     try:
         key_file_path = _write_key_file(key_material)
         last_err: Optional[Exception] = None
+        # Overall wall-time cap across all candidate nodes. This is a synchronous,
+        # interactively-called API (unlike the batch build runner), so we bound the
+        # whole sweep — not just each node — and return a fast, clean 503 rather
+        # than letting per-node login_timeouts stack up past the caller's timeout.
+        deadline = time.monotonic() + GBSERVER_LSF_FILE_API_SSH_BUDGET_S
         for node in candidates:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                last_err = last_err or TimeoutError(
+                    f"file-API SSH budget of {GBSERVER_LSF_FILE_API_SSH_BUDGET_S}s "
+                    "exhausted before a reachable node was found"
+                )
+                logger.warning(
+                    "[build-files] SSH budget exhausted after %ds; "
+                    "not trying remaining nodes",
+                    GBSERVER_LSF_FILE_API_SSH_BUDGET_S,
+                )
+                break
             attempt = SshTunnel(
                 host=node,
                 username=username,
                 key_file=key_file_path,
                 host_key_verification=ENABLE_SSH_HOST_KEY_VERIFICATION,
+                # Bound the banner/login phase and detect a wedged session so a
+                # slow bluevela login node fails over here instead of hanging
+                # open() unbounded (same symptom as the build runner's tunnel).
+                # login_timeout is the per-node bound; the deadline above caps the
+                # total across nodes, so a node is given at most whichever is less.
+                connect_timeout=GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S,
+                login_timeout=GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
+                keepalive_interval=GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
+                keepalive_count_max=GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
             )
             logger.info(
                 "[build-files] opening tunnel: space=%s node=%s key_file=%s",
@@ -241,11 +276,18 @@ async def open_lsf_tunnel(
                 key_file_path,
             )
             try:
-                await attempt.open()
-            except SshTunnelError as e:
+                # Cap this node's open() at the budget still remaining so one slow
+                # node can't consume the whole budget and starve the others.
+                await asyncio.wait_for(attempt.open(), timeout=remaining)
+            except (SshTunnelError, asyncio.TimeoutError) as e:
                 # SshTunnel.open() already calls close() on partial failure
-                # (ssh_tunnel.py:140-145), so no half-open state to clean up.
+                # (SshTunnelError path); on a wait_for timeout the attempt may be
+                # half-open, so close it explicitly. Never let cleanup mask the
+                # original error.
                 last_err = e
+                if isinstance(e, asyncio.TimeoutError):
+                    with contextlib.suppress(Exception):
+                        await attempt.close()
                 logger.warning(
                     "[build-files] tunnel open failed on node %s: %s", node, e
                 )

--- a/src/gbserver/api/lsf_tunnel.py
+++ b/src/gbserver/api/lsf_tunnel.py
@@ -310,10 +310,19 @@ async def open_lsf_tunnel(
         # symlinked parent of the workspace could let validate_subpath's
         # lexical containment check disagree with readlink-based checks
         # downstream.
-        rc, stdout, stderr = await tunnel.run_remote(
-            f"readlink -f -- {shlex.quote(workspace_remote_dir)}",
-            raise_on_error=False,
-        )
+        try:
+            rc, stdout, stderr = await tunnel.run_remote(
+                f"readlink -f -- {shlex.quote(workspace_remote_dir)}",
+                raise_on_error=False,
+            )
+        except (SshTunnelError, TimeoutError) as e:
+            # command_timeout expiry (slow bluevela session setup) or a dropped
+            # tunnel — transient, so 503 not an opaque 500. (asyncssh.TimeoutError
+            # subclasses builtin TimeoutError.)
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "login node is slow or unreachable; please retry",
+            ) from e
         canonical_workspace = (stdout or "").strip()
         if rc != 0 or not canonical_workspace:
             raise HTTPException(

--- a/src/gbserver/api/lsf_tunnel.py
+++ b/src/gbserver/api/lsf_tunnel.py
@@ -316,9 +316,7 @@ async def open_lsf_tunnel(
                 raise_on_error=False,
             )
         except (SshTunnelError, TimeoutError) as e:
-            # command_timeout expiry (slow bluevela session setup) or a dropped
-            # tunnel — transient, so 503 not an opaque 500. (asyncssh.TimeoutError
-            # subclasses builtin TimeoutError.)
+            # command_timeout expiry or dropped tunnel — transient, so 503 not 500.
             raise HTTPException(
                 status.HTTP_503_SERVICE_UNAVAILABLE,
                 "login node is slow or unreachable; please retry",

--- a/src/gbserver/api/lsf_tunnel.py
+++ b/src/gbserver/api/lsf_tunnel.py
@@ -46,8 +46,8 @@ from fastapi import HTTPException, status
 from gbserver.environment.environment import Environment
 from gbserver.types.constants import (
     ENABLE_SSH_HOST_KEY_VERIFICATION,
+    GBSERVER_LSF_FILE_API_COMMAND_TIMEOUT_S,
     GBSERVER_LSF_FILE_API_SSH_BUDGET_S,
-    GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S,
     GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S,
     GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
     GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
@@ -268,7 +268,11 @@ async def open_lsf_tunnel(
                 login_timeout=GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
                 keepalive_interval=GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
                 keepalive_count_max=GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
-                command_timeout=GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S,
+                # File-API commands hit the SAME server-side session/exec setup
+                # slowness as the runner, so they need the same leniency — but a
+                # shorter max, since this runs synchronously for an interactive
+                # caller behind a route, not a patient batch runner.
+                command_timeout=GBSERVER_LSF_FILE_API_COMMAND_TIMEOUT_S,
             )
             logger.info(
                 "[build-files] opening tunnel: space=%s node=%s key_file=%s",

--- a/src/gbserver/api/utils.py
+++ b/src/gbserver/api/utils.py
@@ -69,11 +69,9 @@ def translate_remote_file_errors() -> Iterator[None]:
         )
         raise HTTPException(status_code, str(e)) from e
     except (SshTunnelError, TimeoutError) as e:
-        # A remote command hit the SSH command_timeout (slow bluevela session
-        # setup) or the tunnel dropped mid-op. That's a transient login-node
-        # problem, not a client error — surface 503 so the interactive caller
-        # sees "try again" rather than an opaque 500. (asyncssh.TimeoutError
-        # subclasses builtin TimeoutError.)
+        # SSH command_timeout (slow bluevela session setup) or a dropped tunnel:
+        # transient, so 503 not an opaque 500. Assumes this CM only ever wraps
+        # remote SSH ops; narrow the catch if a non-SSH await is ever wrapped.
         raise HTTPException(
             status.HTTP_503_SERVICE_UNAVAILABLE,
             "login node is slow or unreachable; please retry",

--- a/src/gbserver/api/utils.py
+++ b/src/gbserver/api/utils.py
@@ -31,6 +31,7 @@ from gbserver.utils.remote_files_ops import (
     RemoteFileNotFound,
     RemoteFileOpFailed,
 )
+from gbserver.utils.ssh_tunnel import SshTunnelError
 
 # Maps each remote-file domain error to the HTTP status the API surfaces for it.
 # The remote_files_ops module is framework-free (raises these instead of
@@ -67,6 +68,16 @@ def translate_remote_file_errors() -> Iterator[None]:
             status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
         raise HTTPException(status_code, str(e)) from e
+    except (SshTunnelError, TimeoutError) as e:
+        # A remote command hit the SSH command_timeout (slow bluevela session
+        # setup) or the tunnel dropped mid-op. That's a transient login-node
+        # problem, not a client error — surface 503 so the interactive caller
+        # sees "try again" rather than an opaque 500. (asyncssh.TimeoutError
+        # subclasses builtin TimeoutError.)
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "login node is slow or unreachable; please retry",
+        ) from e
 
 
 def get_row_filter(**kwargs):

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -69,6 +69,7 @@ from gbserver.types.constants import (
     GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
     GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
     GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
+    GBSERVER_LSF_SSH_PROBE_TIMEOUT_S,
     LSF_USE_ASPERA,
     STEP_FILE_NAME,
 )
@@ -223,7 +224,6 @@ class Lsf(Environment):
             "rsync",
         ), f"invalid copy_method: {self.copy_method} (expected 'scp' or 'rsync')"
 
-        self.ssh_timeout = int(authentication.get("ssh_timeout", "5"))
         self.node_search_lock = asyncio.Lock()
         self.unreachable_ssh_nodes = []  # type: ignore[var-annotated]
         # Resilient SSH-tunnel establishment (see _ensure_ssh_tunnel).
@@ -284,6 +284,14 @@ class Lsf(Environment):
             authentication.get(
                 "ssh_command_timeout_s", GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S
             )
+        )
+        # Small, dedicated overall timeout for the reachability probe. Kept short
+        # (not command_timeout) because _get_reachable_ssh_node probes nodes in
+        # sequence with no per-sweep deadline, so the per-probe cap directly bounds
+        # how long a caller with a short budget (e.g. bkill) can block on a hung
+        # cluster.
+        self.ssh_probe_timeout_s = int(
+            authentication.get("ssh_probe_timeout_s", GBSERVER_LSF_SSH_PROBE_TIMEOUT_S)
         )
         if self.use_ssh:
             assert (
@@ -445,21 +453,20 @@ class Lsf(Environment):
         assert node, "Node must be provided, otherwise we have an infinite loop here"
         cmds = await self.create_ssh_base_cmd(node=node)
         # ConnectTimeout bounds connect+banner (modern OpenSSH covers the banner
-        # exchange here); reuse login_timeout so the probe is as patient as the
-        # tunnel and doesn't reject a briefly-slow node the tunnel would accept.
+        # exchange here). ServerAlive* / the subprocess helper don't bound the
+        # post-connect `echo` (which incurs the same session-setup delay), so an
+        # overall wait_for is the real bound. Both use one small probe timeout:
+        # _get_reachable_ssh_node probes nodes in sequence with no per-sweep
+        # deadline, so keeping this small is what stops a hung cluster from
+        # blowing a short-budget caller (bkill) — N nodes * probe_timeout.
         cmds.append("-o")
-        cmds.append(f"ConnectTimeout={self.ssh_login_timeout_s}")
+        cmds.append(f"ConnectTimeout={self.ssh_probe_timeout_s}")
         cmds.append("echo")
         cmds.append("testing node availability")
-        # The `echo` incurs the same slow server-side session/exec setup as a real
-        # command, which ConnectTimeout doesn't bound and the subprocess helper
-        # doesn't time out. Wrap the whole probe in login+command budget: patient
-        # enough for a slow-but-alive node, finite so a wedged one fails over.
-        overall_timeout = self.ssh_login_timeout_s + self.ssh_command_timeout_s
         try:
             await asyncio.wait_for(
                 launch_command_and_raise_errors(command_list=cmds, launch_id=launch_id),
-                timeout=overall_timeout,
+                timeout=self.ssh_probe_timeout_s,
             )
             return True
         except Exception:

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -82,10 +82,7 @@ from gbserver.types.environmentconfig import (
 from gbserver.types.errors import WorkloadFailedException
 from gbserver.types.stepconfig import StepConfig
 from gbserver.utils.filesystem import sync_or_copy
-from gbserver.utils.launch import (
-    launch_command_and_raise_errors,
-    launch_command_and_retry_or_raise_errors,
-)
+from gbserver.utils.launch import launch_command_and_retry_or_raise_errors
 from gbserver.utils.logger import get_logger
 from gbserver.utils.redaction import REDACTED, SENSITIVE_KEY_RE, scrub_url_credentials
 from gbserver.utils.ssh_keys import write_private_key_file
@@ -452,25 +449,44 @@ class Lsf(Environment):
         """"""
         assert node, "Node must be provided, otherwise we have an infinite loop here"
         cmds = await self.create_ssh_base_cmd(node=node)
-        # ConnectTimeout bounds connect+banner (modern OpenSSH covers the banner
-        # exchange here). ServerAlive* / the subprocess helper don't bound the
-        # post-connect `echo` (which incurs the same session-setup delay), so an
-        # overall wait_for is the real bound. Both use one small probe timeout:
-        # _get_reachable_ssh_node probes nodes in sequence with no per-sweep
-        # deadline, so keeping this small is what stops a hung cluster from
-        # blowing a short-budget caller (bkill) — N nodes * probe_timeout.
+        # One small probe timeout for both ConnectTimeout and the overall wait_for
+        # (the `echo` incurs the session-setup delay that ConnectTimeout doesn't
+        # bound). Kept small: _get_reachable_ssh_node probes nodes in sequence with
+        # no per-sweep deadline, so this caps a hung cluster's cost per caller
+        # budget (N * probe_timeout) — notably bkill's short one.
         cmds.append("-o")
         cmds.append(f"ConnectTimeout={self.ssh_probe_timeout_s}")
         cmds.append("echo")
         cmds.append("testing node availability")
+        # Spawn ssh directly (not via the shared helper) so we can kill the child
+        # on timeout: wait_for only cancels the await, it doesn't reap the process.
+        logger.info("probing node reachability: %s", cmd_safe_join(cmds))
+        proc = await asyncio.create_subprocess_exec(
+            *cmds,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
         try:
-            await asyncio.wait_for(
-                launch_command_and_raise_errors(command_list=cmds, launch_id=launch_id),
-                timeout=self.ssh_probe_timeout_s,
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.ssh_probe_timeout_s
             )
-            return True
-        except Exception:
+        except Exception as e:  # noqa: BLE001 — timeout/IO error => unreachable
+            # Kill the child so a timed-out ssh doesn't linger, then reap it.
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            logger.warning("node %s not reachable: %s", node, e)
             return False
+        if proc.returncode == 0:
+            return True
+        logger.warning(
+            "node %s not reachable (rc=%s): %s",
+            node,
+            proc.returncode,
+            (stderr or b"").decode("utf-8", errors="replace").strip(),
+        )
+        return False
 
     def _prepare_assets_replace_vars(
         self: Self,

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -69,9 +69,6 @@ from gbserver.types.constants import (
     GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
     GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
     GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
-    GBSERVER_LSF_SSH_PROBE_CONNECT_TIMEOUT_S,
-    GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX,
-    GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S,
     LSF_USE_ASPERA,
     STEP_FILE_NAME,
 )
@@ -282,34 +279,10 @@ class Lsf(Environment):
             )
         )
         # Per-command execution timeout: bounds the slow server-side session/exec
-        # setup that is the true bluevela bottleneck (connect+auth are ~1s). See
-        # the constant for details.
+        # setup that is the true bluevela bottleneck (connect+auth are ~1s).
         self.ssh_command_timeout_s = int(
             authentication.get(
                 "ssh_command_timeout_s", GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S
-            )
-        )
-        # Banner bound for the plain-`ssh` reachability probe (see
-        # __is_ssh_node_reachable). The probe GATES every tunnel establishment, so
-        # its ConnectTimeout — not ssh_timeout (5s) — must be as patient as the
-        # tunnel's login_timeout, or a slow-banner node is rejected before the
-        # tunnel's own generous timeout can run. ServerAlive* is a secondary net
-        # for a post-banner stall (it can't bound the pre-banner wait).
-        self.ssh_probe_connect_timeout_s = int(
-            authentication.get(
-                "ssh_probe_connect_timeout_s", GBSERVER_LSF_SSH_PROBE_CONNECT_TIMEOUT_S
-            )
-        )
-        self.ssh_probe_server_alive_interval = int(
-            authentication.get(
-                "ssh_probe_server_alive_interval",
-                GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S,
-            )
-        )
-        self.ssh_probe_server_alive_count_max = int(
-            authentication.get(
-                "ssh_probe_server_alive_count_max",
-                GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX,
             )
         )
         if self.use_ssh:
@@ -471,28 +444,18 @@ class Lsf(Environment):
         """"""
         assert node, "Node must be provided, otherwise we have an infinite loop here"
         cmds = await self.create_ssh_base_cmd(node=node)
-        # ConnectTimeout bounds connect+banner (in modern OpenSSH it covers the
-        # banner exchange — our runner log fired "Connection timed out during
-        # banner exchange" at exactly ConnectTimeout). It must not be the old 5s
-        # (ssh_timeout), which could cut off a node whose banner was briefly
-        # delayed before the tunnel ever got to try it. ServerAlive* is a secondary
-        # net for a post-auth stall over the encrypted transport.
+        # ConnectTimeout bounds connect+banner (modern OpenSSH covers the banner
+        # exchange here); reuse login_timeout so the probe is as patient as the
+        # tunnel and doesn't reject a briefly-slow node the tunnel would accept.
         cmds.append("-o")
-        cmds.append(f"ConnectTimeout={self.ssh_probe_connect_timeout_s}")
-        cmds.append("-o")
-        cmds.append(f"ServerAliveInterval={self.ssh_probe_server_alive_interval}")
-        cmds.append("-o")
-        cmds.append(f"ServerAliveCountMax={self.ssh_probe_server_alive_count_max}")
+        cmds.append(f"ConnectTimeout={self.ssh_login_timeout_s}")
         cmds.append("echo")
         cmds.append("testing node availability")
-        # The probe's `echo` incurs the same slow server-side session/exec setup as
-        # a real command (connect+auth are ~1s; the exec can take tens of seconds).
-        # ConnectTimeout does not bound that exec phase and the subprocess helper
-        # has no timeout of its own, so wrap the whole probe in an overall deadline
-        # (connect+banner budget plus the command budget) — generous enough to wait
-        # out a slow-but-alive node, finite so a wedged one is marked unreachable
-        # and we fail over instead of hanging.
-        overall_timeout = self.ssh_probe_connect_timeout_s + self.ssh_command_timeout_s
+        # The `echo` incurs the same slow server-side session/exec setup as a real
+        # command, which ConnectTimeout doesn't bound and the subprocess helper
+        # doesn't time out. Wrap the whole probe in login+command budget: patient
+        # enough for a slow-but-alive node, finite so a wedged one fails over.
+        overall_timeout = self.ssh_login_timeout_s + self.ssh_command_timeout_s
         try:
             await asyncio.wait_for(
                 launch_command_and_raise_errors(command_list=cmds, launch_id=launch_id),

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -61,6 +61,7 @@ from gbserver.types.constants import (
     ENABLE_SSH_HOST_KEY_VERIFICATION,
     GBSERVER_LSF_BKILL_SSH_BUDGET_S,
     GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT,
+    GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S,
     GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S,
     GBSERVER_LSF_SSH_CONNECT_BUDGET_S,
     GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S,
@@ -68,6 +69,7 @@ from gbserver.types.constants import (
     GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
     GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
     GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
+    GBSERVER_LSF_SSH_PROBE_CONNECT_TIMEOUT_S,
     GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX,
     GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S,
     LSF_USE_ASPERA,
@@ -279,9 +281,25 @@ class Lsf(Environment):
                 "ssh_keepalive_count_max", GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX
             )
         )
+        # Per-command execution timeout: bounds the slow server-side session/exec
+        # setup that is the true bluevela bottleneck (connect+auth are ~1s). See
+        # the constant for details.
+        self.ssh_command_timeout_s = int(
+            authentication.get(
+                "ssh_command_timeout_s", GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S
+            )
+        )
         # Banner bound for the plain-`ssh` reachability probe (see
-        # __is_ssh_node_reachable). ConnectTimeout is TCP-only; ServerAlive* bounds
-        # a stalled post-TCP phase so a slow banner fails fast instead of hanging.
+        # __is_ssh_node_reachable). The probe GATES every tunnel establishment, so
+        # its ConnectTimeout — not ssh_timeout (5s) — must be as patient as the
+        # tunnel's login_timeout, or a slow-banner node is rejected before the
+        # tunnel's own generous timeout can run. ServerAlive* is a secondary net
+        # for a post-banner stall (it can't bound the pre-banner wait).
+        self.ssh_probe_connect_timeout_s = int(
+            authentication.get(
+                "ssh_probe_connect_timeout_s", GBSERVER_LSF_SSH_PROBE_CONNECT_TIMEOUT_S
+            )
+        )
         self.ssh_probe_server_alive_interval = int(
             authentication.get(
                 "ssh_probe_server_alive_interval",
@@ -453,24 +471,35 @@ class Lsf(Environment):
         """"""
         assert node, "Node must be provided, otherwise we have an infinite loop here"
         cmds = await self.create_ssh_base_cmd(node=node)
+        # ConnectTimeout bounds connect+banner (in modern OpenSSH it covers the
+        # banner exchange — our runner log fired "Connection timed out during
+        # banner exchange" at exactly ConnectTimeout). It must not be the old 5s
+        # (ssh_timeout), which could cut off a node whose banner was briefly
+        # delayed before the tunnel ever got to try it. ServerAlive* is a secondary
+        # net for a post-auth stall over the encrypted transport.
         cmds.append("-o")
-        cmds.append(f"ConnectTimeout={self.ssh_timeout}")
-        # ConnectTimeout bounds only the TCP handshake. bluevela can complete the
-        # TCP connect yet withhold its SSH banner for a minute or more, which would
-        # otherwise hang the probe past ssh_timeout and wrongly mark the node
-        # unreachable. ServerAlive* bounds that stalled banner/post-TCP phase.
+        cmds.append(f"ConnectTimeout={self.ssh_probe_connect_timeout_s}")
         cmds.append("-o")
         cmds.append(f"ServerAliveInterval={self.ssh_probe_server_alive_interval}")
         cmds.append("-o")
         cmds.append(f"ServerAliveCountMax={self.ssh_probe_server_alive_count_max}")
         cmds.append("echo")
         cmds.append("testing node availability")
+        # The probe's `echo` incurs the same slow server-side session/exec setup as
+        # a real command (connect+auth are ~1s; the exec can take tens of seconds).
+        # ConnectTimeout does not bound that exec phase and the subprocess helper
+        # has no timeout of its own, so wrap the whole probe in an overall deadline
+        # (connect+banner budget plus the command budget) — generous enough to wait
+        # out a slow-but-alive node, finite so a wedged one is marked unreachable
+        # and we fail over instead of hanging.
+        overall_timeout = self.ssh_probe_connect_timeout_s + self.ssh_command_timeout_s
         try:
-            await launch_command_and_raise_errors(
-                command_list=cmds, launch_id=launch_id
+            await asyncio.wait_for(
+                launch_command_and_raise_errors(command_list=cmds, launch_id=launch_id),
+                timeout=overall_timeout,
             )
             return True
-        except:
+        except Exception:
             return False
 
     def _prepare_assets_replace_vars(
@@ -1029,9 +1058,15 @@ class Lsf(Environment):
         """
         if budget_s is None:
             budget_s = self.ssh_connect_budget_s
-        assert (
-            self._key_file_path
-        ), "SSH key file must be set up before opening a tunnel"
+        # First-class check (not an assert): teardown_bsub nulls _key_file_path on
+        # cancel, and a best-effort bkill can race in here afterwards. Raising the
+        # normal error keeps that path graceful and survives `python -O` (which
+        # would strip an assert and let a None key fall through to a later assert).
+        if not self._key_file_path:
+            raise SshTunnelError(
+                "SSH key file not set up (environment torn down / build "
+                "cancelled); cannot open a tunnel"
+            )
         # Fast path: a healthy tunnel needs no rebuild, so skip the lock — a burst
         # of concurrent transfers shouldn't serialize on it when it's already up.
         existing = self._ssh_tunnel
@@ -1090,6 +1125,7 @@ class Lsf(Environment):
                         login_timeout=self.ssh_login_timeout_s,
                         keepalive_interval=self.ssh_keepalive_interval_s,
                         keepalive_count_max=self.ssh_keepalive_count_max,
+                        command_timeout=self.ssh_command_timeout_s,
                     )
                     await tunnel.open()
                     # A node can open a connection yet not execute commands; prove

--- a/src/gbserver/environment/lsf.py
+++ b/src/gbserver/environment/lsf.py
@@ -59,10 +59,17 @@ from gbserver.types.buildevent import (
 from gbserver.types.constants import (
     DEFAULT_ROOT_WORKSPACE_DIR,
     ENABLE_SSH_HOST_KEY_VERIFICATION,
+    GBSERVER_LSF_BKILL_SSH_BUDGET_S,
     GBSERVER_LSF_RETRY_ADJUDICATION_TIMEOUT,
     GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S,
     GBSERVER_LSF_SSH_CONNECT_BUDGET_S,
     GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S,
+    GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S,
+    GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX,
+    GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S,
+    GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S,
+    GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX,
+    GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S,
     LSF_USE_ASPERA,
     STEP_FILE_NAME,
 )
@@ -95,6 +102,9 @@ REPLACE_THIS_PREFIX = "LLMB_LSF_REPLACE_THIS_"
 # Bounded drain at teardown: wait this long for an in-flight transfer to
 # release the tunnel before closing anyway.
 SSH_TEARDOWN_DRAIN_S = 30.0
+# Slice length for the SSH-establish backoff sleep, so a teardown mid-backoff is
+# noticed within ~this long rather than after the full (up to a minute) delay.
+SSH_ESTABLISH_CANCEL_POLL_S = 2.0
 
 # Builtin step names auto-injected by this module's pullasset/pushasset
 # handlers.  Each resolves via SpaceURI to the LSF env-keyed copy under
@@ -246,6 +256,43 @@ class Lsf(Environment):
                     "ssh_connect_max_backoff_s", GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S
                 )
             ),
+        )
+        # Per-attempt bounds on the SSH banner/login phase. Distinct from the sweep
+        # budget above: these bound how long one login node may hang (banner never
+        # arriving, or a connected-but-silent session) before we fail over. See the
+        # constants for the bluevela symptom this addresses.
+        self.ssh_login_timeout_s = int(
+            authentication.get("ssh_login_timeout_s", GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S)
+        )
+        self.ssh_connect_timeout_s = int(
+            authentication.get(
+                "ssh_connect_timeout_s", GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S
+            )
+        )
+        self.ssh_keepalive_interval_s = int(
+            authentication.get(
+                "ssh_keepalive_interval_s", GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S
+            )
+        )
+        self.ssh_keepalive_count_max = int(
+            authentication.get(
+                "ssh_keepalive_count_max", GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX
+            )
+        )
+        # Banner bound for the plain-`ssh` reachability probe (see
+        # __is_ssh_node_reachable). ConnectTimeout is TCP-only; ServerAlive* bounds
+        # a stalled post-TCP phase so a slow banner fails fast instead of hanging.
+        self.ssh_probe_server_alive_interval = int(
+            authentication.get(
+                "ssh_probe_server_alive_interval",
+                GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S,
+            )
+        )
+        self.ssh_probe_server_alive_count_max = int(
+            authentication.get(
+                "ssh_probe_server_alive_count_max",
+                GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX,
+            )
         )
         if self.use_ssh:
             assert (
@@ -408,6 +455,14 @@ class Lsf(Environment):
         cmds = await self.create_ssh_base_cmd(node=node)
         cmds.append("-o")
         cmds.append(f"ConnectTimeout={self.ssh_timeout}")
+        # ConnectTimeout bounds only the TCP handshake. bluevela can complete the
+        # TCP connect yet withhold its SSH banner for a minute or more, which would
+        # otherwise hang the probe past ssh_timeout and wrongly mark the node
+        # unreachable. ServerAlive* bounds that stalled banner/post-TCP phase.
+        cmds.append("-o")
+        cmds.append(f"ServerAliveInterval={self.ssh_probe_server_alive_interval}")
+        cmds.append("-o")
+        cmds.append(f"ServerAliveCountMax={self.ssh_probe_server_alive_count_max}")
         cmds.append("echo")
         cmds.append("testing node availability")
         try:
@@ -934,7 +989,7 @@ class Lsf(Environment):
 
     @contextlib.asynccontextmanager
     async def ensure_and_use(
-        self: Self, setup_id: str = "runtime"
+        self: Self, setup_id: str = "runtime", budget_s: Optional[float] = None
     ) -> AsyncIterator[SshTunnel]:
         """Ensure a healthy tunnel and hold it in-use for the enclosed block.
 
@@ -943,25 +998,37 @@ class Lsf(Environment):
         window where a concurrent rebuild could retire it between ensure and use.
         Runtime SSH callers should prefer this over calling ``_ensure_ssh_tunnel``
         then ``tunnel.use()`` as separate statements.
+
+        ``budget_s`` is forwarded to :meth:`_ensure_ssh_tunnel` (see there); it
+        defaults to the multi-hour build-runner budget.
         """
-        tunnel = await self._ensure_ssh_tunnel(setup_id=setup_id)
+        tunnel = await self._ensure_ssh_tunnel(setup_id=setup_id, budget_s=budget_s)
         async with tunnel.use():
             yield tunnel
 
-    async def _ensure_ssh_tunnel(self: Self, setup_id: str = "runtime") -> SshTunnel:
+    async def _ensure_ssh_tunnel(
+        self: Self, setup_id: str = "runtime", budget_s: Optional[float] = None
+    ) -> SshTunnel:
         """Return a healthy persistent SshTunnel, (re)establishing it if needed.
 
         The single entry point for both target setup and every runtime SSH
         command, so a login node that dies mid-build is transparently replaced.
         Reuses a live tunnel; otherwise sweeps the login nodes with failover and
-        backoff+jitter for up to ``ssh_connect_budget_s`` before raising
-        ``SshTunnelError``. ``_tunnel_lock`` serializes rebuilds so concurrent
-        callers don't each open a tunnel.
+        backoff+jitter for up to ``budget_s`` before raising ``SshTunnelError``.
+        ``_tunnel_lock`` serializes rebuilds so concurrent callers don't each open
+        a tunnel.
+
+        ``budget_s`` defaults to ``ssh_connect_budget_s`` (the multi-hour
+        build-runner budget). Best-effort cleanup callers (e.g. ``_bkill``) pass a
+        short budget so they still reconnect/fail over robustly but can't block
+        teardown for hours.
 
         Callers that immediately transfer over the tunnel should use
         :meth:`ensure_and_use` instead, which holds the tunnel in-use before
         releasing the lock and so is atomic against the retire path.
         """
+        if budget_s is None:
+            budget_s = self.ssh_connect_budget_s
         assert (
             self._key_file_path
         ), "SSH key file must be set up before opening a tunnel"
@@ -987,11 +1054,21 @@ class Lsf(Environment):
                 self._retire_tunnel(existing)
                 self._ssh_tunnel = None
 
-            deadline = time.monotonic() + self.ssh_connect_budget_s
+            deadline = time.monotonic() + budget_s
             attempt = 0
             last_err: Optional[Exception] = None
             while True:
                 attempt += 1
+                # Cooperative cancellation: teardown_bsub nulls _key_file_path when
+                # the build is cancelled / torn down. Without this check the sweep
+                # kept probing dead login nodes for seconds after a SIGTERM-driven
+                # cancel (observed in the field). Bail promptly instead — there is
+                # nothing left to connect for once the key is gone.
+                if self._key_file_path is None:
+                    raise SshTunnelError(
+                        "SSH key file removed (environment torn down / build "
+                        "cancelled); aborting tunnel establishment"
+                    ) from last_err
                 # Fresh view each sweep so a recovered node gets retried. Note:
                 # this list is otherwise guarded by node_search_lock, not
                 # _tunnel_lock — the two aren't mutually excluded, so a concurrent
@@ -1009,6 +1086,10 @@ class Lsf(Environment):
                         host_key_verification=self.ssh_host_key_verification,
                         port_forwards=[(0, login_node, self.ssh_port)],
                         max_sessions=self.ssh_max_sessions,
+                        connect_timeout=self.ssh_connect_timeout_s,
+                        login_timeout=self.ssh_login_timeout_s,
+                        keepalive_interval=self.ssh_keepalive_interval_s,
+                        keepalive_count_max=self.ssh_keepalive_count_max,
                     )
                     await tunnel.open()
                     # A node can open a connection yet not execute commands; prove
@@ -1032,7 +1113,7 @@ class Lsf(Environment):
                         raise SshTunnelError(
                             f"Could not establish an SSH tunnel to any login node "
                             f"{self.login_nodes} after {attempt} sweeps over "
-                            f"{self.ssh_connect_budget_s}s"
+                            f"{budget_s:.0f}s"
                         ) from last_err
                     # Floor at 1s so a misconfigured base backoff of 0 can't spin.
                     base = max(1, self.ssh_connect_base_backoff_s)
@@ -1044,15 +1125,25 @@ class Lsf(Environment):
                     delay = min(delay, remaining)
                     logger.warning(
                         "setup_id: %s SSH tunnel establish attempt %d failed (%s); "
-                        "retrying in %.0fs (%.0fs of %ds budget left)",
+                        "retrying in %.0fs (%.0fs of %.0fs budget left)",
                         setup_id,
                         attempt,
                         e,
                         delay,
                         remaining,
-                        self.ssh_connect_budget_s,
+                        budget_s,
                     )
-                    await asyncio.sleep(delay)
+                    # Sleep in short slices so a teardown (key file removed) during
+                    # the backoff is noticed within ~a slice rather than after the
+                    # full delay — the backoff cap can be up to a minute. The
+                    # top-of-loop check does the actual bail.
+                    slept = 0.0
+                    while slept < delay:
+                        if self._key_file_path is None:
+                            break
+                        slice_s = min(SSH_ESTABLISH_CANCEL_POLL_S, delay - slept)
+                        await asyncio.sleep(slice_s)
+                        slept += slice_s
 
     async def _cleanup_asset_dirs(self) -> None:
         # Delete all launch dirs now that all pipeline steps are done.
@@ -2199,19 +2290,21 @@ class Lsf(Environment):
 
         try:
             if self.use_ssh:
-                # Best-effort: reuse a live tunnel but don't trigger the multi-hour
-                # reconnect just to bkill — if it's gone, so is the job's session.
-                ssh_tunnel = self._ssh_tunnel
-                if ssh_tunnel is None or not ssh_tunnel.is_healthy():
-                    logger.warning(
-                        "no healthy SSH tunnel for bkill of job %s; skipping remote kill",
-                        job_id,
-                    )
-                    return
+                # bkill must reach a login node to run a command, so it uses the
+                # same robust establish/failover path as every other SSH caller
+                # (reconnecting a wedged tunnel — the whole point of #368/#369) —
+                # but with a SHORT budget, never the runner's multi-hour one:
+                # teardown can't block for hours, and a job left running is better
+                # surfaced fast than waited out. On failure (all nodes unreachable
+                # within the budget, or the key file already removed by teardown)
+                # this stays best-effort and skips rather than failing teardown.
                 logger.info("running cleanup command via tunnel: bkill %s", job_id)
                 max_attempts = 3
                 try:
-                    async with ssh_tunnel.use():
+                    async with self.ensure_and_use(
+                        setup_id="bkill",
+                        budget_s=GBSERVER_LSF_BKILL_SSH_BUDGET_S,
+                    ) as ssh_tunnel:
                         for attempt in range(1, max_attempts + 1):
                             try:
                                 rc, stdout, stderr = await ssh_tunnel.run_remote(
@@ -2230,8 +2323,9 @@ class Lsf(Environment):
                                 else:
                                     raise
                 except Exception as e:  # noqa: BLE001 — cleanup is best-effort
-                    # Tunnel dropped between the health check and the kill (or the
-                    # kill kept timing out); skip rather than fail teardown.
+                    # Couldn't establish a tunnel within the short budget, the
+                    # tunnel dropped mid-kill, or the kill kept timing out; skip
+                    # rather than fail teardown.
                     logger.warning(
                         "best-effort bkill of job %s via tunnel failed, skipping: %s",
                         job_id,

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -907,6 +907,18 @@ GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX = int(
 GBSERVER_LSF_FILE_API_SSH_BUDGET_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_FILE_API_SSH_BUDGET_S", "45"), base=10
 )
+# Per-command timeout (seconds) for the synchronous file APIs, SEPARATE from the
+# runner's GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S. The file APIs hit the SAME
+# server-side session/exec setup slowness (~28s, "up to a minute") as everything
+# else, so they need the same kind of leniency — but with a SHORTER max, because
+# they run synchronously behind an HTTPS route for an interactive caller that
+# gives up in ~a minute, not the 120s a batch runner tolerates. Sized to wait out
+# the observed session-setup with a little margin (60s) yet stay well under the
+# 600s route ceiling. If a file-API command exceeds this, asyncssh raises
+# TimeoutError and the request returns an error rather than hanging the caller.
+GBSERVER_LSF_FILE_API_COMMAND_TIMEOUT_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_FILE_API_COMMAND_TIMEOUT_S", "60"), base=10
+)
 # Establish budget (seconds) for a best-effort bkill during cleanup. bkill
 # genuinely needs to reach a login node and run a command, so it uses the same
 # robust reconnect/failover path as everything else — but must NOT inherit the

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -826,6 +826,74 @@ GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S = int(
 GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_MAX_BACKOFF_S", "60"), base=10
 )
+# Per-attempt bounds on the SSH banner/login phase for the asyncssh tunnel. These
+# sit *inside* one establish attempt of the sweep above: they bound how long a
+# single login node may hang before we fail over, distinct from the overall
+# connect budget. bluevela can leave a connection TCP-open yet withhold its SSH
+# banner for a minute or more; ConnectTimeout (a TCP-only bound) doesn't cover
+# that, so the login phase must be bounded separately.
+# login_timeout bounds the banner+kex+auth phase (asyncssh raises "Login timeout
+# expired"). Lenient enough to wait out the observed bluevela banner delay on a
+# node before failing over, but bounded so a wedged node can't hang a whole
+# attempt indefinitely. The runner keeps sweeping the node list (see
+# _CONNECT_BUDGET_S) so a per-node give-up here isn't a build failure.
+GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_LOGIN_TIMEOUT_S", "65"), base=10
+)
+# connect_timeout bounds the TCP+initial-connect leg (login_timeout applies to auth
+# on top of this).
+GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_TIMEOUT_S", "10"), base=10
+)
+# Post-connect keepalive: detect a session that connected but then stops responding
+# mid-command. interval * count_max ≈ dead-session detection time (default ~30s).
+GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_KEEPALIVE_INTERVAL_S", "10"), base=10
+)
+GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_KEEPALIVE_COUNT_MAX", "3"), base=10
+)
+# Banner bound for the pre-tunnel reachability probe (plain `ssh` subprocess).
+# ServerAlive* is how OpenSSH bounds a stalled post-TCP phase; interval * count ≈
+# probe banner tolerance. Sized to ≈ the tunnel's login_timeout (10s × 6 ≈ 60s)
+# so the probe and the tunnel agree on which nodes count as reachable.
+GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S", "10"), base=10
+)
+GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX", "6"), base=10
+)
+# Overall wall-time budget (seconds) for the *synchronous file APIs* to open a
+# tunnel across all candidate login nodes. Unlike the build runner — which is
+# batch and may patiently sweep for hours — the env/build file APIs are served
+# over an HTTPS OpenShift route whose HAProxy server-timeout is 600s (see
+# k8s/chart/values.yaml routes.haproxy_timeout): the route HARD-DROPS the
+# connection at 600s no matter what we do here, and the interactive MCP agent
+# calling it realistically gives up well before that. So this is a HARD CEILING
+# well under 600s, and must also leave headroom for the actual file op (readlink
+# canonicalize + grep/list/peek) that runs AFTER the tunnel opens. Default 45s:
+# enough to try a node or two with the banner/login bounds, then return a clean
+# fast 503 instead of letting per-node login_timeouts stack up past the caller's
+# timeout. Do NOT raise this near 600s. Independent of ssh_connect_budget_s.
+GBSERVER_LSF_FILE_API_SSH_BUDGET_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_FILE_API_SSH_BUDGET_S", "45"), base=10
+)
+# Establish budget (seconds) for a best-effort bkill during cleanup. bkill
+# genuinely needs to reach a login node and run a command, so it uses the same
+# robust reconnect/failover path as everything else — but must NOT inherit the
+# runner's multi-hour ssh_connect_budget_s: teardown can't block for hours, and a
+# job left running is better surfaced sooner than waited out for hours.
+# Sized so each attempt gets a *real* chance: one node can consume up to
+# connect_timeout + login_timeout (~10+65s) before failover, so this must span
+# several such attempts across the login nodes (nothing can run until SSH is
+# actually established) — not a fail-fast cap. 5 min covers all nodes with a
+# couple of backoff rounds, then gives up and logs that the remote kill was
+# skipped. Deliberately longer than the file-API budget, whose caller (an
+# interactive agent behind an HTTPS route) gives up in ~a minute; bkill's caller
+# is teardown, which can afford minutes to avoid leaking a running job.
+GBSERVER_LSF_BKILL_SSH_BUDGET_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_BKILL_SSH_BUDGET_S", "300"), base=10
+)
 # Used by the build framework monitoring to allow the consumption of all the events
 GBSERVER_MONITORING_GRACE_PERIOD = int(
     os.getenv(ENV_VAR_PREFIX + "_MONITORING_GRACE_PERIOD", "30"), base=10

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -856,6 +856,15 @@ GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S = int(
 GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_KEEPALIVE_COUNT_MAX", "3"), base=10
 )
+# Overall timeout for the plain-`ssh` reachability probe (__is_ssh_node_reachable),
+# which gates tunnel establishment. Kept SMALL and dedicated (not command_timeout):
+# _get_reachable_ssh_node probes every node in turn with no per-sweep deadline, so
+# a large per-probe cap would let one sweep run N * cap and blow a caller's budget
+# (e.g. bkill's 300s). A wedged node fails over in ~this long; a healthy one
+# answers well within it even with slow session setup.
+GBSERVER_LSF_SSH_PROBE_TIMEOUT_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_TIMEOUT_S", "30"), base=10
+)
 # Establish budget: how long the synchronous file APIs sweep candidate login nodes
 # for a tunnel before returning 503. Short because they run behind an HTTPS route
 # (HAProxy server-timeout 600s, k8s/chart/values.yaml) for an interactive caller;

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -831,9 +831,8 @@ GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S = int(
 # "slow"; the real delay is server-side session/exec setup AFTER auth, bounded by
 # COMMAND_TIMEOUT below. So login/connect timeouts are not the fix — they only
 # bound a genuinely-degraded node before failover.
-# login_timeout: banner+kex+auth ("Login timeout expired"). Also reused as the
-# reachability probe's ConnectTimeout (modern OpenSSH ConnectTimeout covers the
-# banner exchange), so probe and tunnel agree on which nodes are reachable.
+# login_timeout: banner+kex+auth ("Login timeout expired"). The reachability probe
+# has its own bound (PROBE_TIMEOUT below), independent of this.
 GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_LOGIN_TIMEOUT_S", "30"), base=10
 )

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -833,17 +833,31 @@ GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S = int(
 # banner for a minute or more; ConnectTimeout (a TCP-only bound) doesn't cover
 # that, so the login phase must be bounded separately.
 # login_timeout bounds the banner+kex+auth phase (asyncssh raises "Login timeout
-# expired"). Lenient enough to wait out the observed bluevela banner delay on a
-# node before failing over, but bounded so a wedged node can't hang a whole
-# attempt indefinitely. The runner keeps sweeping the node list (see
-# _CONNECT_BUDGET_S) so a per-node give-up here isn't a build failure.
+# expired"). Empirically (ssh -vv against bluevela login nodes) connect+banner+
+# kex+auth all complete in ~1s even when the node is "slow" — the real delay is
+# server-side session/exec setup AFTER auth (see _COMMAND_TIMEOUT_S below), not
+# login. So this is NOT the slow-node fix; it only needs to be generous enough to
+# wait out a login node that is genuinely degraded at the auth stage (or briefly
+# withholding its banner) before failing over. 30s is ample; the runner keeps
+# sweeping the node list (see _CONNECT_BUDGET_S) so a per-node give-up isn't a
+# build failure.
 GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S = int(
-    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_LOGIN_TIMEOUT_S", "65"), base=10
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_LOGIN_TIMEOUT_S", "30"), base=10
 )
 # connect_timeout bounds the TCP+initial-connect leg (login_timeout applies to auth
-# on top of this).
+# on top of this). TCP connect is ~instant on bluevela; kept small.
 GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_TIMEOUT_S", "10"), base=10
+)
+# Per-command execution timeout (asyncssh conn.run(timeout=...)). THIS is the fix
+# for the observed symptom: connect+auth are ~1s, but the server takes tens of
+# seconds (observed ~28s, "up to a minute or longer" under load) to set up the
+# session/exec — slow networked home dir, login rc, module init — before a
+# command produces output. Generous enough to wait that out, finite so a truly
+# wedged session raises TimeoutError (which run_remote_with_retries retries)
+# instead of hanging forever. 120s covers the observed delay with wide margin.
+GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_COMMAND_TIMEOUT_S", "120"), base=10
 )
 # Post-connect keepalive: detect a session that connected but then stops responding
 # mid-command. interval * count_max ≈ dead-session detection time (default ~30s).
@@ -853,10 +867,25 @@ GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S = int(
 GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_KEEPALIVE_COUNT_MAX", "3"), base=10
 )
-# Banner bound for the pre-tunnel reachability probe (plain `ssh` subprocess).
-# ServerAlive* is how OpenSSH bounds a stalled post-TCP phase; interval * count ≈
-# probe banner tolerance. Sized to ≈ the tunnel's login_timeout (10s × 6 ≈ 60s)
-# so the probe and the tunnel agree on which nodes count as reachable.
+# Connect timeout (seconds) for the pre-tunnel reachability probe (plain `ssh`
+# subprocess in __is_ssh_node_reachable). Every tunnel establishment is gated by
+# this probe, so it must not give up before the node has a fair chance: the old
+# 5s (ssh_timeout) could cut off a node whose banner was briefly delayed. In
+# modern OpenSSH ConnectTimeout covers the banner exchange (our runner log fired
+# "Connection timed out during banner exchange" at exactly ConnectTimeout=5s), so
+# sizing this to ≈ the tunnel's login_timeout keeps the probe's verdict consistent
+# with what the tunnel would find. NOTE: ConnectTimeout covers connect+banner, NOT
+# the post-auth session/exec setup — the probe's `echo` still incurs the same
+# tens-of-seconds server delay; the probe tolerates that via the command timeout
+# below, not here.
+GBSERVER_LSF_SSH_PROBE_CONNECT_TIMEOUT_S = int(
+    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_CONNECT_TIMEOUT_S", "30"), base=10
+)
+# Keepalive for the probe's post-banner phase (the trivial `echo` command). NOTE:
+# ServerAlive* runs only over the post-kex encrypted transport, so — unlike the
+# ConnectTimeout above — it does NOT bound the pre-banner wait; it only catches a
+# session that connected+authed but then goes silent during the echo. Kept as a
+# secondary safety net; interval * count ≈ 60s.
 GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S", "10"), base=10
 )

--- a/src/gbserver/types/constants.py
+++ b/src/gbserver/types/constants.py
@@ -826,112 +826,54 @@ GBSERVER_LSF_SSH_CONNECT_BASE_BACKOFF_S = int(
 GBSERVER_LSF_SSH_CONNECT_MAX_BACKOFF_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_MAX_BACKOFF_S", "60"), base=10
 )
-# Per-attempt bounds on the SSH banner/login phase for the asyncssh tunnel. These
-# sit *inside* one establish attempt of the sweep above: they bound how long a
-# single login node may hang before we fail over, distinct from the overall
-# connect budget. bluevela can leave a connection TCP-open yet withhold its SSH
-# banner for a minute or more; ConnectTimeout (a TCP-only bound) doesn't cover
-# that, so the login phase must be bounded separately.
-# login_timeout bounds the banner+kex+auth phase (asyncssh raises "Login timeout
-# expired"). Empirically (ssh -vv against bluevela login nodes) connect+banner+
-# kex+auth all complete in ~1s even when the node is "slow" — the real delay is
-# server-side session/exec setup AFTER auth (see _COMMAND_TIMEOUT_S below), not
-# login. So this is NOT the slow-node fix; it only needs to be generous enough to
-# wait out a login node that is genuinely degraded at the auth stage (or briefly
-# withholding its banner) before failing over. 30s is ample; the runner keeps
-# sweeping the node list (see _CONNECT_BUDGET_S) so a per-node give-up isn't a
-# build failure.
+# Per-SSH-attempt timeouts (asyncssh), inside one establish attempt of the sweep
+# above. Empirically (ssh -vv) connect+banner+auth take ~1s on bluevela even when
+# "slow"; the real delay is server-side session/exec setup AFTER auth, bounded by
+# COMMAND_TIMEOUT below. So login/connect timeouts are not the fix — they only
+# bound a genuinely-degraded node before failover.
+# login_timeout: banner+kex+auth ("Login timeout expired"). Also reused as the
+# reachability probe's ConnectTimeout (modern OpenSSH ConnectTimeout covers the
+# banner exchange), so probe and tunnel agree on which nodes are reachable.
 GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_LOGIN_TIMEOUT_S", "30"), base=10
 )
-# connect_timeout bounds the TCP+initial-connect leg (login_timeout applies to auth
-# on top of this). TCP connect is ~instant on bluevela; kept small.
+# connect_timeout: TCP connect leg only (~instant on bluevela).
 GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_CONNECT_TIMEOUT_S", "10"), base=10
 )
-# Per-command execution timeout (asyncssh conn.run(timeout=...)). THIS is the fix
-# for the observed symptom: connect+auth are ~1s, but the server takes tens of
-# seconds (observed ~28s, "up to a minute or longer" under load) to set up the
-# session/exec — slow networked home dir, login rc, module init — before a
-# command produces output. Generous enough to wait that out, finite so a truly
-# wedged session raises TimeoutError (which run_remote_with_retries retries)
-# instead of hanging forever. 120s covers the observed delay with wide margin.
+# command_timeout (asyncssh conn.run(timeout=...)): THE fix. Bounds the slow
+# server-side session/exec setup (~28s, up to a minute under load) before a
+# command produces output. On expiry asyncssh raises TimeoutError (retried by
+# run_remote_with_retries) instead of hanging. 120s = observed delay + margin.
 GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_COMMAND_TIMEOUT_S", "120"), base=10
 )
-# Post-connect keepalive: detect a session that connected but then stops responding
-# mid-command. interval * count_max ≈ dead-session detection time (default ~30s).
+# Keepalive: drop a session whose server stops answering transport probes.
+# interval * count_max ≈ dead-session detection (~30s).
 GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_KEEPALIVE_INTERVAL_S", "10"), base=10
 )
 GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_KEEPALIVE_COUNT_MAX", "3"), base=10
 )
-# Connect timeout (seconds) for the pre-tunnel reachability probe (plain `ssh`
-# subprocess in __is_ssh_node_reachable). Every tunnel establishment is gated by
-# this probe, so it must not give up before the node has a fair chance: the old
-# 5s (ssh_timeout) could cut off a node whose banner was briefly delayed. In
-# modern OpenSSH ConnectTimeout covers the banner exchange (our runner log fired
-# "Connection timed out during banner exchange" at exactly ConnectTimeout=5s), so
-# sizing this to ≈ the tunnel's login_timeout keeps the probe's verdict consistent
-# with what the tunnel would find. NOTE: ConnectTimeout covers connect+banner, NOT
-# the post-auth session/exec setup — the probe's `echo` still incurs the same
-# tens-of-seconds server delay; the probe tolerates that via the command timeout
-# below, not here.
-GBSERVER_LSF_SSH_PROBE_CONNECT_TIMEOUT_S = int(
-    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_CONNECT_TIMEOUT_S", "30"), base=10
-)
-# Keepalive for the probe's post-banner phase (the trivial `echo` command). NOTE:
-# ServerAlive* runs only over the post-kex encrypted transport, so — unlike the
-# ConnectTimeout above — it does NOT bound the pre-banner wait; it only catches a
-# session that connected+authed but then goes silent during the echo. Kept as a
-# secondary safety net; interval * count ≈ 60s.
-GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S = int(
-    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_SERVER_ALIVE_INTERVAL_S", "10"), base=10
-)
-GBSERVER_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX = int(
-    os.getenv(ENV_VAR_PREFIX + "_LSF_SSH_PROBE_SERVER_ALIVE_COUNT_MAX", "6"), base=10
-)
-# Overall wall-time budget (seconds) for the *synchronous file APIs* to open a
-# tunnel across all candidate login nodes. Unlike the build runner — which is
-# batch and may patiently sweep for hours — the env/build file APIs are served
-# over an HTTPS OpenShift route whose HAProxy server-timeout is 600s (see
-# k8s/chart/values.yaml routes.haproxy_timeout): the route HARD-DROPS the
-# connection at 600s no matter what we do here, and the interactive MCP agent
-# calling it realistically gives up well before that. So this is a HARD CEILING
-# well under 600s, and must also leave headroom for the actual file op (readlink
-# canonicalize + grep/list/peek) that runs AFTER the tunnel opens. Default 45s:
-# enough to try a node or two with the banner/login bounds, then return a clean
-# fast 503 instead of letting per-node login_timeouts stack up past the caller's
-# timeout. Do NOT raise this near 600s. Independent of ssh_connect_budget_s.
+# Establish budget: how long the synchronous file APIs sweep candidate login nodes
+# for a tunnel before returning 503. Short because they run behind an HTTPS route
+# (HAProxy server-timeout 600s, k8s/chart/values.yaml) for an interactive caller;
+# keep well under 600s.
 GBSERVER_LSF_FILE_API_SSH_BUDGET_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_FILE_API_SSH_BUDGET_S", "45"), base=10
 )
-# Per-command timeout (seconds) for the synchronous file APIs, SEPARATE from the
-# runner's GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S. The file APIs hit the SAME
-# server-side session/exec setup slowness (~28s, "up to a minute") as everything
-# else, so they need the same kind of leniency — but with a SHORTER max, because
-# they run synchronously behind an HTTPS route for an interactive caller that
-# gives up in ~a minute, not the 120s a batch runner tolerates. Sized to wait out
-# the observed session-setup with a little margin (60s) yet stay well under the
-# 600s route ceiling. If a file-API command exceeds this, asyncssh raises
-# TimeoutError and the request returns an error rather than hanging the caller.
+# File-API command timeout: same session-setup leniency as the runner's
+# COMMAND_TIMEOUT but a shorter max, since the caller is interactive (not a patient
+# batch runner). Waits out the ~28s setup with margin, stays well under 600s.
 GBSERVER_LSF_FILE_API_COMMAND_TIMEOUT_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_FILE_API_COMMAND_TIMEOUT_S", "60"), base=10
 )
-# Establish budget (seconds) for a best-effort bkill during cleanup. bkill
-# genuinely needs to reach a login node and run a command, so it uses the same
-# robust reconnect/failover path as everything else — but must NOT inherit the
-# runner's multi-hour ssh_connect_budget_s: teardown can't block for hours, and a
-# job left running is better surfaced sooner than waited out for hours.
-# Sized so each attempt gets a *real* chance: one node can consume up to
-# connect_timeout + login_timeout (~10+65s) before failover, so this must span
-# several such attempts across the login nodes (nothing can run until SSH is
-# actually established) — not a fail-fast cap. 5 min covers all nodes with a
-# couple of backoff rounds, then gives up and logs that the remote kill was
-# skipped. Deliberately longer than the file-API budget, whose caller (an
-# interactive agent behind an HTTPS route) gives up in ~a minute; bkill's caller
-# is teardown, which can afford minutes to avoid leaking a running job.
+# Establish budget for a best-effort bkill during cleanup: bkill must reach a
+# login node to run the kill, so it reconnects via the robust path — but with a
+# short budget, not the runner's multi-hour one (teardown can't block for hours; a
+# leaked job is better surfaced fast). 5 min spans a few real attempts across the
+# nodes, then gives up and logs the skip.
 GBSERVER_LSF_BKILL_SSH_BUDGET_S = int(
     os.getenv(ENV_VAR_PREFIX + "_LSF_BKILL_SSH_BUDGET_S", "300"), base=10
 )

--- a/src/gbserver/utils/ssh_tunnel.py
+++ b/src/gbserver/utils/ssh_tunnel.py
@@ -80,6 +80,10 @@ class SshTunnel:
         host_key_verification: bool = True,
         port_forwards: Optional[List[Tuple[int, str, int]]] = None,
         max_sessions: int = 10,  # 10 is the default MaxSessions value for sshd
+        connect_timeout: Optional[float] = None,
+        login_timeout: Optional[float] = None,
+        keepalive_interval: Optional[float] = None,
+        keepalive_count_max: Optional[int] = None,
     ) -> None:
         if not HAS_ASYNCSSH:
             raise ImportError(
@@ -91,6 +95,17 @@ class SshTunnel:
         self.key_file = key_file
         self.host_key_verification = host_key_verification
         self.port_forwards: List[Tuple[int, str, int]] = port_forwards or []
+        # Bound the connect/login phase and detect a wedged post-connect session.
+        # A host can leave the connection TCP-open yet withhold its SSH banner (or
+        # accept the connection then stop responding); without these, open() and
+        # subsequent commands can hang indefinitely. login_timeout bounds the
+        # banner+auth phase; keepalive_* catches a session that goes silent after
+        # auth. Callers pass explicit values (see the LSF environment); the None
+        # defaults leave asyncssh's own behavior unchanged for other callers.
+        self.connect_timeout = connect_timeout
+        self.login_timeout = login_timeout
+        self.keepalive_interval = keepalive_interval
+        self.keepalive_count_max = keepalive_count_max
 
         self._conn: Optional[asyncssh.SSHClientConnection] = None
         self._listeners: List[asyncssh.SSHListener] = []
@@ -118,6 +133,16 @@ class SshTunnel:
             connect_kwargs["client_keys"] = [self.key_file]
         if not self.host_key_verification:
             connect_kwargs["known_hosts"] = None
+        # Only pass a timeout/keepalive when set, so unset values fall back to
+        # asyncssh's defaults rather than overriding them with None.
+        if self.connect_timeout is not None:
+            connect_kwargs["connect_timeout"] = self.connect_timeout
+        if self.login_timeout is not None:
+            connect_kwargs["login_timeout"] = self.login_timeout
+        if self.keepalive_interval is not None:
+            connect_kwargs["keepalive_interval"] = self.keepalive_interval
+        if self.keepalive_count_max is not None:
+            connect_kwargs["keepalive_count_max"] = self.keepalive_count_max
 
         logger.info("[SshTunnel] Connecting to %s", self.host)
         try:

--- a/src/gbserver/utils/ssh_tunnel.py
+++ b/src/gbserver/utils/ssh_tunnel.py
@@ -84,6 +84,7 @@ class SshTunnel:
         login_timeout: Optional[float] = None,
         keepalive_interval: Optional[float] = None,
         keepalive_count_max: Optional[int] = None,
+        command_timeout: Optional[float] = None,
     ) -> None:
         if not HAS_ASYNCSSH:
             raise ImportError(
@@ -106,6 +107,15 @@ class SshTunnel:
         self.login_timeout = login_timeout
         self.keepalive_interval = keepalive_interval
         self.keepalive_count_max = keepalive_count_max
+        # Per-command execution timeout (asyncssh conn.run(timeout=...)). Bounds
+        # the phase that is actually slow on bluevela: connect+auth complete in
+        # ~1s, but SERVER-SIDE session/exec setup (networked home dir, login rc,
+        # module init) can delay a command's first output by tens of seconds. This
+        # must be generous enough to wait that out yet finite so a truly wedged
+        # session can't hang forever; on expiry asyncssh raises TimeoutError, which
+        # run_remote_with_retries retries. None = no command timeout (asyncssh
+        # default) for callers that don't set one.
+        self.command_timeout = command_timeout
 
         self._conn: Optional[asyncssh.SSHClientConnection] = None
         self._listeners: List[asyncssh.SSHListener] = []
@@ -339,8 +349,13 @@ class SshTunnel:
         if self._conn is None:
             raise SshTunnelError("Tunnel is not open. Call open() first.")
         logger.info("[SshTunnel] Running command: %s", logged_command)
+        # command_timeout bounds slow server-side session/exec setup; on expiry
+        # asyncssh raises TimeoutError, which run_remote_with_retries retries.
+        run_kwargs: dict = {"check": False}
+        if self.command_timeout is not None:
+            run_kwargs["timeout"] = self.command_timeout
         async with self._semaphore:
-            result = await self._conn.run(command, check=False)
+            result = await self._conn.run(command, **run_kwargs)
         return result
 
     async def run_local(

--- a/test/integration/ibm/utils/test_ssh_tunnel.py
+++ b/test/integration/ibm/utils/test_ssh_tunnel.py
@@ -183,6 +183,34 @@ async def test_run_returns_stdout_stderr_on_success():
 
 
 @pytest.mark.asyncio
+async def test_run_applies_command_timeout_when_set():
+    """command_timeout should be forwarded to conn.run so a slow server-side
+    session/exec setup is bounded (the bluevela symptom)."""
+    mock_conn, _ = _make_mock_conn(run_exit_status=0, run_stdout="ok\n")
+
+    with patch("asyncssh.connect", new=AsyncMock(return_value=mock_conn)):
+        tunnel = SshTunnel(host="myhost", command_timeout=120)
+        await tunnel.open()
+        await tunnel.run_remote("echo ok")
+
+    mock_conn.run.assert_called_once_with("echo ok", check=False, timeout=120)
+
+
+@pytest.mark.asyncio
+async def test_run_omits_command_timeout_when_unset():
+    """No command_timeout must leave conn.run at its default (no timeout kwarg)."""
+    mock_conn, _ = _make_mock_conn(run_exit_status=0, run_stdout="ok\n")
+
+    with patch("asyncssh.connect", new=AsyncMock(return_value=mock_conn)):
+        tunnel = SshTunnel(host="myhost")
+        await tunnel.open()
+        await tunnel.run_remote("echo ok")
+
+    _, kwargs = mock_conn.run.call_args
+    assert "timeout" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_run_raises_on_nonzero_exit_by_default():
     """run() should raise ValueError on non-zero exit when raise_on_error=True."""
     mock_conn, _ = _make_mock_conn(run_exit_status=1, run_stderr="not found")

--- a/test/integration/ibm/utils/test_ssh_tunnel.py
+++ b/test/integration/ibm/utils/test_ssh_tunnel.py
@@ -77,6 +77,48 @@ async def test_open_connects_with_correct_kwargs():
 
 
 @pytest.mark.asyncio
+async def test_open_passes_timeout_and_keepalive_kwargs():
+    """Timeout/keepalive params should reach asyncssh.connect when set."""
+    mock_conn, _ = _make_mock_conn()
+
+    with patch(
+        "asyncssh.connect", new=AsyncMock(return_value=mock_conn)
+    ) as mock_connect:
+        tunnel = SshTunnel(
+            host="myhost",
+            connect_timeout=20,
+            login_timeout=90,
+            keepalive_interval=10,
+            keepalive_count_max=3,
+        )
+        await tunnel.open()
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["connect_timeout"] == 20
+    assert kwargs["login_timeout"] == 90
+    assert kwargs["keepalive_interval"] == 10
+    assert kwargs["keepalive_count_max"] == 3
+
+
+@pytest.mark.asyncio
+async def test_open_omits_timeout_kwargs_when_unset():
+    """Unset timeout/keepalive params must not override asyncssh defaults."""
+    mock_conn, _ = _make_mock_conn()
+
+    with patch(
+        "asyncssh.connect", new=AsyncMock(return_value=mock_conn)
+    ) as mock_connect:
+        tunnel = SshTunnel(host="myhost")
+        await tunnel.open()
+
+    _, kwargs = mock_connect.call_args
+    assert "connect_timeout" not in kwargs
+    assert "login_timeout" not in kwargs
+    assert "keepalive_interval" not in kwargs
+    assert "keepalive_count_max" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_open_disables_host_key_verification():
     """host_key_verification=False should pass known_hosts=None."""
     mock_conn, _ = _make_mock_conn()

--- a/test/unit/api/test_build_files.py
+++ b/test/unit/api/test_build_files.py
@@ -1562,6 +1562,43 @@ class TestOpenLsfTunnelFailover:
         assert opened_hosts == ["node-a", "node-b"]
 
     @pytest.mark.asyncio
+    async def test_slow_but_alive_node_succeeds(self):
+        """The real bluevela mode: open() is fast (connect+auth ~1s) but the first
+        command (readlink) is slow due to server-side session setup. As long as it
+        finishes under command_timeout, the tunnel must open successfully — this is
+        the case whose failure got a running build cancelled."""
+        from gbserver.api import lsf_tunnel
+
+        resolve, fetch, write, unlink = self._patch_resolvers(["node-a"])
+
+        def make_tunnel(**kwargs):
+            t = MagicMock()
+            t.open = AsyncMock(return_value=None)  # connect+auth: fast
+
+            async def _slow_readlink(cmd, raise_on_error=True):
+                # Simulate the ~28s session-setup latency, compressed for the test.
+                await asyncio.sleep(0.05)
+                return (0, "/ws\n", "")
+
+            t.run_remote = AsyncMock(side_effect=_slow_readlink)
+            t.close = AsyncMock()
+            return t
+
+        with (
+            resolve,
+            fetch,
+            write,
+            unlink,
+            patch.object(lsf_tunnel, "SshTunnel", side_effect=make_tunnel),
+        ):
+            async with lsf_tunnel.open_lsf_tunnel("space-a", "env://x") as (
+                tunnel,
+                cfg,
+            ):
+                assert cfg.workspace_remote_dir == "/ws"
+                assert tunnel is not None
+
+    @pytest.mark.asyncio
     async def test_readlink_timeout_returns_503_not_500(self):
         """A command_timeout on the post-open readlink canonicalize (slow session
         setup) must surface as a clean 503, not an opaque 500."""

--- a/test/unit/api/test_build_files.py
+++ b/test/unit/api/test_build_files.py
@@ -26,6 +26,7 @@ What we exercise here is the request/response surface: path-traversal
 rejection, build-root resolution, size caps, and auth.
 """
 
+import asyncio
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1591,3 +1592,88 @@ class TestOpenLsfTunnelFailover:
         assert "node-a" in detail
         assert "node-b" in detail
         assert "node-c" in detail
+
+    @pytest.mark.asyncio
+    async def test_tunnel_constructed_with_banner_login_bounds(self):
+        """The file-API tunnel carries the connect/login/keepalive bounds so a
+        slow bluevela login node fails over instead of hanging open()."""
+        from gbserver.api import lsf_tunnel
+
+        resolve, fetch, write, unlink = self._patch_resolvers(["node-a"])
+        seen: dict = {}
+
+        def make_tunnel(**kwargs):
+            seen.update(kwargs)
+            t = MagicMock()
+
+            async def _run_remote(cmd, raise_on_error=True):
+                return (0, "/ws\n", "")
+
+            t.open = AsyncMock(return_value=None)
+            t.run_remote = AsyncMock(side_effect=_run_remote)
+            t.close = AsyncMock()
+            return t
+
+        with (
+            resolve,
+            fetch,
+            write,
+            unlink,
+            patch.object(lsf_tunnel, "SshTunnel", side_effect=make_tunnel),
+        ):
+            async with lsf_tunnel.open_lsf_tunnel("space-a", "env://x"):
+                pass
+
+        assert seen["connect_timeout"] == lsf_tunnel.GBSERVER_LSF_SSH_CONNECT_TIMEOUT_S
+        assert seen["login_timeout"] == lsf_tunnel.GBSERVER_LSF_SSH_LOGIN_TIMEOUT_S
+        assert (
+            seen["keepalive_interval"]
+            == lsf_tunnel.GBSERVER_LSF_SSH_KEEPALIVE_INTERVAL_S
+        )
+        assert (
+            seen["keepalive_count_max"]
+            == lsf_tunnel.GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX
+        )
+
+    @pytest.mark.asyncio
+    async def test_overall_budget_short_circuits_remaining_nodes(self):
+        """A node that hangs open() past the total file-API budget must not let
+        the loop grind through every remaining node — it returns 503 promptly."""
+        from gbserver.api import lsf_tunnel
+
+        resolve, fetch, write, unlink = self._patch_resolvers(
+            ["node-a", "node-b", "node-c"]
+        )
+        shuffle_noop = patch("random.shuffle", side_effect=lambda lst: None)
+
+        tried = []
+
+        def make_tunnel(**kwargs):
+            tried.append(kwargs["host"])
+            t = MagicMock()
+
+            async def _hang():
+                await asyncio.sleep(3600)  # longer than the (patched tiny) budget
+
+            t.open = AsyncMock(side_effect=_hang)
+            t.close = AsyncMock()
+            return t
+
+        with (
+            resolve,
+            fetch,
+            write,
+            unlink,
+            shuffle_noop,
+            # Tiny budget so the first node's hang exhausts it immediately.
+            patch.object(lsf_tunnel, "GBSERVER_LSF_FILE_API_SSH_BUDGET_S", 0.05),
+            patch.object(lsf_tunnel, "SshTunnel", side_effect=make_tunnel),
+        ):
+            with pytest.raises(HTTPException) as ei:
+                async with lsf_tunnel.open_lsf_tunnel("space-a", "env://x"):
+                    pass
+
+        assert ei.value.status_code == 503
+        # Budget exhausted on the first node; the loop broke instead of trying
+        # node-b and node-c (which would each cost another wait_for).
+        assert tried == ["node-a"]

--- a/test/unit/api/test_build_files.py
+++ b/test/unit/api/test_build_files.py
@@ -1634,6 +1634,13 @@ class TestOpenLsfTunnelFailover:
             seen["keepalive_count_max"]
             == lsf_tunnel.GBSERVER_LSF_SSH_KEEPALIVE_COUNT_MAX
         )
+        # File-API commands use the shorter file-API command timeout (tolerate the
+        # same session-setup slowness, but with a shorter max than the runner's),
+        # NOT the runner's GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S.
+        assert (
+            seen["command_timeout"]
+            == lsf_tunnel.GBSERVER_LSF_FILE_API_COMMAND_TIMEOUT_S
+        )
 
     @pytest.mark.asyncio
     async def test_overall_budget_short_circuits_remaining_nodes(self):

--- a/test/unit/api/test_build_files.py
+++ b/test/unit/api/test_build_files.py
@@ -1562,6 +1562,36 @@ class TestOpenLsfTunnelFailover:
         assert opened_hosts == ["node-a", "node-b"]
 
     @pytest.mark.asyncio
+    async def test_readlink_timeout_returns_503_not_500(self):
+        """A command_timeout on the post-open readlink canonicalize (slow session
+        setup) must surface as a clean 503, not an opaque 500."""
+        from gbserver.api import lsf_tunnel
+
+        resolve, fetch, write, unlink = self._patch_resolvers(["node-a"])
+
+        def make_tunnel(**kwargs):
+            t = MagicMock()
+            t.open = AsyncMock(return_value=None)
+            # asyncssh raises TimeoutError (subclasses builtin) when conn.run
+            # exceeds command_timeout.
+            t.run_remote = AsyncMock(side_effect=TimeoutError("command timed out"))
+            t.close = AsyncMock()
+            return t
+
+        with (
+            resolve,
+            fetch,
+            write,
+            unlink,
+            patch.object(lsf_tunnel, "SshTunnel", side_effect=make_tunnel),
+        ):
+            with pytest.raises(HTTPException) as ei:
+                async with lsf_tunnel.open_lsf_tunnel("space-a", "env://x"):
+                    pass
+
+        assert ei.value.status_code == 503
+
+    @pytest.mark.asyncio
     async def test_all_nodes_fail_returns_503_with_list(self):
         from gbserver.api import lsf_tunnel
         from gbserver.utils.ssh_tunnel import SshTunnelError

--- a/test/unit/environment/test_lsf_cleanup.py
+++ b/test/unit/environment/test_lsf_cleanup.py
@@ -49,6 +49,11 @@ def _make_lsf(use_ssh: bool = True) -> Lsf:
     lsf._ssh_tunnel = _mock_tunnel() if use_ssh else None
     lsf._send_message = MagicMock()
     lsf._dispatch_event = MagicMock()
+    # _bkill now reconnects through ensure_and_use -> _ensure_ssh_tunnel, whose
+    # fast path reuses a healthy tunnel but first asserts the key file and may take
+    # _tunnel_lock. Provide both so a healthy mock tunnel is returned as-is.
+    lsf._key_file_path = "/tmp/fake_key"
+    lsf._tunnel_lock = asyncio.Lock()
     return lsf
 
 
@@ -159,6 +164,61 @@ class TestCleanupBsub:
         )
 
         assert lsf._ssh_tunnel.run_remote.call_count == 3
+        lsf._send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bkill_reconnects_dead_tunnel_with_short_budget(self: Self) -> None:
+        """A wedged/absent tunnel is no longer a skip: bkill reconnects through the
+        robust establish path, but with the short bkill budget, not the 4h one."""
+        from gbserver.environment import lsf as lsf_mod
+
+        lsf = _make_lsf(use_ssh=True)
+        lsf._launched_jobs["launch-1"] = "12345"
+        lsf._ssh_tunnel = None  # no live tunnel at cleanup time
+
+        fresh = _mock_tunnel()
+        fresh.run_remote = AsyncMock(
+            return_value=(0, "Job <12345> is being terminated\n", "")
+        )
+
+        with patch.object(
+            lsf, "_ensure_ssh_tunnel", new=AsyncMock(return_value=fresh)
+        ) as ensure:
+            await lsf.cleanup_bsub(
+                launch_id="launch-1",
+                run_metadata={"build_id": "b1"},
+            )
+
+        # Reconnected (not skipped) and used the short bkill budget.
+        ensure.assert_awaited_once()
+        assert (
+            ensure.await_args.kwargs["budget_s"]
+            == lsf_mod.GBSERVER_LSF_BKILL_SSH_BUDGET_S
+        )
+        fresh.run_remote.assert_awaited_once()
+        lsf._send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bkill_skips_when_reconnect_fails(self: Self) -> None:
+        """If the short-budget reconnect can't establish a tunnel, bkill stays
+        best-effort: log and skip, never fail teardown."""
+        from gbserver.utils.ssh_tunnel import SshTunnelError
+
+        lsf = _make_lsf(use_ssh=True)
+        lsf._launched_jobs["launch-1"] = "12345"
+        lsf._ssh_tunnel = None
+
+        with patch.object(
+            lsf,
+            "_ensure_ssh_tunnel",
+            new=AsyncMock(side_effect=SshTunnelError("no reachable node in budget")),
+        ):
+            # No exception propagates out of teardown.
+            await lsf.cleanup_bsub(
+                launch_id="launch-1",
+                run_metadata={"build_id": "b1"},
+            )
+
         lsf._send_message.assert_not_called()
 
 

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -52,6 +52,13 @@ def _make_lsf(login_nodes: List[str]) -> Lsf:
     lsf.ssh_connect_budget_s = 3600
     lsf.ssh_connect_base_backoff_s = 1
     lsf.ssh_connect_max_backoff_s = 4
+    # Per-attempt banner/login bounds threaded into the tunnel + probe.
+    lsf.ssh_connect_timeout_s = 20
+    lsf.ssh_login_timeout_s = 90
+    lsf.ssh_keepalive_interval_s = 10
+    lsf.ssh_keepalive_count_max = 3
+    lsf.ssh_probe_server_alive_interval = 10
+    lsf.ssh_probe_server_alive_count_max = 9
     return lsf
 
 
@@ -224,6 +231,53 @@ class TestEnsureSshTunnel:
         assert lsf._ssh_tunnel is good
 
     @pytest.mark.asyncio
+    async def test_builds_tunnel_with_banner_login_bounds(self: Self) -> None:
+        """The tunnel is constructed with the connect/login/keepalive bounds so a
+        slow-banner or wedged login node fails over instead of hanging."""
+        lsf = _make_lsf(["a"])
+        good = _healthy_tunnel("a")
+
+        with (
+            patch("gbserver.environment.lsf.SshTunnel", return_value=good) as cls,
+            patch.object(
+                lsf, "_get_reachable_ssh_node", new=AsyncMock(return_value="a")
+            ),
+        ):
+            await lsf._ensure_ssh_tunnel()
+
+        _, kwargs = cls.call_args
+        assert kwargs["connect_timeout"] == lsf.ssh_connect_timeout_s
+        assert kwargs["login_timeout"] == lsf.ssh_login_timeout_s
+        assert kwargs["keepalive_interval"] == lsf.ssh_keepalive_interval_s
+        assert kwargs["keepalive_count_max"] == lsf.ssh_keepalive_count_max
+
+    @pytest.mark.asyncio
+    async def test_aborts_when_key_file_removed_by_teardown(self: Self) -> None:
+        """A teardown mid-sweep (key file nulled) aborts promptly, rather than
+        continuing to probe dead nodes for the rest of the budget."""
+        lsf = _make_lsf(["a", "b"])
+        lsf.ssh_connect_budget_s = 14400  # long budget; teardown must still win
+
+        async def _node_then_teardown() -> str:
+            # Simulate teardown_bsub racing in: the key file is removed while the
+            # sweep is between attempts.
+            lsf._key_file_path = None
+            raise RuntimeError("no reachable node")
+
+        get_node = AsyncMock(wraps=_node_then_teardown)
+        with (
+            patch("gbserver.environment.lsf.SshTunnel"),
+            patch.object(lsf, "_get_reachable_ssh_node", new=get_node),
+            patch("gbserver.environment.lsf.asyncio.sleep", new=AsyncMock()) as sleep,
+        ):
+            with pytest.raises(SshTunnelError, match="torn down / build"):
+                await lsf._ensure_ssh_tunnel()
+            # Second sweep's top-of-loop check bails before another node search.
+            assert get_node.await_count == 1
+            # No long budget wait — we aborted, not slept out 4h.
+            sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_healthy_fast_path_skips_lock(self: Self) -> None:
         """A healthy tunnel is returned without ever taking _tunnel_lock."""
         lsf = _make_lsf(["a"])
@@ -313,6 +367,33 @@ class TestEnsureSshTunnelConcurrency:
         await holder
         await asyncio.sleep(0)  # let close_when_idle drain and close
         first.close.assert_awaited()  # closed once the in-flight use drained
+
+
+class TestReachabilityProbeBannerBound:
+    """The pre-tunnel `ssh` probe must bound the banner phase, not just TCP."""
+
+    @pytest.mark.asyncio
+    async def test_probe_command_includes_server_alive_flags(self: Self) -> None:
+        lsf = _make_lsf(["a"])
+        captured: dict = {}
+
+        async def _capture(command_list, launch_id):  # noqa: ANN001
+            captured["cmd"] = command_list
+            return MagicMock(), "", ""
+
+        with patch(
+            "gbserver.environment.lsf.launch_command_and_raise_errors",
+            new=AsyncMock(side_effect=_capture),
+        ):
+            ok = await lsf._Lsf__is_ssh_node_reachable(node="a", launch_id="lid")
+
+        assert ok is True
+        cmd = captured["cmd"]
+        # ConnectTimeout (TCP) is still present, and ServerAlive* now bounds the
+        # banner/post-TCP phase with the configured values.
+        assert f"ConnectTimeout={lsf.ssh_timeout}" in cmd
+        assert f"ServerAliveInterval={lsf.ssh_probe_server_alive_interval}" in cmd
+        assert f"ServerAliveCountMax={lsf.ssh_probe_server_alive_count_max}" in cmd
 
 
 class TestSshTunnelIsHealthy:

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -376,18 +376,27 @@ class TestReachabilityProbeBannerBound:
     no per-sweep deadline, so it uses a small dedicated probe timeout — keeping a
     hung cluster from blowing a short-budget caller (bkill)."""
 
+    @staticmethod
+    def _mock_proc(returncode: int = 0) -> MagicMock:
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = returncode
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+        return proc
+
     @pytest.mark.asyncio
     async def test_probe_uses_small_probe_timeout(self: Self) -> None:
         lsf = _make_lsf(["a"])
         captured: dict = {}
 
-        async def _capture(command_list, launch_id):  # noqa: ANN001
-            captured["cmd"] = command_list
-            return MagicMock(), "", ""
+        async def _spawn(*args, **kwargs):  # noqa: ANN002, ANN003
+            captured["cmd"] = list(args)
+            return self._mock_proc(returncode=0)
 
         with patch(
-            "gbserver.environment.lsf.launch_command_and_raise_errors",
-            new=AsyncMock(side_effect=_capture),
+            "gbserver.environment.lsf.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=_spawn),
         ):
             ok = await lsf._Lsf__is_ssh_node_reachable(node="a", launch_id="lid")
 
@@ -396,6 +405,23 @@ class TestReachabilityProbeBannerBound:
         # Probe uses the small dedicated timeout, not the long command/login ones.
         assert f"ConnectTimeout={lsf.ssh_probe_timeout_s}" in cmd
         assert f"ConnectTimeout={lsf.ssh_command_timeout_s}" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_probe_kills_child_on_timeout(self: Self) -> None:
+        """A timed-out probe must kill the ssh child so it doesn't linger."""
+        lsf = _make_lsf(["a"])
+        proc = self._mock_proc()
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        with patch(
+            "gbserver.environment.lsf.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ):
+            ok = await lsf._Lsf__is_ssh_node_reachable(node="a", launch_id="lid")
+
+        assert ok is False
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited_once()
 
 
 class TestSshTunnelIsHealthy:

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -58,9 +58,6 @@ def _make_lsf(login_nodes: List[str]) -> Lsf:
     lsf.ssh_keepalive_interval_s = 10
     lsf.ssh_keepalive_count_max = 3
     lsf.ssh_command_timeout_s = 120
-    lsf.ssh_probe_connect_timeout_s = 65
-    lsf.ssh_probe_server_alive_interval = 10
-    lsf.ssh_probe_server_alive_count_max = 9
     return lsf
 
 
@@ -376,13 +373,11 @@ class TestEnsureSshTunnelConcurrency:
 
 class TestReachabilityProbeBannerBound:
     """The pre-tunnel `ssh` probe gates tunnel establishment, so its ConnectTimeout
-    must be as patient as the tunnel's login_timeout — NOT the old 5s ssh_timeout,
-    which cut off a slow-but-recoverable banner before the tunnel could try it."""
+    reuses the tunnel's login_timeout — NOT the old 5s ssh_timeout, which cut off a
+    slow-but-recoverable node before the tunnel could try it."""
 
     @pytest.mark.asyncio
-    async def test_probe_uses_patient_connect_timeout_not_ssh_timeout(
-        self: Self,
-    ) -> None:
+    async def test_probe_uses_login_timeout_not_ssh_timeout(self: Self) -> None:
         lsf = _make_lsf(["a"])
         captured: dict = {}
 
@@ -398,13 +393,9 @@ class TestReachabilityProbeBannerBound:
 
         assert ok is True
         cmd = captured["cmd"]
-        # The probe waits for a slow banner using the patient probe timeout, and
-        # must NOT fall back to the old rigid 5s ssh_timeout.
-        assert f"ConnectTimeout={lsf.ssh_probe_connect_timeout_s}" in cmd
+        # Probe reuses the tunnel's patient login_timeout, never the rigid 5s.
+        assert f"ConnectTimeout={lsf.ssh_login_timeout_s}" in cmd
         assert f"ConnectTimeout={lsf.ssh_timeout}" not in cmd
-        # ServerAlive* is present as a secondary post-banner net.
-        assert f"ServerAliveInterval={lsf.ssh_probe_server_alive_interval}" in cmd
-        assert f"ServerAliveCountMax={lsf.ssh_probe_server_alive_count_max}" in cmd
 
 
 class TestSshTunnelIsHealthy:

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -57,6 +57,8 @@ def _make_lsf(login_nodes: List[str]) -> Lsf:
     lsf.ssh_login_timeout_s = 90
     lsf.ssh_keepalive_interval_s = 10
     lsf.ssh_keepalive_count_max = 3
+    lsf.ssh_command_timeout_s = 120
+    lsf.ssh_probe_connect_timeout_s = 65
     lsf.ssh_probe_server_alive_interval = 10
     lsf.ssh_probe_server_alive_count_max = 9
     return lsf
@@ -250,6 +252,9 @@ class TestEnsureSshTunnel:
         assert kwargs["login_timeout"] == lsf.ssh_login_timeout_s
         assert kwargs["keepalive_interval"] == lsf.ssh_keepalive_interval_s
         assert kwargs["keepalive_count_max"] == lsf.ssh_keepalive_count_max
+        # command_timeout bounds the slow server-side session/exec setup that is
+        # the actual bluevela bottleneck.
+        assert kwargs["command_timeout"] == lsf.ssh_command_timeout_s
 
     @pytest.mark.asyncio
     async def test_aborts_when_key_file_removed_by_teardown(self: Self) -> None:
@@ -370,10 +375,14 @@ class TestEnsureSshTunnelConcurrency:
 
 
 class TestReachabilityProbeBannerBound:
-    """The pre-tunnel `ssh` probe must bound the banner phase, not just TCP."""
+    """The pre-tunnel `ssh` probe gates tunnel establishment, so its ConnectTimeout
+    must be as patient as the tunnel's login_timeout — NOT the old 5s ssh_timeout,
+    which cut off a slow-but-recoverable banner before the tunnel could try it."""
 
     @pytest.mark.asyncio
-    async def test_probe_command_includes_server_alive_flags(self: Self) -> None:
+    async def test_probe_uses_patient_connect_timeout_not_ssh_timeout(
+        self: Self,
+    ) -> None:
         lsf = _make_lsf(["a"])
         captured: dict = {}
 
@@ -389,9 +398,11 @@ class TestReachabilityProbeBannerBound:
 
         assert ok is True
         cmd = captured["cmd"]
-        # ConnectTimeout (TCP) is still present, and ServerAlive* now bounds the
-        # banner/post-TCP phase with the configured values.
-        assert f"ConnectTimeout={lsf.ssh_timeout}" in cmd
+        # The probe waits for a slow banner using the patient probe timeout, and
+        # must NOT fall back to the old rigid 5s ssh_timeout.
+        assert f"ConnectTimeout={lsf.ssh_probe_connect_timeout_s}" in cmd
+        assert f"ConnectTimeout={lsf.ssh_timeout}" not in cmd
+        # ServerAlive* is present as a secondary post-banner net.
         assert f"ServerAliveInterval={lsf.ssh_probe_server_alive_interval}" in cmd
         assert f"ServerAliveCountMax={lsf.ssh_probe_server_alive_count_max}" in cmd
 

--- a/test/unit/environment/test_lsf_ssh_resilience.py
+++ b/test/unit/environment/test_lsf_ssh_resilience.py
@@ -47,7 +47,6 @@ def _make_lsf(login_nodes: List[str]) -> Lsf:
     lsf.ssh_host_key_verification = False
     lsf.ssh_port = 22
     lsf.ssh_max_sessions = 10
-    lsf.ssh_timeout = 5
     # Short budget + backoff so a failing test fails fast rather than hanging.
     lsf.ssh_connect_budget_s = 3600
     lsf.ssh_connect_base_backoff_s = 1
@@ -58,6 +57,7 @@ def _make_lsf(login_nodes: List[str]) -> Lsf:
     lsf.ssh_keepalive_interval_s = 10
     lsf.ssh_keepalive_count_max = 3
     lsf.ssh_command_timeout_s = 120
+    lsf.ssh_probe_timeout_s = 30
     return lsf
 
 
@@ -372,12 +372,12 @@ class TestEnsureSshTunnelConcurrency:
 
 
 class TestReachabilityProbeBannerBound:
-    """The pre-tunnel `ssh` probe gates tunnel establishment, so its ConnectTimeout
-    reuses the tunnel's login_timeout — NOT the old 5s ssh_timeout, which cut off a
-    slow-but-recoverable node before the tunnel could try it."""
+    """The pre-tunnel `ssh` probe gates tunnel establishment and runs per node with
+    no per-sweep deadline, so it uses a small dedicated probe timeout — keeping a
+    hung cluster from blowing a short-budget caller (bkill)."""
 
     @pytest.mark.asyncio
-    async def test_probe_uses_login_timeout_not_ssh_timeout(self: Self) -> None:
+    async def test_probe_uses_small_probe_timeout(self: Self) -> None:
         lsf = _make_lsf(["a"])
         captured: dict = {}
 
@@ -393,9 +393,9 @@ class TestReachabilityProbeBannerBound:
 
         assert ok is True
         cmd = captured["cmd"]
-        # Probe reuses the tunnel's patient login_timeout, never the rigid 5s.
-        assert f"ConnectTimeout={lsf.ssh_login_timeout_s}" in cmd
-        assert f"ConnectTimeout={lsf.ssh_timeout}" not in cmd
+        # Probe uses the small dedicated timeout, not the long command/login ones.
+        assert f"ConnectTimeout={lsf.ssh_probe_timeout_s}" in cmd
+        assert f"ConnectTimeout={lsf.ssh_command_timeout_s}" not in cmd
 
 
 class TestSshTunnelIsHealthy:


### PR DESCRIPTION
## Problem

Builds against the bluevela LSF environment stall or get cancelled when its login nodes are slow. The original runner log showed SSH probes failing, and the first hypothesis was a slow SSH **banner exchange**. Running `ssh -vv` against a live (slow) bluevela login node corrected that diagnosis:

```
17:04:58  TCP connect established        (instant)
17:04:59  banner + kex + host key + AUTH (~1s, fast)
17:05:00  exec request accepted
   ...    <-- 28-second gap, no output -->
17:05:28  command output finally appears
```

**Connect + banner + kex + auth all complete in ~1 second.** The multi-second delay (observed ~28s, "up to a minute or longer" under load, and consistent on every connect) happens **after** the exec request is accepted — it is **server-side session/exec setup** (slow networked home dir, login `rc`, module init) before a command produces output. Once the session is live, commands run at full speed.

The prior code left the relevant phases unbounded and mis-targeted:
- `SshTunnel.open` / `asyncssh.connect` had no `connect_timeout`/`login_timeout`/keepalive, and `conn.run()` had **no command timeout** — so a wedged session-setup could hang forever.
- The reachability probe used `ConnectTimeout=5s` (`ssh_timeout`), which could reject a briefly-slow node before the tunnel even tried it, and its `echo` (which incurs the same session-setup delay) had no timeout at all.
- `bkill` **skipped the remote kill** when the tunnel was unhealthy — leaking the LSF job exactly when the cluster was wedged, despite `bkill` fundamentally needing an SSH connection.
- The establish sweep kept probing dead nodes for ~24s **after** a SIGTERM cancel.

## Solution

**The real fix — bound the slow phase (command/session exec):**
- `SshTunnel` gains `command_timeout`, forwarded to `asyncssh conn.run(timeout=...)`. This bounds the server-side session-setup that is actually slow; on expiry asyncssh raises `TimeoutError`, which `run_remote_with_retries` already retries. Default **120s** (covers the observed ~28s with wide margin), tunable.

**Connect/login bounds — kept but right-sized:**
- `SshTunnel` also gains `connect_timeout` / `login_timeout` / `keepalive_*` → `asyncssh.connect`. These are **not** the slow-session fix (auth is ~1s), but they still bound the *genuinely-down-node* case (connect/banner never completing) from the original log. Sized modestly: `connect_timeout=10s`, `login_timeout=30s`.
- The reachability probe no longer uses the old 5s `ssh_timeout`; it gets its own small `GBSERVER_LSF_SSH_PROBE_TIMEOUT_S` (**30s**) — see **Bounded reachability probe** below for why it's dedicated rather than reusing login/command. (In modern OpenSSH `ConnectTimeout` does cover the banner exchange.)
- keepalive `10s × 3`: asyncssh keepalive probes the transport and only drops on **server non-response**, so it will not sever a slow-but-alive session-setup — verified against asyncssh source. (The reachability probe's old `ServerAlive*` flags were dropped: they run post-kex and never bounded the pre-output phase; the probe's own overall `wait_for` bound covers it.)

**Per-caller give-up budgets** (all env-var tunable):
- **Build runner** (batch): keeps sweeping the node list up to the existing **4h** budget; a per-node give-up isn't a build failure.
- **Job kill** (`cleanup_bsub` → `_bkill`): now **reconnects** through the robust path (5-min budget) instead of skipping when the tunnel is unhealthy, so a wedged tunnel no longer leaks the LSF job. Best-effort: on failure it logs and skips, never fails teardown. (This is the only cleanup-path function that gained reconnect — because a running job is worth reaching a node to kill.)
- **File APIs** (interactive, HTTPS via an OpenShift route with a 600s HAProxy timeout): the tunnel-establish sweep is capped at a separate **45s** budget (hard ceiling well under 600s) so the caller gets a fast clean 503. The file-API commands hit the **same** session-setup slowness as everything else, so they get the same leniency but with a **shorter max** than the batch runner — a separate `GBSERVER_LSF_FILE_API_COMMAND_TIMEOUT_S` (**60s**, vs the runner's 120s), matching the interactive caller's tolerance.

**Cancellation responsiveness:** `_ensure_ssh_tunnel` / `ensure_and_use` take an optional `budget_s`; the sweep observes teardown (`_key_file_path` nulled) at top-of-loop (now a first-class `SshTunnelError`, not an `assert`) and in a sliced backoff, so a cancelled build stops sweeping within ~2s.

**Bounded reachability probe:** the establish sweep (`_get_reachable_ssh_node`) probes login nodes in sequence with no per-sweep deadline, so the probe uses a small dedicated `GBSERVER_LSF_SSH_PROBE_TIMEOUT_S` (**30s**) for its `ConnectTimeout` and overall `wait_for` — not the long command/login timeouts — so one sweep over a hung cluster can't blow a short-budget caller (e.g. `bkill`'s 300s). (The file API doesn't use this path; its own candidate loop is already budget-bounded.)

**Clean error surfacing:** the new `command_timeout` makes remote commands raise `TimeoutError`; `translate_remote_file_errors` and the `open_lsf_tunnel` canonicalize step now map `TimeoutError`/`SshTunnelError` to **503** ("login node slow or unreachable; please retry") so the interactive caller gets a meaningful status instead of an opaque 500.

**Removed dead config:** `ssh_timeout` (default 5s) had no consumer after the probe switched to the dedicated probe timeout; removed so setting it in `environment.yaml` isn't a silent no-op.

**Node ordering** — already best-practice, unchanged: runner round-robins from a random offset (skipping known-unreachable nodes); file API random-shuffles per request.

**Not changed** (deliberately — don't confuse these with `cleanup_bsub`/`_bkill` above, despite the similar names):
- `teardown_bsub` — closes/drains the existing tunnel and deletes the key file; reconnecting in order to tear down would be backwards.
- `_cleanup_asset_dirs` — removes remote scratch dirs on the existing tunnel; a leaked temp dir if the tunnel is already gone is harmless, unlike a leaked running job, so it's not worth a reconnect.

Both still read `self._ssh_tunnel` directly and skip if it's absent/unhealthy.

## Test plan

- `test/integration/ibm/utils/test_ssh_tunnel.py` — connect/login/keepalive and `command_timeout` reach asyncssh (`connect` and `conn.run`), and are omitted when unset.
- `test/unit/environment/test_lsf_ssh_resilience.py` — tunnel built with all bounds incl. `command_timeout`; probe uses the small dedicated probe timeout and kills its `ssh` child on timeout; teardown aborts the sweep promptly.
- `test/unit/environment/test_lsf_cleanup.py` — `bkill` reconnects a dead/None tunnel with the short budget; skips (never raises) when the reconnect fails.
- `test/unit/api/test_build_files.py` — file-API tunnel carries the bounds; establish budget short-circuits remaining nodes; the slow-but-alive scenario (fast open, slow-but-under-timeout first command) opens successfully; a readlink `command_timeout` surfaces as 503, not 500.
- Full run of the touched test files: **131 passed** (`GB_ENVIRONMENT=STANDALONE GBTEST_MODE=mock`). `asyncssh` is an optional `[ssh]` extra; asyncssh-constructing tests run only where it's installed.
- Diagnosis verified live with `ssh -vv` against a bluevela login node (timeline above).

## Notes

- New env vars: `GBSERVER_LSF_SSH_COMMAND_TIMEOUT_S`, `_FILE_API_COMMAND_TIMEOUT_S`, `_SSH_LOGIN_TIMEOUT_S`, `_SSH_CONNECT_TIMEOUT_S`, `_SSH_KEEPALIVE_INTERVAL_S`, `_SSH_KEEPALIVE_COUNT_MAX`, `_SSH_PROBE_TIMEOUT_S`, `_FILE_API_SSH_BUDGET_S`, `_BKILL_SSH_BUDGET_S`. All have sensible defaults; no config change required. Removes the previously-unused `ssh_timeout` knob.
- The ~28s server-side session-setup is itself worth investigating on the bluevela side (home-dir mount / login rc); this PR makes the client resilient to it.
- Follow-up to the SSH-tunnel resilience work (#368 / #369).

Generated with [Claude Code](https://claude.com/claude-code)





